### PR TITLE
fix(Warehouse): add buttons only if the user can use them

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.js
+++ b/erpnext/stock/doctype/warehouse/warehouse.js
@@ -40,32 +40,40 @@ frappe.ui.form.on("Warehouse", {
 		if (!frm.is_new()) {
 			frappe.contacts.render_address_and_contact(frm);
 
-			let enable_toggle = frm.doc.disabled ? "Enable" : "Disable";
-			frm.add_custom_button(__(enable_toggle), () => {
-				frm.set_value("disabled", 1 - frm.doc.disabled);
-				frm.save();
-			});
-
-			frm.add_custom_button(__("Stock Balance"), function () {
-				frappe.set_route("query-report", "Stock Balance", {
-					warehouse: frm.doc.name,
-					company: frm.doc.company,
+			if (frm.has_perm("write")) {
+				let enable_toggle = frm.doc.disabled ? "Enable" : "Disable";
+				frm.add_custom_button(__(enable_toggle), () => {
+					frm.set_value("disabled", 1 - frm.doc.disabled);
+					frm.save();
 				});
-			});
 
-			frm.add_custom_button(
-				frm.doc.is_group
-					? __("Convert to Ledger", null, "Warehouse")
-					: __("Convert to Group", null, "Warehouse"),
-				function () {
-					convert_to_group_or_ledger(frm);
-				}
-			);
+				frm.add_custom_button(
+					frm.doc.is_group
+						? __("Convert to Ledger", null, "Warehouse")
+						: __("Convert to Group", null, "Warehouse"),
+					function () {
+						convert_to_group_or_ledger(frm);
+					}
+				);
+			}
+
+			if ("Stock Balance" in frappe.boot.user.all_reports) {
+				frm.add_custom_button(__("Stock Balance"), function () {
+					frappe.set_route("query-report", "Stock Balance", {
+						warehouse: frm.doc.name,
+						company: frm.doc.company,
+					});
+				});
+			}
 		} else {
 			frappe.contacts.clear_address_and_contact(frm);
 		}
 
-		if (!frm.doc.is_group && frm.doc.__onload && frm.doc.__onload.account) {
+		if (
+			!frm.doc.is_group &&
+			frm.doc.__onload?.account &&
+			"General Ledger" in frappe.boot.user.all_reports
+		) {
 			frm.add_custom_button(__("General Ledger", null, "Warehouse"), function () {
 				frappe.route_options = {
 					account: frm.doc.__onload.account,


### PR DESCRIPTION
Avoid adding buttons that will throw a permission error when the user clicks on them.

### Before

```js
frm.add_custom_button()
```

### After

```js
if (has_required_perm()) {
    frm.add_custom_button()
}
```
