### PR TITLE
fix: Purchase Order Analysis Report Data

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -46,9 +46,9 @@ def get_data(filters):
 		frappe.qb.from_(po)
 		.from_(po_item)
 		.left_join(pi_item)
-		.on(pi_item.po_detail == po_item.name)
+		.on(pi_item.po_detail == po_item.name & pi_item.docstatus == 1)
 		.left_join(pi)
-		.on(pi.name == pi_item.parent)
+		.on(pi.name == pi_item.parent & pi.docstatus == 1)
 		.select(
 			po.transaction_date.as_("date"),
 			po_item.schedule_date.as_("required_date"),
@@ -72,7 +72,6 @@ def get_data(filters):
 			po_item.name,
 		)
 		.where((po_item.parent == po.name) & (po.status.notin(("Stopped", "Closed"))) & (po.docstatus == 1))
-		.where(pi.docstatus == 1)
 		.groupby(po_item.name)
 		.orderby(po.transaction_date)
 	)


### PR DESCRIPTION
After the [fix](https://github.com/frappe/erpnext/pull/42100), users won't be able to see purchase orders in the report  "Purchase Order Analysis" against which purchase invoice has not created 

<img width="1307" alt="Screenshot 2024-07-18 at 2 49 07 PM" src="https://github.com/user-attachments/assets/9e7acba8-8afa-43ae-b378-6da0f8b7203c">



**After fix**
<img width="1330" alt="Screenshot 2024-07-18 at 2 49 25 PM" src="https://github.com/user-attachments/assets/56cdce64-9be4-4cd9-aaa3-cff6b03a9e70">

