### PR TITLE
fix: Create Sales Order from Quotation for Prospect

### DIFF
--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -27,6 +27,26 @@ class TestProspect(unittest.TestCase):
 		address_doc.reload()
 		self.assertEqual(address_doc.has_link("Prospect", prospect_doc.name), True)
 
+	def test_make_customer_from_prospect(self):
+		from erpnext.crm.doctype.prospect.prospect import make_customer as make_customer_from_prospect
+
+		frappe.delete_doc_if_exists("Customer", "_Test Prospect")
+
+		prospect = frappe.get_doc({
+			"doctype": "Prospect",
+			"company_name": "_Test Prospect",
+			"customer_group": "_Test Customer Group",
+		})
+		prospect.insert()
+
+		customer = make_customer_from_prospect("_Test Prospect")
+
+		self.assertEqual(customer.doctype, "Customer")
+		self.assertEqual(customer.company_name, "_Test Prospect")
+		self.assertEqual(customer.customer_group, "_Test Customer Group")
+
+		customer.company = "_Test Company"
+		customer.insert()
 
 def make_prospect(**args):
 	args = frappe._dict(args)

--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -32,11 +32,13 @@ class TestProspect(unittest.TestCase):
 
 		frappe.delete_doc_if_exists("Customer", "_Test Prospect")
 
-		prospect = frappe.get_doc({
-			"doctype": "Prospect",
-			"company_name": "_Test Prospect",
-			"customer_group": "_Test Customer Group",
-		})
+		prospect = frappe.get_doc(
+			{
+				"doctype": "Prospect",
+				"company_name": "_Test Prospect",
+				"customer_group": "_Test Customer Group",
+			}
+		)
 		prospect.insert()
 
 		customer = make_customer_from_prospect("_Test Prospect")

--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -50,6 +50,7 @@ class TestProspect(unittest.TestCase):
 		customer.company = "_Test Company"
 		customer.insert()
 
+
 def make_prospect(**args):
 	args = frappe._dict(args)
 

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -21,6 +21,7 @@
   "gender",
   "lead_name",
   "opportunity_name",
+  "prospect_name",
   "account_manager",
   "image",
   "defaults_tab",
@@ -570,6 +571,14 @@
   {
    "fieldname": "column_break_nwor",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "prospect_name",
+   "fieldtype": "Link",
+   "label": "From Prospect",
+   "no_copy": 1,
+   "options": "Prospect",
+   "print_hide": 1
   }
  ],
  "icon": "fa fa-user",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -76,6 +76,7 @@ class Customer(TransactionBase):
 		payment_terms: DF.Link | None
 		portal_users: DF.Table[PortalUser]
 		primary_address: DF.Text | None
+		prospect_name: DF.Link | None
 		represents_company: DF.Link | None
 		sales_team: DF.Table[SalesTeam]
 		salutation: DF.Link | None


### PR DESCRIPTION
**Version:** dev and 15

fixes: #42136

**Before:**

- Suppose we create an opportunity for a prospect without a lead and then create a quotation from the opportunity, then the quotation will be created but when you create a sales order from the quotation, the lead error occurs. Because the opportunity is not connected to the lead. But sometimes it is also a case that when an opportunity is created for a direct prospect, this case fails.


https://github.com/user-attachments/assets/04190f38-4be3-4258-a533-ce97e994da2f

**After:**

- When creating a sales order from a quotation for a prospect, if the prospect is not a customer, then first create a customer and then create a sales order.


https://github.com/user-attachments/assets/5c136fc4-3c26-4646-86d9-d8a9535d4e8f

