### PR TITLE
fix: Prevent set_payment_schedule when creating SI that is return

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1061,7 +1061,7 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 	automatically_fetch_payment_terms = cint(
 		frappe.db.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
 	)
-	if automatically_fetch_payment_terms:
+	if automatically_fetch_payment_terms and not doc.is_return:
 		doc.set_payment_schedule()
 
 	return doc


### PR DESCRIPTION
The set_payment_schedule() function should not be used in Sales Invoices that are returns (see the reference below).

[Reference](https://github.com/frappe/erpnext/blob/develop/erpnext/controllers/accounts_controller.py#L461)

This commit adds a validation to prevent set_payment_schedule() from being called when creating a Sales Invoice from a Delivery Note, if the Sales Invoice is a return.