### PR TITLE
fix: correct validation for depreciation posting date

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -775,11 +775,8 @@ frappe.ui.form.on("Asset Finance Book", {
 
 	depreciation_start_date: function (frm, cdt, cdn) {
 		const book = locals[cdt][cdn];
-		if (
-			frm.doc.available_for_use_date &&
-			book.depreciation_start_date == frm.doc.available_for_use_date
-		) {
-			frappe.msgprint(__("Depreciation Posting Date should not be equal to Available for Use Date."));
+		if (frm.doc.available_for_use_date && book.depreciation_start_date < frm.doc.available_for_use_date) {
+			frappe.msgprint(__("Depreciation Posting Date cannot be before Available-for-use Date"));
 			book.depreciation_start_date = "";
 			frm.refresh_field("finance_books");
 		}

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -268,10 +268,10 @@ class Asset(AccountsController):
 			frappe.throw(_("Available for use date is required"))
 
 		for d in self.finance_books:
-			if d.depreciation_start_date == self.available_for_use_date:
+			if getdate(d.depreciation_start_date) < getdate(self.available_for_use_date):
 				frappe.throw(
 					_(
-						"Row #{}: Depreciation Posting Date should not be equal to Available for Use Date."
+						"Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 					).format(d.idx),
 					title=_("Incorrect Date"),
 				)


### PR DESCRIPTION
Previously, the system validated that the Depreciation Posting date could not be equal to the available for use date.
This fix updates the validation to allow the depreciation posting date to be equal to the available use date but not before it.
