### PR TITLE
fix: allow company sales from A to company B applying valuation rate

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -580,7 +580,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								},
 								() => {
 									// for internal customer instead of pricing rule directly apply valuation rate on item
-									if ((me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) && me.frm.doc.represents_company === me.frm.doc.company) {
+									if (me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) {
 										me.get_incoming_rate(item, me.frm.posting_date, me.frm.posting_time,
 											me.frm.doc.doctype, me.frm.doc.company);
 									} else {


### PR DESCRIPTION
https://docs.erpnext.com/docs/user/manual/en/inter-company-invoices

Following the docs when i want to create a inter company  sales first step is configure customer and supplier example:

Companies:
A (Parent Company)
B (Branch)

Configure Customers:
1. Customer **A**, Represent company A, allow transaction with company B.
2. Customer **B**, Represent company B, allow transaction with company A.

did the same for supplier...

everything is configured, the first step is to sell the products of the company holding the stock that has the cost value of the stock, following my example will be a sales From **Company A** to **Company B**.

On sales Invoice fields will be setted:
customer: B 
company: A
is_internal_customer: 1
represents_company: B

Following validade made on this commit https://github.com/frappe/erpnext/pull/35465 NEVER will use the valuation rate, because represents_company never will be equals company.


NOTE: It doesn't matter if it's a sales order, invoice or delivery note, because all use transaction.js