### PR TITLE
fix: parenttype in purchase and sales item query

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -315,8 +315,9 @@ def apply_conditions(query, pi, pii, filters):
 
 
 def get_items(filters, additional_table_columns):
-	pi = frappe.qb.DocType("Purchase Invoice")
-	pii = frappe.qb.DocType("Purchase Invoice Item")
+	doctype = "Purchase Invoice"
+	pi = frappe.qb.DocType(doctype)
+	pii = frappe.qb.DocType(f"{doctype} Item")
 	Item = frappe.qb.DocType("Item")
 	query = (
 		frappe.qb.from_(pi)
@@ -353,6 +354,7 @@ def get_items(filters, additional_table_columns):
 			pi.mode_of_payment,
 		)
 		.where(pi.docstatus == 1)
+		.where(pii.parenttype == doctype)
 	)
 
 	if filters.get("supplier"):

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -410,8 +410,9 @@ def apply_group_by_conditions(query, si, ii, filters):
 
 
 def get_items(filters, additional_query_columns, additional_conditions=None):
-	si = frappe.qb.DocType("Sales Invoice")
-	sii = frappe.qb.DocType("Sales Invoice Item")
+	doctype = "Sales Invoice"
+	si = frappe.qb.DocType(doctype)
+	sii = frappe.qb.DocType(f"{doctype} Item")
 	item = frappe.qb.DocType("Item")
 
 	query = (
@@ -459,6 +460,7 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 			sii.qty,
 		)
 		.where(si.docstatus == 1)
+		.where(sii.parenttype == doctype)
 	)
 
 	if additional_query_columns:


### PR DESCRIPTION
Item Table can be used in any other custom doctypes also.

Internal Issue: https://support.frappe.io/app/hd-ticket/19053

