### PR TITLE
fix: process on background based on number of invoices on POS Closing Entry

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -388,11 +388,13 @@ def consolidate_pos_invoices(pos_invoices=None, closing_entry=None):
 
 
 def unconsolidate_pos_invoices(closing_entry):
+	invoices = frappe.db.count("POS Invoice Reference", filters={"parent": closing_entry.name})
+
 	merge_logs = frappe.get_all(
 		"POS Invoice Merge Log", filters={"pos_closing_entry": closing_entry.name}, pluck="name"
 	)
 
-	if len(merge_logs) >= 10:
+	if invoices >= 10:
 		closing_entry.set_status(update=True, status="Queued")
 		enqueue_job(cancel_merge_logs, merge_logs=merge_logs, closing_entry=closing_entry)
 	else:

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -388,13 +388,11 @@ def consolidate_pos_invoices(pos_invoices=None, closing_entry=None):
 
 
 def unconsolidate_pos_invoices(closing_entry):
-	invoices = frappe.db.count("POS Invoice Reference", filters={"parent": closing_entry.name})
-
 	merge_logs = frappe.get_all(
 		"POS Invoice Merge Log", filters={"pos_closing_entry": closing_entry.name}, pluck="name"
 	)
 
-	if invoices >= 10:
+	if len(closing_entry.pos_transactions) >= 10:
 		closing_entry.set_status(update=True, status="Queued")
 		enqueue_job(cancel_merge_logs, merge_logs=merge_logs, closing_entry=closing_entry)
 	else:


### PR DESCRIPTION
At the moment the parameter to cancel a POS Closing Entry on backgroud is the number of consolidate "grouped" invoices.

**Problem:**
but if i use a commum customer for all sales, i can have 500 POS Invoice consolidate on a unique Sales Invoice, for this case i need to process the cancel on background.

**Solution:**
Count number of POS Invoice inside of this POS Closing Entry, if is to big process on background