### PR TITLE
fix: missing discount on POS Credit Notes

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -508,6 +508,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 				return this.frm.call({
 					doc: me.frm.doc,
 					method: "set_missing_values",
+					args: {
+						for_validate: true,
+					},
 					callback: function (r) {
 						if (!r.exc) {
 							if (r.message && r.message.print_format) {


### PR DESCRIPTION
POS Credit Notes didn't inherit pricing rules, or discount applied on its parent.

Internal Ref: [16540](https://support.frappe.io/helpdesk/tickets/16540)