### PR TITLE
fix: remove redundant proprietorship field from customer type and supplier type (backport #42307)

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -170,7 +170,7 @@
    "fieldname": "supplier_type",
    "fieldtype": "Select",
    "label": "Supplier Type",
-   "options": "Company\nIndividual\nProprietorship\nPartnership",
+   "options": "Company\nIndividual\nPartnership",
    "reqd": 1
   },
   {

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -271,6 +271,7 @@ erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
 erpnext.patches.v14_0.update_reference_due_date_in_journal_entry
 erpnext.patches.v14_0.france_depreciation_warning
 erpnext.patches.v14_0.clear_reconciliation_values_from_singles
+erpnext.patches.v14_0.update_proprietorship_to_individual
 
 [post_model_sync]
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')

--- a/erpnext/patches/v14_0/update_proprietorship_to_individual.py
+++ b/erpnext/patches/v14_0/update_proprietorship_to_individual.py
@@ -1,0 +1,7 @@
+import frappe
+
+
+def execute():
+	for doctype in ["Customer", "Supplier"]:
+		field = doctype.lower() + "_type"
+		frappe.db.set_value(doctype, {field: "Proprietorship"}, field, "Individual")

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -131,7 +131,7 @@
    "label": "Customer Type",
    "oldfieldname": "customer_type",
    "oldfieldtype": "Select",
-   "options": "Company\nIndividual\nProprietorship\nPartnership",
+   "options": "Company\nIndividual\nPartnership",
    "reqd": 1
   },
   {


### PR DESCRIPTION
Removed the redundant Proprietorship field from `customer_type` and `supplier_type`.
Added a patch to update Proprietorship to Individual.
