### PR TITLE
fix: provision to enable do not use batch-wise valuation

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -373,3 +373,4 @@ erpnext.patches.v15_0.enable_old_serial_batch_fields
 erpnext.patches.v15_0.update_warehouse_field_in_asset_repair_consumed_item_doctype
 erpnext.patches.v15_0.update_asset_repair_field_in_stock_entry
 erpnext.patches.v15_0.update_total_number_of_booked_depreciations
+erpnext.patches.v15_0.do_not_use_batchwise_valuation

--- a/erpnext/patches/v15_0/do_not_use_batchwise_valuation.py
+++ b/erpnext/patches/v15_0/do_not_use_batchwise_valuation.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+	valuation_method = frappe.db.get_single_value("Stock Settings", "valuation_method")
+	if valuation_method in ["FIFO", "LIFO"]:
+		return
+
+	if frappe.get_all("Batch", filters={"use_batchwise_valuation": 1}, limit=1):
+		return
+
+	if frappe.get_all("Item", filters={"has_batch_no": 1, "valuation_method": "FIFO"}, limit=1):
+		return
+
+	frappe.db.set_single_value("Stock Settings", "do_not_use_batchwise_valuation", 1)

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -158,6 +158,10 @@ class Batch(Document):
 
 	def set_batchwise_valuation(self):
 		if self.is_new():
+			if frappe.db.get_single_value("Stock Settings", "do_not_use_batchwise_valuation"):
+				self.use_batchwise_valuation = 0
+				return
+
 			self.use_batchwise_valuation = 1
 
 	def before_save(self):

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1681,7 +1681,7 @@ class TestDeliveryNote(FrappeTestCase):
 			{
 				"is_stock_item": 1,
 				"has_batch_no": 1,
-				"batch_no_series": "BATCH-TESTSERIAL-.#####",
+				"batch_number_series": "BATCH-TESTSERIAL-.#####",
 				"create_new_batch": 1,
 			},
 		)

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -648,7 +648,7 @@ class TestPickList(FrappeTestCase):
 	def test_picklist_for_batch_item(self):
 		warehouse = "_Test Warehouse - _TC"
 		item = make_item(
-			properties={"is_stock_item": 1, "has_batch_no": 1, "batch_no_series": "PICKLT-.######"}
+			properties={"is_stock_item": 1, "has_batch_no": 1, "batch_number_series": "PICKLT-.######"}
 		).name
 
 		# create batch

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -3210,6 +3210,65 @@ class TestPurchaseReceipt(FrappeTestCase):
 		lcv.save().submit()
 		return lcv
 
+	def test_do_not_use_batchwise_valuation_rate(self):
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		item_code = "Test Item for Do Not Use Batchwise Valuation"
+		make_item(
+			item_code,
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TIDNBV-.#####",
+				"valuation_method": "Moving Average",
+			},
+		)
+
+		# 1st pr for 100 rate
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			qty=1,
+			rate=100,
+			posting_date=add_days(today(), -2),
+		)
+
+		make_purchase_receipt(
+			item_code=item_code,
+			qty=1,
+			rate=200,
+			posting_date=add_days(today(), -1),
+		)
+
+		dn = create_delivery_note(
+			item_code=item_code,
+			qty=1,
+			rate=300,
+			posting_date=today(),
+			use_serial_batch_fields=1,
+			batch_no=get_batch_from_bundle(pr.items[0].serial_and_batch_bundle),
+		)
+		dn.reload()
+		bundle = dn.items[0].serial_and_batch_bundle
+
+		valuation_rate = frappe.db.get_value("Serial and Batch Bundle", bundle, "avg_rate")
+		self.assertEqual(valuation_rate, 100)
+
+		doc = frappe.get_doc("Stock Settings")
+		doc.do_not_use_batchwise_valuation = 1
+		doc.flags.ignore_validate = True
+		doc.save()
+
+		pr.repost_future_sle_and_gle(force=True)
+
+		valuation_rate = frappe.db.get_value("Serial and Batch Bundle", bundle, "avg_rate")
+		self.assertEqual(valuation_rate, 150)
+
+		doc = frappe.get_doc("Stock Settings")
+		doc.do_not_use_batchwise_valuation = 0
+		doc.flags.ignore_validate = True
+		doc.save()
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -228,6 +228,16 @@ class SerialandBatchBundle(Document):
 	def get_serial_nos(self):
 		return [d.serial_no for d in self.entries if d.serial_no]
 
