### PR TITLE
perf: huge number of serial no creation

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -92,8 +92,10 @@ class SerialandBatchBundle(Document):
 		if self.type_of_transaction == "Maintenance":
 			return
 
-		self.validate_serial_nos_duplicate()
-		self.check_future_entries_exists()
+		if not self.flags.ignore_validate_serial_batch or frappe.flags.in_test:
+			self.validate_serial_nos_duplicate()
+			self.check_future_entries_exists()
+
 		self.set_is_outward()
 		self.calculate_total_qty()
 		self.set_warehouse()
@@ -340,6 +342,9 @@ class SerialandBatchBundle(Document):
 			rate = frappe.db.get_value(child_table, self.voucher_detail_no, valuation_field)
 
 		for d in self.entries:
+			if (d.incoming_rate == rate) and d.qty and d.stock_value_difference:
+				continue
+
 			d.incoming_rate = flt(rate, precision)
 			if d.qty:
 				d.stock_value_difference = flt(d.qty) * flt(d.incoming_rate)
@@ -841,6 +846,9 @@ class SerialandBatchBundle(Document):
 		self.validate_serial_nos_inventory()
 
 	def set_purchase_document_no(self):
+		if self.flags.ignore_validate_serial_batch:
+			return
+
 		if not self.has_serial_no:
 			return
 

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -435,7 +435,6 @@
   },
   {
    "default": "1",
-   "depends_on": "use_serial_batch_fields",
    "description": "If enabled, do not update serial / batch values in the stock transactions on creation of auto Serial \n / Batch Bundle. ",
    "fieldname": "do_not_update_serial_batch_on_creation_of_auto_bundle",
    "fieldtype": "Check",
@@ -468,7 +467,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-15 17:18:23.872161",
+ "modified": "2024-07-29 14:55:19.093508",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",


### PR DESCRIPTION
**Issue**
System were throwing the timeout error for 10,000 serial no creation from the purchase receipt

**After Fix**

Able to submit the purchase receipt in 60 seconds
<img width="828" alt="Screenshot 2024-07-29 at 5 34 05 PM" src="https://github.com/user-attachments/assets/6947b35f-1113-473e-9ac9-80baa1b78832">

