### PR TITLE
fix: Freeze Screen on load invoices on POS Closing Entry

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -80,8 +80,10 @@ frappe.ui.form.on("POS Closing Entry", {
 		) {
 			reset_values(frm);
 			frappe.run_serially([
+				() => frappe.dom.freeze(__("Loading Invoices! Please Wait...")),
 				() => frm.trigger("set_opening_amounts"),
 				() => frm.trigger("get_pos_invoices"),
+				() => frappe.dom.unfreeze(),
 			]);
 		}
 	},


### PR DESCRIPTION
When creating a `POS Closing Entry`, when I enter the "Opening Entry" all invoices are loaded, however, when there are many invoices (250 - 500), the system does not display any message and leaves the screen available for clicking.

If the user clicks on save, the javascript will restart this process by executing the `before_save` method and reloading the invoices. [Line ](https://github.com/frappe/erpnext/blob/06e2d7265c2f7dceedf3fc75462f1bb3190b6d4a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js#L135)

This creates problems with the totals received by payment method. To avoid this, please notify the user who is uploading the invoices and prevent to start another action before finish to load all invoices

