### PR TITLE
feat: configurable depreciation calculation via accounts settings

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -309,7 +309,6 @@
    "label": "Credit Limits"
   },
   {
-   "description": "Enable this option to calculate daily depreciation by considering the total number of days in the entire depreciation period, including leap years..",
    "fieldname": "assets_tab",
    "fieldtype": "Tab Break",
    "label": "Assets"
@@ -472,10 +471,10 @@
   },
   {
    "default": "0",
-   "description": "Enable this option to calculate daily depreciation by considering the total number of days in the entire depreciation period, including leap years",
+   "description": "Enable this option to calculate daily depreciation by considering the total number of days in the entire depreciation period, (including leap years) while using daily pro-rata based depreciation",
    "fieldname": "calculate_depr_using_total_days",
    "fieldtype": "Check",
-   "label": "Calculate depreciation using total days in depreciation period"
+   "label": "Calculate daily depreciation using total days in depreciation period"
   }
  ],
  "icon": "icon-cog",
@@ -483,7 +482,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-10 18:12:16.225069",
+ "modified": "2024-07-12 00:24:20.957726",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -55,6 +55,8 @@
   "post_change_gl_entries",
   "assets_tab",
   "asset_settings_section",
+  "calculate_depr_using_total_days",
+  "column_break_gjcc",
   "book_asset_depreciation_entry_automatically",
   "closing_settings_tab",
   "period_closing_settings_section",
@@ -307,6 +309,7 @@
    "label": "Credit Limits"
   },
   {
+   "description": "Enable this option to calculate daily depreciation by considering the total number of days in the entire depreciation period, including leap years..",
    "fieldname": "assets_tab",
    "fieldtype": "Tab Break",
    "label": "Assets"
@@ -462,6 +465,17 @@
    "fieldname": "enable_immutable_ledger",
    "fieldtype": "Check",
    "label": "Enable Immutable Ledger"
+  },
+  {
+   "fieldname": "column_break_gjcc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Enable this option to calculate daily depreciation by considering the total number of days in the entire depreciation period, including leap years",
+   "fieldname": "calculate_depr_using_total_days",
+   "fieldtype": "Check",
+   "label": "Calculate depreciation using total days in depreciation period"
   }
  ],
  "icon": "icon-cog",
@@ -469,7 +483,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-11 23:19:44.673975",
+ "modified": "2024-07-10 18:12:16.225069",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -33,6 +33,7 @@ class AccountsSettings(Document):
 		book_deferred_entries_based_on: DF.Literal["Days", "Months"]
 		book_deferred_entries_via_journal_entry: DF.Check
 		book_tax_discount_loss: DF.Check
