### PR TITLE
fix: promotional scheme doctype fields in consitency with pricing rule

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
@@ -15,6 +15,10 @@ frappe.ui.form.on("Promotional Scheme", {
 		frm.trigger("set_options_for_applicable_for");
 	},
 
+	currency: function (frm) {
+		frm.trigger("set_price_list_query");
+	},
+
 	set_options_for_applicable_for: function (frm) {
 		var options = [""];
 		var applicable_for = frm.doc.applicable_for;
@@ -36,6 +40,18 @@ frappe.ui.form.on("Promotional Scheme", {
 
 		if (!in_list(options, applicable_for)) applicable_for = null;
 		frm.set_value("applicable_for", applicable_for);
+
+		frm.trigger("set_price_list_query");
+	},
+
+	set_price_list_query: function (frm) {
+		frm.set_query("for_price_list", "price_discount_slabs", {
+			filters: {
+				selling: frm.doc.selling,
+				buying: frm.doc.buying,
+				currency: frm.doc.currency,
+			},
+		});
 	},
 
 	apply_on: function (frm) {

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
@@ -2,6 +2,18 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Promotional Scheme", {
+	setup: function (frm) {
+		frm.set_query("for_price_list", "price_discount_slabs", (doc) => {
+			return {
+				filters: {
+					selling: doc.selling,
+					buying: doc.buying,
+					currency: doc.currency,
+				},
+			};
+		});
+	},
+
 	refresh: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
 		frm.trigger("toggle_reqd_apply_on");
@@ -13,10 +25,6 @@ frappe.ui.form.on("Promotional Scheme", {
 
 	buying: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
-	},
-
-	currency: function (frm) {
-		frm.trigger("set_price_list_query");
 	},
 
 	set_options_for_applicable_for: function (frm) {
@@ -40,18 +48,6 @@ frappe.ui.form.on("Promotional Scheme", {
 
 		if (!in_list(options, applicable_for)) applicable_for = null;
 		frm.set_value("applicable_for", applicable_for);
-
-		frm.trigger("set_price_list_query");
-	},
-
-	set_price_list_query: function (frm) {
-		frm.set_query("for_price_list", "price_discount_slabs", {
-			filters: {
-				selling: frm.doc.selling,
-				buying: frm.doc.buying,
-				currency: frm.doc.currency,
-			},
-		});
 	},
 
 	apply_on: function (frm) {

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -51,6 +51,7 @@ price_discount_fields = [
 	"discount_percentage",
 	"validate_applied_rule",
 	"apply_multiple_pricing_rules",
+	"for_price_list",
 ]
 
 product_discount_fields = [

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -63,6 +63,7 @@ product_discount_fields = [
 	"recurse_for",
 	"apply_recursion_over",
 	"apply_multiple_pricing_rules",
+	"round_free_qty",
 ]
 
 

--- a/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.json
+++ b/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.json
@@ -21,6 +21,7 @@
   "rate",
   "discount_amount",
   "discount_percentage",
+  "for_price_list",
   "section_break_11",
   "warehouse",
   "threshold_percentage",
@@ -121,6 +122,13 @@
    "label": "Discount Percentage"
   },
   {
+   "depends_on": "eval:doc.rate_or_discount!=\"Rate\"",
+   "fieldname": "for_price_list",
+   "fieldtype": "Link",
+   "label": "For Price List",
+   "options": "Price List"
+  },
+  {
    "fieldname": "section_break_11",
    "fieldtype": "Section Break"
   },
@@ -169,7 +177,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:22.448265",
+ "modified": "2024-07-23 12:33:46.574950",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Promotional Scheme Price Discount",

--- a/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.py
+++ b/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.py
@@ -19,6 +19,7 @@ class PromotionalSchemePriceDiscount(Document):
 		disable: DF.Check
 		discount_amount: DF.Currency
 		discount_percentage: DF.Float
+		for_price_list: DF.Link | None
 		max_amount: DF.Currency
 		max_qty: DF.Float
 		min_amount: DF.Currency

--- a/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.json
+++ b/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.json
@@ -22,6 +22,7 @@
   "column_break_9",
   "free_item_uom",
   "free_item_rate",
+  "round_free_qty",
   "section_break_12",
   "warehouse",
   "threshold_percentage",
@@ -181,12 +182,18 @@
    "fieldtype": "Float",
    "label": "Apply Recursion Over (As Per Transaction UOM)",
    "mandatory_depends_on": "is_recursive"
+  },
+  {
+   "default": "0",
+   "fieldname": "round_free_qty",
+   "fieldtype": "Check",
+   "label": "Round Free Qty"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:22.605892",
+ "modified": "2024-07-22 17:25:07.880984",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Promotional Scheme Product Discount",

--- a/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.py
+++ b/erpnext/accounts/doctype/promotional_scheme_product_discount/promotional_scheme_product_discount.py
@@ -53,6 +53,7 @@ class PromotionalSchemeProductDiscount(Document):
 			"20",
 		]
 		recurse_for: DF.Float
+		round_free_qty: DF.Check
 		rule_description: DF.SmallText
 		same_item: DF.Check
 		threshold_percentage: DF.Percent


### PR DESCRIPTION
For consistency with the Pricing Rule, added the `round_free_qty` field in the Promotional Scheme Product Discount  (Child Table) and `for_price_list` field in the Promotiona Scheme Price Discount (Child Table)


Internal Issue: https://support.frappe.io/app/hd-ticket/19075