### PR TITLE
fix(task): Fix invalid comparison of date/datetime in reschedule_dependent_tasks

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -253,7 +253,7 @@ class Task(NestedSet):
 				if (
 					task.exp_start_date
 					and task.exp_end_date
-					and task.exp_start_date < end_date
+					and getdate(task.exp_start_date) < end_date
 					and task.status == "Open"
 				):
 					task_duration = date_diff(task.exp_end_date, task.exp_start_date)


### PR DESCRIPTION
```py
end_date: datetime | date = self.exp_end_date or self.act_end_date
task.exp_start_date: datetime

... task.exp_start_date < end_date  # is invalid
... task.exp_start_date < getdate(end_date)  # is the previous code
... getdate(task.exp_start_date) < end_date  # is my suggestion
```