+	def update_valuation_rate(self, valuation_rate=None, save=False):
+		for row in self.entries:
+			row.incoming_rate = valuation_rate
+			row.stock_value_difference = flt(row.qty) * flt(valuation_rate)
+
+			if save:
+				row.db_set(
+					{"incoming_rate": row.incoming_rate, "stock_value_difference": row.stock_value_difference}
+				)
+
 	def set_incoming_rate_for_outward_transaction(self, row=None, save=False, allow_negative_stock=False):
 		sle = self.get_sle_for_outward_transaction()
 

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -653,7 +653,7 @@ class TestSerialandBatchBundle(FrappeTestCase):
 				"is_stock_item": 1,
 				"has_batch_no": 1,
 				"create_new_batch": 1,
-				"batch_no_series": "PSNBI-TSNVL-.#####",
+				"batch_number_series": "PSNBI-TSNVL-.#####",
 				"has_serial_no": 1,
 				"serial_no_series": "SN-PSNBI-TSNVL-.#####",
 			},

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -44,6 +44,7 @@
   "auto_reserve_serial_and_batch",
   "serial_and_batch_item_settings_tab",
   "section_break_7",
+  "do_not_use_batchwise_valuation",
   "auto_create_serial_and_batch_bundle_for_outward",
   "pick_serial_and_batch_based_on",
   "column_break_mhzc",
@@ -437,6 +438,14 @@
    "fieldname": "do_not_update_serial_batch_on_creation_of_auto_bundle",
    "fieldtype": "Check",
    "label": "Do Not Update Serial / Batch on Creation of Auto Bundle"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.valuation_method === \"Moving Average\"",
+   "description": "If enabled, the system will use the moving average valuation method to calculate the valuation rate for the batched items and will not consider the individual batch-wise incoming rate.",
+   "fieldname": "do_not_use_batchwise_valuation",
+   "fieldtype": "Check",
+   "label": "Do Not Use Batch-wise Valuation"
   }
  ],
  "icon": "icon-cog",
@@ -444,7 +453,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:45.423987",
+ "modified": "2024-07-04 12:45:09.811280",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -244,6 +244,8 @@ def get_incoming_rate(args, raise_error_if_no_rate=True):
 		"Item", args.get("item_code"), ["has_serial_no", "has_batch_no"], as_dict=1
 	)
 
+	use_moving_avg_for_batch = frappe.db.get_single_value("Stock Settings", "do_not_use_batchwise_valuation")
+
 	if isinstance(args, dict):
 		args = frappe._dict(args)
 
@@ -257,7 +259,12 @@ def get_incoming_rate(args, raise_error_if_no_rate=True):
 
 		return sn_obj.get_incoming_rate()
 
-	elif item_details and item_details.has_batch_no and args.get("serial_and_batch_bundle"):
+	elif (
+		item_details
+		and item_details.has_batch_no
+		and args.get("serial_and_batch_bundle")
+		and not use_moving_avg_for_batch
+	):
 		args.actual_qty = args.qty
 		batch_obj = BatchNoValuation(
 			sle=args,
@@ -274,7 +281,7 @@ def get_incoming_rate(args, raise_error_if_no_rate=True):
 		sn_obj = SerialNoValuation(sle=args, warehouse=args.get("warehouse"), item_code=args.get("item_code"))
 
 		return sn_obj.get_incoming_rate()
-	elif args.get("batch_no") and not args.get("serial_and_batch_bundle"):
+	elif args.get("batch_no") and not args.get("serial_and_batch_bundle") and not use_moving_avg_for_batch:
 		args.actual_qty = args.qty
 		args.batch_nos = frappe._dict({args.batch_no: args})
 


### PR DESCRIPTION
Batch-wise Valuation Rate

- Purchase Receipt 1, Batch 1 with qty 1 and Rate 100
- Purchase Receipt 2, Batch 2 with qty 1 and Rate 200
- Consumed Batch 1 with qty 1 using delivery note
    - Valuation rate = 100 because Batch 1 has purchased with 100 rate in the purchase receipt 1

Do No Use Batch-wise Valuation Rate

- Purchase Receipt 1, Batch 1 with qty 1 and Rate 100
- Purchase Receipt 2, Batch 2 with qty 1 and Rate 200
- Consumed Batch 1 with qty 1 using delivery note
    - Valuation rate = (100 * 1 + 200 * 1) / 1+1 = 300 / 2 = 150 (Average)

To enable "Do No Use Batch-wise Valuation Rate", added checkbox in the stock settings
<img width="1322" alt="Screenshot 2024-07-04 at 5 20 15 PM" src="https://github.com/frappe/erpnext/assets/8780500/8f96771a-5a48-49a8-beac-0a7d04abfa4f">



