### PR TITLE
fix: min height for rows in sales funnel

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -193,6 +193,9 @@ erpnext.SalesFunnel = class SalesFunnel {
 		this.options.width = ($(this.elements.funnel_wrapper).width() * 2.0) / 3.0;
 		this.options.height = (Math.sqrt(3) * this.options.width) / 2.0;
 
+		const min_height = (this.options.height * 0.1) / this.options.data.length;
+		const height = this.options.height * 0.9;
+
 		// calculate total weightage
 		// as height decreases, area decreases by the square of the reduction
 		// hence, compensating by squaring the index value
@@ -202,7 +205,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 
 		// calculate height for each data
 		$.each(this.options.data, function (i, d) {
-			d.height = (me.options.height * d.value * Math.pow(i + 1, 2)) / me.options.total_weightage;
+			d.height = (height * d.value * Math.pow(i + 1, 2)) / me.options.total_weightage + min_height;
 		});
 
 		this.elements.canvas = $("<canvas></canvas>")


### PR DESCRIPTION
Rows were getting combined if values were zero.

Before:
![image](https://github.com/user-attachments/assets/e16d38a8-550e-488d-8f28-d3bff3eb3472)

After:
![image](https://github.com/user-attachments/assets/2b89f79c-4005-4a7d-abff-4011b291c025)


Internal Issue No: https://support.frappe.io/app/hd-ticket/19154