### PR TITLE
fix: address and contact filters for SCO and SCR

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -9,6 +9,7 @@ frappe.ui.form.on("Subcontracting Order", {
 	setup: (frm) => {
 		frm.get_field("items").grid.cannot_add_rows = true;
 		frm.get_field("items").grid.only_sortable();
+		frm.trigger("set_queries");
 
 		frm.set_indicator_formatter("item_code", (doc) => (doc.qty <= doc.received_qty ? "green" : "orange"));
 
@@ -77,6 +78,17 @@ frappe.ui.form.on("Subcontracting Order", {
 		});
 	},
 
+	set_queries: (frm) => {
+		frm.set_query("contact_person", erpnext.queries.contact_query);
+		frm.set_query("supplier_address", erpnext.queries.address_query);
+
+		frm.set_query("billing_address", erpnext.queries.company_address_query);
+
+		frm.set_query("shipping_address", () => {
+			return erpnext.queries.company_address_query(frm.doc);
+		});
+	},
+
 	onload: (frm) => {
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());
@@ -100,6 +112,8 @@ frappe.ui.form.on("Subcontracting Order", {
 	},
 
 	refresh: function (frm) {
+		frappe.dynamic_link = { doc: frm.doc, fieldname: "supplier", doctype: "Supplier" };
+
 		if (frm.doc.docstatus == 1 && frm.has_perm("submit")) {
 			if (frm.doc.status == "Closed") {
 				frm.add_custom_button(

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -28,6 +28,8 @@ frappe.ui.form.on("Subcontracting Receipt", {
 	},
 
 	refresh: (frm) => {
+		frappe.dynamic_link = { doc: frm.doc, fieldname: "supplier", doctype: "Supplier" };
+
 		if (frm.doc.docstatus === 1) {
 			frm.add_custom_button(
 				__("Stock Ledger"),
@@ -163,6 +165,15 @@ frappe.ui.form.on("Subcontracting Receipt", {
 					is_group: 0,
 				},
 			};
+		});
+
+		frm.set_query("contact_person", erpnext.queries.contact_query);
+		frm.set_query("supplier_address", erpnext.queries.address_query);
+
+		frm.set_query("billing_address", erpnext.queries.company_address_query);
+
+		frm.set_query("shipping_address", () => {
+			return erpnext.queries.company_address_query(frm.doc);
 		});
 
 		frm.set_query("rejected_warehouse", () => {


### PR DESCRIPTION
Supplier filter not applied on Address and Contact fields on SCO and SCR

**Issue**
Showing all addresses

<img width="646" alt="Screenshot 2024-07-13 at 2 48 21 PM" src="https://github.com/user-attachments/assets/a4799319-32e2-407f-b612-ddb2b88f14fa">


**After Fix**
<img width="664" alt="Screenshot 2024-07-13 at 2 48 08 PM" src="https://github.com/user-attachments/assets/b134ed6f-3c68-4a8b-a12a-b18867003aff">

