### PR TITLE
fix: Fields Modification for Subcontracting DocTypes

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -83,7 +83,8 @@
   "total_amount",
   "amended_from",
   "credit_note",
-  "is_return"
+  "is_return",
+  "tab_connections"
  ],
  "fields": [
   {
@@ -683,6 +684,12 @@
    "label": "Asset Repair",
    "options": "Asset Repair",
    "read_only": 1
+  },
+  {
+    "fieldname": "tab_connections",
+    "fieldtype": "Tab Break",
+    "label": "Connections",
+    "show_dashboard": 1
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py
@@ -1,0 +1,26 @@
+from frappe import _
+
+
+# Todo: non_standard_fieldnames is to be decided
+def get_data():
+	return {
+		"fieldname": "stock_entry",
+		"non_standard_fieldnames": {
+			# "DocType Name": "Reference field name",
+		},
+		"internal_links": {
+			"Purchase Order": ["items", "purchase_order"],
+			"Subcontracting Order": ["items", "subcontracting_order"],
+			"Subcontracting Receipt": ["items", "subcontracting_receipt"],
+		},
+		"transactions": [
+			{
+				"label": _("Reference"),
+				"items": [
+					"Purchase Order",
+					"Subcontracting Order",
+					"Subcontracting Receipt",
+				],
+			},
+		],
+	}

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
@@ -23,18 +23,6 @@
   "cost_center",
   "dimension_col_break",
   "project",
-  "address_and_contact_section",
-  "supplier_address",
-  "address_display",
-  "contact_person",
-  "contact_display",
-  "contact_mobile",
-  "contact_email",
-  "column_break_19",
-  "shipping_address",
-  "shipping_address_display",
-  "billing_address",
-  "billing_address_display",
   "section_break_24",
   "column_break_25",
   "set_warehouse",
@@ -48,10 +36,23 @@
   "raw_materials_supplied_section",
   "set_reserve_warehouse",
   "supplied_items",
-  "additional_costs_section",
+  "tab_address_and_contact",
+  "supplier_address",
+  "address_display",
+  "contact_person",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "column_break_19",
+  "shipping_address",
+  "shipping_address_display",
+  "billing_address",
+  "billing_address_display",
+  "tab_additional_costs",
   "distribute_additional_costs_based_on",
   "additional_costs",
   "total_additional_costs",
+  "tab_other_info",
   "order_status_section",
   "status",
   "column_break_39",
@@ -59,7 +60,8 @@
   "printing_settings_section",
   "select_print_heading",
   "column_break_43",
-  "letter_head"
+  "letter_head",
+  "tab_connections"
  ],
  "fields": [
   {
@@ -95,7 +97,7 @@
    "fieldtype": "Link",
    "in_global_search": 1,
    "in_standard_filter": 1,
-   "label": "Supplier",
+   "label": "Job Worker",
    "options": "Supplier",
    "print_hide": 1,
    "reqd": 1,
@@ -107,7 +109,7 @@
    "fieldname": "supplier_name",
    "fieldtype": "Data",
    "in_global_search": 1,
-   "label": "Supplier Name",
+   "label": "Job Worker Name",
    "read_only": 1,
    "reqd": 1
   },
@@ -115,7 +117,7 @@
    "depends_on": "supplier",
    "fieldname": "supplier_warehouse",
    "fieldtype": "Link",
-   "label": "Supplier Warehouse",
+   "label": "Job Worker Warehouse",
    "options": "Warehouse",
    "reqd": 1
   },
@@ -166,9 +168,8 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "address_and_contact_section",
-   "fieldtype": "Section Break",
+   "fieldname": "tab_address_and_contact",
+   "fieldtype": "Tab Break",
    "label": "Address and Contact"
   },
   {
@@ -176,14 +177,14 @@
    "fetch_if_empty": 1,
    "fieldname": "supplier_address",
    "fieldtype": "Link",
-   "label": "Supplier Address",
+   "label": "Job Worker Address",
    "options": "Address",
    "print_hide": 1
   },
   {
    "fieldname": "address_display",
    "fieldtype": "Text Editor",
-   "label": "Supplier Address Details",
+   "label": "Job Worker Address Details",
    "read_only": 1
   },
   {
@@ -191,7 +192,7 @@
    "fetch_if_empty": 1,
    "fieldname": "contact_person",
    "fieldtype": "Link",
-   "label": "Supplier Contact",
+   "label": "Job Worker Contact",
    "options": "Contact",
    "print_hide": 1
   },
@@ -337,11 +338,9 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "collapsible_depends_on": "total_additional_costs",
    "depends_on": "eval:(doc.docstatus == 0 || doc.total_additional_costs)",
