### PR TITLE
fix: Force Fetching updates on Subscriptions

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.js
+++ b/erpnext/accounts/doctype/subscription/subscription.js
@@ -39,6 +39,12 @@ frappe.ui.form.on("Subscription", {
 			);
 
 			frm.add_custom_button(
+				__("Force Fetch Subscription Updates"),
+				() => frm.trigger("force_fetch_subscription_updates"),
+				__("Actions")
+			);
+
+			frm.add_custom_button(
 				__("Cancel Subscription"),
 				() => frm.trigger("cancel_this_subscription"),
 				__("Actions")
@@ -77,6 +83,13 @@ frappe.ui.form.on("Subscription", {
 
 	get_subscription_updates: function (frm) {
 		frm.call("process").then((r) => {
+			if (!r.exec) {
+				frm.reload_doc();
+			}
+		});
+	},
+	force_fetch_subscription_updates: function (frm) {
+		frm.call("force_fetch_subscription_updates").then((r) => {
 			if (!r.exec) {
 				frm.reload_doc();
 			}

--- a/erpnext/accounts/doctype/subscription/subscription.js
+++ b/erpnext/accounts/doctype/subscription/subscription.js
@@ -39,7 +39,7 @@ frappe.ui.form.on("Subscription", {
 			);
 
 			frm.add_custom_button(
-				__("Force Fetch Subscription Updates"),
+				__("Force-Fetch Subscription Updates"),
 				() => frm.trigger("force_fetch_subscription_updates"),
 				__("Actions")
 			);

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -717,6 +717,25 @@ class Subscription(Document):
 		self.update_subscription_period(posting_date or nowdate())
 		self.save()
 
+	@frappe.whitelist()
+	def force_fetch_subscription_updates(self):
+		"""
+		Process Subscription and create Invoices even if current date doesn't lie between current_invoice_start and currenct_invoice_end
+		It makes use of 'Proces Subscription' to force processing in a specific 'posting_date'
+		"""
+		processing_date = None
+		if self.generate_invoice_at == "Beginning of the current subscription period":
+			processing_date = self.current_invoice_start
+		elif self.generate_invoice_at == "End of the current subscription period":
+			processing_date = self.current_invoice_end
+		elif self.generate_invoice_at == "Days before the current subscription period":
+			processing_date = add_days(self.current_invoice_start, -self.number_of_days)
+
+		process_subscription = frappe.new_doc("Process Subscription")
+		process_subscription.posting_date = processing_date
+		process_subscription.subscription = self.name
+		process_subscription.save().submit()
+
 
 def is_prorate() -> int:
 	return cint(frappe.db.get_single_value("Subscription Settings", "prorate"))

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -723,6 +723,12 @@ class Subscription(Document):
 		Process Subscription and create Invoices even if current date doesn't lie between current_invoice_start and currenct_invoice_end
 		It makes use of 'Proces Subscription' to force processing in a specific 'posting_date'
 		"""
+
+		# Don't process future subscriptions
+		if nowdate() < self.current_invoice_start:
+			frappe.msgprint(_("Subscription for Future dates cannot be processed."))
+			return
+
 		processing_date = None
 		if self.generate_invoice_at == "Beginning of the current subscription period":
 			processing_date = self.current_invoice_start

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -521,6 +521,18 @@ class TestSubscription(FrappeTestCase):
 		subscription.process(posting_date="2023-01-22")
 		self.assertEqual(len(subscription.invoices), 2)
 
+	def test_future_subscription(self):
+		"""Force-Fetch should not process future subscriptions"""
+		subscription = create_subscription(
+			start_date=add_months(nowdate(), 1),
+			submit_invoice=0,
+			generate_new_invoices_past_due_date=1,
+			party="_Test Subscription Customer John Doe",
+		)
+		subscription.force_fetch_subscription_updates()
+		subscription.reload()
+		self.assertEqual(len(subscription.invoices), 0)
+
 
 def make_plans():
 	create_plan(plan_name="_Test Plan Name", cost=900, currency="INR")


### PR DESCRIPTION
# Issue
Post [this](https://github.com/frappe/erpnext/pull/30963) refactor, `Fetch Subscription Updates` creates Invoices only if the Current Invoice Start / End date matches the current date. For old subscriptions, this also resets these values to the current periods' start and end dates without creating any pending invoices.

Consider the below subscription,

|||
|-|-|
|Subscription Start Date| 1st Jan|
|Subscription End Date|31 Dec|
|Plan Interval|1 Month|

and current date is 2nd March

When 'Fetch Subscription Updates' is triggered,
### Current behavior:
No Invoices are created for Jan and Feb and `current_invoice_start` and `current_invoice_end` date are updated to the latest month - March

### Expected behavior:
Invoice for January should be created and the `current_invoice_start` and `current_invoice_end` should be updated to February. Upon triggering 'Fetch Subscription Updated' again, the same should happen for February. Triggering it again, should not create any invoices as the current period - March, is not over.

# Fix
Adding a new Action button `Force-Fetch Subscription Updates`. This will have the expected behavior stated above, without allowing the scheduled job to create invoices for old subscriptions on its own.

![Screenshot from 2024-08-13 14-54-19](https://github.com/user-attachments/assets/f821adc0-af50-4529-95bb-73b923555d7e)



Internal Ref: [13453](https://support.frappe.io/helpdesk/tickets/13453)