### PR TITLE
fix: source warehouse in the stock entry  when the backflush is disabled in the Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -134,7 +134,6 @@ frappe.ui.form.on("Work Order", {
 		erpnext.toggle_naming_series();
 		erpnext.work_order.set_custom_buttons(frm);
 		frm.set_intro("");
-
 		if (frm.doc.docstatus === 0 && !frm.is_new()) {
 			frm.set_intro(__("Submit this Work Order for further processing."));
 		} else {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1422,12 +1422,16 @@ def make_stock_entry(work_order_id, purpose, qty=None):
 
 	if purpose == "Material Transfer for Manufacture":
 		stock_entry.to_warehouse = wip_warehouse
-		stock_entry.project = work_order.project
 	else:
-		stock_entry.from_warehouse = wip_warehouse
+		if work_order.skip_transfer:
+			if work_order.from_wip_warehouse:
+				stock_entry.from_warehouse = wip_warehouse
+			else:
+				stock_entry.from_warehouse = work_order.source_warehouse
+		else:
+			stock_entry.from_warehouse = work_order.source_warehouse
 		stock_entry.to_warehouse = work_order.fg_warehouse
-		stock_entry.project = work_order.project
-
+	stock_entry.project = work_order.project
 	stock_entry.set_stock_entry_type()
 	stock_entry.get_items()
 	stock_entry.set_serial_no_batch_for_finished_good()


### PR DESCRIPTION
In the Work Order, When the Skip Material Transfer to WIP Warehouse check is enabled and the Backflush Raw Materials From Work-in-Progress Warehouse is disabled then the Stock Entry of type Manufacture was setting the Source warehouse as WIP Warehouse instead of Source warehouse.
Work order:
![image](https://github.com/user-attachments/assets/3c372555-f110-4900-999f-483069d68aa5)

Stock Entry of type Manufacture:
![image](https://github.com/user-attachments/assets/6e027b1a-eac6-44c3-b6fa-423c9f3d6253)
