### PR TITLE
fix: price_list_currency not found error

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1791,6 +1791,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	apply_price_list(item, reset_plc_conversion) {
 		// We need to reset plc_conversion_rate sometimes because the call to
 		// `erpnext.stock.get_item_details.apply_price_list` is sensitive to its value
+
+
+		if (this.frm.doc.doctype === "Material Request") {
+			return;
+		}
+
 		if (!reset_plc_conversion) {
 			this.frm.set_value("plc_conversion_rate", "");
 		}


### PR DESCRIPTION
On changing of the UOM in the material request on a line item, system throws the below error

<img width="811" alt="Screenshot 2024-07-30 at 1 45 09 PM" src="https://github.com/user-attachments/assets/4858602e-629b-4aae-96b8-cddb838eb14f">
