### PR TITLE
fix: Show the rows in AR/AP report where outstanding equals to 0.01

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -288,13 +288,13 @@ class ReceivablePayableReport:
 
 			must_consider = False
 			if self.filters.get("for_revaluation_journals"):
-				if (abs(row.outstanding) > 0.0 / 10**self.currency_precision) or (
-					abs(row.outstanding_in_account_currency) > 0.0 / 10**self.currency_precision
+				if (abs(row.outstanding) >= 0.0 / 10**self.currency_precision) or (
+					abs(row.outstanding_in_account_currency) >= 0.0 / 10**self.currency_precision
 				):
 					must_consider = True
 			else:
-				if (abs(row.outstanding) > 1.0 / 10**self.currency_precision) and (
-					(abs(row.outstanding_in_account_currency) > 1.0 / 10**self.currency_precision)
+				if (abs(row.outstanding) >= 1.0 / 10**self.currency_precision) and (
+					(abs(row.outstanding_in_account_currency) >= 1.0 / 10**self.currency_precision)
 					or (row.voucher_no in self.err_journals)
 				):
 					must_consider = True

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -253,7 +253,6 @@ erpnext.patches.v13_0.reset_corrupt_defaults
 erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
 erpnext.patches.v15_0.delete_taxjar_doctypes
 erpnext.patches.v15_0.delete_ecommerce_doctypes
-erpnext.patches.v15_0.create_asset_depreciation_schedules_from_assets
 erpnext.patches.v14_0.update_reference_due_date_in_journal_entry
 erpnext.patches.v15_0.saudi_depreciation_warning
 erpnext.patches.v15_0.delete_saudi_doctypes
@@ -262,6 +261,7 @@ erpnext.patches.v14_0.clear_reconciliation_values_from_singles
 execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Details", force=True)
 
 [post_model_sync]
+erpnext.patches.v15_0.create_asset_depreciation_schedules_from_assets
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')
 erpnext.patches.v14_0.update_posting_datetime_and_dropped_indexes #22-02-2024
 erpnext.patches.v14_0.rename_ongoing_status_in_sla_documents


### PR DESCRIPTION
Issue: Earlier it used to show the invoices where the outstanding amount is greater than 0.01 (based on precision). Now it also shows 0.01