### PR TITLE
fix: Sort lists before calling itertools.groupby

### DIFF
--- a/erpnext/crm/report/opportunity_summary_by_sales_stage/opportunity_summary_by_sales_stage.py
+++ b/erpnext/crm/report/opportunity_summary_by_sales_stage/opportunity_summary_by_sales_stage.py
@@ -108,7 +108,9 @@ class OpportunitySummaryBySalesStage:
 			self.grouped_data = []
 
 			grouping_key = lambda o: (o["sales_stage"], o[based_on])  # noqa
-			for (sales_stage, _based_on), rows in groupby(self.query_result, grouping_key):
+			for (sales_stage, _based_on), rows in groupby(
+				sorted(self.query_result, key=grouping_key), key=grouping_key
+			):
 				self.grouped_data.append(
 					{
 						"sales_stage": sales_stage,

--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -114,7 +114,9 @@ class SalesPipelineAnalytics:
 			self.grouped_data = []
 
 			grouping_key = lambda o: (o.get(self.pipeline_by) or "Not Assigned", o[self.period_by])  # noqa
-			for (pipeline_by, period_by), rows in groupby(self.query_result, grouping_key):
+			for (pipeline_by, period_by), rows in groupby(
+				sorted(self.query_result, key=grouping_key), grouping_key
+			):
 				self.grouped_data.append(
 					{
 						self.pipeline_by: pipeline_by,

--- a/erpnext/selling/page/sales_funnel/sales_funnel.py
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.py
@@ -93,7 +93,7 @@ def get_opp_by_lead_source(from_date, to_date, company):
 		summary = {}
 		sales_stages = set()
 		group_key = lambda o: (o["source"], o["sales_stage"])  # noqa
-		for (source, sales_stage), rows in groupby(cp_opportunities, group_key):
+		for (source, sales_stage), rows in groupby(sorted(cp_opportunities, key=group_key), group_key):
 			summary.setdefault(source, {})[sales_stage] = sum(r["compound_amount"] for r in rows)
 			sales_stages.add(sales_stage)
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1097,7 +1097,8 @@ def create_delivery_note(source_name, target_doc=None):
 				)
 			)
 
-	for customer, rows in groupby(sales_orders, key=lambda so: so["customer"]):
+	group_key = lambda so: so["customer"]  # noqa
+	for customer, rows in groupby(sorted(sales_orders, key=group_key), key=group_key):
 		sales_dict[customer] = {row.sales_order for row in rows}
 
 	if sales_dict:


### PR DESCRIPTION
`itertools.groupby` returns consecutive groups only when the keys are consecutive. An input of `aBaB` will create 4 groups, not 2.

https://docs.python.org/3/library/itertools.html#itertools.groupby
https://stackoverflow.com/a/7286