### PR TITLE
chore: Update __init__.py - 15.29.4 instead of 15.29.3

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -3,7 +3,7 @@ import inspect
 
 import frappe
 
-__version__ = "15.29.3"
+__version__ = "15.29.4"
 
 
 def get_default_company(user=None):


### PR DESCRIPTION
v15 branch 
installing v15.29.4 shows version as follows:

Installed Apps

ERPNext: v15.29.3

Frappe Framework: v15.34.1

This is due to version number not being updated on __init__.py