### PR TITLE
fix: qty in the 'Serial No Ledger' report

### DIFF
--- a/erpnext/stock/report/serial_no_ledger/serial_no_ledger.py
+++ b/erpnext/stock/report/serial_no_ledger/serial_no_ledger.py
@@ -157,6 +157,7 @@ def get_data(filters):
 					{
 						"serial_no": bundle_data.get("serial_no"),
 						"valuation_rate": bundle_data.get("valuation_rate"),
+						"qty": args.qty,
 					}
 				)
 


### PR DESCRIPTION
Before

<img width="1330" alt="Screenshot 2024-07-22 at 3 02 28 PM" src="https://github.com/user-attachments/assets/ce39c691-b947-4544-a639-be9218da73e9">



**After Fix**

<img width="1323" alt="Screenshot 2024-07-22 at 3 12 14 PM" src="https://github.com/user-attachments/assets/b31e1a77-f9c2-446b-bf46-64cc28cbbd2d">
