### PR TITLE
fix(Supplier Group): display of root group

### DIFF
--- a/erpnext/setup/doctype/supplier_group/supplier_group.js
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.js
@@ -35,7 +35,6 @@ frappe.ui.form.on("Supplier Group", {
 		});
 	},
 	refresh: function (frm) {
-		frm.set_intro(frm.doc.__islocal ? "" : __("There is nothing to edit."));
 		frm.trigger("set_root_readonly");
 	},
 	set_root_readonly: function (frm) {

--- a/erpnext/setup/doctype/supplier_group/supplier_group.js
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.js
@@ -40,7 +40,7 @@ frappe.ui.form.on("Supplier Group", {
 	},
 	set_root_readonly: function (frm) {
 		if (!frm.doc.parent_supplier_group && !frm.doc.__islocal) {
-			frm.trigger("set_read_only");
+			frm.set_read_only();
 			frm.set_intro(__("This is a root supplier group and cannot be edited."));
 		} else {
 			frm.set_intro(null);

--- a/erpnext/setup/doctype/supplier_group/supplier_group.js
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.js
@@ -38,7 +38,7 @@ frappe.ui.form.on("Supplier Group", {
 		frm.trigger("set_root_readonly");
 	},
 	set_root_readonly: function (frm) {
-		if (!frm.doc.parent_supplier_group && !frm.doc.__islocal) {
+		if (!frm.doc.parent_supplier_group && !frm.is_new()) {
 			frm.set_read_only();
 			frm.set_intro(__("This is a root supplier group and cannot be edited."));
 		} else {


### PR DESCRIPTION
- Properly call `frm.set_read_only()` (was not working before)
- Remove useless headline "There is nothing to edit."

    Not sure what it was supposed to mean. It was only visible on root group, along with the other message.

- Use `frm.is_new()` instead of `frm.doc.__islocal`


> [!NOTE]
> https://github.com/frappe/frappe/pull/26998 fixes unexpected behavior of `frm.set_read_only()`. You may need to check this out to see ideal behavior on this PR. However, these fixes are valid independently.

### Before

![Bildschirmfoto 2024-07-18 um 21 03 35](https://github.com/user-attachments/assets/ad6a69d8-6b81-42b5-ac43-a2560e1fad7f)

### After

![Bildschirmfoto 2024-07-18 um 21 03 19](https://github.com/user-attachments/assets/6384a2cd-4b5b-4620-8782-0e49de474cf2)
