### PR TITLE
fix(Putaway Rule): reduce perms for Stock User

### DIFF
--- a/erpnext/stock/doctype/putaway_rule/putaway_rule.json
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule.json
@@ -111,10 +111,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:27.240606",
+ "modified": "2024-07-08 09:19:26.711470",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Putaway Rule",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -130,16 +131,10 @@
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Stock User",
-   "share": 1,
-   "write": 1
+   "role": "Stock User"
   },
   {
    "email": 1,


### PR DESCRIPTION
**Putaway Rule** is a setup/configuration document. A regular user should not be able to edit or delete it.