### PR TITLE
fix: Inventory Dimension from Pick List table not getting mapped to Delivery Note Table 

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -8,7 +8,7 @@ from itertools import groupby
 import frappe
 from frappe import _, bold
 from frappe.model.document import Document
-from frappe.model.mapper import map_child_doc
+from frappe.model.mapper import map_child_doc, map_doc
 from frappe.query_builder import Case
 from frappe.query_builder.custom import GROUP_CONCAT
 from frappe.query_builder.functions import Coalesce, Locate, Replace, Sum
@@ -1173,11 +1173,15 @@ def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
 		dn_item = map_child_doc(source_doc, delivery_note, item_mapper)
 
 		if dn_item:
-			dn_item.pick_list_item = location.name
-			dn_item.warehouse = location.warehouse
+			if sales_order_item:
+				pick_list_table_mapper = {
+					"doctype": "Delivery Note Item",
+					"field_map": {
+						"name": "pick_list_item",
+					}
+				}
+				map_doc(location, dn_item, pick_list_table_mapper)
 			dn_item.qty = flt(location.picked_qty) / (flt(location.conversion_factor) or 1)
-			dn_item.batch_no = location.batch_no
-			dn_item.serial_no = location.serial_no
 
 			update_delivery_note_item(source_doc, dn_item, delivery_note)
 


### PR DESCRIPTION
When a delivery note is created from the pick list, the inventory dimensions (if any) added by a user are not being mapped in the delivery note items table from the pick list items table.

I have tested the flow with this fix and the Delivery Note is being created properly and further Sales Invoice from Delivery Note is also being created.

