### PR TITLE
fix: bin deadlock issue

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -200,7 +200,7 @@ def get_bin(item_code, warehouse):
 	if not bin:
 		bin_obj = _create_bin(item_code, warehouse)
 	else:
-		bin_obj = frappe.get_doc("Bin", bin, for_update=True)
+		bin_obj = frappe.get_doc("Bin", bin)
 	bin_obj.flags.ignore_permissions = True
 	return bin_obj
 


### PR DESCRIPTION
**Issue**

While submitting bulk sales orders from the list view user is getting the deadlock error

```
File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 404, in on_submit
    self.update_reserved_qty()
      self = 
  File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 530, in update_reserved_qty
    update_bin_qty(item_code, warehouse, {"reserved_qty": get_reserved_qty(item_code, warehouse)})
      self = 
      so_item_rows = None
      _valid_for_reserve = ._valid_for_reserve at 0x7f9ecd539da0>
      d = 
      item_code = 'GMMSAF011'
      warehouse = 'SD Global Master WH - SET'
  File "apps/erpnext/erpnext/stock/stock_balance.py", line 214, in update_bin_qty
    bin = get_bin(item_code, warehouse)
      item_code = 'GMMSAF011'
      warehouse = 'SD Global Master WH - SET'
      qty_dict = {'reserved_qty': 182.0}
      get_bin = 
  File "apps/erpnext/erpnext/stock/utils.py", line 203, in get_bin
    bin_obj = frappe.get_doc("Bin", bin, for_update=True)
      item_code = 'GMMSAF011'
      warehouse = 'SD Global Master WH - SET'
      bin = 'a80d92d73b'
  File "apps/frappe/frappe/__init__.py", line 1333, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
      args = ('Bin', 'a80d92d73b')
      kwargs = {'for_update': True}
      frappe = 
  File "apps/frappe/frappe/model/document.py", line 85, in get_doc
    return controller(*args, **kwargs)
      args = ('Bin', 'a80d92d73b')
      kwargs = {'for_update': True}
      doctype = 'Bin'
      controller = 
  File "apps/frappe/frappe/model/document.py", line 126, in __init__
    self.load_from_db()
      self = 
      args = ('Bin', 'a80d92d73b')
      kwargs = {'for_update': True}
      __class__ = 
  File "apps/frappe/frappe/model/document.py", line 167, in load_from_db
    d = frappe.db.get_value(
      self = 
      get_value_kwargs = {'for_update': True, 'as_dict': True, 'order_by': None}
      __class__ = 
  File "apps/frappe/frappe/database/database.py", line 519, in get_value
    result = self.get_values(
      self = 
      doctype = 'Bin'
      filters = 'a80d92d73b'
      fieldname = '*'
      ignore = None
      as_dict = True
      debug = False
      order_by = None
      cache = False
      for_update = True
      run = True
      pluck = False
      distinct = False
      skip_locked = False
      wait = True
  File "apps/frappe/frappe/database/database.py", line 623, in get_values
    out = self._get_values_from_table(
      self = 
      doctype = 'Bin'
      filters = 'a80d92d73b'
      fieldname = '*'
      ignore = None
      as_dict = True
      debug = False
      order_by = None
      update = None
      cache = False
      for_update = True
      run = True
      pluck = False
      distinct = False
      limit = 1
      skip_locked = False
      wait = True
      out = None
      fields = '*'
  File "apps/frappe/frappe/database/database.py", line 896, in _get_values_from_table
    return query.run(as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
      self = 
      fields = '*'
      filters = 'a80d92d73b'
      doctype = 'Bin'
      as_dict = True
      debug = False
      order_by = None
      update = None
      for_update = True
      skip_locked = False
      wait = True
      run = True
      pluck = False
      distinct = False
      limit = 1
      query = SELECT * FROM `tabBin` WHERE `name`='a80d92d73b' LIMIT 1 FOR UPDATE
  File "apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
      query = 'SELECT * FROM `tabBin` WHERE `name`=%(param1)s LIMIT 1 FOR UPDATE'
      args = ()
      kwargs = {'as_dict': True, 'debug': False, 'update': None, 'run': True, 'pluck': False}
      child_queries = []
      params = {'param1': 'a80d92d73b'}
      execute_child_queries = .execute_child_queries at 0x7f9ecee80180>
      prepare_query = .prepare_query at 0x7f9ecee80360>
  File "apps/frappe/frappe/database/database.py", line 240, in sql
    raise frappe.QueryDeadlockError(e) from e
      self = 
      query = 'SELECT * FROM `tabBin` WHERE `name`=%(param1)s LIMIT 1 FOR UPDATE /* FRAPPE_TRACE_ID: gomechanic-staging.frappe.cloud::6b9d883a-2c4d-453f-9eaa-1a1774fe946b */'
      values = {'param1': 'a80d92d73b'}
      as_dict = True
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      trace_id = 'gomechanic-staging.frappe.cloud::6b9d883a-2c4d-453f-9eaa-1a1774fe946b'
frappe.exceptions.QueryDeadlockError: (1213, 'Deadlock found when trying to get lock; try restarting transaction')
```