-   "fieldname": "additional_costs_section",
-   "fieldtype": "Section Break",
+   "fieldname": "tab_additional_costs",
+   "fieldtype": "Tab Break",
    "label": "Additional Costs"
   },
   {
@@ -449,6 +448,17 @@
    "fieldtype": "Link",
    "label": "Project",
    "options": "Project"
+  },
+  {
+    "fieldname": "tab_other_info",
+    "fieldtype": "Tab Break",
+    "label": "Other Info"
+  },
+  {
+    "fieldname": "tab_connections",
+    "fieldtype": "Tab Break",
+    "label": "Connections",
+    "show_dashboard": 1
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -23,18 +23,6 @@
   "cost_center",
   "dimension_col_break",
   "project",
-  "section_addresses",
-  "supplier_address",
-  "contact_person",
-  "address_display",
-  "contact_display",
-  "contact_mobile",
-  "contact_email",
-  "col_break_address",
-  "shipping_address",
-  "shipping_address_display",
-  "billing_address",
-  "billing_address_display",
   "sec_warehouse",
   "set_warehouse",
   "rejected_warehouse",
@@ -53,23 +41,36 @@
   "get_current_stock",
   "raw_material_details",
   "supplied_items",
-  "additional_costs_section",
-  "distribute_additional_costs_based_on",
-  "additional_costs",
-  "total_additional_costs",
   "section_break_46",
   "in_words",
   "bill_no",
   "bill_date",
+  "tab_addresses",
+  "supplier_address",
+  "contact_person",
+  "address_display",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "col_break_address",
+  "shipping_address",
+  "shipping_address_display",
+  "billing_address",
+  "billing_address_display",
+  "tab_additional_costs",
+  "distribute_additional_costs_based_on",
+  "additional_costs",
+  "total_additional_costs",
+  "tab_other_info",
   "more_info",
-  "status",
-  "column_break_39",
-  "per_returned",
-  "section_break_47",
   "amended_from",
   "range",
   "column_break4",
   "represents_company",
+  "order_status_section",
+  "status",
+  "column_break_39",
+  "per_returned",
   "subscription_detail",
   "auto_repeat",
   "printing_settings",
@@ -84,7 +85,8 @@
   "transporter_name",
   "column_break5",
   "lr_no",
-  "lr_date"
+  "lr_date",
+  "tab_connections"
  ],
  "fields": [
   {
@@ -112,7 +114,7 @@
    "fieldname": "supplier",
    "fieldtype": "Link",
    "in_global_search": 1,
-   "label": "Supplier",
+   "label": "Job Worker",
    "options": "Supplier",
    "print_hide": 1,
    "print_width": "150px",
@@ -127,7 +129,7 @@
    "fieldname": "supplier_name",
    "fieldtype": "Data",
    "in_global_search": 1,
-   "label": "Supplier Name",
+   "label": "Job Worker Name",
    "read_only": 1
   },
   {
@@ -174,15 +176,14 @@
    "width": "150px"
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_addresses",
-   "fieldtype": "Section Break",
+   "fieldname": "tab_addresses",
+   "fieldtype": "Tab Break",
    "label": "Address and Contact"
   },
   {
    "fieldname": "supplier_address",
    "fieldtype": "Link",
-   "label": "Select Supplier Address",
+   "label": "Select Job Worker Address",
    "options": "Address",
    "print_hide": 1
   },
@@ -269,7 +270,7 @@
   {
    "fieldname": "supplier_warehouse",
    "fieldtype": "Link",
-   "label": "Supplier Warehouse",
+   "label": "Job Worker Warehouse",
    "no_copy": 1,
    "options": "Warehouse",
    "print_hide": 1,
@@ -414,6 +415,7 @@
    "width": "50%"
   },
   {
+   "collapsible": 1,
    "fieldname": "subscription_detail",
    "fieldtype": "Section Break",
    "label": "Auto Repeat Detail"
@@ -572,10 +574,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "section_break_47",
-   "fieldtype": "Section Break"
-  },
-  {
    "collapsible": 1,
    "fieldname": "accounting_dimensions_section",
    "fieldtype": "Section Break",
@@ -598,11 +596,9 @@
    "options": "Project"
   },
   {
-   "collapsible": 1,
-   "collapsible_depends_on": "total_additional_costs",
    "depends_on": "eval:(doc.docstatus == 0 || doc.total_additional_costs)",
-   "fieldname": "additional_costs_section",
-   "fieldtype": "Section Break",
+   "fieldname": "tab_additional_costs",
+   "fieldtype": "Tab Break",
    "label": "Additional Costs"
   },
   {
@@ -658,6 +654,23 @@
   {
    "fieldname": "column_break_uinr",
    "fieldtype": "Column Break"
+  },
+  {
+    "fieldname": "tab_other_info",
+    "fieldtype": "Tab Break",
+    "label": "Other Info"
+  },
+  {
+    "collapsible": 1,
+    "fieldname": "order_status_section",
+    "fieldtype": "Section Break",
+    "label": "Order Status"
+  },
+  {
+    "fieldname": "tab_connections",
+    "fieldtype": "Tab Break",
+    "label": "Connections",
+    "show_dashboard": 1
   }
  ],
  "in_create": 1,


### PR DESCRIPTION
**Current Issues:**

- All fields in both `Subcontracting Order` and `Subcontracting Receipt` are currently organized under a single tab which is less user-friendly and harder to navigate.

- And field labels related to `Supplier` in subcontracting doctypes should be `Job Worker`, to accurately reflect the role in the subcontracting process.


**After Changes:**

- Subcontracting Receipt

![image](https://github.com/user-attachments/assets/08af9de4-c3d5-4c29-9626-3a15355d1e4c)

- Subcontracting Order

![image](https://github.com/user-attachments/assets/b52bda2c-60e8-4d70-b8f3-e9c569e9f725)