### PR TITLE
refactor: index on Purchase Invoice 'release_date'

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -363,7 +363,8 @@
    "description": "Once set, this invoice will be on hold till the set date",
    "fieldname": "release_date",
    "fieldtype": "Date",
-   "label": "Release Date"
+   "label": "Release Date",
+   "search_index": 1
   },
   {
    "fieldname": "cb_17",
@@ -1630,7 +1631,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-07-18 15:31:49.488566",
+ "modified": "2024-07-25 19:42:36.931278",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",


### PR DESCRIPTION
Payment Entry submission slows down when there are large number of Purchase Invoices. This is due to the validation that checks for 'Held Invoices'. Adding index on 'release_date' to speed up this validation.

https://github.com/frappe/erpnext/blob/302339998f89cd1e6482a9c51f70dda98714a8c7/erpnext/accounts/utils.py#L993-L1006