### PR TITLE
fix: items not fetching in End Transit entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2779,7 +2779,7 @@ def make_stock_in_entry(source_name, target_doc=None):
 					"batch_no": "batch_no",
 				},
 				"postprocess": update_item,
-				"condition": lambda doc: flt(doc.qty) - flt(doc.transferred_qty) > 0.01,
+				"condition": lambda doc: flt(doc.qty) - flt(doc.transferred_qty) > 0.00001,
 			},
 		},
 		target_doc,


### PR DESCRIPTION
Items having qty less than or equal to 0.01 not fetching in the End Transit entry

![stock-entry-issue](https://github.com/user-attachments/assets/f8ecad6e-b882-4b84-9e89-80b6be9326fe)
