### PR TITLE
fix(Holiday List): sort holidays on save to avoid disorienting the user

### DIFF
--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -43,6 +43,7 @@ class HolidayList(Document):
 		self.validate_days()
 		self.total_holidays = len(self.holidays)
 		self.validate_duplicate_date()
+		self.sort_holidays()
 
 	@frappe.whitelist()
 	def get_weekly_off_dates(self):
@@ -56,8 +57,6 @@ class HolidayList(Document):
 				continue
 
 			self.append("holidays", {"description": _(self.weekly_off), "holiday_date": d, "weekly_off": 1})
-
-		self.sort_holidays()
 
 	@frappe.whitelist()
 	def get_supported_countries(self):
@@ -99,8 +98,6 @@ class HolidayList(Document):
 			self.append(
 				"holidays", {"description": holiday_name, "holiday_date": holiday_date, "weekly_off": 0}
 			)
-
-		self.sort_holidays()
 
 	def sort_holidays(self):
 		self.holidays.sort(key=lambda x: getdate(x.holiday_date))


### PR DESCRIPTION
If the holidays table already has some weekly holidays and local holidays are added using the button, they get sorted even before saving. This might be disorienting for the user if they want to check and remove/change some local holidays. Append holidays at the end of the table and sort on save instead.


https://github.com/frappe/erpnext/assets/24353136/722a0bef-731c-428d-9c1f-39316ef433e9

