### PR TITLE
fix: added filter to show only submitted assets

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -20,6 +20,15 @@ frappe.ui.form.on("Asset Repair", {
 			};
 		};
 
+		frm.set_query("asset", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+					docstatus: 1,
+				},
+			};
+		});
+
 		frm.set_query("warehouse", "stock_items", function () {
 			return {
 				filters: {


### PR DESCRIPTION
While creating asset repair the system shows all assets in link field, where it should only show asset with docstatus=1. 