### PR TITLE
fix: use company default currency in report

### DIFF
--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -130,6 +130,7 @@ class PaymentLedger:
 		)
 
 	def get_columns(self):
+		company_currency = frappe.get_cached_value("Company", self.filters.get("company"), "default_currency")
 		options = None
 		self.columns.append(
 			dict(
@@ -194,7 +195,7 @@ class PaymentLedger:
 				label=_("Amount"),
 				fieldname="amount",
 				fieldtype="Currency",
-				options="Company:company:default_currency",
+				options=company_currency,
 				width="100",
 			)
 		)


### PR DESCRIPTION
**Problem Statement:**
Using `Company:company:default_currency` as an option in the `Amount` field does not provide the correct currency format when the company information is not loaded.

**Before: When using the `Company:company:default_currency` option in the Amount field without the company information being loaded, the currency format displayed is incorrect.**
![image](https://github.com/user-attachments/assets/f3bc2d2d-9c8e-4ea6-bc37-e82f093b870c)

**After: Retrieve the default currency from the company to ensure the Amount field displays the correct currency format.**
![image](https://github.com/user-attachments/assets/b5c09147-fd61-4a5d-8eb0-a6503e74710a)
