### PR TITLE
fix: Fields Alteration Related to Subcontracting

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -639,7 +639,7 @@
   {
    "fieldname": "supplier_delivery_note",
    "fieldtype": "Data",
-   "label": "Supplier Delivery Note"
+   "label": "Job Worker Delivery Note"
   },
   {
    "fieldname": "raw_materials_consumed_section",


### PR DESCRIPTION
- In Subcontracting Receipt use `Job Worker Delivery Note` instead of `Supplier Delivery Note` which is more relevant for Subcontracting workflow.

![image](https://github.com/user-attachments/assets/fbf6abc9-1372-4564-90ec-c6286c1b92e8)

For related field changes refer: https://github.com/frappe/erpnext/pull/42383