### PR TITLE
fix: not able to save QC

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -242,6 +242,9 @@ class QualityInspection(Document):
 			# numeric readings
 			for i in range(1, 11):
 				field = "reading_" + str(i)
+				if reading.get(field) is None:
+					continue
+
 				data[field] = parse_float(reading.get(field))
 			data["mean"] = self.calculate_mean(reading)
 


### PR DESCRIPTION
Getting the below error on save of the qc
```
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/doctype/quality_inspection/quality_inspection.py", line 74, in validate
    self.inspect_and_set_status()
  File "apps/erpnext/erpnext/stock/doctype/quality_inspection/quality_inspection.py", line 172, in inspect_and_set_status
    self.set_status_based_on_acceptance_formula(reading)
  File "apps/erpnext/erpnext/stock/doctype/quality_inspection/quality_inspection.py", line 218, in set_status_based_on_acceptance_formula
    data = self.get_formula_evaluation_data(reading)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/doctype/quality_inspection/quality_inspection.py", line 245, in get_formula_evaluation_data
    data[field] = parse_float(reading.get(field))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/doctype/quality_inspection/quality_inspection.py", line 370, in parse_float
    num = num.replace(",", "#$")
          ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```