### PR TITLE
refactor: checkbox to control Payment Request creation

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -73,7 +73,9 @@
   "remarks_section",
   "general_ledger_remarks_length",
   "column_break_lvjk",
-  "receivable_payable_remarks_length"
+  "receivable_payable_remarks_length",
+  "payment_request_settings",
+  "create_pr_in_draft_status"
  ],
  "fields": [
   {
@@ -475,6 +477,18 @@
    "fieldname": "calculate_depr_using_total_days",
    "fieldtype": "Check",
    "label": "Calculate daily depreciation using total days in depreciation period"
+  },
+  {
+   "description": "Payment Request created from Sales Order or Purchase Order will be in Draft status. When disabled document will be in unsaved state.",
+   "fieldname": "payment_request_settings",
+   "fieldtype": "Tab Break",
+   "label": "Payment Request"
+  },
+  {
+   "default": "1",
+   "fieldname": "create_pr_in_draft_status",
+   "fieldtype": "Check",
+   "label": "Create in Draft Status"
   }
  ],
  "icon": "icon-cog",
@@ -482,7 +496,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-12 00:24:20.957726",
+ "modified": "2024-07-26 06:48:52.714630",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -35,6 +35,7 @@ class AccountsSettings(Document):
 		book_tax_discount_loss: DF.Check
 		calculate_depr_using_total_days: DF.Check
 		check_supplier_invoice_uniqueness: DF.Check
+		create_pr_in_draft_status: DF.Check
 		credit_controller: DF.Link | None
 		delete_linked_ledger_entries: DF.Check
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -509,7 +509,8 @@ def make_payment_request(**args):
 		for dimension in get_accounting_dimensions():
 			pr.update({dimension: ref_doc.get(dimension)})
 
-		pr.insert(ignore_permissions=True)
+		if frappe.db.get_single_value("Accounts Settings", "create_pr_in_draft_status", cache=True):
+			pr.insert(ignore_permissions=True)
 		if args.submit_doc:
 			pr.submit()
 


### PR DESCRIPTION
Payment Request created from Sales Order / Purchase Order is by default in Draft status. This makes it impossible to select a different naming series.

A New checkbox in `Accounts Settings` is added to control this behavior.
<img width="1436" alt="Screenshot 2024-07-26 at 6 56 07 AM" src="https://github.com/user-attachments/assets/1d32b047-df35-43e3-9670-d784843cf966">


https://github.com/user-attachments/assets/aa124467-6bce-4cae-93ce-fcbd3bd4d3ab

