### PR TITLE
fix(Stock Entry Type): reduce perms for Stock User

### DIFF
--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
@@ -29,7 +29,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:44.322729",
+ "modified": "2024-07-08 08:41:19.385020",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Type",
@@ -72,16 +72,8 @@
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
-   "role": "Stock User",
-   "share": 1,
-   "write": 1
+   "role": "Stock User"
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
**Stock Entry Type** is a setup/configuration document. A regular user should not be able to edit or delete it.