### PR TITLE
fix: purchase return from rejected warehouse

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -640,6 +640,12 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 	def update_terms(source_doc, target_doc, source_parent):
 		target_doc.payment_amount = -source_doc.payment_amount
 
+	def item_condition(doc):
+		if return_against_rejected_qty:
+			return doc.rejected_qty
+
+		return doc.qty
+
 	doclist = get_mapped_doc(
 		doctype,
 		source_name,
@@ -654,6 +660,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 				"doctype": doctype + " Item",
 				"field_map": {"serial_no": "serial_no", "batch_no": "batch_no", "bom": "bom"},
 				"postprocess": update_item,
+				"condition": item_condition,
 			},
 			"Payment Schedule": {"doctype": "Payment Schedule", "postprocess": update_terms},
 		},

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1925,9 +1925,19 @@ class TestPurchaseReceipt(FrappeTestCase):
 			rate=100,
 			rejected_qty=2,
 			rejected_warehouse=rejected_warehouse,
+			do_not_save=1,
 		)
 
+		pr.append(
+			"items",
+			{"item_code": item_code, "qty": 2, "rate": 100, "warehouse": warehouse, "rejected_qty": 0},
+		)
+		pr.save()
+		pr.submit()
+		self.assertEqual(len(pr.items), 2)
+
 		pr_return = make_purchase_return_against_rejected_warehouse(pr.name)
+		self.assertEqual(len(pr_return.items), 1)
 		self.assertEqual(pr_return.items[0].warehouse, rejected_warehouse)
 		self.assertEqual(pr_return.items[0].qty, 2.0 * -1)
 		self.assertEqual(pr_return.items[0].rejected_qty, 0.0)


### PR DESCRIPTION
**Steps to Replicate Issue**

- Create a purchase receipt with 3 line items Item A, Item B, Item C
- Set Accepted Qty as 10 and Rejected qty as 2 for Item A
- Set Accepted Qty as 5 and Rejected qty as 0 for Item B
- Set Accepted Qty as 5 and Rejected qty as 0 for Item C
- Now submit the purchase receipt entry and create the purchase return entry
- While return, enable "Return Qty from Rejected Warehouse" 
- You will see 3 line items on the purchase return entry which ideally should be one (because only one has rejected qty)
![purchase-return-issue](https://github.com/user-attachments/assets/575aa2df-ab9d-4215-85db-f699b1f4bc91)


**After Fix**
![purchase-return-after-fix](https://github.com/user-attachments/assets/a4d1e40d-c683-43a0-931e-2054543da83b)


