### PR TITLE
refactor: cleaning up stale code related to reposting

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -25,30 +25,6 @@ frappe.ui.form.on("Journal Entry", {
 	refresh: function (frm) {
 		erpnext.toggle_naming_series();
 
-		if (frm.doc.repost_required && frm.doc.docstatus === 1) {
-			frm.set_intro(
-				__(
-					"Accounting entries for this Journal Entry need to be reposted. Please click on 'Repost' button to update."
-				)
-			);
-			frm.add_custom_button(__("Repost Accounting Entries"), () => {
-				frm.call({
-					doc: frm.doc,
-					method: "repost_accounting_entries",
-					freeze: true,
-					freeze_message: __("Reposting..."),
-					callback: (r) => {
-						if (!r.exc) {
-							frappe.msgprint(__("Accounting Entries are reposted."));
-							frm.refresh();
-						}
-					},
-				});
-			})
-				.removeClass("btn-default")
-				.addClass("btn-warning");
-		}
-
 		if (frm.doc.docstatus > 0) {
 			frm.add_custom_button(
 				__("Ledger"),

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -64,8 +64,7 @@
   "stock_entry",
   "subscription_section",
   "auto_repeat",
-  "amended_from",
-  "repost_required"
+  "amended_from"
  ],
  "fields": [
   {
@@ -544,15 +543,6 @@
    "label": "Is System Generated",
    "no_copy": 1,
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "repost_required",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Repost Required",
-   "print_hide": 1,
-   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
@@ -567,7 +557,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2024-03-27 13:09:58.366953",
+ "modified": "2024-07-18 15:32:29.413598",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -195,14 +195,10 @@ class JournalEntry(AccountsController):
 		self.update_booked_depreciation()
 
 	def on_update_after_submit(self):
-		if hasattr(self, "repost_required"):
-			self.needs_repost = self.check_if_fields_updated(
-				fields_to_check=[], child_tables={"accounts": []}
-			)
-			if self.needs_repost:
-				self.validate_for_repost()
-				self.db_set("repost_required", self.needs_repost)
-				self.repost_accounting_entries()
+		self.needs_repost = self.check_if_fields_updated(fields_to_check=[], child_tables={"accounts": []})
+		if self.needs_repost:
+			self.validate_for_repost()
+			self.repost_accounting_entries()
 
 	def on_cancel(self):
 		# References for this Journal are removed on the `on_cancel` event in accounts_controller

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -47,9 +47,7 @@ class JournalEntry(AccountsController):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from erpnext.accounts.doctype.journal_entry_account.journal_entry_account import (
-			JournalEntryAccount,
-		)
+		from erpnext.accounts.doctype.journal_entry_account.journal_entry_account import JournalEntryAccount
 
 		accounts: DF.Table[JournalEntryAccount]
 		amended_from: DF.Link | None

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -77,31 +77,6 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			erpnext.accounts.ledger_preview.show_stock_ledger_preview(this.frm);
 		}
 
-		if (this.frm.doc.repost_required && this.frm.doc.docstatus === 1) {
-			this.frm.set_intro(
-				__(
-					"Accounting entries for this invoice need to be reposted. Please click on 'Repost' button to update."
-				)
-			);
-			this.frm
-				.add_custom_button(__("Repost Accounting Entries"), () => {
-					this.frm.call({
-						doc: this.frm.doc,
-						method: "repost_accounting_entries",
-						freeze: true,
-						freeze_message: __("Reposting..."),
-						callback: (r) => {
-							if (!r.exc) {
-								frappe.msgprint(__("Accounting Entries are reposted."));
-								me.frm.refresh();
-							}
-						},
-					});
-				})
-				.removeClass("btn-default")
-				.addClass("btn-warning");
-		}
-
 		if (!doc.is_return && doc.docstatus == 1 && doc.outstanding_amount != 0) {
 			if (doc.on_hold) {
 				this.frm.add_custom_button(

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -170,7 +170,6 @@
   "against_expense_account",
   "column_break_63",
   "unrealized_profit_loss_account",
-  "repost_required",
   "subscription_section",
   "subscription",
   "auto_repeat",
@@ -1606,15 +1605,6 @@
   },
   {
    "default": "0",
-   "fieldname": "repost_required",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Repost Required",
-   "options": "Account",
-   "read_only": 1
-  },
-  {
-   "default": "0",
    "fieldname": "use_transaction_date_exchange_rate",
    "fieldtype": "Check",
    "label": "Use Transaction Date Exchange Rate",
@@ -1640,7 +1630,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-11 11:28:42.802211",
+ "modified": "2024-07-18 15:31:49.488566",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -159,7 +159,6 @@ class PurchaseInvoice(BuyingController):
 		rejected_warehouse: DF.Link | None
 		release_date: DF.Date | None
 		remarks: DF.SmallText | None
-		repost_required: DF.Check
 		represents_company: DF.Link | None
 		return_against: DF.Link | None
 		rounded_total: DF.Currency

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -796,19 +796,17 @@ class PurchaseInvoice(BuyingController):
 		self.process_common_party_accounting()
 
 	def on_update_after_submit(self):
-		if hasattr(self, "repost_required"):
-			fields_to_check = [
-				"cash_bank_account",
-				"write_off_account",
-				"unrealized_profit_loss_account",
-				"is_opening",
-			]
-			child_tables = {"items": ("expense_account",), "taxes": ("account_head",)}
-			self.needs_repost = self.check_if_fields_updated(fields_to_check, child_tables)
-			if self.needs_repost:
-				self.validate_for_repost()
-				self.db_set("repost_required", self.needs_repost)
-				self.repost_accounting_entries()
+		fields_to_check = [
+			"cash_bank_account",
+			"write_off_account",
+			"unrealized_profit_loss_account",
+			"is_opening",
+		]
+		child_tables = {"items": ("expense_account",), "taxes": ("account_head",)}
+		self.needs_repost = self.check_if_fields_updated(fields_to_check, child_tables)
+		if self.needs_repost:
+			self.validate_for_repost()
+			self.repost_accounting_entries()
 
 	def make_gl_entries(self, gl_entries=None, from_repost=False):
 		update_outstanding = "No" if (cint(self.is_paid) or self.write_off_account) else "Yes"

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2024,8 +2024,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 			["Service - _TC", 1000, 0.0, nowdate()],
 		]
 		check_gl_entries(self, pi.name, expected_gle, nowdate())
-		pi.load_from_db()
-		self.assertFalse(pi.repost_required)
 
 	@change_settings("Buying Settings", {"supplier_group": None})
 	def test_purchase_invoice_without_supplier_group(self):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -68,31 +68,6 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 		this.frm.toggle_reqd("due_date", !this.frm.doc.is_return);
 
-		if (this.frm.doc.repost_required && this.frm.doc.docstatus === 1) {
-			this.frm.set_intro(
-				__(
-					"Accounting entries for this invoice needs to be reposted. Please click on 'Repost' button to update."
-				)
-			);
-			this.frm
-				.add_custom_button(__("Repost Accounting Entries"), () => {
-					this.frm.call({
-						doc: this.frm.doc,
-						method: "repost_accounting_entries",
-						freeze: true,
-						freeze_message: __("Reposting..."),
-						callback: (r) => {
-							if (!r.exc) {
-								frappe.msgprint(__("Accounting Entries are reposted"));
-								me.frm.refresh();
-							}
-						},
-					});
-				})
-				.removeClass("btn-default")
-				.addClass("btn-warning");
-		}
-
 		if (this.frm.doc.is_return) {
 			this.frm.return_print_format = "Sales Invoice Return";
 		}

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -215,7 +215,6 @@
   "is_internal_customer",
   "is_discounted",
   "remarks",
-  "repost_required",
   "connections_tab"
  ],
  "fields": [
@@ -2129,15 +2128,6 @@
    "width": "50%"
   },
   {
-   "default": "0",
-   "fieldname": "repost_required",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Repost Required",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
    "fieldname": "incoterm",
    "fieldtype": "Link",
    "label": "Incoterm",
@@ -2205,7 +2195,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2024-05-23 14:02:28.549041",
+ "modified": "2024-07-18 15:30:39.428519",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -568,7 +568,6 @@ class SalesInvoice(SellingController):
 			self.repost_future_sle_and_gle()
 
 		self.db_set("status", "Cancelled")
-		self.db_set("repost_required", 0)
 
 		if self.coupon_code:
 			update_coupon_code_count(self.coupon_code, "cancelled")
@@ -721,25 +720,23 @@ class SalesInvoice(SellingController):
 				data.sales_invoice = sales_invoice
 
 	def on_update_after_submit(self):
-		if hasattr(self, "repost_required"):
-			fields_to_check = [
-				"additional_discount_account",
-				"cash_bank_account",
-				"account_for_change_amount",
-				"write_off_account",
-				"loyalty_redemption_account",
-				"unrealized_profit_loss_account",
-				"is_opening",
-			]
-			child_tables = {
-				"items": ("income_account", "expense_account", "discount_account"),
-				"taxes": ("account_head",),
-			}
-			self.needs_repost = self.check_if_fields_updated(fields_to_check, child_tables)
-			if self.needs_repost:
-				self.validate_for_repost()
-				self.db_set("repost_required", self.needs_repost)
-				self.repost_accounting_entries()
+		fields_to_check = [
+			"additional_discount_account",
+			"cash_bank_account",
+			"account_for_change_amount",
+			"write_off_account",
+			"loyalty_redemption_account",
+			"unrealized_profit_loss_account",
+			"is_opening",
+		]
+		child_tables = {
+			"items": ("income_account", "expense_account", "discount_account"),
+			"taxes": ("account_head",),
+		}
+		self.needs_repost = self.check_if_fields_updated(fields_to_check, child_tables)
+		if self.needs_repost:
+			self.validate_for_repost()
+			self.repost_accounting_entries()
 
 	def set_paid_amount(self):
 		paid_amount = 0.0

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -166,7 +166,6 @@ class SalesInvoice(SellingController):
 		project: DF.Link | None
 		redeem_loyalty_points: DF.Check
 		remarks: DF.SmallText | None
-		repost_required: DF.Check
 		represents_company: DF.Link | None
 		return_against: DF.Link | None
 		rounded_total: DF.Currency

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2965,9 +2965,6 @@ class TestSalesInvoice(FrappeTestCase):
 
 		check_gl_entries(self, si.name, expected_gle, add_days(nowdate(), -1))
 
-		si.load_from_db()
-		self.assertFalse(si.repost_required)
-
 	def test_asset_depreciation_on_sale_with_pro_rata(self):
 		"""
 		Tests if an Asset set to depreciate yearly on June 30, that gets sold on Sept 30, creates an additional depreciation entry on its date of sale.

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2517,16 +2517,12 @@ class AccountsController(TransactionBase):
 
 	@frappe.whitelist()
 	def repost_accounting_entries(self):
-		if self.repost_required:
-			repost_ledger = frappe.new_doc("Repost Accounting Ledger")
-			repost_ledger.company = self.company
-			repost_ledger.append("vouchers", {"voucher_type": self.doctype, "voucher_no": self.name})
-			repost_ledger.flags.ignore_permissions = True
-			repost_ledger.insert()
-			repost_ledger.submit()
-			self.db_set("repost_required", 0)
-		else:
-			frappe.throw(_("No updates pending for reposting"))
+		repost_ledger = frappe.new_doc("Repost Accounting Ledger")
+		repost_ledger.company = self.company
+		repost_ledger.append("vouchers", {"voucher_type": self.doctype, "voucher_no": self.name})
+		repost_ledger.flags.ignore_permissions = True
+		repost_ledger.insert()
+		repost_ledger.submit()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Reposting has been made [implicit](https://github.com/frappe/erpnext/pull/42294). Hence, no need for a separate checkbox.

Cleaning up code.