### PR TITLE
fix: inter company sales to get valuation rate

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -581,8 +581,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								() => {
 									// for internal customer instead of pricing rule directly apply valuation rate on item
 									if (me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) {
-										me.get_incoming_rate(item, me.frm.posting_date, me.frm.posting_time,
-											me.frm.doc.doctype, me.frm.doc.company);
+										let posting_date = me.frm.doc.posting_date || me.frm.doc.transaction_date;
+										let posting_time = me.frm.doc.posting_time || frappe.datetime.now_time();
+
+										me.get_incoming_rate(item, posting_date, posting_time, me.frm.doc.doctype,
+											me.frm.doc.company);
 									} else {
 										me.frm.script_manager.trigger("price_list_rate", cdt, cdn);
 									}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -580,7 +580,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								},
 								() => {
 									// for internal customer instead of pricing rule directly apply valuation rate on item
-									if ((me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) && me.frm.doc.represents_company === me.frm.doc.company) {
+									if (me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) {
 										me.get_incoming_rate(item, me.frm.posting_date, me.frm.posting_time,
 											me.frm.doc.doctype, me.frm.doc.company);
 									} else {


### PR DESCRIPTION
https://docs.erpnext.com/docs/user/manual/en/inter-company-invoices

Following the docs when i want to create a inter company sales first step is configure customer and supplier example:

Companies:
A (Parent Company)
B (Branch)

Configure Customers:

Customer A, Represent company A, allow transaction with company B.
Customer B, Represent company B, allow transaction with company A.
did the same for supplier...

everything is configured, the first step is to sell the products of the company holding the stock that has the cost value of the stock, following my example will be a sales From Company A to Company B.

On sales Invoice fields will be setted:
customer: B
company: A
is_internal_customer: 1
represents_company: B

Following validade made on this commit https://github.com/frappe/erpnext/pull/35465 NEVER will use the valuation rate, because represents_company never will be equals company.


**Some others fixes:**
1. method called get_incoming_rate call a function were  is necessary date and time to get valuation rate from SLE.
2. some fields were trying to pass data without getting it from the doc 
Example:
me.frm.posting_date
me.frm.posting_time

3. transcation.js is used for purchase and sales, then we can create a Inter company sales order, invoice and orders has a diferent field, the i fixed it.
4. Sales order has no time, the use current time to get SLE from the same day


@rohitwaghchaure  can u guide me and explain better this change https://github.com/frappe/erpnext/pull/35465 ? i can test and improve this...


