### PR TITLE
fix: extra qty pick in pick list

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -603,6 +603,17 @@ class SalesOrder(SellingController):
 		if total_picked_qty and total_qty:
 			per_picked = total_picked_qty / total_qty * 100
 
+			pick_percentage = frappe.db.get_single_value("Stock Settings", "over_picking_allowance")
+			if pick_percentage:
+				total_qty += flt(total_qty) * (pick_percentage / 100)
+
+			if total_picked_qty > total_qty:
+				frappe.throw(
+					_(
+						"Total Picked Quantity {0} is more than ordered qty {1}. You can set the Over Picking Allowance in Stock Settings."
+					).format(total_picked_qty, total_qty)
+				)
+
 		self.db_set("per_picked", flt(per_picked), update_modified=False)
 
 	def set_indicator(self):

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -26,6 +26,7 @@
   "section_break_9",
   "over_delivery_receipt_allowance",
   "mr_qty_allowance",
+  "over_picking_allowance",
   "column_break_121",
   "role_allowed_to_over_deliver_receive",
   "allow_negative_stock",
@@ -446,6 +447,12 @@
    "fieldname": "do_not_use_batchwise_valuation",
    "fieldtype": "Check",
    "label": "Do Not Use Batch-wise Valuation"
+  },
+  {
+   "description": "The percentage you are allowed to pick more items in the pick list than the ordered quantity.",
+   "fieldname": "over_picking_allowance",
+   "fieldtype": "Percent",
+   "label": "Over Picking Allowance"
   }
  ],
  "icon": "icon-cog",
@@ -453,7 +460,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-04 12:45:09.811280",
+ "modified": "2024-07-15 17:18:23.872161",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -47,6 +47,7 @@ class StockSettings(Document):
 		mr_qty_allowance: DF.Float
 		naming_series_prefix: DF.Data | None
 		over_delivery_receipt_allowance: DF.Float
+		over_picking_allowance: DF.Percent
 		pick_serial_and_batch_based_on: DF.Literal["FIFO", "LIFO", "Expiry"]
 		reorder_email_notify: DF.Check
 		role_allowed_to_create_edit_back_dated_transactions: DF.Link | None


### PR DESCRIPTION
User won't be able to pick extra qty in the pick list and system will throw below error
<img width="694" alt="image" src="https://github.com/user-attachments/assets/10c29e81-a6c7-4d2b-a12f-a4c8d0a2424b">


If user want to bypass the validation then they have to set the "Over Picking Allowance" in the stock settings
<img width="856" alt="Screenshot 2024-07-15 at 6 36 31 PM" src="https://github.com/user-attachments/assets/2628e9df-40ed-4999-87ff-e288b0888876">
