### PR TITLE
fix: set filter to show only submitted asset

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance/asset_maintenance.js
+++ b/erpnext/assets/doctype/asset_maintenance/asset_maintenance.js
@@ -3,6 +3,15 @@
 
 frappe.ui.form.on("Asset Maintenance", {
 	setup: (frm) => {
+		frm.set_query("asset_name", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+					docstatus: 1,
+				},
+			};
+		});
+
 		frm.set_query("assign_to", "asset_maintenance_tasks", function (doc) {
 			return {
 				query: "erpnext.assets.doctype.asset_maintenance.asset_maintenance.get_team_members",


### PR DESCRIPTION
While creating asset maintenance the system shows all assets in link field, where it should only show asset with docstatus=1.
