### PR TITLE
fix: auto serial and batch bundle not creating for Asset Capitalization

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -218,7 +218,7 @@ class StockController(AccountsController):
 					"do_not_submit": True if not via_landed_cost_voucher else False,
 				}
 
-				if row.get("qty") or row.get("consumed_qty"):
+				if row.get("qty") or row.get("consumed_qty") or row.get("stock_qty"):
 					self.update_bundle_details(bundle_details, table_name, row)
 					self.create_serial_batch_bundle(bundle_details, row)
 


### PR DESCRIPTION
- Create the Asset Capitalization
- Enable "Use Serial No / Batch Fields" and enter serial no
- Try to submit the Asset Capitalization, you will get the below error
<img width="607" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/ac7549f5-0643-4697-b369-e4bf8f46fa5c">
