### PR TITLE
fix: provide initial value for `.reduce()` call

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -161,7 +161,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 				const payment_is_overdue = doc.payment_schedule
 					.map((row) => Date.parse(row.due_date) < Date.now())
-					.reduce((prev, current) => prev || current);
+					.reduce((prev, current) => prev || current, false);
 
 				if (payment_is_overdue) {
 					this.frm.add_custom_button(


### PR DESCRIPTION
Fixes the error "TypeError: Reduce of empty array with no initial value" (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value#invalid_cases) that would show up in the browser console when creating or opening a **Sales Invoice**.

If the array was empty (i.e. no overdue payments), `.reduce()` would raise the above error because an initial value was not provided. By providing `false` as initial value, the UX stays identical but we get rid of the error.

This had no noticeable impact because it is the last part of the function.