+		calculate_depr_using_total_days: DF.Check
 		check_supplier_invoice_uniqueness: DF.Check
 		credit_controller: DF.Link | None
 		delete_linked_ledger_entries: DF.Check

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -701,18 +701,56 @@ def get_straight_line_or_manual_depr_amount(
 def get_daily_prorata_based_straight_line_depr(
 	asset, row, schedule_idx, number_of_pending_depreciations, amount
 ):
-	total_years = flt(number_of_pending_depreciations * row.frequency_of_depreciation) / 12
-	every_year_depr = amount / total_years
+	if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_total_days")):
+		total_days = (
+			date_diff(
+				get_last_day(
+					add_months(
+						row.depreciation_start_date,
+						flt(
+							row.total_number_of_depreciations
+							- asset.opening_number_of_booked_depreciations
+							- 1
+						)
+						* row.frequency_of_depreciation,
+					)
+				),
+				add_days(
+					get_last_day(add_months(row.depreciation_start_date, -1 * row.frequency_of_depreciation)),
+					1,
+				),
+			)
+			+ 1
+		)
 
-	year_start_date = add_years(
-		row.depreciation_start_date, (row.frequency_of_depreciation * schedule_idx) // 12
-	)
-	year_end_date = add_days(add_years(year_start_date, 1), -1)
-	daily_depr_amount = every_year_depr / (date_diff(year_end_date, year_start_date) + 1)
-	from_date, total_depreciable_days = _get_total_days(
-		row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
-	)
-	return daily_depr_amount * total_depreciable_days
+		daily_depr_amount = amount / total_days
+		from_date, total_depreciable_days = _get_total_days(
+			row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
+		)
+		return daily_depr_amount * total_depreciable_days
+
+	else:
+		total_years = (
+			flt(
+				(row.total_number_of_depreciations - row.total_number_of_booked_depreciations)
+				* row.frequency_of_depreciation
+			)
+			/ 12
+		)
+
+		every_year_depr = amount / total_years
+
+		year_start_date = add_years(
+			row.depreciation_start_date, (row.frequency_of_depreciation * schedule_idx) // 12
+		)
+		year_end_date = add_days(add_years(year_start_date, 1), -1)
+
+		daily_depr_amount = every_year_depr / (date_diff(year_end_date, year_start_date) + 1)
+
+		from_date, total_depreciable_days = _get_total_days(
+			row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
+		)
+		return daily_depr_amount * total_depreciable_days
 
 
 def get_shift_depr_amount(asset_depr_schedule, asset, row, schedule_idx):

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -701,6 +701,15 @@ def get_straight_line_or_manual_depr_amount(
 def get_daily_prorata_based_straight_line_depr(
 	asset, row, schedule_idx, number_of_pending_depreciations, amount
 ):
+	daily_depr_amount = get_daily_depr_amount(asset, row, schedule_idx, amount)
+
+	from_date, total_depreciable_days = _get_total_days(
+		row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
+	)
+	return daily_depr_amount * total_depreciable_days
+
+
+def get_daily_depr_amount(asset, row, schedule_idx, amount):
 	if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_total_days")):
 		total_days = (
 			date_diff(
@@ -723,12 +732,7 @@ def get_daily_prorata_based_straight_line_depr(
 			+ 1
 		)
 
-		daily_depr_amount = amount / total_days
-		from_date, total_depreciable_days = _get_total_days(
-			row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
-		)
-		return daily_depr_amount * total_depreciable_days
-
+		return amount / total_days
 	else:
 		total_years = (
 			flt(
@@ -745,12 +749,7 @@ def get_daily_prorata_based_straight_line_depr(
 		)
 		year_end_date = add_days(add_years(year_start_date, 1), -1)
 
-		daily_depr_amount = every_year_depr / (date_diff(year_end_date, year_start_date) + 1)
-
-		from_date, total_depreciable_days = _get_total_days(
-			row.depreciation_start_date, schedule_idx, row.frequency_of_depreciation
-		)
-		return daily_depr_amount * total_depreciable_days
+		return every_year_depr / (date_diff(year_end_date, year_start_date) + 1)
 
 
 def get_shift_depr_amount(asset_depr_schedule, asset, row, schedule_idx):

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -75,6 +75,68 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 		]
 		self.assertEqual(schedules, expected_schedules)
 
+	# Enable Checkbox to Calculate depreciation using total days in depreciation period
+	def test_daily_prorata_based_depr_after_enabling_configuration(self):
+		frappe.db.set_single_value("Accounts Settings", "calculate_depr_using_total_days", 1)
+
+		asset = create_asset(
+			calculate_depreciation=1,
+			depreciation_method="Straight Line",
+			daily_prorata_based=1,
+			gross_purchase_amount=1096,
+			available_for_use_date="2020-01-15",
+			depreciation_start_date="2020-01-31",
+			frequency_of_depreciation=1,
+			total_number_of_depreciations=36,
+		)
+
+		expected_schedule = [
+			["2020-01-31", 17.0, 17.0],
+			["2020-02-29", 29.0, 46.0],
+			["2020-03-31", 31.0, 77.0],
+			["2020-04-30", 30.0, 107.0],
+			["2020-05-31", 31.0, 138.0],
+			["2020-06-30", 30.0, 168.0],
+			["2020-07-31", 31.0, 199.0],
+			["2020-08-31", 31.0, 230.0],
+			["2020-09-30", 30.0, 260.0],
+			["2020-10-31", 31.0, 291.0],
+			["2020-11-30", 30.0, 321.0],
+			["2020-12-31", 31.0, 352.0],
+			["2021-01-31", 31.0, 383.0],
+			["2021-02-28", 28.0, 411.0],
+			["2021-03-31", 31.0, 442.0],
+			["2021-04-30", 30.0, 472.0],
+			["2021-05-31", 31.0, 503.0],
+			["2021-06-30", 30.0, 533.0],
+			["2021-07-31", 31.0, 564.0],
+			["2021-08-31", 31.0, 595.0],
+			["2021-09-30", 30.0, 625.0],
+			["2021-10-31", 31.0, 656.0],
+			["2021-11-30", 30.0, 686.0],
+			["2021-12-31", 31.0, 717.0],
+			["2022-01-31", 31.0, 748.0],
+			["2022-02-28", 28.0, 776.0],
+			["2022-03-31", 31.0, 807.0],
+			["2022-04-30", 30.0, 837.0],
+			["2022-05-31", 31.0, 868.0],
+			["2022-06-30", 30.0, 898.0],
+			["2022-07-31", 31.0, 929.0],
+			["2022-08-31", 31.0, 960.0],
+			["2022-09-30", 30.0, 990.0],
+			["2022-10-31", 31.0, 1021.0],
+			["2022-11-30", 30.0, 1051.0],
+			["2022-12-31", 31.0, 1082.0],
+			["2023-01-15", 14.0, 1096.0],
+		]
+
+		schedules = [
+			[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedule)
+		frappe.db.set_single_value("Accounts Settings", "calculate_depr_using_total_days", 0)
+
 	# Test for Written Down Value Method
 	# Frequency of deprciation = 3
 	def test_for_daily_prorata_based_depreciation_wdv_method_frequency_3_months(self):


### PR DESCRIPTION
Introduced a checkbox in account settings to enable calculation of daily depreciation based on the total number of days in the depreciation period, including leap years.

- Default method divides the asset amount on a per-day basis and then by the days in the year.

- Enabling the checkbox changes the calculation to divide the asset amount by the total days in the depreciation period.

no-docs