### PR TITLE
fix: Billing hours is not updated in Time sheet#19026

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -296,6 +296,7 @@ frappe.ui.form.on("Timesheet Detail", {
 
 	hours: function (frm, cdt, cdn) {
 		calculate_end_time(frm, cdt, cdn);
+		update_billing_hours(frm, cdt, cdn);
 		calculate_billing_costing_amount(frm, cdt, cdn);
 		calculate_time_and_amount(frm);
 	},

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -36,6 +36,7 @@ class Timesheet(Document):
 		for row in self.time_logs:
 			if row.to_time and row.from_time:
 				row.hours = time_diff_in_hours(row.to_time, row.from_time)
+				self.update_billing_hours(row)
 
 	def calculate_total_amounts(self):
 		self.total_hours = 0.0


### PR DESCRIPTION
When the Is Billable is checked in the Timesheet Details,  On updating the Hrs manually, it was not updating the Billing Hours.  But now it updates the Billing Hours based on the On updating the Hrs manually.
![image](https://github.com/user-attachments/assets/d5a8c0eb-6ced-4d72-b47a-a21d25d4b580)
