### PR TITLE
refactor: date filters should be mandatory in Sales Pipeline Analytics report

### DIFF
--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -8,7 +8,7 @@ from itertools import groupby
 import frappe
 from dateutil.relativedelta import relativedelta
 from frappe import _
-from frappe.utils import cint, flt
+from frappe.utils import cint, flt, getdate
 
 from erpnext.setup.utils import get_exchange_rate
 
@@ -235,10 +235,9 @@ class SalesPipelineAnalytics:
 
 	def get_month_list(self):
 		month_list = []
-		current_date = date.today()
-		month_number = date.today().month
+		current_date = getdate(self.filters.get("from_date"))
 
-		for _month in range(month_number, 13):
+		while current_date < getdate(self.filters.get("to_date")):
 			month_list.append(current_date.strftime("%B"))
 			current_date = current_date + relativedelta(months=1)
 

--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -147,6 +147,10 @@ class SalesPipelineAnalytics:
 			conditions.append(
 				["expected_closing", "between", [self.filters.get("from_date"), self.filters.get("to_date")]]
 			)
+		elif self.filters.get("from_date") and not self.filters.get("to_date"):
+			conditions.append(["expected_closing", ">=", self.filters.get("from_date")])
+		elif not self.filters.get("from_date") and self.filters.get("to_date"):
+			conditions.append(["expected_closing", "<=", self.filters.get("to_date")])
 
 		return conditions
 

--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -193,7 +193,7 @@ class SalesPipelineAnalytics:
 			count_or_amount = info.get(based_on)
 
 			if self.filters.get("pipeline_by") == "Owner":
-				if value == "Not Assigned" or value == "[]" or value is None:
+				if value == "Not Assigned" or value == "[]" or value is None or not value:
 					assigned_to = ["Not Assigned"]
 				else:
 					assigned_to = json.loads(value)

--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -21,7 +21,15 @@ class SalesPipelineAnalytics:
 	def __init__(self, filters=None):
 		self.filters = frappe._dict(filters or {})
 
+	def validate_filters(self):
+		if not self.filters.from_date:
+			frappe.throw(_("From Date is mandatory"))
+
+		if not self.filters.to_date:
+			frappe.throw(_("To Date is mandatory"))
+
 	def run(self):
+		self.validate_filters()
 		self.get_columns()
 		self.get_data()
 		self.get_chart_data()
@@ -147,10 +155,6 @@ class SalesPipelineAnalytics:
 			conditions.append(
 				["expected_closing", "between", [self.filters.get("from_date"), self.filters.get("to_date")]]
 			)
-		elif self.filters.get("from_date") and not self.filters.get("to_date"):
-			conditions.append(["expected_closing", ">=", self.filters.get("from_date")])
-		elif not self.filters.get("from_date") and self.filters.get("to_date"):
-			conditions.append(["expected_closing", "<=", self.filters.get("to_date")])
 
 		return conditions
 

--- a/erpnext/crm/report/sales_pipeline_analytics/test_sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/test_sales_pipeline_analytics.py
@@ -1,19 +1,21 @@
 import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from erpnext.crm.report.sales_pipeline_analytics.sales_pipeline_analytics import execute
 
 
-class TestSalesPipelineAnalytics(unittest.TestCase):
-	@classmethod
-	def setUpClass(self):
+class TestSalesPipelineAnalytics(FrappeTestCase):
+	def setUp(self):
 		frappe.db.delete("Opportunity")
 		create_company()
 		create_customer()
 		create_opportunity()
 
 	def test_sales_pipeline_analytics(self):
+		self.from_date = "2021-01-01"
+		self.to_date = "2021-12-31"
 		self.check_for_monthly_and_number()
 		self.check_for_monthly_and_amount()
 		self.check_for_quarterly_and_number()
@@ -28,6 +30,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -43,6 +47,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -59,6 +65,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -74,6 +82,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -90,6 +100,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -105,6 +117,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -121,6 +135,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -136,6 +152,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -153,8 +171,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"opportunity_type": "Sales",
 			"company": "Best Test",
 			"opportunity_source": "Cold Calling",
-			"from_date": "2021-08-01",
-			"to_date": "2021-08-31",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)


### PR DESCRIPTION
`From Date` and `To Date` filters should take effect regardless of one another.

Report will only output columns for the months in-between `From Date` and `To Date`.

Ref: https://support.frappe.io/helpdesk/tickets/19523