### PR TITLE
fix(tds): use doctype reference when mapping keys across multiple doctypes

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -12,7 +12,7 @@ def execute(filters=None):
 	else:
 		party_naming_by = frappe.db.get_single_value("Buying Settings", "supp_master_name")
 
-	filters.update({"naming_series": party_naming_by})
+	filters["naming_series"] = party_naming_by
 
 	validate_filters(filters)
 	(
@@ -99,7 +99,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 				}
 
 				if filters.naming_series == "Naming Series":
-					row.update({"party_name": party_map.get(party, {}).get(party_name)})
+					row["party_name"] = party_map.get(party, {}).get(party_name)
 
 				row.update(
 					{
@@ -281,7 +281,6 @@ def get_tds_docs(filters):
 	journal_entries = []
 	tax_category_map = frappe._dict()
 	net_total_map = frappe._dict()
-	frappe._dict()
 	journal_entry_party_map = frappe._dict()
 	bank_accounts = frappe.get_all("Account", {"is_group": 0, "account_type": "Bank"}, pluck="name")
 
@@ -418,7 +417,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 	)
 
 	for entry in entries:
-		tax_category_map.update({(doctype, entry.name): entry.tax_withholding_category})
+		tax_category_map[(doctype, entry.name)] = entry.tax_withholding_category
 		if doctype == "Purchase Invoice":
 			value = [
 				entry.base_tax_withholding_net_total,
@@ -434,7 +433,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 		else:
 			value = [entry.total_amount] * 3
 
-		net_total_map.update({(doctype, entry.name): value})
+		net_total_map[(doctype, entry.name)] = value
 
 
 def get_tax_rate_map(filters):

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -63,21 +63,23 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 				tax_withholding_category = tds_accounts.get(entry.account)
 				# or else the consolidated value from the voucher document
 				if not tax_withholding_category:
-					tax_withholding_category = tax_category_map.get(name)
+					tax_withholding_category = tax_category_map.get((voucher_type, name))
 				# or else from the party default
 				if not tax_withholding_category:
 					tax_withholding_category = party_map.get(party, {}).get("tax_withholding_category")
 
 				rate = tax_rate_map.get(tax_withholding_category)
-			if net_total_map.get(name):
+			if net_total_map.get((voucher_type, name)):
 				if voucher_type == "Journal Entry" and tax_amount and rate:
 					# back calcalute total amount from rate and tax_amount
 					if rate:
 						total_amount = grand_total = base_total = tax_amount / (rate / 100)
 				elif voucher_type == "Purchase Invoice":
-					total_amount, grand_total, base_total, bill_no, bill_date = net_total_map.get(name)
+					total_amount, grand_total, base_total, bill_no, bill_date = net_total_map.get(
+						(voucher_type, name)
+					)
 				else:
-					total_amount, grand_total, base_total = net_total_map.get(name)
+					total_amount, grand_total, base_total = net_total_map.get((voucher_type, name))
 			else:
 				total_amount += entry.credit
 
@@ -416,7 +418,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 	)
 
 	for entry in entries:
-		tax_category_map.update({entry.name: entry.tax_withholding_category})
+		tax_category_map.update({(doctype, entry.name): entry.tax_withholding_category})
 		if doctype == "Purchase Invoice":
 			value = [
 				entry.base_tax_withholding_net_total,
@@ -431,7 +433,8 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 			value = [entry.paid_amount, entry.paid_amount_after_tax, entry.base_paid_amount]
 		else:
 			value = [entry.total_amount] * 3
-		net_total_map.update({entry.name: value})
+
+		net_total_map.update({(doctype, entry.name): value})
 
 
 def get_tax_rate_map(filters):


### PR DESCRIPTION
### Issue

Same naming series could be used for Sales Invoice and Purchase Invoice.

Resolves following error:
```
request.js:473 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1768, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 921, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 223, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 921, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 84, in generate_report_result
    res = get_report_result(report, filters) or []
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 65, in get_report_result
    res = report.execute_script_report(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 162, in execute_script_report
    res = self.execute_module(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 179, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py", line 28, in execute
    res = get_result(
          ^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py", line 80, in get_result
    total_amount, grand_total, base_total = net_total_map.get(name)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 3)
```

Frappe Internal Reference: https://support.frappe.io/helpdesk/tickets/18446