### PR TITLE
fix: Reopen Project if Completion Percentage is Below 100%

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -262,8 +262,7 @@ class Project(Document):
 		if self.status == "Cancelled":
 			return
 
-		if self.percent_complete == 100:
-			self.status = "Completed"
+		self.status = "Completed" if self.percent_complete == 100 else "Open"
 
 	def update_costing(self):
 		from frappe.query_builder.functions import Max, Min, Sum


### PR DESCRIPTION
### Before
When a project is marked as completed, reopening any task within it will not change the project's status from **Completed**.

https://github.com/frappe/erpnext/assets/54097382/ff1a845c-9c97-417b-b03a-d09a4db3bbca


### After
If any task is reopened after the project is completed, the project's status will be updated to **Open**.

https://github.com/frappe/erpnext/assets/54097382/42abba71-16b0-411f-b3f5-8a7e8a39d7cd

