### PR TITLE
fix: keep status as In Progress for RIV for Timeout Error

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -284,6 +284,11 @@ def repost(doc):
 		if isinstance(message, dict):
 			message = message.get("message")
 
+		status = "Failed"
+		# If failed because of timeout, set status to In Progress
+		if traceback and "timeout" in traceback.lower():
+			status = "In Progress"
+
 		if traceback:
 			message += "<br><br>" + "<b>Traceback:</b> <br>" + traceback
 
@@ -292,7 +297,7 @@ def repost(doc):
 			doc.name,
 			{
 				"error_log": message,
-				"status": "Failed",
+				"status": status,
 			},
 		)
 


### PR DESCRIPTION
System change the status to Failed for the Repost Item Valuation record, if the Reposting failed because of the timeout error

