### PR TITLE
fix: set pos data if not return doc

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -505,11 +505,12 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 				frappe.msgprint(__("Please specify Company to proceed"));
 			} else {
 				var me = this;
+				const for_validate = me.frm.doc.is_return ? true : false;
 				return this.frm.call({
 					doc: me.frm.doc,
 					method: "set_missing_values",
 					args: {
-						for_validate: true,
+						for_validate: for_validate,
 					},
 					callback: function (r) {
 						if (!r.exc) {


### PR DESCRIPTION
POS Data is not set in all documents  due to https://github.com/frappe/erpnext/pull/42287.

It should not be set in return documents only.

Internal Issue: https://support.frappe.io/app/hd-ticket/18971

