### PR TITLE
fix: honor 'disable rounded total' flag in invoice

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -563,9 +563,12 @@ class calculate_taxes_and_totals:
 
 	def calculate_totals(self):
 		if self.doc.get("taxes"):
-			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(
-				self.doc.get("grand_total_diff")
-			)
+			if self.doc.get("disable_rounded_total"):
+				self.doc.grand_total = flt(self.doc.get("taxes")[-1].total)
+			else:
+				self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(
+					self.doc.get("grand_total_diff")
+				)
 		else:
 			self.doc.grand_total = flt(self.doc.net_total)
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -573,9 +573,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		// Changing sequence can cause rounding_adjustmentng issue and on-screen discrepency
 		var me = this;
 		var tax_count = this.frm.doc["taxes"] ? this.frm.doc["taxes"].length : 0;
-		this.frm.doc.grand_total = flt(tax_count
-			? this.frm.doc["taxes"][tax_count - 1].total + flt(this.frm.doc.grand_total_diff)
-			: this.frm.doc.net_total);
+		if (tax_count) {
+			if (me.frm.doc.disable_rounded_total) {
+				this.frm.doc.grand_total =  flt(this.frm.doc["taxes"][tax_count - 1].total);
+			} else {
+				this.frm.doc.grand_total = flt(this.frm.doc["taxes"][tax_count - 1].total + flt(this.frm.doc.grand_total_diff));
+			}
+		} else {
+			this.frm.doc.grand_total = flt(this.frm.doc.net_total);
+		}
+
 
 		if(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
 			this.frm.doc.base_grand_total = (this.frm.doc.total_taxes_and_charges) ?


### PR DESCRIPTION
Possible fix for https://github.com/frappe/erpnext/issues/42376 and https://github.com/frappe/erpnext/issues/38137.

Consider below scenario,
1. Sales Invoice with 2 items, 1x90 and 1x55. `Disable Rounded Total` is enabled.
2. Add a tax of 5% on net total and tax should be ` Is this Tax included in Basic Rate?` enabled.

Grand total should've been 144.99 /-, but is rounded to 144.50, even though rounding is disabled. This difference of 0.01 is posted to the rounding adjustment account by general ledger.

This PR is trying to change this behavior. When `Disable Rounded Total` is enabled, no rounding will be posted to ledger.

### Before

https://github.com/user-attachments/assets/3f3ba0b0-dc62-4b47-ae00-bf749ffbb28a

### After

https://github.com/user-attachments/assets/b92dadff-6e0c-4c5d-ac30-29faef8dd45e

Reference: https://support.frappe.io/helpdesk/tickets/18968