### PR TITLE
fix: incorrect valuation rate for items from different warehouses in Gross Profit

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -713,7 +713,8 @@ class GrossProfitGenerator:
 
 	def get_average_buying_rate(self, row, item_code):
 		args = row
-		if item_code not in self.average_buying_rate:
+		key = (item_code, row.warehouse)
+		if key not in self.average_buying_rate:
 			args.update(
 				{
 					"voucher_type": row.parenttype,
@@ -727,9 +728,9 @@ class GrossProfitGenerator:
 				args.update({"serial_and_batch_bundle": row.serial_and_batch_bundle})
 
 			average_buying_rate = get_incoming_rate(args)
-			self.average_buying_rate[item_code] = flt(average_buying_rate)
+			self.average_buying_rate[key] = flt(average_buying_rate)
 
-		return self.average_buying_rate[item_code]
+		return self.average_buying_rate[key]
 
 	def get_last_purchase_rate(self, item_code, row):
 		purchase_invoice = frappe.qb.DocType("Purchase Invoice")

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -558,3 +558,50 @@ class TestGrossProfit(FrappeTestCase):
 		}
 		gp_entry = [x for x in data if x.parent_invoice == sinv.name]
 		self.assertEqual(gp_entry[0], gp_entry[0] | expected_entry)
+
+	def test_valuation_rate_without_previous_sle(self):
+		"""
+		Test Valuation rate calculation when stock ledger is empty and invoices are against different warehouses
+		"""
+		stock_settings = frappe.get_doc("Stock Settings")
+		stock_settings.valuation_method = "FIFO"
+		stock_settings.save()
+
+		item = create_item(
+			item_code="_Test Wirebound Notebook",
+			is_stock_item=1,
+		)
+		item.allow_negative_stock = True
+		item.save()
+		self.item = item.item_code
+
+		item.reload()
+		item.valuation_rate = 1900
+		item.save()
+		sinv1 = self.create_sales_invoice(qty=1, rate=2000, posting_date=nowdate(), do_not_submit=True)
+		sinv1.update_stock = 1
+		sinv1.set_warehouse = self.warehouse
+		sinv1.items[0].warehouse = self.warehouse
+		sinv1.save().submit()
+
+		item.reload()
+		item.valuation_rate = 1800
+		item.save()
+		sinv2 = self.create_sales_invoice(qty=1, rate=2000, posting_date=nowdate(), do_not_submit=True)
+		sinv2.update_stock = 1
+		sinv2.set_warehouse = self.finished_warehouse
+		sinv2.items[0].warehouse = self.finished_warehouse
+		sinv2.save().submit()
+
+		filters = frappe._dict(
+			company=self.company, from_date=nowdate(), to_date=nowdate(), group_by="Invoice"
+		)
+		columns, data = execute(filters=filters)
+
+		item_from_sinv1 = [x for x in data if x.parent_invoice == sinv1.name]
+		self.assertEqual(len(item_from_sinv1), 1)
+		self.assertEqual(1900, item_from_sinv1[0].valuation_rate)
+
+		item_from_sinv2 = [x for x in data if x.parent_invoice == sinv2.name]
+		self.assertEqual(len(item_from_sinv2), 1)
+		self.assertEqual(1800, item_from_sinv2[0].valuation_rate)


### PR DESCRIPTION
## Scenario
Consider an Item with Negative stock enabled and currently has no stock left in any warehouse and the valuation rate of that item is 1900 /-
1. Make an Invoice from 'Warehouse 1'
2. Change the valuation rate in Item Master to 1800/-
3. Make another Invoice from 'Warehouse  2'

## Issue
Gross Profit incorrectly reported valuation rate of 1900/- for both the invoices.

## Expected
Gross Profit should used below valuation rates:
|Invoice|Valuation Rate|
|-|-|
|Invoice 1| 1900|
|Invoice 2| 1800|


## Cause
`get_average_buying_rate` was memoizing based on item_code. 
https://github.com/frappe/erpnext/blob/61daa318fe01d36a26470baa17043b7c853565fd/erpnext/accounts/report/gross_profit/gross_profit.py#L714-L731

## Fix
`get_average_buying_rate` will memoize results based on (item_code, warehouse)