### PR TITLE
fix: QC mapping in sales/purchase with same items

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1510,6 +1510,7 @@ def make_quality_inspections(doctype, docname, items, inspection_type):
 				"sample_size": flt(item.get("sample_size")),
 				"item_serial_no": item.get("serial_no").split("\n")[0] if item.get("serial_no") else None,
 				"batch_no": item.get("batch_no"),
+				"rowname": item.get("docname"),
 			}
 		).insert()
 		quality_inspection.save()

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.json
@@ -22,6 +22,7 @@
   "sample_size",
   "column_break1",
   "item_name",
+  "rowname",
   "description",
   "bom_no",
   "specification_details",
@@ -238,6 +239,13 @@
    "fieldname": "manual_inspection",
    "fieldtype": "Check",
    "label": "Manual Inspection"
+  },
+  {
+   "fieldname": "rowname",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Rowname",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-search",
@@ -245,7 +253,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:28.680815",
+ "modified": "2024-07-08 12:08:50.904016",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection",

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -52,6 +52,7 @@ class QualityInspection(Document):
 		]
 		remarks: DF.Text | None
 		report_date: DF.Date
+		rowname: DF.Data | None
 		sample_size: DF.Float
 		status: DF.Literal["", "Accepted", "Rejected"]
 		verified_by: DF.Data | None

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -125,10 +125,10 @@ class QualityInspection(Document):
 
 		if self.reference_type == "Job Card":
 			if self.reference_name:
-				frappe.db.set_value(self.reference_type, self.reference_name,
-									"quality_inspection", quality_inspection)
-				frappe.db.set_value(self.reference_type, self.reference_name,
-									"modified", self.modified)
+				frappe.db.set_value(
+					self.reference_type, self.reference_name, "quality_inspection", quality_inspection
+				)
+				frappe.db.set_value(self.reference_type, self.reference_name, "modified", self.modified)
 
 		else:
 			conditions = {"parent": self.reference_name, "item_code": self.item_code}
@@ -138,7 +138,7 @@ class QualityInspection(Document):
 			if self.docstatus == 2:  # if cancel, then remove qi link wherever same name
 				conditions["quality_inspection"] = self.name
 
-			if hasattr(self, 'rowname') and self.rowname:
+			if hasattr(self, "rowname") and self.rowname:
 				conditions["name"] = self.rowname
 
 			if self.reference_type == "Stock Entry":
@@ -146,11 +146,9 @@ class QualityInspection(Document):
 			else:
 				doctype = self.reference_type + " Item"
 
-			frappe.db.set_value(doctype, conditions,
-								"quality_inspection", quality_inspection)
+			frappe.db.set_value(doctype, conditions, "quality_inspection", quality_inspection)
 
-			frappe.db.set_value(self.reference_type, self.reference_name,
-								"modified", self.modified)
+			frappe.db.set_value(self.reference_type, self.reference_name, "modified", self.modified)
 
 	def inspect_and_set_status(self):
 		for reading in self.readings:

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -134,7 +134,7 @@ class QualityInspection(Document):
 				)
 
 		else:
-			args = [quality_inspection, self.modified, self.reference_name, self.item_code]
+			args = [quality_inspection, self.modified, self.reference_name, self.item_code, self.rowname]
 			doctype = self.reference_type + " Item"
 
 			if self.reference_type == "Stock Entry":
@@ -160,6 +160,7 @@ class QualityInspection(Document):
 						t1.parent = %s
 						and t1.item_code = %s
 						and t1.parent = t2.name
+						and t1.name = %s
 						{conditions}
 				""",
 					args,

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -126,9 +126,8 @@ class QualityInspection(Document):
 		if self.reference_type == "Job Card":
 			if self.reference_name:
 				frappe.db.set_value(
-					self.reference_type, self.reference_name, "quality_inspection", quality_inspection
+					self.reference_type, self.reference_name, "quality_inspection", quality_inspection, update_modified=True
 				)
-				frappe.db.set_value(self.reference_type, self.reference_name, "modified", self.modified)
 
 		else:
 			conditions = {"parent": self.reference_name, "item_code": self.item_code}

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -145,9 +145,7 @@ class QualityInspection(Document):
 			else:
 				doctype = self.reference_type + " Item"
 
-			frappe.db.set_value(doctype, conditions, "quality_inspection", quality_inspection)
-
-			frappe.db.set_value(self.reference_type, self.reference_name, "modified", self.modified)
+			frappe.db.set_value(doctype, conditions, "quality_inspection", quality_inspection, update_modified=True)
 
 	def inspect_and_set_status(self):
 		for reading in self.readings:

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -270,6 +270,10 @@ class TestQualityInspection(FrappeTestCase):
 		se.items[0].quality_inspection = qa.name
 		se.save()
 
+		# Unlink the quality inspection from stock entry item
+		se.items[0].quality_inspection = None
+		se.save()
+
 		qa.delete()
 
 		se.reload()


### PR DESCRIPTION
Version: **15** & **14**

fixes: #42213

**Before:** 

- When I add the same item in the Purchase Receipt/Delivery Note Item table and create a Quality Inspection for both, it adds the same Quality Inspection for each. When submitting the Quality Inspection, it sets the same reference in both child tables in the Purchase Invoice/Delivery Note.


https://github.com/frappe/erpnext/assets/141945075/eae2a1ce-072d-4e7c-92d0-20d06a661268


**After:**

- fixed for the sales/purchase process.


https://github.com/frappe/erpnext/assets/141945075/01734ec4-816e-48c8-bf19-0b90963b6fe4

