### PR TITLE
fix: consider payment entries for checking if tds is deducted

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1709,6 +1709,9 @@ class PurchaseInvoice(BuyingController):
 		self.db_set("release_date", None)
 
 	def set_tax_withholding(self):
+		self.set("advance_tax", [])
+		self.set("tax_withheld_vouchers", [])
+
 		if not self.apply_tds:
 			return
 
@@ -1750,8 +1753,6 @@ class PurchaseInvoice(BuyingController):
 			self.remove(d)
 
 		## Add pending vouchers on which tax was withheld
-		self.set("tax_withheld_vouchers", [])
-
 		for voucher_no, voucher_details in voucher_wise_amount.items():
 			self.append(
 				"tax_withheld_vouchers",
@@ -1766,7 +1767,6 @@ class PurchaseInvoice(BuyingController):
 		self.calculate_taxes_and_totals()
 
 	def allocate_advance_tds(self, tax_withholding_details, advance_taxes):
-		self.set("advance_tax", [])
 		for tax in advance_taxes:
 			allocated_amount = 0
 			pending_amount = flt(tax.tax_amount - tax.allocated_amount)


### PR DESCRIPTION
Issue:
If TDS is adjusted from advance payment it was not considered in the TDS amount calculation.

Adv Payment = 500
TDS= 50

1 st Invoice = 500
TDS = 0 (Adjust from advance Payment)

2nd Invoice = 1000
Tax withheld amount = 1000+500
TDS = 150


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/18632

