### PR TITLE
chore: backport german translations from develop

### DIFF
--- a/erpnext/translations/de.csv
+++ b/erpnext/translations/de.csv
@@ -8852,3 +8852,2964 @@ Lost Quotations,Verlorene Angebote,
 Lost Quotations %,Verlorene Angebote %,
 Lost Value,Verlorener Wert,
 Lost Value %,Verlorener Wert %,
+ Address, Adresse,
+ Amount, Betrag,
+ Is Child Table, Ist Untertabelle,
+ Rate, Preis,
+ Summary, Zusammenfassung,
+"# Account Settings
+
+In ERPNext, Accounting features are configurable as per your business needs. Accounts Settings is the place to define some of your accounting preferences like:
+
+ - Credit Limit and over billing settings
+ - Taxation preferences
+ - Deferred accounting preferences
+","# Buchhaltungseinstellungen
+
+In ERPNext können Sie die Buchhaltungsfunktionen entsprechend Ihren geschäftlichen Anforderungen konfigurieren. In den Buchhaltungseinstellungen können Sie unter anderem Folgendes konfigurieren:
+
+ - Einstellungen für Kreditlimit und Überfakturierung
+ - Einstellungen für die Besteuerung
+ - Einstellungen für die Rechnungsabgrenzung
+",
+"# Account Settings
+
+This is a crucial piece of configuration. There are various account settings in ERPNext to restrict and configure actions in the Accounting module.
+
+The following settings are avaialble for you to configure
+
+1. Account Freezing 
+2. Credit and Overbilling
+3. Invoicing and Tax Automations
+4. Balance Sheet configurations
+
+There's much more, you can check it all out in this step","# Kontoeinstellungen
+
+Dies ist eine entscheidende Konfiguration. Es gibt verschiedene Kontoeinstellungen in ERPNex, um Aktionen im Accounting Modul einzuschränken und zu konfigurieren.
+
+Die folgenden Einstellungen sind verfügbar für Sie
+
+1. Konto einfrieren 
+2. Kredit- und Überabrechnung
+3. Rechnungs- und Steuerautomationen
+4. Bilanzkonfigurationen
+
+Es gibt noch viel mehr, du kannst es alles in diesem Schritt überprüfen",
+"# Add an Existing Asset
+
+If you are just starting with ERPNext, you will need to enter Assets you already possess. You can add them as existing fixed assets in ERPNext. Please note that you will have to make a Journal Entry separately updating the opening balance in the fixed asset account.","# Vorhandene Vermögensgegenstände hinzufügen
+
+Wenn Sie gerade erst mit ERPNext beginnen, müssen Sie die Vermögensgegenstände, die Sie bereits besitzen, eingeben. Sie können sie als bestehende Vermögensgegenstände in ERPNext hinzufügen. Bitte beachten Sie, dass Sie einen separaten Buchungssatz vornehmen müssen, um den Eröffnungssaldo des Anlagenkontos zu aktualisieren.",
+"# All about sales invoice
+
+A Sales Invoice is a bill that you send to your Customers against which the Customer makes the payment. Sales Invoice is an accounting transaction. On submission of Sales Invoice, the system updates the receivable and books income against a Customer Account.","# Alles über Verkaufsrechnung
+
+Eine Verkaufsrechnung ist eine Rechnung, die Sie an Ihre Kunden senden, für die der Kunde die Zahlung vornimmt. Verkaufsrechnung ist eine buchhalterische Transaktion. Mit der Einreichung der Verkaufsrechnung aktualisiert das System die Forderungen und Bucheinnahmen gegenüber einem Kundenkonto.",
+"# All about sales invoice
+
+A Sales Invoice is a bill that you send to your Customers against which the Customer makes the payment. Sales Invoice is an accounting transaction. On submission of Sales Invoice, the system updates the receivable and books income against a Customer Account.
+
+Here's the flow of how a sales invoice is generally created
+
+
+![Sales Flow](https://docs.erpnext.com/docs/assets/img/accounts/so-flow.png)","# Alles über Verkaufsrechnung
+
+Eine Verkaufsrechnung ist eine Rechnung, die Sie an Ihre Kunden senden, für die der Kunde die Zahlung vornimmt. Verkaufsrechnung ist eine buchhalterische Transaktion. Mit der Einreichung von Verkaufsrechnungen aktualisiert das System die Forderungs- und Bucherträge gegenüber einem Kundenkonto.
+
+Hier ist der Fluss wie eine Verkaufsrechnung generiert wird
+
+
+![Verkaufsfluss](https://docs.erpnext.com/docs/assets/img/accounts/so-flow.png)",
+"# Asset Item
+
+Asset items are created based on Asset Category. You can create one or multiple items against once Asset Category. The sales and purchase transaction for Asset is done via Asset Item. ","# Vermögensgegenstand-Artikel
+
+Vermögensgegenstände werden auf der Grundlage der Vermögensgegenstand-Kategorie erstellt. Sie können einen oder mehrere Artikel für eine Vermögensgegenstand-Kategorie erstellen. Die Verkaufs- und Kauftransaktionen für Vermögensgegenstände werden über Vermögensgegenstand-Artikel abgewickelt. ",
+"# Buying Settings
+
+
+Buying module’s features are highly configurable as per your business needs. Buying Settings is the place where you can set your preferences for:
+
+- Supplier naming and default values
+- Billing and shipping preference in buying transactions
+
+
+","# Einkaufseinstellungen
+
+
+Die Funktionen des Einkaufsmoduls sind nach Ihren Geschäftsanforderungen hochgradig konfigurierbar. Einkaufseinstellungen sind der Ort, an dem Sie Ihre Einstellungen festlegen können für:
+
+- Lieferantennamen und Standardwerte
+- Rechnungs- und Versandpräferenz für Einkaufstransaktionen
+
+
+",
+"# CRM Settings
+
+CRM module’s features are configurable as per your business needs. CRM Settings is the place where you can set your preferences for:
+- Campaign
+- Lead
+- Opportunity
+- Quotation","# CRM-Einstellungen
+
+Die Funktionen des CRM-Moduls sind je nach Ihren geschäftlichen Anforderungen konfigurierbar. In den CRM-Einstellungen können Sie Ihre Präferenzen festlegen für:
+- Kampagne
+- Lead
+- Verkaufschance
+- Angebot",
+"# Chart Of Accounts
+
+ERPNext sets up a simple chart of accounts for each Company you create, but you can modify it according to business and legal requirements.","# Kontenplan
+
+ERPNext erstellt ein einfaches Kontendiagramm für jede von Ihnen erstellte Firma, aber Sie können es entsprechend den geschäftlichen und rechtlichen Anforderungen ändern.",
+"# Check Stock Reports
+Based on the various stock transactions, you can get a host of one-click Stock Reports in ERPNext like Stock Ledger, Stock Balance, Projected Quantity, and Ageing analysis.","# Bestandsberichte prüfen
+Basierend auf den verschiedenen Bestandstransaktionen können Sie in ERPNext mit einem Klick eine Vielzahl von Bestandsberichten abrufen, z. B. Bestandsbuch, Bestandsbilanz, prognostizierte Menge und Alterungsanalyse.",
+"# Cost Centers for Budgeting and Analysis
+
+While your Books of Accounts are framed to fulfill statutory requirements, you can set up Cost Center and Accounting Dimensions to address your companies reporting and budgeting requirements.
+
+Click here to learn more about how  <b>[Cost Center](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/cost-center)</b> and <b> [Dimensions](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/accounting-dimensions)</b> allow you to get advanced financial analytics reports from ERPNext.","# Kostenstellen für Budgetierung und Analyse
+
+Während Ihre Geschäftsbücher so gestaltet sind, dass sie die gesetzlichen Anforderungen erfüllen, können Sie Kostenstellen und Buchhaltungsdimensionen einrichten, um die Berichts- und Budgetierungsanforderungen Ihres Unternehmens zu erfüllen.
+
+Klicken Sie hier, um mehr darüber zu erfahren, wie Sie mit  <b>[Kostenstellen](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/cost-center)</b> und <b> [Dimensionen](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/accounting-dimensions)</b> fortschrittliche Finanzanalyseberichte von ERPNext erhalten können.",
+"# Create Items for Bill of Materials
+
+One of the prerequisites of a BOM is the creation of raw materials, sub-assembly, and finished items. Once these items are created, you will be able to proceed to the Bill of Materials master, which is composed of items and routing.
+","# Erstellen von Artikeln für Stücklisten
+
+Eine der Voraussetzungen für eine Stückliste ist das Anlegen von Rohstoffen, Untermontagen und fertigen Gegenständen. Sobald diese Artikel erstellt wurden, können Sie zur Stückliste weitergehen, die sich aus Artikeln und Routings zusammensetzt.
+",
+"# Create Operations
+
+An Operation refers to any manufacturing operation performed on the raw materials to process it further in the manufacturing path. As an example, if you are into garments manufacturing, you will create Operations like fabric cutting, stitching, and washing as some of the operations.","# Erstellen von Operationen
+
+Eine Operation bezieht sich auf jede Fertigungsvorgänge, die an den Rohstoffen durchgeführt werden, um sie weiter im Fertigungsweg zu verarbeiten. Wenn Sie zum Beispiel in der Herstellung von Kleidungsstücken sind, werden Sie Operationen wie Stoffschneiden, Nähen und Waschen wie einige der Operationen erstellen.",
+"# Create Workstations
+
+A Workstation stores information regarding the place where the workstation operations are performed. As an example, if you have ten sewing machines doing stitching jobs, each machine will be added as a workstation.","# Erstellen von Arbeitsplätzen
+
+Ein Arbeitsplatz speichert Informationen über den Ort, an dem die Arbeitsplatz-Vorgänge ausgeführt werden. Wenn Sie zum Beispiel zehn Nähmaschinen haben, die Nähaufträge erledigen, wird jede Maschine als Arbeitsplatz hinzugefügt.",
+"# Create a Bill of Materials
+
+A Bill of Materials (BOM) is a list of items and sub-assemblies with quantities required to manufacture an Item.
+
+BOM also provides cost estimation for the production of the item. It takes raw-materials cost based on valuation and operations to cost based on routing, which gives total costing for a BOM.","# Erstellen einer Stückliste
+
+Eine Stückliste ist eine Liste von Artikeln und Unterbaugruppen mit Mengen, die für die Herstellung eines Artikels erforderlich sind.
+
+Stücklisten bieten auch Kostenschätzungen für die Produktion des Artikels. Die Kosten für Rohstoffe basieren auf deren Werten und Vorgangskosten basierend auf dessen Routings. Zusammen ergeben sich die Gesamtkosten für einen Stückliste.",
+"# Create a Customer
+
+The Customer master is at the heart of your sales transactions. Customers are linked in Quotations, Sales Orders, Invoices, and Payments. Customers can be either numbered or identified by name (you would typically do this based on the number of customers you have).
+
+Through Customer’s master, you can effectively track essentials like:
+ - Customer’s multiple address and contacts
+ - Account Receivables
+ - Credit Limit and Credit Period
+","# Erstellen Sie einen Kunden
+
+Der Kundenstamm ist das Herzstück Ihrer Verkaufstransaktionen. Kunden werden in Angeboten, Kundenaufträgen, Rechnungen und Zahlungen verknüpft. Kunden können entweder nummeriert oder namentlich identifiziert werden (je nachdem, wie viele Kunden Sie haben).
+
+Über den Kundenstamm können Sie wichtige Informationen wie:
+ - Mehrere Adressen und Kontakte des Kunden
+ - Forderungen
+ - Kreditlimit und Kreditzeitraum
+",
+"# Create a Letter Head
+
+A Letter Head contains your organization's name, logo, address, etc which appears at the header and footer portion in documents. You can learn more about Setting up Letter Head in ERPNext here.
+","# Erstellen Sie einen Briefkopf
+
+Ein Briefkopf enthält den Namen, das Logo, die Adresse usw. Ihrer Organisation, die in der Kopf- und Fußzeile von Dokumenten angezeigt werden. Weitere Informationen zum Einrichten des Briefkopfes in ERPNext finden Sie hier.
+",
+"# Create a Quotation
+
+Let’s get started with business transactions by creating your first Quotation. You can create a Quotation for an existing customer or a prospect. It will be an approved document, with items you sell and the proposed price + taxes applied. After completing the instructions, you will get a Quotation in a ready to share print format.","# Angebot erstellen
+
+Lassen Sie uns mit geschäftlichen Transaktionen beginnen, indem Sie Ihr erstes Angebot erstellen. Sie können ein Angebot für einen bestehenden Kunden oder einen potenziellen Kunden erstellen. Es handelt sich dabei um ein genehmigtes Dokument mit den Artikeln, die Sie verkaufen, und dem vorgeschlagenen Preis + Steuern. Nachdem Sie die Anweisungen befolgt haben, erhalten Sie ein Angebot in einem druckfertigen Format, das Sie mit anderen teilen können.",
+"# Create a Supplier
+
+Also known as Vendor, is a master at the center of your purchase transactions. Suppliers are linked in Request for Quotation, Purchase Orders, Receipts, and Payments. Suppliers can be either numbered or identified by name.
+
+Through Supplier’s master, you can effectively track essentials like:
+ - Supplier’s multiple address and contacts
+ - Account Receivables
+ - Credit Limit and Credit Period
+","# Erstellen Sie einen Lieferanten
+
+Die Lieferantenstammdaten stehen im Zentrum Ihrer Einkaufstransaktionen. Lieferanten werden in Angebotsanfragen, Lieferantenaufträgen, Eingangsbelegen und Auszahlungen verknüpft. Lieferanten können entweder nummeriert oder mit ihrem Namen identifiziert werden.
+
+Über den Stammdatenstamm des Lieferanten können Sie wichtige Informationen wie:
+ - Mehrere Adressen und Kontakte des Lieferanten
+ - Forderungen
+ - Kreditlimit und Kreditzeitraum
+",
+"# Create a Supplier
+In this step we will create a **Supplier**. If you have already created a **Supplier** you can skip this step.","# Erstellen Sie einen Lieferanten
+In diesem Schritt erstellen wir einen **Lieferanten**. Wenn Sie bereits einen **Lieferanten** erstellt haben, können Sie diesen Schritt überspringen.",
+"# Create a Work Order
+
+A Work Order or a Job order is given to the manufacturing shop floor by the Production Manager to initiate the manufacturing of a certain quantity of an item. Work Order carriers details of production Item, its BOM, quantities to be manufactured, and operations.
+
+Through Work Order, you can track various production status like:
+
+- Issue of raw-material to shop material
+- Progress on each Workstation via Job Card
+- Manufactured Quantity against Work Order
+","# Erstellen Sie einen Arbeitsauftrag
+
+Ein Arbeitsauftrag oder ein Job wird von der Produktionsleitung an die Fertigungsabteilung erteilt, um die Herstellung einer bestimmten Menge eines Artikels zu veranlassen. Ein Arbeitsauftrag enthält Details über den Produktionsartikel, seine Stückliste, die zu produzierenden Mengen und die Vorgänge.
+
+Über den Arbeitsauftrag können Sie verschiedene Produktionsstatus verfolgen, wie z. B.:
+
+- Ausgabe des Rohmaterials an das Fertigungsmaterial
+- Fortschritt an jedem Arbeitsplatz über die Jobkarte
+- Gefertigte Menge im Arbeitsauftrag
+",
+"# Create an Item
+
+Item is a product or a service offered by your company, or something you buy as a part of your supplies or raw materials.
+
+Items are integral to everything you do in ERPNext - from billing, purchasing to managing inventory. Everything you buy or sell, whether it is a physical product or a service is an Item. Items can be stock, non-stock, variants, serialized, batched, assets, etc.
+","# Artikel erstellen
+
+Ein Artikel ist ein Produkt oder eine Dienstleistung, die von Ihrem Unternehmen angeboten wird, oder etwas, das Sie als Teil Ihrer Vorräte oder Rohmaterialien kaufen.
+
+Artikel sind ein integraler Bestandteil aller Vorgänge in ERPNext - von der Rechnungsstellung über den Einkauf bis hin zur Bestandsverwaltung. Alles, was Sie kaufen oder verkaufen, egal ob es sich um ein physisches Produkt oder eine Dienstleistung handelt, ist ein Artikel. Artikel können mit Lagerhaltung, ohne Lagerhaltung, in Varianten, in Seriennummern, in Chargen, als Anlagegüter usw. sein.
+",
+"# Create an Item
+The Stock module deals with the movement of items.
+
+In this step we will create an  [**Item**](https://docs.erpnext.com/docs/user/manual/en/stock/item).","# Erstellen Sie einen Artikel
+Das Modul Lagerverwaltung befasst sich mit der Bewegung von Artikeln.
+
+In diesem Schritt werden wir einen [**Artikel**] (https://docs.erpnext.com/docs/user/manual/en/stock/item) erstellen.",
+"# Create first Purchase Order
+
+Purchase Order is at the heart of your buying transactions. In ERPNext, Purchase Order can can be created against a Purchase Material Request (indent) and Supplier Quotation as well.  Purchase Orders is also linked to Purchase Receipt and Purchase Invoices, allowing you to keep a birds-eye view on your purchase deals.
+
+","# Ersten Lieferantenauftrag erstellen
+
+Der Lieferantenauftrag ist das Herzstück Ihrer Einkaufstransaktionen. In ERPNext kann ein Lieferantenauftrag auch aus einer Materialanforderung und einem Lieferantenangebot erstellt werden.  Lieferantenaufträge sind auch mit Eingangsbelegen und Eingangsrechnungen verknüpft, so dass Sie Ihre Einkaufsgeschäfte aus der Vogelperspektive verfolgen können.
+
+",
+"# Create your first Purchase Invoice
+
+A Purchase Invoice is a bill received from a Supplier for a product(s) or service(s) delivery to your company. You can track payables through Purchase Invoice and process Payment Entries against it.
+
+Purchase Invoices can also be created against a Purchase Order or Purchase Receipt.","# Erstellen Sie Ihre erste Eingangsrechnung
+
+Eine Eingangsrechnung ist eine Rechnung, die Sie von einem Lieferanten für eine Produkt- oder Dienstleistungslieferung an Ihr Unternehmen erhalten. Sie können die Verbindlichkeiten über die Eingangsrechnung verfolgen und Auszahlungen mit ihr verarbeiten.
+
+Eingangsrechnungen können auch mit einem Lieferantenauftrag oder Eingangsbeleg erstellt werden.",
+"# Financial Statements
+
+In ERPNext, you can get crucial financial reports like [Balance Sheet] and [Profit and Loss] statements with a click of a button. You can run in the report for a different period and plot analytics charts premised on statement data. For more reports, check sections like Financial Statements, General Ledger, and Profitability reports.
+
+<b>[Check Accounting reports](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/accounting-reports)</b>","# Finanzberichte
+
+In ERPNext können Sie mit einem Klick wichtige Finanzberichte wie [Bilanz] und [Gewinn- und Verlustrechnungen] abrufen. Sie können den Bericht für einen beliebigen Zeitraum ausführen und Diagramme basierend auf den Daten erstellen. Weitere Berichte finden Sie in den Abschnitten „Finanzberichte“, „Hauptbuch“ und „Rentabilitätsberichte“.
+
+<b>[Buchhaltungsberichte prüfen](https://docs.erpnext.com/docs/v13/user/manual/en/accounts/accounting-reports)</b>",
+"# Fixed Asset Accounts
+
+With the company, a host of fixed asset accounts are pre-configured. To ensure your asset transactions are leading to correct accounting entries, you can review and set up following asset accounts as per your business  requirements.
+ - Fixed asset accounts (Asset account)
+ - Accumulated depreciation
+ - Capital Work in progress (CWIP) account
+ - Asset Depreciation account (Expense account)","# Vermögenskonten
+
+Mit dem Unternehmen ist eine Vielzahl von Vermögenskonten vorkonfiguriert. Um sicherzustellen, dass Ihre Vermögenstransaktionen zu korrekten Buchungen führen, können Sie die folgenden Vermögenskonten entsprechend Ihren geschäftlichen Anforderungen überprüfen und einrichten.
+ - Anlagekonten (Aktivkonto)
+ - Kumulierte Abschreibung
+ - Konto für Anlagen im Bau (CWIP)
+ - Konto für die Abschreibung von Anlagen (Aufwandskonto)",
+"# How Production Planning Works
+
+Production Plan helps in production and material planning for the Items planned for manufacturing. These production items can be committed via Sales Order (to Customers) or Material Requests (internally).
+","# So funktioniert die Produktionsplanung
+
+Der Produktionsplan hilft bei der Produktions- und Materialplanung für die Artikel, die für die Herstellung geplant sind. Diese Produktionsartikel können über Kundenaufträge (an Kunden) oder Materialanforderungen (intern) bereitgestellt werden.
+",
+"# Import Data from Spreadsheet
+
+In ERPNext, you can easily migrate your historical data using spreadsheets. You can use it for migrating not just masters (like Customer, Supplier, Items), but also for transactions like (outstanding invoices, opening stock and accounting entries, etc).","# Daten aus Tabellen importieren
+
+In ERPNext können Sie Ihre historischen Daten ganz einfach mithilfe von Tabellen migrieren. Sie können damit nicht nur Stammdaten (wie Kunden, Lieferanten, Artikel) migrieren, sondern auch Transaktionen (ausstehende Rechnungen, Anfangsbestand und Buchungen, etc.).",
+# In Stock,# Auf Lager,
+"# Introduction to Stock Entry
+This video will give a quick introduction to [**Stock Entry**](https://docs.erpnext.com/docs/user/manual/en/stock/stock-entry).","# Einführung in die Lagerbewegung
+Dieses Video gibt eine kurze Einführung in die [**Lagerbewegung**] (https://docs.erpnext.com/docs/user/manual/en/stock/stock-entry).",
+"# Manage Stock Movements
+Stock entry allows you to register the movement of stock for various purposes like transfer, received, issues, repacked, etc. To address issues related to theft and pilferages,  you can always ensure that the movement of goods happens against a document reference Stock Entry in ERPNext.
+
+Let’s get a quick walk-through on the various scenarios covered in Stock Entry by watching [*this video*](https://www.youtube.com/watch?v=Njt107hlY3I).","# Bestandsbewegungen verwalten
+Mit der Lagerbewegung können Sie die Bestandsbewegungen für verschiedene Zwecke wie Transfer, Empfang, Ausgabe, Umpacken usw. registrieren. Um Probleme im Zusammenhang mit Diebstahl und Unterschlagung zu lösen, können Sie immer sicherstellen, dass die Warenbewegung gegen eine Dokumentenreferenz in ERPNext, der sogenannten Lagerbewegung, erfolgt.
+
+Schauen wir uns [*dieses Video*](https://www.youtube.com/watch?v=Njt107hlY3I) an, um einen kurzen Überblick über die verschiedenen Szenarien zu erhalten, die in Lagerbewegung
+ behandelt werden.",
+"# Navigation in ERPNext
+
+Ease of navigating and browsing around the ERPNext is one of our core strengths. In the following video, you will learn how to reach a specific feature in ERPNext via module page or AwesomeBar.","# Navigation in ERPNext
+
+Einfaches Navigieren und Browsen in ERPNext ist eine unserer Hauptstärken. Im folgenden Video erfahren Sie, wie Sie eine bestimmte Funktion in ERPNext über die Modulseite oder die AwesomeBar erreichen.",
+"# Purchase an Asset
+
+Assets purchases process if done following the standard Purchase cycle. If capital work in progress is enabled in Asset Category, Asset will be created as soon as Purchase Receipt is created for it. You can quickly create a Purchase Receipt for Asset and see its impact on books of accounts.","# Kauf eines Vermögensgegenstandes
+
+Der Kauf eines Vermögensgegenstandes wird nach dem Standard-Kaufzyklus abgewickelt. Falls Anlagen im Bau in der Vermögensgegenstand-Kategorie aktiviert sind, wird ein Vermögensgegenstand angelegt, sobald ein Eingangsbeleg für ihn erstellt wird. Sie können schnell einen Eingangsbeleg für einen Vermögensgegenstand erstellen und dessen Auswirkungen auf die Buchhaltung sehen.",
+# Req'd Items,# Ben. Artikel,
+"# Review Manufacturing Settings
+
+In ERPNext, the Manufacturing module’s features are configurable as per your business needs. Manufacturing Settings is the place where you can set your preferences for:
+
+- Capacity planning for allocating jobs to workstations
+- Raw-material consumption based on BOM or actual
+- Default values and over-production allowance
+","# Fertigungseinstellungen
+
+Im ERPNext sind die Funktionen des Fertigungsmoduls nach Ihren Geschäftsanforderungen konfigurierbar. Fertigungseinstellungen sind der Ort, an dem Sie Ihre Einstellungen festlegen können für:
+
+- Kapazitätsplanung für die Zuweisung von Jobs an Arbeitsplätze
+- Rohstoffverbrauch basierend auf Stücklisten oder effektiven Bedarf
+- Standardwerte und Erlaubnis zur Überproduktion
+",
+"# Review Stock Settings
+
+In ERPNext, the Stock module’s features are configurable as per your business needs. Stock Settings is the place where you can set your preferences for:
+- Default values for Item and Pricing
+- Default valuation method for inventory valuation
+- Set preference for serialization and batching of item
+- Set tolerance for over-receipt and delivery of items","# Lagereinstellungen überprüfen
+
+In ERPNext können die Funktionen des Lagermoduls entsprechend Ihren Geschäftsanforderungen konfiguriert werden. In den Lagereinstellungen können Sie Ihre Präferenzen festlegen für:
+– Standardwerte für Artikel und Preise
+– Standardbewertungsmethode für die Bestandsbewertung
+– Präferenzen für die Serialisierung und Stapelverarbeitung
+– Toleranz für den übermäßigen Eingang und die übermäßige Lieferung von Artikeln",
+"# Sales Order
+
+A Sales Order is a confirmation of an order from your customer. It is also referred to as Proforma Invoice.
+
+Sales Order at the heart of your sales and purchase transactions. Sales Orders are linked in Delivery Note, Sales Invoices, Material Request, and Maintenance transactions. Through Sales Order, you can track fulfillment of the overall deal towards the customer.","# Kundenauftrag
+
+Ein Kundenauftrag ist eine Bestätigung einer Bestellung Ihres Kunden. Er wird auch als Proforma-Rechnung bezeichnet.
+
+Der Kundenauftrag ist das Herzstück Ihrer Verkaufs- und Einkaufstransaktionen. Kundenaufträge sind mit Lieferscheinen, Ausgangsrechnungen, Materialanforderungen und Wartungstransaktionen verknüpft. Über den Kundenauftrag können Sie die Erfüllung des gesamten Geschäfts mit dem Kunden verfolgen.",
+"# Selling Settings
+
+CRM and Selling module’s features are configurable as per your business needs. Selling Settings is the place where you can set your preferences for:
+ - Customer naming and default values
+ - Billing and shipping preference in sales transactions
+","# Verkaufseinstellungen
+
+Die Funktionen des CRM- und Verkaufsmoduls lassen sich entsprechend Ihren geschäftlichen Anforderungen konfigurieren. In den Verkaufseinstellungen können Sie Ihre Präferenzen für folgende Bereiche festlegen:
+ - Kundenbenennung und Standardwerte
+ - Rechnungs- und Versandpräferenzen bei Verkaufstransaktionen
+",
+"# Set Up a Company
+
+A company is a legal entity for which you will set up your books of account and create accounting transactions. In ERPNext, you can create multiple companies, and establish relationships (group/subsidiary) among them.
+
+Within the company master, you can capture various default accounts for that Company and set crucial settings related to the accounting methodology followed for a company.
+","# Ein Unternehmen einrichten
+
+Ein Unternehmen ist eine juristische Person, für die Sie Ihre Geschäftsbücher einrichten und Buchhaltungstransaktionen erstellen werden. In ERPNext können Sie mehrere Unternehmen anlegen und Beziehungen (Konzern/Tochtergesellschaft) zwischen ihnen herstellen.
+
+Im Unternehmensstamm können Sie verschiedene Standardkonten für das Unternehmen erfassen und wichtige Einstellungen zur Buchhaltungsmethodik für ein Unternehmen vornehmen.
+",
+"# Setting up Taxes
+
+ERPNext lets you configure your taxes so that they are automatically applied in your buying and selling transactions. You can configure them globally or even on Items. ERPNext taxes are pre-configured for most regions.","# Steuern einrichten
+
+Mit ERPNext können Sie Ihre Steuern so konfigurieren, dass sie bei Ihren Kauf- und Verkaufstransaktionen automatisch angewendet werden. Sie können sie global oder für einzelne Artikel konfigurieren. ERPNext-Steuern sind für die meisten Regionen vorkonfiguriert.",
+"# Setup Routing
+
+A Routing stores all Operations along with the description, hourly rate, operation time, batch size, etc. Click below to learn how the Routing template can be created, for quick selection in the BOM.","# Routing einrichten
+
+Ein Routing speichert alle Vorgänge zusammen mit der Beschreibung, dem Stundensatz, der Operationszeit, der Chargengröße usw. Klicken Sie unten, um zu erfahren, wie die Routing-Vorlage erstellt werden kann, um sie schnell in der Stückliste auszuwählen.",
+"# Setup a Warehouse
+The warehouse can be your location/godown/store where you maintain the item's inventory, and receive/deliver them to various parties.
+
+In ERPNext, you can maintain a Warehouse in the tree structure, so that location and sub-location of an item can be tracked. Also, you can link a Warehouse to a specific Accounting ledger, where the real-time stock value of that warehouse’s item will be reflected.","# Richten Sie ein Lager ein
+Das Lager kann Ihr Standort/Ihre Niederlassung/Ihr Geschäft sein, in dem Sie den Bestand der Artikel verwalten und diese an verschiedene Parteien empfangen/liefern.
+
+In ERPNext können Sie ein Lager in der Baumstruktur verwalten, sodass Standort und Unterstandort eines Artikels verfolgt werden können. Außerdem können Sie ein Lager mit einem bestimmten Buchhaltungskonto verknüpfen, in dem der Echtzeit-Bestandswert des Artikels dieses Lagers angezeigt wird.",
+"# Track Material Request
+
+
+Also known as Purchase Request or an Indent, is a document identifying a requirement of a set of items (products or services) for various purposes like procurement, transfer, issue, or manufacturing. Once the Material Request is validated, a purchase manager can take the next actions for purchasing items like requesting RFQ from a supplier or directly placing an order with an identified Supplier.
+
+","# Materialanforderung verfolgen
+
+Eine Materialanforderung ist ein Dokument, das den Bedarf an einer Reihe von Artikeln (Produkten oder Dienstleistungen) für verschiedene Zwecke wie Beschaffung, Transfer, Ausgabe oder Herstellung angibt. Sobald die Materialanforderung validiert ist, kann ein Einkaufsleiter die nächsten Schritte für den Einkauf von Artikeln einleiten, z. B. eine Anfrage bei einem Lieferanten stellen oder direkt eine Bestellung bei einem bestimmten Lieferanten aufgeben.
+
+",
+"# Update Stock Opening Balance
+It’s an entry to update the stock balance of an item, in a warehouse, on a date and time you are going live on ERPNext.
+
+Once opening stocks are updated, you can create transactions like manufacturing and stock deliveries, where this opening stock will be consumed.","# Eröffnungsbestand aktualisieren
+Es handelt sich um einen Eintrag, mit dem Sie den Bestand eines Artikels in einem Lager an einem Datum und zu einer Uhrzeit aktualisieren, zu der Sie ihn in ERPNext in Betrieb nehmen.
+
+Sobald der Anfangsbestand aktualisiert ist, können Sie Transaktionen wie Fertigung und Lagerlieferungen erstellen, bei denen dieser Anfangsbestand verbraucht wird.",
+"# Updating Opening Balances
+
+Once you close the financial statement in previous accounting software, you can update the same as opening in your ERPNext's Balance Sheet accounts. This will allow you to get complete financial statements from ERPNext in the coming years, and discontinue the parallel accounting system right away.","# Aktualisieren der Eröffnungssalden
+
+Sobald Sie den Jahresabschluss in der vorherigen Buchhaltungssoftware abgeschlossen haben, können Sie die Eröffnungssalden auch in den Bilanzkonten von ERPNext aktualisieren. Auf diese Weise erhalten Sie in den kommenden Jahren vollständige Jahresabschlüsse von ERPNext und können nun das parallele Buchhaltungssystem abschaffen.",
+"# View Warehouse
+In ERPNext the term 'warehouse' can be thought of as a storage location.
+
+Warehouses are arranged in ERPNext in a tree like structure, where multiple sub-warehouses can be grouped under a single warehouse.
+
+In this step we will view the [**Warehouse Tree**](https://docs.erpnext.com/docs/user/manual/en/stock/warehouse#21-tree-view) to view the [**Warehouses**](https://docs.erpnext.com/docs/user/manual/en/stock/warehouse) that are set by default.","# Lager anzeigen
+In ERPNext kann der Begriff 'Lager' als ein Lagerort verstanden werden.
+
+Lager werden in ERPNext in einer baumartigen Struktur angeordnet, wobei mehrere Unterlager unter einem einzigen Lager zusammengefasst werden können.
+
+In diesem Schritt sehen wir uns den [**Lagerbaum**] (https://docs.erpnext.com/docs/user/manual/en/stock/warehouse#21-tree-view) an, um die [**Lager**] (https://docs.erpnext.com/docs/user/manual/en/stock/warehouse) zu sehen, die standardmäßig eingestellt sind.",
+"## Products and Services
+
+Depending on the nature of your business, you might be selling products or services to your clients or even both. 
+ERPNext is optimized for itemized management of your sales and purchase.
+
+The **Item Master**  is where you can add all your sales items. If you are in services, you can create an Item for each service that you offer. If you run a manufacturing business, the same master is used for keeping a record of raw materials, sub-assemblies etc.
+
+Completing the Item Master is very essential for the successful implementation of ERPNext. We have a brief video introducing the item master for you, you can watch it in the next step.","## Produkte und Dienstleistungen
+
+Je nach Art Ihres Unternehmens verkaufen Sie Ihren Kunden Produkte oder Dienstleistungen oder beides. 
+ERPNext ist für die Verwaltung Ihrer Verkäufe und Einkäufe pro Artikel optimiert.
+
+Im Artikelstamm können Sie alle Ihre Verkaufsartikel erfassen. Wenn Sie ein Dienstleistungsunternehmen sind, können Sie für jede Dienstleistung, die Sie anbieten, einen Artikel anlegen. Wenn Sie ein produzierendes Unternehmen sind, wird derselbe Artikelstamm für die Erfassung von Rohstoffen, Halbfertigprodukten usw. verwendet.
+
+Vollständige Artikelstammdaten sind sehr wichtig für die erfolgreiche Implementierung von ERPNext. Wir haben für Sie ein kurzes Video zur Einführung in den Artikelstamm vorbereitet, das Sie sich im nächsten Schritt ansehen können.",
+"## Who is a Customer?
+
+A customer, who is sometimes known as a client, buyer, or purchaser is the one who receives goods, services, products, or ideas, from a seller for a monetary consideration.
+
+Every customer needs to be assigned a unique id. Customer name itself can be the id or you can set a naming series for ids to be generated in Selling Settings.
+
+Just like the supplier, let's quickly create a customer.","## Wer ist ein Kunde?
+
+Ein Kunde, der manchmal auch als Auftraggeber, Käufer oder Abnehmer bezeichnet wird, ist derjenige, der Waren, Dienstleistungen, Produkte oder Ideen von einem Verkäufer gegen eine finanzielle Gegenleistung erhält.
+
+Jedem Kunden muss eine eindeutige ID zugewiesen werden. Der Name des Kunden selbst kann die ID sein oder Sie können in den Verkaufseinstellungen einen Nummernkreis für die zu generierenden IDs festlegen.
+
+Lassen Sie uns, genau wie beim Lieferanten, schnell einen Kunden anlegen.",
+"## Who is a Supplier?
+
+Suppliers are companies or individuals who provide you with products or services. ERPNext has comprehensive features for purchase cycles. 
+
+Let's quickly create a supplier with the minimal details required. You need the name of the supplier, assign the supplier to a group, and select the type of the supplier, viz. Company or Individual.","## Wer ist ein Lieferant?
+
+Lieferanten sind Unternehmen oder Einzelpersonen, die Ihnen Produkte oder Dienstleistungen zur Verfügung stellen. ERPNext verfügt über umfassende Funktionen für Einkaufszyklen. 
+
+Lassen Sie uns schnell einen Lieferanten mit den minimal erforderlichen Details anlegen. Sie benötigen den Namen des Lieferanten, müssen den Lieferanten einer Gruppe zuordnen und den Typ des Lieferanten auswählen, d. h. Unternehmen oder Einzelperson.",
+% Finished Item Quantity,% fertige Artikelmenge,
+% Occupied,% Besetzt,
+% Process Loss,% Prozessverlust,
+% Returned,% Zurückgegeben,
+'Account' in the Accounting section of Customer {0},„Konto“ im Abschnitt „Buchhaltung“ von Kunde {0},
+'Allow Multiple Sales Orders Against a Customer's Purchase Order',Mehrere Aufträge (je Kunde) mit derselben Bestellnummer erlauben,
+'Default {0} Account' in Company {1},'Standardkonto {0} ' in Unternehmen {1},
+'Sales Invoice Item' reference ({1}) is missing in row {0},Die Referenz 'Ausgangsrechnungsposition' ({1}) fehlt in der Zeile {0},
+'Sales Invoice' reference ({1}) is missing in row {0},Die Referenz 'Ausgangsrechnung' ({1}) fehlt in der Zeile {0},
+'Sales Order Item' reference ({1}) is missing in row {0},Die Referenz 'Kundenauftragsposition' ({1}) fehlt in der Zeile {0},
+'Sales Order' reference ({1}) is missing in row {0},Die Referenz 'Kundenauftrag' ({1}) fehlt in der Zeile {0},
+'To Package No.' cannot be less than 'From Package No.',„Bis Paket-Nr.' darf nicht kleiner als „Von Paket Nr.“ sein,
+'{0}' account is already used by {1}. Use another account.,Das Konto '{0}' wird bereits von {1} verwendet. Verwenden Sie ein anderes Konto.,
+'{0}' account: '{1}' should match the Return Against Invoice,'{0}' Konto: '{1}' sollte mit dem der zu berichtigenden Rechnung übereinstimmen,
+'{0}' should be in company currency {1}.,„{0}“ sollte in der Unternehmenswährung {1} sein.,
+(A) Qty After Transaction,(A) Menge nach Transaktion,
+(B) Expected Qty After Transaction,(B) Erwartete Menge nach Transaktion,
+(C) Total Qty in Queue,(C) Gesamtmenge in der Warteschlange,
+(C) Total qty in queue,(C) Gesamtmenge in der Warteschlange,
+(D) Balance Stock Value,(D) Saldo Lagerwert,
+(E) Balance Stock Value in Queue,(E) Saldo Lagerwert in der Warteschlange,
+(F) Change in Stock Value,(F) Änderung des Lagerwerts,
+(G) Sum of Change in Stock Value,(G) Summe der Veränderung des Lagerwerts,
+(H) Change in Stock Value (FIFO Queue),(H) Änderung des Lagerwertes (FIFO-Warteschlange),
+(H) Valuation Rate,(H) Wertersatz,
+(I) Valuation Rate,(I) Wertansatz,
+(J) Valuation Rate as per FIFO,(J) Wertansatz nach FIFO,
+(K) Valuation = Value (D) ÷ Qty (A),(K) Bewertung = Wert (D) ÷ Menge (A),
+", with the inventory {0}: {1}",", mit dem Inventar {0}: {1}",
+0-30 Days,0-30 Tage,
+3 Yearly,Alle 3 Jahre,
+30-60 Days,30-60 Tage,
+60-90 Days,60-90 Tage,
+90 Above,über 90,
+"<br>
+<h4>Note</h4>
+<ul>
+<li>
+You can use <a href=""https://jinja.palletsprojects.com/en/2.11.x/"" target=""_blank"">Jinja tags</a> in <b>Subject</b> and <b>Body</b> fields for dynamic values.
+</li><li>
+    All fields in this doctype are available under the <b>doc</b> object and all fields for the customer to whom the mail will go to is available under the  <b>customer</b> object.
+</li></ul>
+<h4> Examples</h4>
+<!-- {% raw %} -->
+<ul>
+    <li><b>Subject</b>:<br><br><pre><code>Statement Of Accounts for {{ customer.customer_name }}</code></pre><br></li>
+    <li><b>Body</b>: <br><br>
+<pre><code>Hello {{ customer.customer_name }},<br>PFA your Statement Of Accounts from {{ doc.from_date }} to {{ doc.to_date }}.</code> </pre></li>
+</ul>
+<!-- {% endraw %} -->","<br>
+<h4>Hinweis</h4>
+<ul>
+<li>
+Sie können <a href=""https://jinja.palletsprojects.com/en/2.11.x/"" target=""_blank"">Jinja-Tags</a> in den Feldern <b>Betreff</b> und <b>Body</b> für dynamische Werte verwenden.
+</li><li>
+    Alle Felder in diesem DocType sind über das Objekt <b>doc</b> verfügbar und alle Felder für den Kunden, an den die Mail gehen soll, sind über das Objekt  <b>customer</b> verfügbar.
+</li></ul>
+<h4> Beispiele</h4>
+<!-- {% raw %} -->
+<ul>
+    <li><b>Betreff</b>:<br><br><pre><code>Kontoauszug für {{ customer.customer_name }}</code></pre><br></li>
+    <li><b>Body</b>: <br><br>
+<pre><code>Hallo {{ customer.customer_name }},<br>Im Anhang finden Sie Ihren Kontoauszug von {{ doc.from_date }} bis {{ doc.to_date }}.</code> </pre></li>
+</ul>
+<!-- {% endraw %} -->",
+"<div class=""columnHeading"">Other Details</div>","<div class=""columnHeading"">Weitere Details</div>",
+"<div class=""text-muted text-center"">No Matching Bank Transactions Found</div>","<div class=""text-muted text-center"">Keine übereinstimmenden Banktransaktionen gefunden</div>",
+"<div>
+<h3> All dimensions in centimeter only </h3>
+</div>","<div>
+<h3> Alle Abmessungen nur in Zentimeter </h3>
+</div>",
+"<h3>About Product Bundle</h3>
+
+<p>Aggregate group of <b>Items</b> into another <b>Item</b>. This is useful if you are bundling a certain <b>Items</b> into a package and you maintain stock of the packed <b>Items</b> and not the aggregate <b>Item</b>.</p>
+<p>The package <b>Item</b> will have <code>Is Stock Item</code> as <b>No</b> and <code>Is Sales Item</code> as <b>Yes</b>.</p>
+<h4>Example:</h4>
+<p>If you are selling Laptops and Backpacks separately and have a special price if the customer buys both, then the Laptop + Backpack will be a new Product Bundle Item.</p>","<h3>Über Produktbündel</h3>
+
+<p>Bündeln Sie eine Gruppe von <b>Artikeln</b> zu einem anderen <b>Artikel</b>. Dies ist nützlich, wenn Sie bestimmte <b>Artikel</b> zu einem Paket bündeln und Sie den Bestand der einzelnen <b>Artikel</b> und nicht den des Bündels führen.</p>
+<p>Der Bündel-<b>Artikel</b> wird <code>Ist Lagerartikel</code> auf <b>Nein</b> und <code>Ist Verkaufsartikel</code> auf <b>Ja</b> gesetzt haben.</p>
+<h4>Beispiel:</h4>
+<p>Wenn Sie Laptops und Rucksäcke separat verkaufen und einen Sonderpreis anbieten, wenn der Kunde beides zusammen kauft, dann ist der Laptop + Rucksack ein Produktbündel.</p>",
+"<h3>Currency Exchange Settings Help</h3>
+<p>There are 3 variables that could be used within the endpoint, result key and in values of the parameter.</p>
+<p>Exchange rate between {from_currency} and {to_currency} on {transaction_date} is fetched by the API.</p>
+<p>Example: If your endpoint is exchange.com/2021-08-01, then, you will have to input exchange.com/{transaction_date}</p>","<h3>Wechselkurseinstellungen Hilfe</h3>
+<p>Es gibt 3 Variablen, die innerhalb des Endpunkts, des Ergebnisschlüssels und in den Werten des Parameters verwendet werden können.</p>
+<p>Der Wechselkurs zwischen {from_currency} und {to_currency} am {transaction_date} wird von der API abgefragt.</p>
+<p>Beispiel: Wenn Ihr Endpunkt exchange.com/2021-08-01 lautet, dann müssen Sie exchange.com/{transaction_date} eingeben.</p>",
+"<h4>Body Text and Closing Text Example</h4>
+
+<div>We have noticed that you have not yet paid invoice {{sales_invoice}} for {{frappe.db.get_value(""Currency"", currency, ""symbol"")}} {{outstanding_amount}}. This is a friendly reminder that the invoice was due on {{due_date}}. Please pay the amount due immediately to avoid any further dunning cost.</div>
+
+<h4>How to get fieldnames</h4>
+
+<p>The fieldnames you can use in your template are the fields in the document. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>
+
+<h4>Templating</h4>
+
+<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">read this documentation.</a></p>","<h4>Textkörper und Schlusstext Beispiel</h4>
+
+<div>Wir haben festgestellt, dass Sie die Rechnung {{sales_invoice}} für {{frappe.db.get_value(""Currency"", currency, ""symbol"")}} {{outstanding_amount}} noch nicht bezahlt haben. Dies ist eine freundliche Erinnerung daran, dass die Rechnung am {{due_date}}fällig war. Bitte zahlen Sie den fälligen Betrag sofort, um weitere Mahngebühren zu vermeiden.</div>
+
+<h4>Feldnamen herausfinden</h4>
+
+<p>Die Feldnamen, die Sie in Ihrer Vorlage verwenden können, sind die Felder im Dokument. Sie können die Feldnamen aller Dokumente finden, indem Sie Setup &gt; Formular anpassen öffen und den DocTyp (z.B. Ausgangsrechnung) auswählen</p>
+
+<h4>Vorlagen</h4>
+
+<p>Vorlagen werden mithilfe von Jinja erstellt. Wenn Sie mehr über Jinja erfahren möchten, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">lesen Sie diese Dokumentation.</a></p>",
+"<h4>Contract Template Example</h4>
+
+<pre>Contract for Customer {{ party_name }}
+
+-Valid From : {{ start_date }} 
+-Valid To : {{ end_date }}
+</pre>
+
+<h4>How to get fieldnames</h4>
+
+<p>The field names you can use in your Contract Template are the fields in the Contract for which you are creating the template. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Contract)</p>
+
+<h4>Templating</h4>
+
+<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">read this documentation.</a></p>","<h4>Beispiel für eine Vertragsvorlage</h4>
+
+<pre>Vertrag für einen Kunden {{ party_name }}
+
+-Gültig von : {{ start_date }} 
+-Gültig bis : {{ end_date }}
+</pre>
+
+<h4>So erhalten Sie Feldnamen</h4>
+
+<p>Die Feldnamen, die Sie in Ihrer Vertragsvorlage verwenden können, sind die Felder des Vertrags, für den Sie die Vorlage erstellen. Sie können die Felder aller Dokumente über Setup &gt; Formularansicht anpassen und den Dokumententyp (z.B. Vertrag) auswählen</p>
+
+<h4>Vorlagenerstellung</h4>
+
+<p>Vorlagen werden mit der Jinja-Vorlagensprache erstellt. Wenn Sie mehr über Jinja erfahren möchten, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">lesen Sie diese Dokumentation.</a></p>",
+"<h4>Standard Terms and Conditions Example</h4>
+
+<pre>Delivery Terms for Order number {{ name }}
+
+-Order Date : {{ transaction_date }} 
+-Expected Delivery Date : {{ delivery_date }}
+</pre>
+
+<h4>How to get fieldnames</h4>
+
+<p>The fieldnames you can use in your email template are the fields in the document from which you are sending the email. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>
+
+<h4>Templating</h4>
+
+<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">read this documentation.</a></p>","<h4>Allgemeine Geschäftsbedingungen Beispiel</h4>
+
+<pre>Lieferbedingungen für Bestellnummer {{ name }}
+
+-Bestelldatum : {{ transaction_date }} 
+-erwartetes Lieferdatum : {{ delivery_date }}
+</pre>
+
+<h4>So erhalten Sie Feldnamen</h4>
+
+<p>Die Feldnamen, die Sie in Ihrer E-Mail-Vorlage verwenden können, sind die Felder in dem Dokument, aus dem Sie die E-Mail versenden. Sie können die Felder aller Dokumente über Setup &gt; Formularansicht anpassen und den Dokumententyp (z.B. Ausgangsrechnung) auswählen</p>
+
+<h4>Vorlagen</h4>
+
+<p>Vorlagen werden mit der Jinja-Vorlagensprache erstellt. Wenn Sie mehr über Jinja erfahren möchten, <a class=""strong"" href=""http://jinja.pocoo.org/docs/dev/templates/"">lesen Sie diese Dokumentation.</a></p>",
+"<h5 class=""text-muted uppercase"">Or</h5>","<h5 class=""text-muted uppercase"">Oder</h5>",
+"<label class=""control-label"" style=""margin-bottom: 0px;"">Account Number Settings</label>","<label class=""control-label"" style=""margin-bottom: 0px;"">Kontonummerneinstellungen</label>",
+"<label class=""control-label"" style=""margin-bottom: 0px;"">Amount In Words</label>","<label class=""control-label"" style=""margin-bottom: 0px;"">Betrag in Worten</label>",
+"<label class=""control-label"" style=""margin-bottom: 0px;"">Date Settings</label>","<label class=""control-label"" style=""margin-bottom: 0px;"">Datumseinstellungen</label>",
+"<p>In your <b>Email Template</b>, you can use the following special variables:
+</p>
+<ul>
+        <li>
+            <code>{{ update_password_link }}</code>: A link where your supplier can set a new password to log into your portal.
+        </li>
+        <li>
+            <code>{{ portal_link }}</code>: A link to this RFQ in your supplier portal.
+        </li>
+        <li>
+            <code>{{ supplier_name }}</code>: The company name of your supplier.
+        </li>
+        <li>
+            <code>{{ contact.salutation }} {{ contact.last_name }}</code>: The contact person of your supplier.
+        </li><li>
+            <code>{{ user_fullname }}</code>: Your full name.
+        </li>
+    </ul>
+<p></p>
+<p>Apart from these, you can access all values in this RFQ, like <code>{{ message_for_supplier }}</code> or <code>{{ terms }}</code>.</p>","<p>In Ihrer <b>E-Mail Vorlage</b>, Sie können folgende Sondervariablen verwenden:
+</p>
+<ul>
+        <li>
+            <code>{{ update_password_link }}</code>: Ein Link, mit dem Ihr Lieferant ein neues Passwort festlegen kann, um sich in Ihr Portal einzuloggen.
+        </li>
+        <li>
+            <code>{{ portal_link }}</code>: Ein Link zu diesem RFQ in Ihrem Lieferantenportal.
+        </li>
+        <li>
+            <code>{{ supplier_name }}</code>: Der Firmenname Ihres Anbieters.
+        </li>
+        <li>
+            <code>{{ contact.salutation }} {{ contact.last_name }}</code>: Der Ansprechpartner Ihres Lieferanten.
+        </li><li>
+            <code>{{ user_fullname }}</code>: Ihr vollständiger Name.
+        </li>
+    </ul>
+<p></p>
+<p>Davon abgesehen, Sie können auf alle Werte in diesem RFQ zugreifen, wie <code>{{ message_for_supplier }}</code> oder <code>{{ terms }}</code>.</p>",
+"<pre><h5>Message Example</h5>
+
+&lt;p&gt; Thank You for being a part of {{ doc.company }}! We hope you are enjoying the service.&lt;/p&gt;
+
+&lt;p&gt; Please find enclosed the E Bill statement. The outstanding amount is {{ doc.grand_total }}.&lt;/p&gt;
+
+&lt;p&gt; We don't want you to be spending time running around in order to pay for your Bill.<br>After all, life is beautiful and the time you have in hand should be spent to enjoy it!<br>So here are our little ways to help you get more time for life! &lt;/p&gt;
+
+&lt;a href=""{{ payment_url }}""&gt; click here to pay &lt;/a&gt;
+
+</pre>
+","<pre><h5>Beispiel für eine Nachricht</h5>
+
+&lt;p&gt; Vielen Dank, dass Sie Teil von {{ doc.company }}sind! Wir hoffen, Sie genießen den Service.&lt;/p&gt;
+
+&lt;p&gt; Anbei finden Sie die E-Rechnung. Der ausstehende Betrag beträgt {{ doc.grand_total }}.&lt;/p&gt;
+
+&lt;p&gt; Wir möchten nicht, dass Sie unnötig viel Zeit damit verbringen, Ihre Rechnung zu bezahlen.<br>Schließlich ist das Leben schön und die Zeit, die Sie zur Verfügung haben, sollten Sie nutzen, um es zu genießen!<br>Hier sind also unsere kleinen Möglichkeiten, um Ihnen zu helfen, mehr Zeit für das Leben zu haben! &lt;/p&gt;
+
+&lt;a href=""{{ payment_url }}""&gt; klicken Sie hier, um zu bezahlen &lt;/a&gt;
+
+</pre>
+",
+"<pre><h5>Message Example</h5>
+
+&lt;p&gt;Dear {{ doc.contact_person }},&lt;/p&gt;
+
+&lt;p&gt;Requesting payment for {{ doc.doctype }}, {{ doc.name }} for {{ doc.grand_total }}.&lt;/p&gt;
+
+&lt;a href=""{{ payment_url }}""&gt; click here to pay &lt;/a&gt;
+
+</pre>
+","<pre><h5>Beispiel Nachricht</h5>
+
+&lt;p&gt;Lieber {{ doc.contact_person }},&lt;/p&gt;
+
+&lt;p&gt;wir würden Sie bitten, die {{ doc.doctype }}, {{ doc.name }} für {{ doc.grand_total }}.&lt;/p&gt; zu begleichen.
+
+&lt;a href=""{{ payment_url }}""&gt; Bitte klicken Sie hier zur Bezahlung &lt;/a&gt;
+
+</pre>
+",
+"<table class=""table table-bordered table-condensed"">
+<thead>
+  <tr>
+         <th class=""table-sr"" style=""width: 50%;"">Child Document</th>
+         <th class=""table-sr"" style=""width: 50%;"">Non Child Document</th>
+   </tr>
+</thead>
+<tbody>
+<tr>
+         <td>
+                  <p> To access parent document field use parent.fieldname and to access child table document field use doc.fieldname </p>
+
+         </td>
+         <td>
+                    <p>To access document field use doc.fieldname </p>
+         </td>
+</tr>
+<tr>
+        <td>
+                   <p><b>Example: </b> parent.doctype == ""Stock Entry"" and doc.item_code == ""Test"" </p>
+
+        </td>
+         <td>
+                   <p><b>Example: </b> doc.doctype == ""Stock Entry"" and doc.purpose == ""Manufacture""</p>    
+          </td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+
+
+
+","<table class=""table table-bordered table-condensed"">
+<thead>
+  <tr>
+         <th class=""table-sr"" style=""width: 50%;"">Dokument für die untergeordneten Eintragungen</th>
+         <th class=""table-sr"" style=""width: 50%;"">kein untergeordnetes Dokument</th>
+   </tr>
+</thead>
+<tbody>
+<tr>
+         <td>
+                  <p> Für den Zugriff auf das Feld des übergeordneten Dokuments verwenden Sie parent.fieldname und für den Zugriff auf das Feld des Dokuments der untergeordneten Tabelle verwenden Sie doc.fieldname </p>
+
+         </td>
+         <td>
+                    <p>Für den Zugriff auf ein Dokumentfeld verwenden Sie doc.fieldname </p>
+         </td>
+</tr>
+<tr>
+        <td>
+                   <p><b>Beispiel: </b> parent.doctype == ""Lagereintrag"" und doc.item_code == ""Test"" </p>
+
+        </td>
+         <td>
+                   <p><b>Beispiel: </b> doc.doctype == ""Lagereintrag"" und doc.purpose == ""Herstellung""</p>    
+          </td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+
+
+
+",
+A Holiday List can be added to exclude counting these days for the Workstation.,"Sie können eine Liste der arbeitsfreien Tage hinzufügen, um die Zählung dieser Tage für den Arbeitsplatz auszuschließen.",
+A Packing Slip can only be created for Draft Delivery Note.,Ein Packzettel kann nur für Entwürfe von Lieferscheinen erstellt werden.,
+"A Price List is a collection of Item Prices either Selling, Buying, or both","Eine Preisliste ist eine Sammlung von Artikelpreisen, entweder für den Verkauf, den Einkauf oder für beides",
+A Reconciliation Job {0} is running for the same filters. Cannot reconcile now,Ein Abstimmungsauftrag {0} wird für dieselben Filter ausgeführt. Kann gerade nicht erneut gestartet werden,
+"A Sales Order is a confirmation of an order from your customer. It is also referred to as Proforma Invoice.
+
+Sales Order at the heart of your sales and purchase transactions. Sales Orders are linked in Delivery Note, Sales Invoices, Material Request, and Maintenance transactions. Through Sales Order, you can track fulfillment of the overall deal towards the customer.","Ein Kundenauftrag ist eine Bestätigung einer Bestellung Ihres Kunden. Er wird auch als Proforma-Rechnung bezeichnet.
+
+Der Kundenauftrag ist das Herzstück Ihrer Verkaufs- und Einkaufstransaktionen. Kundenaufträge sind mit Lieferscheinen, Ausgangsrechnungen, Materialanforderungen und Wartungstransaktionen verknüpft. Über den Kundenauftrag können Sie die Erfüllung des gesamten Geschäfts mit dem Kunden verfolgen.",
+A customer must have primary contact email.,Ein Kunde muss über eine primäre Kontakt-E-Mail-Adresse verfügen.,
+A driver must be set to submit.,Ein Fahrer muss zum Buchen angegeben werden.,
+A template with tax category {0} already exists. Only one template is allowed with each tax category,Eine Vorlage mit der Steuerkategorie {0} existiert bereits. Für jede Steuerkategorie ist nur eine Vorlage zulässig,
+AWB Number,Luftfrachtbrief Nr.,
+Abbreviation: {0} must appear only once,Abkürzung: {0} darf nur einmal erscheinen,
+About {0} minute remaining,Noch ungefähr {0} Minuten,
+About {0} minutes remaining,Noch ungefähr {0} Minuten,
+About {0} seconds remaining,Noch ungefähr {0} Sekunden,
+Acceptance Criteria Formula,Akzeptanzkriterien Formel,
+Acceptance Criteria Value,Akzeptanzkriterien Wert,
+Accepted Qty in Stock UOM,Angenommene Menge in Lagereinheit,
+Access Key,Zugriffsschlüssel,
+Access Key is required for Service Provider: {0},Zugangsschlüssel ist erforderlich für Dienstanbieter: {0},
+Account Balance (From),Kontostand (Ausgangskonto),
+Account Balance (To),Kontostand (Eingangskonto),
+Account Closing Balance,Kontoabschlusssaldo,
+Account Currency (From),Kontowährung (Ausgangskonto),
+Account Currency (To),Kontowährung (Eingangskonto),
+Account Opening Balance,Kontoeröffnungssaldo,
+Account not Found,Konto nicht gefunden,
+Account {0} added multiple times,Konto {0} mehrmals hinzugefügt,
+Accounting Dimension Filter,Filter für Buchhaltungsdimension,
+Accounting Dimensions Filter,Filter für Buchhaltungsdimensionen,
+Accounting Entry for {0},Buchungen für {0},
+Accounts Closing,Kontenabschluss,
+Accounts Missing Error,Fehler „Konten fehlen“,
+Accounts Receivable/Payable,Forderungen/Verbindlichkeiten,
+Accounts to Merge,Zu verschmelzende Konten,
+"Accounts, Invoices, Taxation, and more.","Konten, Rechnungen, Steuern und mehr.",
+Action If Quality Inspection Is Rejected,Maßnahmen bei Ablehnung der Qualitätsprüfung,
+Action If Same Rate is Not Maintained,"Maßnahmen, wenn derselbe Preis nicht beibehalten wird",
+Action if Same Rate is Not Maintained Throughout Sales Cycle,"Maßnahmen, wenn derselbe Preis nicht während des gesamten Verkaufszyklus beibehalten wird",
+Active Status,Aktiver Status,
+Actual Balance Qty,Ist-Saldomenge,
+Actual Expense,Ist-Ausgaben,
+Actual Posting,Aktuelle Beiträge,
+Actual Qty in Warehouse,IST Menge im Lager,
+Actual Time,IST Zeit,
+Add Columns in Transaction Currency,Spalten in Transaktionswährung hinzufügen,
+Add Corrective Operation Cost in Finished Good Valuation,Fügen Sie die Kosten für Korrekturmaßnahmen zur Bewertung der Fertigerzeugnisse hinzu,
+Add Discount,Rabatt hinzufügen,
+Add Items in the Purpose Table,Artikel in der Zieltabelle hinzufügen,
+Add Lead to Prospect,Interessenten zu einem Potenziellen Kunden hinzufügen,
+Add Manually,Manuell hinzufügen,
+Add Or Deduct,Hinzufügen oder Abziehen,
+Add Serial / Batch Bundle,Serien-/Chargenbündel hinzufügen,
+Add Serial / Batch No,Serien-/Chargennummer hinzufügen,
+Add Serial / Batch No (Rejected Qty),Serien-/Chargennummer hinzufügen (Abgelehnte Menge),
+Add Stock,Bestand hinzufügen,
+Add Sub Assembly,Unterbaugruppe hinzufügen,
+Add a Note,Notiz hinzufügen,
+Add an Existing Asset,Vorhandene Anlagegüter hinzufügen,
+Add an existing Asset,Vorhandenes Anlagegut hinzufügen,
+Add details,Details hinzufügen,
+Add to Prospect,Zu Potenziellem Kunden hinzufügen,
+Added By,Hinzugefügt von,
+Added On,Hinzugefügt am,
+Added Supplier Role to User {0}.,Lieferantenrolle zu Benutzer {0} hinzugefügt.,
+Added {1} Role to User {0}.,Rolle {1} zu Benutzer {0} hinzugefügt.,
+Adding Lead to Prospect...,Interessent wird zu Potenziellem Kunden hinzugefügt...,
+Additional,Zusätzlich,
+Additional Asset Cost,Zusätzliche Kosten,
+Additional Cost Per Qty,Zusätzliche Kosten je Einheit,
+Address And Contacts,Adressen und Kontakte,
+Adjust Asset Value,Wert des Vermögensgegenstands anpassen,
+Adjustment Against,Anpassung gegen,
+Adjustment based on Purchase Invoice rate,Anpassung basierend auf dem Rechnungspreis,
+Advance Account: {0} must be in Company default currency: {1},Vorschusskonto: {0} muss in der Standardwährung des Unternehmens sein: {1},
+Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2},Vorschusskonto: {0} muss entweder in der Rechnungswährung des Kunden: {1} oder in der Standardwährung des Unternehmens: {2} angegeben werden,
+Advance Payment,Anzahlung,
+Advance Tax,Steuervorauszahlung,
+Advance Taxes and Charges,Weitere Steuern und Abgaben,
+Advance paid against {0} {1} cannot be greater than Grand Total {2},Der auf {0} {1} gezahlte Vorschuss kann nicht höher sein als die Gesamtsumme {2},
+Advance payments allocated against orders will only be fetched,Vorauszahlungen für Bestellungen werden nur abgerufen,
+Affected Transactions,Betroffene Transaktionen,
+Against Customer Order {0} dated {1},Gegen Kundenauftrag {0} vom {1},
+Against Voucher No,Belegnr.,
+Age ({0}),Alter ({0}),
+Ageing Report based on ,Alterungsbericht basierend auf ,
+Agent Busy Message,Meldung „Agent besetzt“,
+Agent Group,Agentengruppe,
+Agent Unavailable Message,Meldung „Agent nicht verfügbar“,
+Aggregate a group of Items into another Item. This is useful if you are maintaining the stock of the packed items and not the bundled item,"Fassen Sie eine Gruppe von Artikeln in einem anderen Artikel zusammen. Dies ist nützlich, wenn Sie den Bestand der verpackten Artikel und nicht den der gebündelten Artikel verwalten",
+Algorithm,Algorithmus,
+All Activities,Alle Aktivitäten,
+All Activities HTML,Alle Aktivitäten HTML,
+All Items,Alle Artikel,
+All Sales Transactions can be tagged against multiple Sales Persons so that you can set and monitor targets.,"Alle Verkaufstransaktionen können mehreren Verkäufern zugeordnet werden, so dass Sie Ziele festlegen und überwachen können.",
+All allocations have been successfully reconciled,Alle Zuweisungen wurden erfolgreich abgeglichen,
+All items have already been received,Alle Artikel sind bereits eingegangen,
+All items in this document already have a linked Quality Inspection.,Für alle Artikel in diesem Dokument ist bereits eine Qualitätsprüfung verknüpft.,
+All the Comments and Emails will be copied from one document to another newly created document(Lead -> Opportunity -> Quotation) throughout the CRM documents.,Alle Kommentare und E-Mails werden von einem Dokument zu einem anderen neu erstellten Dokument kopiert (Lead -> Opportunity -> Quotation) über alle CRM-Dokumente.,
+"All the required items (raw materials) will be fetched from BOM and populated in this table. Here you can also change the Source Warehouse for any item. And during the production, you can track transferred raw materials from this table.",Alle benötigten Artikel (Rohmaterial) werden aus der Stückliste geholt und in diese Tabelle eingetragen. Hier können Sie auch das Quelllager für jeden Artikel ändern. Und während der Produktion können Sie das übertragene Rohmaterial in dieser Tabelle verfolgen.,
+Allocated Entries,Zugeordnete Einträge,
+Allocated To:,Zugewiesen zu:,
+Allocations,Zuweisungen,
+Allow,Zulassen,
+Allow Alternative Item must be checked on Item {},„Alternative Artikel zulassen“ muss für Artikel {} aktiviert sein,
+Allow Continuous Material Consumption,Kontinuierlichen Materialverbrauch zulassen,
+Allow Excess Material Transfer,Transfer von überschüssigem Material zulassen,
+Allow Item to be Added Multiple Times in a Transaction,"Zulassen, dass Artikel in einer Transaktion mehrmals hinzugefügt werden",
+Allow Lead Duplication based on Emails,Mehrere Interessenten mit derselben E-Mail-Adresse erlauben,
+Allow Negative rates for Items,Negative Preise für Artikel zulassen,
+Allow Or Restrict Dimension,Dimension zulassen oder einschränken,
+Allow Partial Reservation,Teilweise Reservierung zulassen,
+Allow Sales Order Creation For Expired Quotation,Erstellung von Aufträgen aus abgelaufenen Angeboten zulassen,
+Allow User to Edit Discount,Benutzern das Bearbeiten von Rabatten erlauben,
+Allow User to Edit Rate,Benutzer dürfen Preise ändern,
+Allow Zero Rate,Null-Bewertung erlauben,
+Allow material consumptions without immediately manufacturing finished goods against a Work Order,Materialverbrauch gegen einen Arbeitsauftrag ohne sofortige Herstellung von Fertigwaren zulassen,
+Allow multi-currency invoices against single party account ,Rechnungswährung darf sich von Kontowährung unterscheiden,
+Allow to Edit Stock UOM Qty for Purchase Documents,Bearbeitung der Menge in Lager-ME für Einkaufsdokumente zulassen,
+Allow to Edit Stock UOM Qty for Sales Documents,Bearbeitung der Menge in Lager-ME für Verkaufsdokumente zulassen,
+Allow transferring raw materials even after the Required Quantity is fulfilled,Rohstoffübertragung auch nach Erfüllung der erforderlichen Menge erlauben,
+Allowed,Erlaubt,
+Allowed Dimension,Erlaubte Dimension,
+Allowed Doctypes,Erlaubte DocTypes,
+Allowed Items,Erlaubte Artikel,
+Allowed primary roles are 'Customer' and 'Supplier'. Please select one of these roles only.,Zulässige Hauptrollen sind „Kunde“ und „Lieferant“. Bitte wählen Sie nur eine dieser Rollen aus.,
+Allows to keep aside a specific quantity of inventory for a particular order.,"Ermöglicht es, eine bestimmte Lagerbestandsmenge für eine bestimmte Bestellung zurückzubehalten.",
+Already Picked,Bereits kommissioniert,
+"Alternatively, you can download the template and fill your data in.",Alternativ können Sie auch die Vorlage herunterladen und Ihre Daten eingeben.,
+Amount (AED),Betrag (AED),
+Amount Eligible for Commission,Provisionsfähiger Betrag,
+Amount in Account Currency,Betrag in Kontowährung,
+An Item Group is a way to classify items based on types.,"Artikelgruppen bieten die Möglichkeit, Artikel nach Typ zu klassifizieren.",
+An error has been appeared while reposting item valuation via {0},Beim Umbuchen der Artikelbewertung über {0} ist ein Fehler aufgetreten,
+An error has occurred during {0}. Check {1} for more details,Während {0} ist ein Fehler aufgetreten. Prüfen Sie {1} für weitere Details,<a href='/app/error-log' class='variant-click'>Error Log</a>
+"Another Cost Center Allocation record {0} applicable from {1}, hence this allocation will be applicable upto {2}","Ein weiterer Datensatz der Kostenstellen-Zuordnung {0} gilt ab {1}, daher gilt diese Zuordnung bis {2}",
+"Any one of following filters required: warehouse, Item Code, Item Group","Einer der folgenden Filter ist erforderlich: Lager, Artikelcode, Artikelgruppe",
+Applicable Dimension,Anwendbare Dimension,
+Applicable On Account,Auf Konto anwendbar,
+Applied on each reading.,Wird bei jedem Ablesen angewendet.,
+Applied putaway rules.,Angewandte Einlagerungsregeln.,
+Apply Recursion Over (As Per Transaction UOM),Rekursion anwenden über (gemäß Transaktions-ME),
+Apply SLA for Resolution Time,SLA für Lösungszeit anwenden,
+Apply TDS,Quellensteuer (TDS) anwenden,
+Apply Tax Withholding Amount ,Quellensteuerbetrag anwenden,
+Apply restriction on dimension values,Einschränkung auf Dimensionswerte anwenden,
+Apply to All Inventory Documents,Auf alle Inventardokumente anwenden,
+Apply to Document,Auf Dokument anwenden,
+Appointment Created Successfully,Termin erfolgreich erstellt,
+Appointment Scheduling Disabled,Terminplanung deaktiviert,
+Appointment Scheduling has been disabled for this site,Terminplanung wurde für diese Instanz deaktiviert,
+Appointment was created. But no lead was found. Please check the email to confirm,Ein Termin wurde vereinbart. Es wurde jedoch kein Interessent gefunden. Bitte prüfen Sie die E-Mail zur Bestätigung,
+Approximately match the description/party name against parties,Partei automatisch anhand grober Übereinstimmung des Namens zuordnen,
+Are you sure you want to clear all demo data?,"Sind Sie sicher, dass Sie alle Demodaten löschen möchten?",
+Are you sure you want to delete this Item?,"Sind Sie sicher, dass Sie diesen Artikel löschen möchten?",
+Are you sure you want to restart this subscription?,"Sind Sie sicher, dass Sie dieses Abonnement erneut starten möchten?",
+As on Date,Zum,
+"As there are existing submitted transactions against item {0}, you can not change the value of {1}.","Da es bereits gebuchte Transaktionen für den Artikel {0} gibt, können Sie den Wert von {1} nicht ändern.",
+"As there are negative stock, you can not enable {0}.","Da es negative Bestände gibt, können Sie {0} nicht aktivieren.",
+"As there are reserved stock, you cannot disable {0}.","Da es reservierte Bestände gibt, können Sie {0} nicht deaktivieren.",
+"As there are sufficient Sub Assembly Items, Work Order is not required for Warehouse {0}.","Da es genügend Artikel für die Unterbaugruppe gibt, ist ein Arbeitsauftrag für das Lager {0} nicht erforderlich.",
+"As {0} is enabled, you can not enable {1}.","Da {0} aktiviert ist, können Sie {1} nicht aktivieren.",
+Assembly Items,Montageartikel,
+Asset Activity,Vermögensgegenstand Aktivität,
+Asset Capitalization,Vermögensgegenstand-Aktivierung,
+Asset Capitalization Asset Item,Zu aktivierender Vermögensgegenstand,
+Asset Capitalization Service Item,Dienstleistung für Anlagenaktivierung,
+Asset Capitalization Stock Item,Lagerartikel für Vermögensgegenstand-Aktivierung,
+Asset Depreciation Details,Details zur Abschreibung von Vermögensgegenständen,
+Asset Depreciation Schedule,Zeitplan für die Abschreibung von Vermögensgegenständen,
+Asset Depreciation Schedule for Asset {0} and Finance Book {1} is not using shift based depreciation,Zeitplan zur Abschreibung von Vermögensgegenstand {0} und Finanzbuch {1} verwendet keine schichtbasierte Abschreibung,
+Asset Depreciation Schedule not found for Asset {0} and Finance Book {1},Vermögensgegenstand Abschreibungsplan nicht gefunden für Vermögensgegenstand {0} und Finanzbuch {1},
+Asset Depreciation Schedule {0} for Asset {1} already exists.,Abschreibungsplan {0} für Sachanlage {1} existiert bereits.,
+Asset Depreciation Schedule {0} for Asset {1} and Finance Book {2} already exists.,Abschreibungsplan {0} für Sachanlage {1} und Finanzbuch {2} existiert bereits.,
+"Asset Depreciation Schedules created:<br>{0}<br><br>Please check, edit if needed, and submit the Asset.","Abschreibungspläne für Vermögensgegenstand erstellt:<br>{0}<br><br>Bitte prüfen Sie, bearbeiten Sie sie bei Bedarf und buchen Sie den Vermögensgegenstand.",
+Asset ID,Vermögensgegenstand ID,
+Asset Quantity,Anzahl,
+Asset Repair Consumed Item,Vermögensgegenstand Reparatur Verbrauchter Artikel,
+Asset Settings,Vermögensgegenstand Einstellungen,
+Asset Shift Allocation,Sachanlagen-Schicht-Zuweisung,
+Asset Shift Factor,Sachanlagen-Schichtfaktor,
+Asset Shift Factor {0} is set as default currently. Please change it first.,Als Standard ist derzeit der Sachanlagen-Schichtfaktor {0} eingestellt. Bitte ändern Sie ihn zuerst.,
+Asset cancelled,Vermögensgegenstand storniert,
+Asset capitalized after Asset Capitalization {0} was submitted,"Vermögensgegenstand aktiviert, nachdem die Vermögensgegenstand-Aktivierung {0} gebucht wurde",
+Asset created,Vermögensgegenstand erstellt,
+Asset created after Asset Capitalization {0} was submitted,"Vermögensgegenstand angelegt, nachdem die Vermögensgegenstand-Aktivierung {0} gebucht wurde",
+Asset created after being split from Asset {0},"Vermögensgegenstand, der nach der Abspaltung von Vermögensgegenstand {0} erstellt wurde",
+Asset deleted,Vermögensgegenstand gelöscht,
+Asset issued to Employee {0},Vermögensgegenstand ausgegeben an Mitarbeiter {0},
+Asset out of order due to Asset Repair {0},Vermögensgegenstand außer Betrieb aufgrund von Reparatur {0},
+Asset received at Location {0} and issued to Employee {1},Vermögensgegenstand erhalten am Standort {0} und ausgegeben an Mitarbeiter {1},
+Asset restored,Vermögensgegenstand wiederhergestellt,
+Asset restored after Asset Capitalization {0} was cancelled,"Vermögensgegenstand wiederhergestellt, nachdem die Vermögensgegenstand-Aktivierung {0} storniert wurde",
+Asset returned,Vermögensgegenstand zurückgegeben,
+Asset scrapped,Vermögensgegenstand verschrottet,
+Asset sold,Vermögensgegenstand verkauft,
+Asset submitted,Vermögensgegenstand gebucht,
+Asset transferred to Location {0},Vermögensgegenstand an Standort {0} übertragen,
+Asset updated after being split into Asset {0},Vermögensgegenstand nach der Abspaltung in Vermögensgegenstand {0} aktualisiert,
+Asset updated after cancellation of Asset Repair {0},Vermögensgegenstand aktualisiert nach Stornierung der Reparatur {0},
+Asset updated after completion of Asset Repair {0},Vermögensgegenstand nach Abschluss der Reparatur {0} aktualisiert,
+Asset {0} cannot be received at a location and given to an employee in a single movement,Vermögensgegenstand {0} kann nicht in derselben Bewegung an einem Ort entgegengenommen und an einen Mitarbeiter übergeben werden,
+Asset {0} does not belong to Item {1},Vermögensgegenstand {0} gehört nicht zum Artikel {1},
+Asset {0} does not exist,Vermögensgegenstand {0} existiert nicht,
+Asset {0} has been created. Please set the depreciation details if any and submit it.,"Vermögensgegenstand {0} wurde erstellt. Bitte geben Sie die Abschreibungsdetails ein, falls vorhanden, und buchen Sie sie.",
+Asset {0} has been updated. Please set the depreciation details if any and submit it.,"Vermögensgegenstand {0} wurde aktualisiert. Bitte geben Sie die Abschreibungsdetails ein, falls vorhanden, und buchen Sie sie.",
+Asset's depreciation schedule updated after Asset Shift Allocation {0},Abschreibungsplan der Sachanlage nach der Sachanlagen-Schicht-Zuweisung {0} aktualisiert,
+Asset's value adjusted after cancellation of Asset Value Adjustment {0},Wert des Vermögensgegenstandes nach Stornierung der Vermögenswertanpassung {0} angepasst,
+Asset's value adjusted after submission of Asset Value Adjustment {0},Der Wert des Vermögensgegenstandes wurde nach der Buchung der Vermögenswertanpassung angepasst {0},
+"Assets, Depreciations, Repairs, and more.","Vermögensgegenstände, Abschreibungen, Reparaturen und mehr.",
+Assign Job to Employee,Aufgabe an Mitarbeiter zuweisen,
+Assignment,Zuordnung,
+Assignment Conditions,Zuweisungsbedingungen,
+At Row #{0}: The picked quantity {1} for the item {2} is greater than available stock {3} for the batch {4} in the warehouse {5}.,In Zeile #{0}: Die kommissionierte Menge {1} für den Artikel {2} ist größer als der verfügbare Bestand {3} für die Charge {4} im Lager {5}.,
+At Row #{0}: The picked quantity {1} for the item {2} is greater than available stock {3} in the warehouse {4}.,In Zeile #{0}: Die kommissionierte Menge {1} für den Artikel {2} ist größer als der verfügbare Bestand {3} im Lager {4}.,
+At row {0}: Batch No is mandatory for Item {1},In Zeile {0}: Chargennummer ist obligatorisch für Artikel {1},
+At row {0}: Parent Row No cannot be set for item {1},In Zeile {0}: Übergeordnete Zeilennummer kann für Element {1} nicht festgelegt werden,
+At row {0}: Qty is mandatory for the batch {1},In der Zeile {0}: Menge ist obligatorisch für die Charge {1},
+At row {0}: Serial No is mandatory for Item {1},In Zeile {0}: Seriennummer ist obligatorisch für Artikel {1},
+At row {0}: Serial and Batch Bundle {1} has already created. Please remove the values from the serial no or batch no fields.,In Zeile {0}: Serien- und Chargenbündel {1} wurde bereits erstellt. Bitte entfernen Sie die Werte aus den Feldern Seriennummer oder Chargennummer.,
+At row {0}: set Parent Row No for item {1},In Zeile {0}: übergeordnete Zeilennummer für Element {1} festlegen,
+Attach CSV File,CSV-Datei anhängen,
+Attribute value: {0} must appear only once,Attributwert: {0} darf nur einmal vorkommen,
+Auto Create Exchange Rate Revaluation,Wechselkursneubewertung automatisch erstellen,
+Auto Create Purchase Receipt,Eingangsbeleg automatisch erstellen,
+Auto Create Serial and Batch Bundle For Outward,Seriennummern und Chargenbündel für den Ausgang automatisch erstellen,
+Auto Create Subcontracting Order,Unterauftrag automatisch erstellen,
+Auto Created Serial and Batch Bundle,Automatisch erstelltes Serien- und Chargenbündel,
+Auto Creation of Contact,Automatische Kontakterstellung,
+Auto Insert Item Price If Missing,"Artikelpreis automatisch einfügen, falls er fehlt",
+Auto Name,Automatische Benennung,
+Auto Reconcile,Automatisch abgleichen,
+Auto Reconcile Payments,Zahlungen automatisch abgleichen,
+Auto Reconciliation,Automatischer Abgleich,
+Auto Reconciliation of Payments has been disabled. Enable it through {0},Der automatische Abgleich von Zahlungen wurde deaktiviert. Aktivieren Sie ihn über {0},
+Auto Reserve Serial and Batch Nos,Serien- und Chargennummern automatisch reservieren,
+Auto Reserve Stock for Sales Order on Purchase,Automatische Bestandsreserve für Kundenauftrag bei Kauf,
+Auto match and set the Party in Bank Transactions,Partei automatisch anhand der Kontonummer bzw. IBAN zuordnen,
+Auto write off precision loss while consolidation,Präzisionsverluste bei der Konsolidierung automatisch abschreiben,
+Automatically Add Filtered Item To Cart,Gefilterten Artikel automatisch zum Warenkorb hinzufügen,
+Automatically Fetch Payment Terms from Order,Zahlungsbedingungen aus Auftrag in die Rechnung übernehmen,
+Automatically post balancing accounting entry,Ausgleichsbuchung automatisch vornehmen,
+Available Batch Report,Verfügbare Chargen,
+Available Qty For Consumption,Verfügbare Menge zum Verbrauch,
+Available Qty at Company,Verfügbare Menge im Unternehmen,
+Available Qty at Target Warehouse,Verfügbare Menge im Ziellager,
+Available Qty to Reserve,Verfügbare Menge zum Reservieren,
+Average Completion,Durchschnittliche Fertigstellung,
+Avg Rate,Durchschnittspreis,
+BFS,Breitensuche,
+BOM Created,Stückliste erstellt,
+BOM Creator,Stücklistenersteller,
+BOM Creator Item,Stücklistenerstellerelement,
+BOM Info,Stücklisten-Infos,
+BOM Level,Stücklistenebene,
+BOM Tree,Stücklistenbaum,
+BOM UoM,Stücklisten-ME,
+BOM Update Batch,Stücklisten-Aktualisierungsstapel,
+BOM Update Initiated,Stücklistenaktualisierung eingeleitet,
+BOM Update Log,Stücklistenaktualisierungsprotokoll,
+BOM Update Tool Log with job status maintained,Stücklisten Update Tool Protokoll mit gepflegtem Auftragsstatus,
+BOM Updation already in progress. Please wait until {0} is complete.,"Stücklistenaktualisierung bereits im Gange. Bitte warten Sie, bis {0} abgeschlossen ist.",
+BOM Updation is queued and may take a few minutes. Check {0} for progress.,Die Stücklistenaktualisierung befindet sich in der Warteschlange und kann einige Minuten dauern. Überprüfen Sie {0} auf Fortschritt.,
+BOM recursion: {1} cannot be parent or child of {0},Stücklistenrekursion: {1} kann nicht über- oder untergeordnet von {0} sein,
+BOMs Updated,Stücklisten aktualisiert,
+BOMs created successfully,Stücklisten erfolgreich erstellt,
+BOMs creation failed,Die Stücklistenerstellung ist fehlgeschlagen,
+"BOMs creation has been enqueued, kindly check the status after some time",Die Stücklistenerstellung wurde in die Warteschlange gestellt. Bitte überprüfen Sie den Status nach einiger Zeit,
+Balance Qty (Stock),Saldomenge (Lager),
+Balance Sheet Summary,Bilanzübersicht,
+Bank Reconciliation Tool,Bankabstimmungswerkzeug,
+Bank Statement Import,Kontoauszug Import,
+Bank Transaction {0} Matched,Banktransaktion {0} übereinstimmend,
+Bank Transaction {0} added as Journal Entry,Banktransaktion {0} als Buchungssatz hinzugefügt,
+Bank Transaction {0} added as Payment Entry,Banktransaktion {0} als Zahlungseintrag hinzugefügt,
+Bank Transaction {0} is already fully reconciled,Die Banktransaktion {0} ist bereits vollständig abgeglichen,
+Bank Transaction {0} updated,Banktransaktion {0} aktualisiert,
+Bank/Cash Account,Bank- / Kassenkonto,
+Bank/Cash Account {0} doesn't belong to company {1},Das Bank- / Kassenkonto {0} gehört nicht zu Unternehmen {1},
+Base Amount,Basisbetrag,
+Base Total Billed Amount,Insg. abgerechneter Betrag in Basiswährung,
+Base Total Costing Amount,Gesamtkosten in Basiswährung,
+"Based on your HR Policy, select your leave allocation period's end date",Wählen Sie auf der Grundlage Ihrer HR-Richtlinien das Enddatum Ihres Abwesenheitskontingents aus,
+"Based on your HR Policy, select your leave allocation period's start date",Wählen Sie auf der Grundlage Ihrer HR-Richtlinie das Startdatum Ihres Abwesenheitskontingents aus,
+Batch No is mandatory,Chargennummer ist obligatorisch,
+Batch No {0} does not exists,Charge Nr. {0} existiert nicht,
+Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead.,"Die Chargennummer {0} ist mit dem Artikel {1} verknüpft, der eine Seriennummer hat. Bitte scannen Sie stattdessen die Seriennummer.",
+Batch No.,Chargennummer.,
+Batch Nos,Chargennummern,
+Batch Nos are created successfully,Chargennummern wurden erfolgreich erstellt,
+Batch Not Available for Return,Charge nicht zur Rückgabe verfügbar,
+Batch Qty,Chargenmenge,
+Batch and Serial No,Chargen- und Seriennummer,
+Batch not created for item {} since it does not have a batch series.,"Für Artikel {} wurde keine Charge erstellt, da er keinen Nummernkreis für Chargen vorgibt.",
+Batch {0} and Warehouse,Charge {0} und Lager,
+Batch {0} is not available in warehouse {1},Charge {0} ist im Lager {1} nicht verfügbar,
+Batchwise Valuation,Chargenweise Bewertung,
+Beginning of the current subscription period,Beginn des aktuellen Abonnementzeitraums,
+Below Subscription Plans are of different currency to the party default billing currency/Company currency: {0},Die folgenden Abonnementpläne haben eine andere Währung als die Standardabrechnungswährung/Unternehmenswährung der Partei: {0},
+Bill of Materials,Stückliste,
+Billed Items To Be Received,Zu erhaltende abgerechnete Artikel,
+"Billed, Received & Returned","Abgerechnet, empfangen & zurückgegeben",
+Bisect Accounting Statements,Buchhaltungsberichte teilen,
+Bisect Left,Links teilen,
+Bisect Nodes,Knoten halbieren,
+Bisect Right,Rechts teilen,
+Bisecting From,Teilen ab,
+Bisecting Left ...,Teile links ...,
+Bisecting Right ...,Teile rechts ...,
+Bisecting To,Teilen bis,
+Blanket Order Allowance (%),Rahmenauftrag Zulage (%),
+Bom No,Stücklisten-Nr.,
+Book Tax Loss on Early Payment Discount,Umsatzsteueranteil bei Skonto berücksichtigen,
+Book an appointment,Termin buchen,
+Booking stock value across multiple accounts will make it harder to track stock and account value.,Das Verbuchen von Lagerbeständen auf mehreren Konten erschwert die Nachverfolgung von Lagerbeständen und Kontowerten.,
+Books have been closed till the period ending on {0},Die Bücher wurden bis zu dem am {0} endenden Zeitraum geschlossen,
+Both Payable Account: {0} and Advance Account: {1} must be of same currency for company: {2},Sowohl das Kreditorenkonto: {0} als auch das Vorschusskonto: {1} müssen für das Unternehmen: {2} die gleiche Währung haben,
+Both Receivable Account: {0} and Advance Account: {1} must be of same currency for company: {2},Sowohl das Debitorenkonto: {0} als auch das Vorschusskonto: {1} müssen für das Unternehmen: {2} die gleiche Währung haben,
+Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3},Sowohl das {0} Konto: {1} als auch das Vorschusskonto: {2} müssen für das Unternehmen dieselbe Währung haben: {3},
+Budget Exceeded,Budget überschritten,
+Build All?,"Bereit, gebaut zu werden?",
+Build Tree,Baum erstellen,
+Buildable Qty,Herstellbare Menge,
+Bulk Transaction Log,Massentransaktion Log,
+Bulk Transaction Log Detail,Massentransaktion Log-Detail,
+Bundle Items,Bündelartikel,
+Buying & Selling Settings,Einkaufs- & Verkaufseinstellungen,
+Buying and Selling,Kaufen und Verkaufen,
+"By default, the Supplier Name is set as per the Supplier Name entered. If you want Suppliers to be named by a <a href='https://docs.erpnext.com/docs/user/manual/en/setting-up/settings/naming-series' target='_blank'>Naming Series</a> choose the 'Naming Series' option.","Standardmäßig wird die ID des Lieferanten basierend auf dem eingegebenen Lieferantennamen festgelegt. Wenn Sie möchten, dass Lieferanten nach einem <a href='https://docs.erpnext.com/docs/user/manual/en/setting-up/settings/naming-series' target='_blank'>Nummernkreis</a> benannt werden, wählen Sie die Option 'Nummernkreis'.",
+Bypass credit check at Sales Order,Kreditprüfung im Kundenauftrag umgehen,
+COGS By Item Group,Herstellungskosten nach Artikelgruppe,
+COGS Debit,Herstellungskosten Soll,
+CRM Note,CRM Notiz,
+CRM Settings,CRM-Einstellungen,
+Calculate Product Bundle Price based on Child Items' Rates,Preis der Produktbündel basierend auf den Preisen der enthaltenen Artikel berechnen,
+Call Again,Erneut anrufen,
+Call Ended,Anruf beendet,
+Call Handling Schedule,Zeitplan für die Bearbeitung von Anrufen,
+Call Received By,Anruf empfangen von,
+Call Receiving Device,Anrufempfangsgerät,
+Call Routing,Anrufweiterleitung,
+Call Type,Anruftyp,
+Callback,Rückruf,
+Campaign Item,Kampagne Element,
+Can not close Work Order. Since {0} Job Cards are in Work In Progress state.,"Der Arbeitsauftrag kann nicht geschlossen werden, da sich {0} Jobkarten im Status „In Bearbeitung“ befinden.",
+"Can not filter based on Child Account, if grouped by Account","Kann nicht nach untergeordnetem Konto filtern, wenn nach Konto gruppiert",
+"Can't change the valuation method, as there are transactions against some items which do not have its own valuation method","Die Bewertungsmethode kann nicht geändert werden, da es Transaktionen gegen einige Artikel gibt, die keine eigene Bewertungsmethode haben",
+Cannot Merge,Zusammenführung nicht möglich,
+Cannot Resubmit Ledger entries for vouchers in Closed fiscal year.,Erneutes Buchen von Belegen in einem abgeschlossenem Wirtschaftsjahr ist nicht möglich.,
+"Cannot amend {0} {1}, please create a new one instead.",{0} {1} kann nicht berichtigt werden. Bitte erstellen Sie stattdessen einen neuen Eintrag.,
+Cannot apply TDS against multiple parties in one entry,Quellensteuer (TDS) kann nicht auf mehrere Parteien in einer Buchung angewendet werden,
+Cannot cancel as processing of cancelled documents is pending.,"Kann nicht storniert werden, da die Verarbeitung der stornierten Dokumente noch nicht abgeschlossen ist.",
+Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet.,Sie können die Transaktion nicht stornieren. Die Umbuchung der Artikelbewertung bei der Buchung ist noch nicht abgeschlossen.,
+Cannot change Reference Document Type.,Der Referenzdokumenttyp kann nicht geändert werden.,
+Cannot complete task {0} as its dependant task {1} are not completed / cancelled.,"Die Aufgabe {0} kann nicht abgeschlossen werden, da die von ihr abhängige Aufgabe {1} nicht abgeschlossen / storniert ist.",
+Cannot convert Task to non-group because the following child Tasks exist: {0}.,"Aufgabe kann nicht in Nicht-Gruppe konvertiert werden, da die folgenden untergeordneten Aufgaben existieren: {0}.",
+Cannot convert to Group because Account Type is selected.,"Kann nicht in eine Gruppe umgewandelt werden, weil Kontentyp ausgewählt ist.",
+Cannot create Stock Reservation Entries for future dated Purchase Receipts.,Für in der Zukunft datierte Kaufbelege kann keine Bestandsreservierung erstellt werden.,
+Cannot create a pick list for Sales Order {0} because it has reserved stock. Please unreserve the stock in order to create a pick list.,"Es kann keine Pickliste für den Kundenauftrag {0} erstellt werden, da dieser einen reservierten Bestand hat. Bitte heben Sie die Reservierung des Bestands auf, um eine Pickliste zu erstellen.",
+Cannot create accounting entries against disabled accounts: {0},Es kann nicht auf deaktivierte Konten gebucht werden: {0},
+Cannot make any transactions until the deletion job is completed,"Es können keine Transaktionen durchgeführt werden, bis der Löschvorgang abgeschlossen ist",
+Cannot produce more item for {0},Kann nicht mehr Artikel für {0} produzieren,
+Cannot produce more than {0} items for {1},Es können nicht mehr als {0} Artikel für {1} produziert werden,
+Cannot retrieve link token for update. Check Error Log for more information,Link-Token für Update kann nicht abgerufen werden. Prüfen Sie das Fehlerprotokoll für weitere Informationen,
+Cannot retrieve link token. Check Error Log for more information,Link-Token kann nicht abgerufen werden. Prüfen Sie das Fehlerprotokoll für weitere Informationen,
+Capacity (Stock UOM),Kapazität (Lagereinheit),
+Capacity in Stock UOM,Kapazität in Lager-ME,
+Capacity must be greater than 0,Die Kapazität muss größer als 0 sein,
+Capitalization,Aktivierung,
+Capitalization Method,Aktivierungsmethode,
+Capitalize Asset,Vermögensgegenstand aktivieren,
+Capitalize Repair Cost,Reparaturkosten aktivieren,
+Capitalized,Aktiviert,
+Carrier,Anbieter,
+Carrier Service,Versanddienst,
+Carry Forward Communication and Comments,Kommunikation und Kommentare mitschleifen,
+Category Details,Kategorie Details,
+Caution: This might alter frozen accounts.,Vorsicht! Dies könnte eingefrorene Konten verändern.,
+Change in Stock Value,Änderung des Lagerwerts,
+Changed customer name to '{}' as '{}' already exists.,"Kundenname in „{}“ geändert, da „{}“ bereits existiert.",
+Changes,Änderungen,
+Chart Of Accounts,Kontenplan,
+Chart of Accounts,Kontenplan,Account
+Chart of Cost Centers,Kostenstellenplan,Cost Center
+Check Stock Ledger,Lagerbuch prüfen,
+Check Stock Projected Qty,Prognostizierten Lagerbestand prüfen,
+Check help to setup Routing,Sehen Sie sich die Hilfe zum Einrichten des Routings an,
+Checked On,Geprüft am,
+Checking this will round off the tax amount to the nearest integer,"Falls aktiviert, wird der Steuerbetrag auf die nächste ganze Zahl gerundet",
+Clear Demo Data,Demodaten löschen,
+Clear Notifications,Benachrichtigungen löschen,
+Clearing Demo Data...,Lösche Demodaten...,
+Click on 'Get Finished Goods for Manufacture' to fetch the items from the above Sales Orders. Items only for which a BOM is present will be fetched.,"Klicken Sie auf „Fertigwaren zur Herstellung abrufen“, um die Artikel aus den oben genannten Kundenaufträgen abzurufen. Es werden nur Artikel abgerufen, für die eine Stückliste vorhanden ist.",
+Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays,"Klicken Sie auf „Zu arbeitsfreien Tagen hinzufügen“. Dadurch wird die Tabelle der arbeitsfreien Tage mit allen Terminen gefüllt, die auf den ausgewählten Wochentag fallen. Wiederholen Sie den Vorgang, um die Daten für alle arbeitsfreien Wochentage einzugeben",
+Click on Get Sales Orders to fetch sales orders based on the above filters.,"Klicken Sie auf Kundenaufträge abrufen, um die Kundenaufträge auf der Grundlage der obigen Filter abzurufen.",
+Click to add email / phone,Klicken um E-Mail / Telefon hinzuzufügen,
+Close Replied Opportunity After Days,Beantwortete Chance nach Tagen schließen,
+Closed Work Order can not be stopped or Re-opened,Ein geschlossener Arbeitsauftrag kann nicht gestoppt oder erneut geöffnet werden,
+Closing,Abschluss,
+Closing Balance as per Bank Statement,Schlusssaldo laut Kontoauszug,
+Closing Balance as per ERP,Schlusssaldo laut ERP,
+Closing Stock Balance,Schlussbestand,
+Communication Channel,Kommunikationskanal,
+Company Address Display,Anzeige der Unternehmensadresse,
+Company and Posting Date is mandatory,Unternehmen und Buchungsdatum sind obligatorisch,
+Company is mandatory for generating an invoice. Please set a default company in Global Defaults.,Für die Rechnungserstellung ist die Angabe eines Unternehmens obligatorisch. Bitte legen Sie in den globalen Standardeinstellungen ein Standardunternehmen fest.,
+Company which internal customer represents,"Unternehmen, für das der interne Kunde steht",
+Company which internal customer represents.,"Unternehmen, für das der interne Kunde steht.",
+Company which internal supplier represents,"Unternehmen, für das der interne Lieferant steht",
+Company {0} is added more than once,Unternehmen {0} wird mehr als einmal hinzugefügt,
+Company {} does not exist yet. Taxes setup aborted.,Unternehmen {} existiert noch nicht. Einrichtung der Steuern wurde abgebrochen.,
+Company {} does not match with POS Profile Company {},Unternehmen {} stimmt nicht mit POS-Profil Unternehmen {} überein,
+Competitor,Konkurrent,
+Competitor Detail,Mitbewerberdetails,
+Competitor Name,Name des Mitbewerbers,
+Competitors,Mitbewerber,
+Complete Job,Auftrag abschließen,
+Complete Order,Bestellung abschließen,
+Completed On,Abgeschlossen am,
+Completed On cannot be greater than Today,„Abgeschlossen am“ darf nicht in der Zukunft liegen,
+Completed Tasks,Abgeschlossene Aufgaben,
+Completed Time,Benötigte Zeit,
+Conditional Rule,Bedingte Regel,
+Conditional Rule Examples,Beispiele für bedingte Regeln,
+Configure Account Settings,Buchhaltungseinstellungen konfigurieren,
+Configure Buying Settings.,Einkaufseinstellungen konfigurieren.,
+Configure Product Assembly,Produktmontage konfigurieren,
+Configure the action to stop the transaction or just warn if the same rate is not maintained.,"Konfigurieren Sie die Aktion, um die Transaktion zu stoppen oder nur zu warnen, wenn derselbe Einzelpreis nicht beibehalten wird.",
+Connections,Verknüpfungen,
+Consider Minimum Order Qty,Mindestbestellmenge berücksichtigen,
+Consider Rejected Warehouses,Lager für abgelehnte Ware einschließen,
+Considered In Paid Amount,Im gezahlten Betrag berücksichtigt,
+Consolidate Sales Order Items,Kundenauftragspositionen konsolidieren,
+Consolidate Sub Assembly Items,Artikel der Unterbaugruppe konsolidieren,
+Consumed Asset Total Value,Wer des verbrauchten Anlagevermögens,
+Consumed Assets,Verbrauchte Vermögensgegenstände,
+Consumed Quantity,Verbrauchte Menge,
+Consumed Stock Items,Verbrauchte Lagerartikel,
+Consumed Stock Total Value,Wert des verbrauchten Lagerbestands,
+Consumption Rate,Verbrauchsrate,
+Contact Details,Kontakt-Details,
+Contact Mobile,Kontakt-Mobiltelefonnummer,
+Contacts,Kontakte,
+Contract Template Help,Vertragsvorlage Hilfe,
+Contribution Qty,Beitragsmenge,
+Control Historical Stock Transactions,Historische Lagerbewegungen überprüfen,
+Convert Item Description to Clean HTML in Transactions,Artikelbeschreibung in sauberes HTML umwandeln,
+Convert to Group,In Gruppe umwandeln,Warehouse
+Core,Kern,
+Corrective Job Card,Nacharbeitsauftrag,
+Corrective Operation,Nacharbeit,
+Corrective Operation Cost,Nacharbeitskosten,
+Cost Center Allocation,Kostenstellenzuordnung,
+Cost Center Allocation Percentage,Kostenstellenzuordnungsprozentsatz,
+Cost Center Allocation Percentages,Kostenstellenzuordnungsprozentsätze,
+Cost Center For Item with Item Code {0} has been Changed to {1},Die Kostenstelle für Artikel mit Artikelcode {0} wurde auf {1} geändert,
+"Cost Center is a part of Cost Center Allocation, hence cannot be converted to a group",Kostenstelle ist Teil der Kostenstellenzuordnung und kann daher nicht in eine Gruppe umgewandelt werden,
+Cost Center with Allocation records can not be converted to a group,Kostenstelle mit bestehenden Zuordnungen kann nicht in eine Gruppe umgewandelt werden,
+Cost Center {0} cannot be used for allocation as it is used as main cost center in other allocation record.,"Kostenstelle {0} kann nicht für die Zuordnung verwendet werden, da sie in anderen Zuordnungsdatensätzen als Hauptkostenstelle verwendet wird.",
+Cost Center {} doesn't belong to Company {},Kostenstelle {} gehört nicht zum Unternehmen {},
+Cost Center {} is a group cost center and group cost centers cannot be used in transactions,Kostenstelle {} ist eine Gruppenkostenstelle und Gruppenkostenstellen können nicht in Transaktionen verwendet werden,
+Cost Centers for Budgeting and Analysis,Kostenstellen für Budgetierung und Analyse,
+Cost Configuration,Kostenkonfiguration,
+Cost Per Unit,Kosten pro Einheit,
+Cost of Poor Quality Report,Kosten mangelhafter Qualität,
+Cost to Company (CTC),Kosten für das Unternehmen (CTC),
+Costing Details,Kostendetails,
+Could Not Delete Demo Data,Demodaten konnten nicht gelöscht werden,
+Could not auto update shifts. Shift with shift factor {0} needed.,Schichten konnten nicht automatisch aktualisiert werden. Schicht mit Schichtfaktor {0} erforderlich.,
+Could not detect the Company for updating Bank Accounts,Konnte das Unternehmen für die Aktualisierung der Bankkonten nicht finden,
+Could not find path for ,Konnte keinen Pfad finden für ,
+Count,Anzahl,
+Create Depreciation Entry,Abschreibungseintrag erstellen,
+Create Employee records.,Mitarbeiter-Datensätze erstellen.,
+Create Grouped Asset,Gruppierte Anlage erstellen,
+Create Job Card based on Batch Size,Auftragskarte nach Chargengröße erstellen,
+Create Ledger Entries for Change Amount,Buchungssätze für Wechselgeld erstellen,
+Create Link,Verknüpfung erstellen,
+Create Multi-level BOM,Mehrstufige Stücklisten erstellen,
+Create New Customer,Neuen Kunden erstellen,
+Create Opportunity,Chance erstellen,
+Create Prospect,Potenziellen Kunde erstellen,
+Create Raw Materials,Rohmaterialien erstellen,
+Create Reposting Entries,Umbuchungseinträge erstellen,
+Create Reposting Entry,Umbuchungseintrag erstellen,
+Create Serial Nos,Seriennummern erstellen,
+Create Stock Entry,Lagerbewegung erstellen,
+Create Your First Purchase Invoice ,Erstellen Sie Ihre erste Eingangsrechnung ,
+Create Your First Sales Invoice ,Erstellen Sie Ihre erste Ausgangsrechnung ,
+Create a Customer,Kunde erstellen,
+Create a Finished Good,Fertigerzeugnis erstellen,
+Create a Fixed Asset Item,Einen Vermögensgegenstand-Artikel erstellen,
+Create a Material Transfer Entry,Materialübertrag erstellen,
+Create a Product,Produkt erstellen,
+Create a Quotation,Angebot erstellen,
+Create a Sales Item,Verkaufsartikel erstellen,
+Create a Sales Order,Kundenauftrag erstellen,
+Create a Supplier,Lieferanten erstellen,
+Create a Warehouse,Lager erstellen,
+Create a new Item,Neuen Artikel erstellen,
+Create a new composite asset,Neuen zusammengesetzten Vermögensgegenstand erstellen,
+Create an Asset,Vermögensgegenstand erstellen,
+Create an Asset Category,Vermögensgegenstand-Kategorie erstellen,
+Create an Asset Item,Vermögensgegenstand-Artikel erstellen,
+Create an Item,Einen Artikel erstellen,
+Create and Send Quotation,Angebot erstellen und versenden,
+Create first Purchase Order,Ersten Lieferantenauftrag erstellen,
+Create your first Bill of Materials,Erstellen Sie Ihre erste Stückliste,
+Create your first Quotation,Erstellen Sie Ihr erstes Angebot,
+Create your first Sales Order,Erstellen Sie Ihren ersten Kundenauftrag,
+Create your first Work Order,Erstellen Sie Ihren ersten Arbeitsauftrag,
+Create {0} {1} ?,{0} {1} erstellen?,
+Created On,Erstellt am,
+Created {0} scorecards for {1} between:,Erstellte {0} Scorecards für {1} zwischen:,
+Creating Delivery Note ...,Lieferschein erstellen ...,
+Creating Packing Slip ...,Packzettel erstellen ...,
+Creating Purchase Receipt ...,Eingangsbeleg erstellen ...,
+Creating Stock Entry,Lagerbewegung erstellen,
+Creating Subcontracting Order ...,Erstelle Unterauftrag ...,
+Creating Subcontracting Receipt ...,Erstelle Unterauftragsbeleg ...,
+Creating User...,Benutzer erstellen...,
+Creation,Erstellung,
+Creation of <b><a href='/app/{0}'>{1}(s)</a></b> successful,Erstellung erfolgreich: <b><a href='/app/{0}'>{1}</a></b>,
+"Creation of {0} failed.
+				Check <b><a href=""/app/bulk-transaction-log"">Bulk Transaction Log</a></b>","Die Erstellung von {0} ist fehlgeschlagen.
+				Überprüfen Sie <b><a href=""/app/bulk-transaction-log"">Massentransaktionsprotokoll</a></b>",
+"Creation of {0} partially successful.
+				Check <b><a href=""/app/bulk-transaction-log"">Bulk Transaction Log</a></b>","Erstellung von {0} teilweise erfolgreich.
+				Überprüfen Sie <b><a href=""/app/bulk-transaction-log"">Massentransaktionsprotokoll</a></b>",
+Credit (Transaction),Haben (Transaktion),
+Credit Amount in Transaction Currency,Haben-Betrag in Transaktionswährung,
+Credit Limit Crossed,Kreditlimit überschritten,
+Credit Limit Settings,Kreditlimit-Einstellungen,
+"Credit Note will update it's own outstanding amount, even if ""Return Against"" is specified.","Den ausstehenden Betrag dieser Rechnungskorrektur separat buchen, statt den der korrigierten Rechnung zu verringern.",
+Currency Exchange Settings Details,Details zu den Währungsumrechnungseinstellungen,
+Current Asset,Umlaufvermögen,
+Current Index,Aktueller Index,
+Current Level,Aktuelles Level,
+Current Liability,Kurzfristige Verbindlichkeit,
+Current Node,Aktueller Knoten,
+Current Serial / Batch Bundle,Aktuelles Serien-/Chargen-Bündel,
+Custom,Benutzerdefiniert,
+Customer ,Kunde ,
+Customer / Item / Item Group,Kunde / Artikel / Artikelgruppe,
+Customer Defaults,Kunden-Standardeinstellungen,
+Customer Group Item,Kundengruppe (Zeile),
+Customer Group: {0} does not exist,Kundengruppe: {0} existiert nicht,
+Customer Item,Kunden-Artikel,
+Customer Name: ,Kundenname: ,
+Customer Portal Users,Kundenportal-Benutzer,
+Customer: ,Kunde: ,
+DFS,Tiefensuche,
+Daily Time to send,Tägliche Sendezeit,
+Data Based On,Daten basierend auf,
+Date ,Datum ,
+Date must be between {0} and {1},Das Datum muss zwischen {0} und {1} liegen,
+Date: ,Datum: ,
+Days before the current subscription period,Tage vor dem aktuellen Abonnementzeitraum,
+DeLinked,Verknüpfung gelöst,
+Debit (Transaction),Soll (Transaktion),
+Debit Amount in Transaction Currency,Soll-Betrag in Transaktionswährung,
+"Debit Note will update it's own outstanding amount, even if ""Return Against"" is specified.","Den ausstehenden Betrag dieser Rechnungskorrektur separat buchen, statt den der korrigierten Rechnung zu verringern.",
+Debit-Credit Mismatch,Soll-Haben-Diskrepanz,
+Debit-Credit mismatch,Soll-Haben-Diskrepanz,
+Decapitalization,Entkapitalisierung,
+Default Advance Account,Standard Vorschusskonto,
+Default Advance Paid Account,Standardkonto für geleistete Vorauszahlungen,
+Default Advance Received Account,Standardkonto für erhaltene Vorauszahlungen,
+Default BOM not found for FG Item {0},Standard Stückliste für Fertigprodukt {0} nicht gefunden,
+Default Operating Cost Account,Standardmäßiges Betriebskostenkonto,
+Default Service Level Agreement for {0} already exists.,Standard-Service-Level-Agreement für {0} existiert bereits.,
+Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item.,"Die Standardmaßeinheit für Artikel {0} kann nicht direkt geändert werden, da bereits einige Transaktionen mit einer anderen Maßeinheit durchgeführt wurden. Sie können entweder die verknüpften Dokumente stornieren oder einen neuen Artikel erstellen.",
+Default settings for your stock-related transactions,Standardeinstellungen für Ihre lagerbezogenen Transaktionen,
+"Default tax templates for sales, purchase and items are created.","Es werden Standard-Steuervorlagen für Verkauf, Einkauf und Artikel erstellt.",
+Deferred Accounting,Rechnungsabgrenzung,
+Deferred Accounting Defaults,Standardeinstellungen Rechnungsabgrenzung,
+Deferred Revenue and Expense,Abgegrenzte Einnahmen und Ausgaben,
+Deferred accounting failed for some invoices:,Die Rechnungsabgrenzung ist bei einigen Rechnungen fehlgeschlagen:,
+Define Asset Category,Vermögensgegenstand-Kategorie definieren,
+Delay (In Days),Verzögerung (in Tagen),
+Delayed,Verzögert,
+Delayed Tasks Summary,Zusammenfassung verzögerter Aufgaben,
+Delete Accounting and Stock Ledger Entries on deletion of Transaction,Beim Löschen einer Transaktion auch die entsprechenden Buchungs- und Lagerbuchungssätze löschen,
+Delete Bins,Papierkorb leeren,
+Delete Cancelled Ledger Entries,Stornierte Buchungseinträge löschen,
+Delete Dimension,Dimension löschen,
+Delete Leads and Addresses,Interessenten und Adressen löschen,
+Delete Transactions,Transaktionen löschen,
+Deleted Documents,Gelöschte Dokumente,Deleted Document
+Deletion in Progress!,Löschung im Gange!,
+Delivery Manager,Auslieferungsmanager,
+Delivery Note Packed Item,Lieferschein verpackte Artikel,
+Delivery Note(s) created for the Pick List,Lieferschein(e) für die Pickliste erstellt,
+Delivery User,Auslieferungs-Benutzer,
+Delivery to,Lieferung an,
+Demo Company,Demo-Unternehmen,
+Demo data cleared,Demodaten gelöscht,
+Deposit,Einzahlung,
+Depreciate based on daily pro-rata,Abschreibung auf Basis der täglichen Pro-rata,
+Depreciate based on shifts,Abschreibung auf Basis von Schichten,
+Depreciation Details,Details zur Abschreibung,
+Description of Content,Beschreibung des Inhalts,
+Desk User,Schreibtisch-Benutzer,
+Difference In,Abweichung in,
+Difference Posting Date,Differenz Buchungsdatum,
+Difference Qty,Differenzmenge,
+Different 'Source Warehouse' and 'Target Warehouse' can be set for each row.,Für jede Zeile können unterschiedliche „Quelllager“ und „Ziellager“ festgelegt werden.,
+Dimension Details,Dimensionsdetails,
+Dimension Filter Help,Dimensionsfilter Hilfe,
+Dimension-wise Accounts Balance Report,Kontensalden nach Dimensionen,
+Direct Expense,Direkte Ausgaben,
+Disable Last Purchase Rate,Letzten Kaufpreis deaktivieren,
+Disable Serial No And Batch Selector,Selektor für Seriennummer und Chargen deaktivieren,
+Disabled Account Selected,Deaktiviertes Konto ausgewählt,
+Disabled Warehouse {0} cannot be used for this transaction.,Deaktiviertes Lager {0} kann für diese Transaktion nicht verwendet werden.,
+Disabled pricing rules since this {} is an internal transfer,"Preisregeln deaktiviert, da es sich bei {} um eine interne Übertragung handelt",
+Disabled tax included prices since this {} is an internal transfer,"Bruttopreise deaktiviert, da es sich bei {} um eine interne Übertragung handelt",
+Disables auto-fetching of existing quantity,Deaktiviert das automatische Abrufen der vorhandenen Menge,
+Discount Account,Rabattkonto,
+Discount Date,Rabattdatum,
+Discount of {} applied as per Payment Term,Skonto von {} gemäß Zahlungsbedingung angewendet,
+Discounted Amount,Rabattbetrag,
+"Discounts to be applied in sequential ranges like buy 1 get 1, buy 2 get 2, buy 3 get 3 and so on","Rabatte werden in aufeinanderfolgenden Schritten gewährt, z. B. „Kaufe 1, bekomme 1“, „Kaufe 2, bekomme 2“, „Kaufe 3, bekomme 3“ und so weiter",
+Discrepancy between General and Payment Ledger,Diskrepanz zwischen Hauptbuch und Zahlungsbuch,
+Dispatch Address,Absendeadresse,
+Dispatch Address Name,ID der Absendeadresse,
+Distinct Item and Warehouse,Spezifischer Artikel und Lagerort,
+Distribute Additional Costs Based On ,Zusätzliche Kosten verteilen auf Basis von ,
+Distribute Manually,Manuell verteilen,
+Do Not Explode,Nicht aufklappen,
+Do Not Update Serial / Batch on Creation of Auto Bundle,Seriennummer/Charge beim Erstellen eines automatischen Bündels nicht aktualisieren,
+Do you still want to enable negative inventory?,Möchten Sie immer noch negative Bestände aktivieren?,
+DocTypes should not be added manually to the 'Excluded DocTypes' table. You are only allowed to remove entries from it.,DocTypes sollten nicht manuell zur Tabelle 'Ausgeschlossene DocTypes' hinzugefügt werden. Sie dürfen nur Einträge aus der Tabelle entfernen.,
+Document Type already used as a dimension,Dokumenttyp wird bereits als Dimension verwendet,
+Documents,Dokumente,
+Don't Send Emails,Senden Sie keine E-Mails,
+Dont Recompute tax,Steuer nicht neu berechnen,
+Download Backups,Datensicherungen herunterladen,
+Download CSV Template,CSV-Vorlage herunterladen,
+Download Materials Request Plan,Material-Anforderungsplan herunterladen,
+Dunning Amount (Company Currency),Mahnbetrag (Währung des Unternehmens),
+Duplicate Closing Stock Balance,Doppelter Schlussbestand,
+Duplicate Customer Group,Doppelte Kundengruppe,
+Duplicate Finance Book,Doppeltes Finanzbuch,
+Duplicate Item Group,Doppelte Artikelgruppe,
+Duplicate POS Invoices found,Doppelte POS-Rechnungen gefunden,
+Dynamic Condition,Dynamische Bedingung,
+Edit Capacity,Kapazität bearbeiten,
+Edit Cart,Warenkorb bearbeiten,
+Edit Full Form,Vollständiges Formular bearbeiten,
+Edit Note,Notiz bearbeiten,
+Editing {0} is not allowed as per POS Profile settings,Das Bearbeiten von {0} ist gemäß den POS-Profileinstellungen nicht zulässig,
+Either 'Selling' or 'Buying' must be selected,Es muss entweder „Verkauf“ oder „Einkauf“ ausgewählt werden,
+Email / Notifications,E-Mail / Benachrichtigungen,
+Email Address (required),E-Mail Adresse (erforderlich),
+"Email Address must be unique, it is already used in {0}","Die E-Mail-Adresse muss eindeutig sein, sie wird bereits in {0} verwendet",
+Email Digest: {0},E-Mail-Zusammenfassung: {0},
+Email or Phone/Mobile of the Contact are mandatory to continue.,"Um fortzufahren, sind Nachname, E-Mail oder Telefon/Mobiltelefon des Benutzers erforderlich.",
+Email verification failed.,E-Mail-Verifizierung fehlgeschlagen.,
+Employee User Id,Benutzer-ID des Mitarbeiters,
+Enable Allow Partial Reservation in the Stock Settings to reserve partial stock.,"Aktivieren Sie „Teilreservierung zulassen“ in den Lagereinstellungen, um einen Teilbestand zu reservieren.",
+Enable Automatic Party Matching,Automatisches Zuordnen von Parteien aktivieren,
+Enable Common Party Accounting,Verknüpfung von Kunden und Liefeanten erlauben,
+Enable Discount Accounting for Selling,Rabattabrechnung für den Verkauf aktivieren,
+Enable Fuzzy Matching,Fuzzy Matching aktivieren,
+Enable Health Monitor,Integritätsmonitor aktivieren,
+Enable Provisional Accounting For Non Stock Items,"Vorläufige Buchhaltung für ""Artikel ohne Lagerhaltung"" aktivieren",
+Enable Stock Reservation,Bestandsreservierung aktivieren,
+Enable this checkbox even if you want to set the zero priority,"Aktivieren Sie dieses Kontrollkästchen, auch wenn Sie die Priorität Null festlegen möchten",
+Enable to apply SLA on every {0},Anwendung des SLA auf jede {0} aktivieren,
+Enabling this ensures each Purchase Invoice has a unique value in Supplier Invoice No. field within a particular fiscal year,"Durch Aktivieren dieser Option wird sichergestellt, dass jede Eingangsrechnung innerhalb eines bestimmten Geschäftsjahres einen eindeutigen Wert im Feld Lieferantenrechnungsnummer hat",
+Enabling this option will allow you to record - <br><br> 1. Advances Received in a <b>Liability Account</b> instead of the <b>Asset Account</b><br><br>2. Advances Paid in an <b>Asset Account</b> instead of the <b> Liability Account</b>,"Wenn Sie diese Option aktivieren, können Sie - <br><br> 1. Erhaltene Vorschüsse auf einem <b>Passivkonto</b> statt auf dem <b>Aktivkonto</b> buchen<br><br>2. Gezahlte Vorschüsse auf einem <b>Aktivkonto</b> statt auf dem <b> Passivkonto</b> buchen",
+Enabling this will allow creation of multi-currency invoices against single party account in company currency,Bei Aktivierung können Rechnungen in Fremdwährungen gegen ein Konto in der Hauptwährung gebucht werden,
+Enabling this will change the way how cancelled transactions are handled.,"Wenn Sie dies aktivieren, ändert sich die Art und Weise, wie stornierte Transaktionen behandelt werden.",
+End Transit,Transit beenden,
+End of the current subscription period,Ende des aktuellen Abonnementzeitraums,
+"Enter ""ABC-001::100"" for serial nos ""ABC-001"" to ""ABC-100"".","Geben Sie ""ABC-001::100"" ein, um alle Seriennummern von ""ABC-001"" bis ""ABC-100"" zu erhalten.",
+"Enter First and Last name of Employee, based on Which Full Name will be updated. IN transactions, it will be Full Name which will be fetched.","Geben Sie den Vor- und Nachnamen des Mitarbeiters ein, auf dessen Grundlage der vollständige Name aktualisiert wird. In Transaktionen wird der vollständige Name abgerufen.",
+Enter Serial No Range,Seriennummernbereich eingeben,
+Enter Serial Nos,Seriennummern eingeben,
+Enter Visit Details,Besuchsdetails eingeben,
+Enter a name for Routing.,Geben Sie einen Namen für das Routing ein.,
+"Enter a name for the Operation, for example, Cutting.","Geben Sie einen Namen für den Vorgang ein, zum Beispiel „Schneiden“.",
+Enter a name for this Holiday List.,Geben Sie einen Namen für diese Liste der arbeitsfreien Tage ein.,
+"Enter an Item Code, the name will be auto-filled the same as Item Code on clicking inside the Item Name field.","Geben Sie einen Artikelcode ein. Der Name wird automatisch mit dem Artikelcode ausgefüllt, wenn Sie in das Feld Artikelname klicken.",
+Enter each serial no in a new line,Geben Sie jede Seriennummer in eine neue Zeile ein,
+"Enter the Operation, the table will fetch the Operation details like Hourly Rate, Workstation automatically.
+
+ After that, set the Operation Time in minutes and the table will calculate the Operation Costs based on the Hourly Rate and Operation Time.","Geben Sie den Vorgang ein. Die Tabelle holt sich automatisch die Vorgangsdetails wie Stundensatz und Arbeitsplatz.
+
+ Legen Sie dann die Vorgangsdauer in Minuten fest, und die Tabelle berechnet die Vorgangskosten auf der Grundlage des Stundensatzes und der Vorgangsdauer.",
+Enter the opening stock units.,Geben Sie die Anfangsbestandseinheiten ein.,
+Enter the quantity of the Item that will be manufactured from this Bill of Materials.,"Geben Sie die Menge des Artikels ein, der aus dieser Stückliste hergestellt werden soll.",
+Enter the quantity to manufacture. Raw material Items will be fetched only when this is set.,"Geben Sie die zu produzierende Menge ein. Rohmaterialartikel werden erst abgerufen, wenn dies eingetragen ist.",
+Error during caller information update,Fehler bei der Aktualisierung der Anruferinformationen,
+Error while posting depreciation entries,Fehler beim Buchen von Abschreibungsbuchungen,
+Error while processing deferred accounting for {0},Fehler bei der Verarbeitung der Rechnungsabgrenzung für {0},
+Error while reposting item valuation,Fehler beim Umbuchen der Artikelbewertung,
+"Error: This asset already has {0} depreciation periods booked.
+				The `depreciation start` date must be at least {1} periods after the `available for use` date.
+				Please correct the dates accordingly.","Fehler: Für diese Sachanlage sind bereits {0} Abschreibungszeiträume gebucht.
+				Das Datum „Abschreibungsbeginn“ muss mindestens {1} Zeiträume nach dem Datum „Zeitpunkt der Einsatzbereitschaft“ liegen.
+				Bitte korrigieren Sie die Daten entsprechend.",
+Errors Notification,Fehler-Benachrichtigung,
+Even invoices with apply tax withholding unchecked will be considered for checking cumulative threshold breach,"Auch Rechnungen, bei denen die Option „Steuereinbehalt anwenden“ nicht aktiviert ist, werden bei der Überprüfung der kumulativen Schwellenwertüberschreitung berücksichtigt",
+Example URL,Beispiel URL,
+Example of a linked document: {0},Beispiel für ein verknüpftes Dokument: {0},
+"Example: ABCD.#####
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Beispiel: ABCD.#####
+Wenn ein Nummernkreis festgelegt ist und in einer Transaktion keine Seriennummer angegeben wird, wird diese automatisch auf der Grundlage dieses Nummernkreises erstellt. Wenn Sie die Seriennummern für diesen Artikel immer explizit angeben möchten, lassen Sie dieses Feld leer.",
+Example: Serial No {0} reserved in {1}.,Beispiel: Seriennummer {0} reserviert in {1}.,
+Exchange Gain Or Loss,Wechselkursgewinn oder -verlust,
+Exchange Gain/Loss amount has been booked through {0},Wechselkursgewinne/-verluste wurden über {0} verbucht,
+Exchange Rate Revaluation Settings,Einstellungen für die Neubewertung der Wechselkurse,
+Excluded DocTypes,Ausgeschlossene DocTypes,
+Exempt Supplies,Steuerbefreite Lieferungen,
+Expected,Erwartet,
+Expected Balance Qty,Erwartete Saldomenge,
+Expected End Date should be less than or equal to parent task's Expected End Date {0}.,Das erwartete Enddatum sollte kleiner oder gleich dem erwarteten Enddatum {0} der übergeordneten Aufgabe sein.,
+Expected Stock Value,Erwarteter Lagerwert,
+Expected Time Required (In Mins),Soll-Zeitbedarf (in Minuten),
+Expense Head Changed,Aufwandskonto geändert,
+Expiry,Verfallsdatum,
+Export Data,Daten exportieren,
+Export Errored Rows,Exportieren Sie fehlerhafte Zeilen,
+Export Import Log,Import-Log exportieren,
+Extra Consumed Qty,Zusätzlich verbrauchte Menge,
+Extra Job Card Quantity,Extra Jobkarten Menge,
+"FIFO Stock Queue (qty, rate)","FIFO-Lagerwarteschlange (Menge, Rate)",
+FIFO/LIFO Queue,FIFO/LIFO-Warteschlange,
+Failed Entries,Fehlgeschlagene Einträge,
+"Failed to erase demo data, please delete the demo company manually.",Demodaten konnten nicht gelöscht werden. Bitte löschen Sie das Demounternehmen manuell.,
+Failed to setup defaults for country {0}. Please contact support.,Die Standardeinstellungen für das Land {0} konnten nicht eingerichtet werden. Bitte kontaktieren Sie den Support.,
+Failure,Fehler,
+Failure Description,Fehlerbeschreibung,
+Fetch Based On,Abrufen basierend auf,
+Fetch Overdue Payments,Überfällige Zahlungen abrufen,
+Fetch Value From,Wert abrufen von,
+Fetching exchange rates ...,Wechselkurse werden abgerufen ...,
+Filter by Reference Date,Nach Referenzdatum filtern,
+Filter on Invoice,Nach Rechnung filtern,
+Filter on Payment,Nach Zahlung filtern,
+Final Product,Endprodukt,
+Financial Ratios,Finanzielle Kennziffern,
+Financial Reports,Finanzberichte,
+Financial Year Begins On,Das Geschäftsjahr beginnt am,
+Financial reports will be generated using GL Entry doctypes (should be enabled if Period Closing Voucher is not posted for all years sequentially or missing) ,"Finanzberichte werden unter Verwendung von Hauptbucheinträgen erstellt (sollte aktiviert werden, wenn der Beleg für den Periodenabschluss nicht für alle Jahre nacheinander gebucht wird oder fehlt) ",
+Finished Good BOM,Fertigerzeugnis Stückliste,
+Finished Good Item,Fertigerzeugnisartikel,
+Finished Good Item Qty,Fertigerzeugnisartikel Menge,
+Finished Good Item Quantity,Fertigerzeugnisartikel Menge,
+Finished Good Item is not specified for service item {0},Fertigerzeugnisartikel ist nicht als Dienstleistungsartikel {0} angelegt,
+Finished Good Item {0} Qty can not be zero,Menge für Fertigerzeugnis {0} kann nicht Null sein,
+Finished Good Item {0} must be a sub-contracted item,Fertigerzeugnis {0} muss ein untervergebener Artikel sein,
+Finished Good Qty,Fertigerzeugnis Menge,
+Finished Good Quantity ,Fertigerzeugnis Menge,
+Finished Good UOM,Fertigerzeugnis ME,
+Finished Good {0} does not have a default BOM.,Fertigerzeugnis {0} verfügt nicht über eine Standardstückliste.,
+Finished Good {0} is disabled.,Fertigerzeugnis {0} ist deaktiviert.,
+Finished Good {0} must be a stock item.,Fertigerzeugnis {0} muss ein Lagerartikel sein.,
+Finished Good {0} must be a sub-contracted item.,"Fertigerzeugnis {0} muss ein Artikel sein, der untervergeben wurde.",
+Finished Goods Based Operating Cost,Auf Fertigerzeugnissen basierende Betriebskosten,
+Finished Goods Item,Fertigerzeugnisartikel,
+Finished Goods Reference,Fertigerzeugnis Referenz,
+Finished Goods Value,Fertigerzeugnis Wert,
+Finished Goods based Operating Cost,Auf Fertigerzeugnissen basierende Betriebskosten,
+Finished Item {0} does not match with Work Order {1},Fertigerzeugnis {0} stimmt nicht mit dem Arbeitsauftrag {1} überein,
+Finished Items,Fertigerzeugnisse,
+First Response Due,Erste Antwort fällig,
+First Response SLA Failed by {},Erste Antwort SLA fehlgeschlagen um {},
+Fixed Time,Feste Zeit,
+Floor,Etage,
+Floor Name,Etagenname,
+For Item,Für Artikel,
+For Item {0} cannot be received more than {1} qty against the {2} {3},Für Artikel {0} können nicht mehr als {1} ME gegen {2} {3} in Empfang genommen werden,
+For Job Card,Für Jobkarte,
+For Operation,Für Vorgang,
+For Work Order,Für Arbeitsauftrag,
+For dunning fee and interest,Für Mahngebühren und Zinsen,
+"For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}","Für den Artikel {0} muss der Einzelpreis eine positive Zahl sein. Um negative Einzelpreise zuzulassen, aktivieren Sie {1} in {2}",
+For quantity {0} should not be greater than allowed quantity {1},Denn die Menge {0} darf nicht größer sein als die zulässige Menge {1},
+Forecasting,Prognose,
+Formula Based Criteria,Formelgestützte Kriterien,
+From Date and To Date are mandatory,Von-Datum und Bis-Datum sind obligatorisch,
+From Date: {0} cannot be greater than To date: {1},Von-Datum: {0} kann nicht größer sein als Bis-Datum: {1},
+From Delivery Date,Ab Lieferdatum,
+From Doctype,Von DocType,
+From Due Date,Ab Fälligkeitsdatum,
+From Payment Date,Ab Zahlungsdatum,
+From Reference Date,Ab Referenzdatum,
+From Voucher Detail No,Von Beleg-Position,
+From Voucher No,Von Beleg-Nr.,
+From Voucher Type,Von Beleg-Typ,
+From and To dates are required,Von- und Bis-Daten sind erforderlich,
+Full and Final Statement,Schlussabrechnung,
+GL Balance,Hauptbuchsaldo,
+GL Entry Processing Status,Status der Hauptbucheintragsverarbeitung,
+GL reposting index,Hauptbuch-Umbuchungsindex,
+Gain/Loss accumulated in foreign currency account. Accounts with '0' balance in either Base or Account currency,Auf dem Fremdwährungskonto kumulierte Gewinne/Verluste. Konten mit einem Saldo von '0' entweder in Basis- oder Kontowährung,
+Gain/Loss already booked,Gewinn/Verlust bereits verbucht,
+Gain/Loss from Revaluation,Gewinn/Verlust aus Neubewertung,
+General Ledger,Hauptbuch,Warehouse
+General and Payment Ledger Comparison,Vergleich Hauptbuch und Zahlungsbuch,
+General and Payment Ledger mismatch,Hauptbuch und Zahlungsbuch stimmen nicht überein,
+Generate Demo Data for Exploration,Demo-Daten für die Erkundung generieren,
+Generate E-Invoice,E-Rechnung erstellen,
+Generate Invoice At,Rechnung erstellen am,
+Generated,Erzeugt,
+Generating Preview,Vorschau wird erstellt,
+Get Allocations,Zuordnungen abrufen,
+Get Finished Goods for Manufacture,Fertigwaren zur Herstellung abrufen,
+Get Outstanding Orders,Ausstehende Bestellungen abrufen,
+Get Raw Materials Cost from Consumption Entry,Rohstoffkosten aus Verbrauchserfassung holen,
+Get Raw Materials for Purchase,Rohstoffe zum Kauf abrufen,
+Get Raw Materials for Transfer,Rohstoffe zum Transfer abrufen,
+Get Scrap Items,Ausschussartikel abrufen,
+Get Stock,Lagerbestand abrufen,
+Get Sub Assembly Items,Artikel der Unterbaugruppe abrufen,
+Get Timesheets,Projektzeiterfassung abrufen,
+Get stops from,Stationen abrufen von,
+Getting Scrap Items,Ausschussartikel abrufen,
+Give free item for every N quantity,Einen Artikel für jede Menge N verschenken,
+Go back,Zurück,
+Go to {0} List,Gehen Sie zur Liste {0},
+Goals,Ziele,
+Goods,Waren,
+Greeting Message,Grußnachricht,
+Gross Profit Percent,Bruttogewinn in Prozent,
+Gross Purchase Amount should be <b>equal</b> to purchase amount of one single Asset.,Der Brutto-Kaufbetrag sollte dem Kaufbetrag eines einzelnen Vermögensgegenstandes <b>entsprechen</b>.,
+Group Same Items,Gleiche Artikel gruppieren,
+Growth View,Wachstumsansicht,
+Half-yearly,Halbjährlich,
+Has Alternative Item,Hat alternativen Artikel,
+Has Priority,Hat Priorität,
+Have Default Naming Series for Batch ID?,Gibt es eine Standard-Nummernkreis für Chargen?,
+Height (cm),Höhe (cm),
+"Hello,","Hallo,",
+Helps you distribute the Budget/Target across months if you have seasonality in your business.,"Hilft Ihnen, das Budget/Ziel über die Monate zu verteilen, wenn Sie in Ihrem Geschäft saisonale Schwankungen haben.",
+Here are the error logs for the aforementioned failed depreciation entries: {0},Hier sind die Fehlerprotokolle für die oben erwähnten fehlgeschlagenen Abschreibungseinträge: {0},
+Here are the options to proceed:,Hier sind die Optionen für das weitere Vorgehen:,
+"Here, you can select a senior of this Employee. Based on this, Organization Chart will be populated.",Hier können Sie einen Vorgesetzten dieses Mitarbeiters auswählen. Auf dieser Grundlage wird das Organigramm erstellt.,
+"Here, your weekly offs are pre-populated based on the previous selections. You can add more rows to also add public and national holidays individually.","Hier werden Ihre wöchentlichen freien Tage auf der Grundlage der zuvor getroffenen Auswahlen vorausgefüllt. Sie können weitere Zeilen hinzufügen, um auch gesetzliche und nationale Feiertage individuell hinzuzufügen.",
+"Hi,","Hallo,",
+Hide Images,Bilder ausblenden,
+Holiday Date {0} added multiple times,Arbeitsfreier Tag {0} mehrfach hinzugefügt,
+Hours Spent,Geleistete Stunden,
+How often should Project be updated of Total Purchase Cost ?,Wie häufig sollen Projekte hinsichtlich der Gesamteinkaufskosten aktualisiert werden?,
+How to Navigate in ERPNext,So navigieren Sie in ERPNext,
+Idle,Leerlauf,
+"If an operation is divided into sub operations, they can be added here.","Wenn ein Vorgang in Untervorgänge unterteilt ist, können diese hier hinzugefügt werden.",
+"If checked, Rejected Quantity will be included while making Purchase Invoice from Purchase Receipt.","Falls aktiviert, wird die abgelehnte Menge bei der Erstellung der Eingangsrechnung aus dem Eingangsbeleg berücksichtigt.",
+"If checked, Stock will be reserved on <b>Submit</b>","Falls aktiviert, wird der Bestand beim <b>Buchen</b>reserviert",
+"If checked, picked qty won't automatically be fulfilled on submit of pick list.","Falls aktiviert, wird die gewählte Menge beim Buchen der Pickliste nicht automatisch erfüllt.",
+"If checked, the tax amount will be considered as already included in the Paid Amount in Payment Entry","Falls aktiviert, wird der Betrag in einer Zahlung als Bruttobetrag (inkl. Steuer) betrachtet",
+"If checked, we will create demo data for you to explore the system. This demo data can be erased later.","Falls aktiviert, werden Demodaten erstellt, damit Sie das System erkunden können. Diese Demodaten können später wieder gelöscht werden.",
+If enabled then system won't override the picked qty / batches / serial numbers.,"Falls aktiviert, wird das System die kommissionierten Mengen/Chargen/Seriennummern nicht überschreiben.",
+"If enabled, a print of this document will be attached to each email","Falls aktiviert, wird ein Ausdruck dieses Dokuments an jede E-Mail angehängt",
+"If enabled, additional ledger entries will be made for discounts in a separate Discount Account","Falls aktiviert, werden zusätzliche Buchungen für Rabatte in einem separaten Rabattkonto vorgenommen",
+"If enabled, all files attached to this document will be attached to each email","Falls aktiviert, werden alle Dateien, die an dieses Dokument angehängt sind, an jede E-Mail angehängt",
+"If enabled, do not update serial / batch values in the stock transactions on creation of auto Serial 
+ / Batch Bundle. ","Wenn diese Option aktiviert ist, werden die Serien-/Chargenwerte in den Bestandstransaktionen bei der Erstellung eines automatischen Serien- 
+ / Chargenbündels nicht aktualisiert. ",
+"If enabled, ledger entries will be posted for change amount in POS transactions","Wenn aktiviert, werden Buchungssätze für Wechselgeld in POS-Transaktionen erstellt",
+"If enabled, the consolidated invoices will have rounded total disabled","Falls aktiviert, wird bei konsolidierten Rechnungen die gerundete Summe deaktiviert",
+"If enabled, the system will create material requests even if the stock exists in the 'Raw Materials Warehouse'.","Falls aktiviert, erstellt das System auch dann Materialanforderungen, wenn der Bestand im „Rohstofflager“ vorhanden ist.",
+"If enabled, then system will only validate the pricing rule and not apply automatically. User has to manually set the discount percentage / margin / free items to validate the pricing rule","Wenn diese Option aktiviert ist, validiert das System die Preisregel nur und wendet sie nicht automatisch an. Der Benutzer muss den Rabattprozentsatz / die Marge / die Gratisartikel manuell festlegen, um die Preisregel zu validieren",
+"If mentioned, the system will allow only the users with this Role to create or modify any stock transaction earlier than the latest stock transaction for a specific item and warehouse. If set as blank, it allows all users to create/edit back-dated transactions.","Wenn dies angegeben ist, erlaubt das System nur den Benutzern mit dieser Rolle, eine Bestandstransaktion zu erstellen oder zu ändern, die älter ist als die letzte Bestandstransaktion für einen bestimmten Artikel und ein bestimmtes Lager. Wenn diese Option leer ist, können alle Benutzer rückdatierte Transaktionen erstellen/bearbeiten.",
+"If not, you can Cancel / Submit this entry","Wenn nicht, können Sie diesen Eintrag stornieren / buchen",
+"If rate is zero then item will be treated as ""Free Item""","Wenn der Preis Null ist, wird der Artikel als „Kostenloser Artikel“ behandelt",
+"If the BOM results in Scrap material, the Scrap Warehouse needs to be selected.","Wenn die Stückliste Schrottmaterial ergibt, muss ein Schrottlager ausgewählt werden.",
+"If the selected BOM has Operations mentioned in it, the system will fetch all Operations from BOM, these values can be changed.","Wenn die ausgewählte Stückliste Vorgänge enthält, holt das System alle Vorgänge aus der Stückliste. Diese Werte können geändert werden.",
+"If this checkbox is enabled, then the system won’t run the MRP for the available sub-assembly items.","Falls aktiviert, führt das System keine Bedarfsplanung für verfügbaren Unterbaugruppen durch.",
+"If you are maintaining stock of this Item in your Inventory, ERPNext will make a stock ledger entry for each transaction of this item.","Wenn Sie diesen Artikel in Ihrem Inventar führen, nimmt ERPNext für jede Transaktion dieses Artikels einen Lagerbuch-Eintrag vor.",
+"If you need to reconcile particular transactions against each other, then please select accordingly. If not, all the transactions will be allocated in FIFO order.","Wenn Sie bestimmte Transaktionen gegeneinander abgleichen müssen, wählen Sie bitte entsprechend aus. Wenn nicht, werden alle Transaktionen in der FIFO-Reihenfolge zugeordnet.",
+"If you still want to proceed, please disable 'Skip Available Sub Assembly Items' checkbox.","Wenn Sie trotzdem fortfahren möchten, deaktivieren Sie bitte das Kontrollkästchen 'Verfügbare Unterbaugruppenartikel überspringen'.",
+"If you still want to proceed, please enable {0}.","Wenn Sie dennoch fortfahren möchten, aktivieren Sie bitte {0}.",
+"If your CSV uses a different delimiter, add that character here, ensuring no spaces or additional characters are included.","Wenn Ihre CSV-Datei ein anderes Trennzeichen verwendet, fügen Sie dieses Zeichen hier ein und achten Sie darauf, dass keine Leerzeichen oder zusätzlichen Zeichen enthalten sind.",
+Ignore Account Closing Balance,Saldo des Kontos zum Periodenabschluss ignorieren,
+Ignore Available Stock,Verfügbaren Bestand ignorieren,
+Ignore Closing Balance,Schlusssaldo ignorieren,
+Ignore Default Payment Terms Template,Standardvorlage für Zahlungsbedingungen ignorieren,
+Ignore Empty Stock,Leeren Bestand ignorieren,
+Import Data,Daten importieren,Data Import
+Import Data from Spreadsheet,Daten aus Tabellenkalkulation importieren,
+Import File,Datei importieren,
+Import File Errors and Warnings,Importieren Sie Dateifehler und Warnungen,
+Import Log Preview,Protokollvorschau importieren,
+Import Preview,Vorschau importieren,
+Import Progress,Importfortschritt,
+Import Type,Importtyp,
+Import Using CSV file,Importieren mit CSV-Datei,
+Import Warnings,Warnungen importieren,
+Import from Google Sheets,Import aus Google Sheets,
+"Importing {0} of {1}, {2}","{0} von {1}, {2} importieren",
+In House,Im Haus,
+In Minutes,In Minuten,
+In Party Currency,In Parteiwährung,
+In Transit Transfer,Im Transit Bewegungen,
+In Transit Warehouse,Durchgangslager,
+In mins,In Minuten,
+"In row {0} of Appointment Booking Slots: ""To Time"" must be later than ""From Time"".","In der Zeile {0} der Terminbuchungsplätze: ""Bis-Zeit"" muss später sein als ""Von-Zeit"".",
+"In the case of 'Use Multi-Level BOM' in a work order, if the user wishes to add sub-assembly costs to Finished Goods items without using a job card as well the scrap items, then this option needs to be enable.","In einem Arbeitsauftrag mit der Option „Mehrstufige Stückliste verwenden“, muss diese Option aktiviert werden, wenn der Benutzer Unterbaugruppenkosten zu Fertigerzeugnissen hinzufügen möchte ohne eine Jobkarte und Ausschussartikeln zu benutzen.",
+"In this section, you can define Company-wide transaction-related defaults for this Item. Eg. Default Warehouse, Default Price List, Supplier, etc.","In diesem Abschnitt können Sie unternehmensweite transaktionsbezogene Standardwerte für diesen Artikel festlegen. Z. B. Standardlager, Standardpreisliste, Lieferant, etc.",
+Inactive Status,Inaktiver Status,
+Include Account Currency,Kontowährung einbeziehen,
+Include Disabled,Deaktivierte einbeziehen,
+Include Expired Batches,Abgelaufene Chargen einbeziehen,
+Include Safety Stock in Required Qty Calculation,Sicherheitsbestand in die Berechnung der benötigten Menge einbeziehen,
+Include Timesheets in Draft Status,Entwürfe einbeziehen,
+Incoming Call Handling Schedule,Zeitplan für die Bearbeitung eingehender Anrufe,
+Incoming Call Settings,Einstellungen für eingehende Anrufe,
+Incoming Rate (Costing),Anschaffungs- bzw. Herstellungskosten,
+Incorrect Balance Qty After Transaction,Falsche Saldo-Menge nach Transaktion,
+Incorrect Batch Consumed,Falsche Charge verbraucht,
+Incorrect Invoice,Falsche Rechnung,
+Incorrect Movement Purpose,Falscher Bewegungszweck,
+Incorrect Serial No Valuation,Falsche Bewertung der Seriennummer,
+Incorrect Serial Number Consumed,Falsche Seriennummer verbraucht,
+Incorrect Type of Transaction,Falsche Transaktionsart,
+Increase In Asset Life(Months),Zusätzliche Lebensdauer des Vermögensgegenstandes (in Monaten),
+Indent,Einrücken,
+Indirect Expense,Indirekte Kosten,
+Individual Stock Ledger Entry cannot be cancelled.,Einzelne Lagerbuch-Einträge können nicht storniert werden.,
+Insert New Records,Fügen Sie neue Datensätze ein,
+Inspection Rejected,Inspektion abgelehnt,
+Instruction,Anweisung,
+Insufficient Capacity,Unzureichende Kapazität,
+Insufficient Stock for Batch,Unzureichender Bestand für Charge,
+Interest and/or dunning fee,Zinsen und/oder Mahngebühren,
+Internal,Intern,
+Internal Customer,Interner Kunde,
+Internal Customer for company {0} already exists,Interner Kunde für Unternehmen {0} existiert bereits,
+Internal Sale or Delivery Reference missing.,Interne Verkaufs- oder Lieferreferenz fehlt.,
+Internal Sales Reference Missing,Interne Verkaufsreferenz Fehlt,
+Internal Supplier for company {0} already exists,Interner Lieferant für Unternehmen {0} existiert bereits,
+Internal Transfer Reference Missing,Interne Transferreferenz fehlt,
+Internal Transfers,Interne Transfers,
+Internal transfers can only be done in company's default currency,Interne Transfers können nur in der Standardwährung des Unternehmens durchgeführt werden,
+Introduction to Assets,Einführung in Vermögensgegenstände,
+Introduction to CRM,Einführung in CRM,
+Introduction to Selling,Einführung in den Verkauf,
+Introduction to Stock Entry,Einführung in die Lagerbewegung,
+Invalid,Ungültig,
+Invalid Auto Repeat Date,Ungültiges Datum für die automatische Wiederholung,
+Invalid Cost Center,Ungültige Kostenstelle,
+Invalid Delivery Date,Ungültiges Lieferdatum,
+Invalid Document,Ungültiges Dokument,
+Invalid Document Type,Ungültiger Dokumententyp,
+Invalid Formula,Ungültige Formel,
+Invalid Group By,Ungültige Gruppierung,
+Invalid Item Defaults,Ungültige Artikel-Standardwerte,
+Invalid Primary Role,Ungültige primäre Rolle,
+Invalid Priority,Ungültige Priorität,
+Invalid Process Loss Configuration,Ungültige Prozessverlust-Konfiguration,
+Invalid Qty,Ungültige Menge,
+Invalid Schedule,Ungültiger Zeitplan,
+Invalid Serial and Batch Bundle,Ungültiges Serien- und Chargenbündel,
+Invalid Warehouse,Ungültiges Lager,
+Invalid result key. Response:,Ungültiger Ergebnisschlüssel. Antwort:,
+Invalid value {0} for {1} against account {2},Ungültiger Wert {0} für {1} gegen Konto {2},
+Inventory Dimension,Lagerbestandsdimension,
+Inventory Dimension Negative Stock,Lagerbestandsdimension Negativer Bestand,
+Inventory Settings,Inventareinstellungen,
+Invoice Cancellation,Rechnungsstornierung,
+Invoice Limit,Rechnungslimit,
+Invoice and Billing,Rechnung und Abrechnung,
+Invoiced Qty,In Rechnung gestellte Menge,
+Invoices and Payments have been Fetched and Allocated,Rechnungen und Zahlungen wurden abgerufen und zugeordnet,
+Invoicing Features,Rechnungsfunktionen,
+Is Adjustment Entry,Ist Anpassungseintrag,
+Is Composite Asset,Ist ein zusammengesetzter Vermögensgegenstand,
+Is Corrective Operation,Ist Nacharbeit,
+Is Expandable,Ist erweiterbar,
+Is Fully Depreciated,Ist vollständig abgeschrieben,
+Is Old Subcontracting Flow,Ist der alte Unterauftrags-Workflow,
+Is Outward,Ist Ausgehend,
+Is Recursive,Ist rekursiv,
+Is Rejected,Ist abgelehnt,
+Is Short Year,Ist Rumpfjahr,
+Is Stock Item,Ist Lagerartikel,
+Is System Generated,Wurde vom System generiert,
+Is Tax Withholding Account,Ist Steuereinbehaltungskonto,
+Issue Analytics,Anfragenanalyse,
+Issue Summary,Anfragenübersicht,
+Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to,"Die Ausgabe kann nicht an einen Standort erfolgen. Bitte geben Sie den Mitarbeiter ein, der den Vermögensgegenstand erhalten soll {0}",
+It can take upto few hours for accurate stock values to be visible after merging items.,"Es kann bis zu einigen Stunden dauern, bis nach der Zusammenführung von Artikeln genaue Bestandswerte sichtbar sind.",
+"It's not possible to distribute charges equally when total amount is zero, please set 'Distribute Charges Based On' as 'Quantity'","Es ist nicht möglich, die Gebühren gleichmäßig zu verteilen, wenn der Gesamtbetrag gleich Null ist. Bitte stellen Sie 'Gebühren verteilen auf Basis' auf 'Menge'",
+Item Code (Final Product),Artikelcode (Endprodukt),
+Item Group wise Discount,Artikelgruppenbezogener Rabatt,
+Item Price Settings,Artikelpreiseinstellungen,
+"Item Price appears multiple times based on Price List, Supplier/Customer, Currency, Item, Batch, UOM, Qty, and Dates.","Der Artikelpreis wird auf der Grundlage von Preisliste, Lieferant/Kunde, Währung, Artikel, Charge, ME, Menge und Datum mehrfach angezeigt.",
+Item Reference,Artikel-Referenz,
+Item and Warehouse,Artikel und Lager,
+Item is removed since no serial / batch no selected.,"Artikel wird entfernt, da keine Serien-/Chargennummer ausgewählt wurde.",
+Item qty can not be updated as raw materials are already processed.,"Die Artikelmenge kann nicht aktualisiert werden, da das Rohmaterial bereits verarbeitet werden.",
+Item valuation reposting in progress. Report might show incorrect item valuation.,Neubewertung der Artikel im Gange. Der Bericht könnte eine falsche Artikelbewertung anzeigen.,
+Item {0} cannot be added as a sub-assembly of itself,Artikel {0} kann nicht als Unterbaugruppe für sich selbst hinzugefügt werden,
+Item {0} cannot be ordered more than {1} against Blanket Order {2}.,Artikel {0} kann nicht mehr als {1} im Rahmenauftrag {2} bestellt werden.,
+Item {0} entered multiple times.,Artikel {0} mehrfach eingegeben.,
+Item {0} is already reserved/delivered against Sales Order {1}.,Der Artikel {0} ist bereits für den Kundenauftrag {1} reserviert/geliefert.,
+Item {0} must be a Non-Stock Item,Artikel {0} ein Artikel ohne Lagerhaltung sein,
+Item {0} not found in 'Raw Materials Supplied' table in {1} {2},Artikel {0} wurde in der Tabelle „Gelieferte Rohstoffe“ in {1} {2} nicht gefunden,
+Item {0} not found.,Artikel {0} nicht gefunden.,
+Item {} does not exist.,Artikel {0} existiert nicht.,
+"Item, Customer, Supplier and Quotation","Artikel, Kunde, Lieferant und Angebot",
+Items & Pricing,Artikel & Preise,
+Items Catalogue,Artikelkatalog,
+Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}.,"Artikel können nicht aktualisiert werden, da ein Unterauftrag für die Bestellung {0} erstellt ist.",
+Items rate has been updated to zero as Allow Zero Valuation Rate is checked for the following items: {0},"Artikelkurs wurde auf Null aktualisiert, da „Nullbewertung zulassen“ für die folgenden Artikel aktiviert ist: {0}",
+Items to Order and Receive,Zu bestellende und zu erhaltende Artikel,
+Items to Reserve,Zu reservierende Artikel,
+Job Capacity,Arbeitskapazität,
+Job Card Operation,Jobkartenvorgang,
+Job Card Scheduled Time,Jobkarte Geplante Zeit,
+Job Card Scrap Item,Jobkarte Ausschussartikel,
+Job Cards,Jobkarten,
+Job Paused,Auftrag pausiert,
+Job: {0} has been triggered for processing failed transactions,Job: {0} wurde zur Verarbeitung fehlgeschlagener Transaktionen ausgelöst,
+Journal Entries,Buchungssätze,
+Journal Entry for Asset scrapping cannot be cancelled. Please restore the Asset.,Der Buchungssatz für die Verschrottung von Anlagen kann nicht storniert werden. Bitte stellen Sie die Anlage wieder her.,
+Journal Entry type should be set as Depreciation Entry for asset depreciation,"Buchungssatz-Typ muss als ""Abschreibungs Eintrag"" für Abschreibung von Vermögensgegenständen eingestellt werden",
+Journals,Buchungen,
+Journals have been created,Buchungen wurden erstellt,
+Key,Schlüssel,
+Kindly cancel the Manufacturing Entries first against the work order {0}.,Stornieren Sie bitte zuerst die Fertigungseinträge gegen den Arbeitsauftrag {0}.,
+"Last Name, Email or Phone/Mobile of the user are mandatory to continue.","Um fortzufahren, sind Nachname, E-Mail oder Telefon/Mobiltelefon des Benutzers erforderlich.",
+Lead -> Prospect,Lead -> Potenzieller Kunde,
+Lead Conversion Time,Konvertierungszeit,
+Lead Owner cannot be same as the Lead Email Address,Der Eigentümer des Interessenten darf nicht mit der E-Mail-Adresse des Interessenten übereinstimmen,
+Lead {0} has been added to prospect {1}.,Interessent {0} wurde zu Potenziellem Kunden {1} hinzugefügt.,
+"Lead, Opportunity, Customer, and more.","Interessent, Chance, Kunde und mehr.",
+Leaderboard,Bestenliste,
+Leads,Interessenten,
+Learn Accounting,Buchhaltung lernen,
+Learn Inventory Management,Bestandsverwaltung lernen,
+Learn Manufacturing,Fertigung lernen,
+Learn Procurement,Beschaffung lernen,
+Learn Project Management,Projektmanagement lernen,
+Learn Sales Management,Vertriebsmanagement lernen,
+Learn about  Navigation options,Erfahren Sie mehr über die Navigationsoptionen,
+Learn how to update opening balances,"Erfahren Sie, wie Sie Eröffnungssalden aktualisieren können",
+Learn more about Chart of Accounts,Erfahren Sie mehr über Kontenpläne,
+Learn more about Production Planning,Erfahren Sie mehr über Produktionsplanung,
+Learn more about data migration,Erfahren Sie mehr über Datenmigration,
+"Leave blank for home.
+This is relative to site URL, for example ""about"" will redirect to ""https://yoursitename.com/about""","Für „Home“ leer lassen.
+Dies ist relativ zur Site-URL, beispielsweise wird „about“ zu „https://yoursitename.com/about“ weitergeleitet",
+Ledger Health,Kontenintegrität,
+Ledger Health Monitor,Kontenintegritätsmonitor,
+Ledger Health Monitor Company,Kontenintegritätsmonitor Unternehmen,
+Ledger Merge,Kontenzusammenführung,
+Ledger Merge Accounts,Kontenzusammenführung Konten,
+Ledgers,Bücher,
+Left Child,Linker Unterknoten,
+Legend,Legende,
+Length,Länge,
+Length (cm),Länge (cm),
+Less than 12 months.,Weniger als 12 Monate.,
+Let's Set Up Your Accounts and Taxes.,Lassen Sie uns die Konten und Steuern einrichten.,
+Let's Set Up Your CRM.,Lassen Sie uns das CRM einrichten.,
+Let's Set Up the Assets Module.,Lassen Sie uns die Anlagenverwaltung einrichten.,
+Let's Set Up the Buying Module.,Lassen Sie uns den Einkauf einrichten.,
+Let's Set Up the Manufacturing Module.,Lassen Sie uns die Fertigung einrichten.,
+Let's Set Up the Selling Module.,Lassen Sie uns den Vertrieb einrichten.,
+Let's Set Up the Stock Module.,Lassen Sie uns die Lagerhaltung einrichten.,
+Let's begin your journey with ERPNext,Beginnen wir Ihre Reise mit ERPNext,
+Let's create a Purchase Receipt,Lassen Sie uns einen Eingangsbeleg erstellen,
+Let's create a new Asset item,Lassen Sie uns einen neuen Vermögensgegenstand-Artikel erstellen,
+Let's review existing Asset Category,Lassen Sie uns die bestehende Vermögensgegenstand-Kategorie überprüfen,
+Let's review your Company,Lassen Sie uns Ihr Unternehmen betrachten,
+Let's walk-through Chart of Accounts to review setup,"Gehen wir den Kontenplan durch, um die Einrichtung zu überprüfen",
+Let’s convert your first Sales Order against a Quotation,Konvertieren wir Ihr erstes Angebot in einen Kundenauftrag,
+Let’s create a Workstation,Lass uns einen Arbeitsplatz erstellen,
+Let’s create a stock opening entry,Erstellen wir einen Eintrag für den Anfangsbestand,
+Let’s create an Operation,Lassen Sie uns einen Vorgang erstellen,
+Let’s create your first  warehouse ,Lassen Sie uns Ihr erstes Lager erstellen ,
+Let’s create your first Customer,Lassen Sie uns Ihren ersten Kunden anlegen,
+Let’s create your first Material Request,Lassen Sie uns Ihre erste Materialanfrage erstellen,
+Let’s create your first Purchase Invoice,Lassen Sie uns Ihre erste Eingangsrechnung erstellen,
+Let’s create your first Purchase Order,Lassen Sie uns Ihren ersten Lieferantenauftrag erstellen,
+Let’s create your first Quotation,Lassen Sie uns Ihr erstes Angebot erstellen,
+Let’s create your first Supplier,Lassen Sie uns Ihren ersten Lieferanten erstellen,
+Let’s setup your first Letter Head,Lassen Sie uns Ihren ersten Briefkopf einrichten,
+Let’s walk-through Selling Settings,Lassen Sie uns die Verkaufseinstellungen durchgehen,
+Let’s walk-through few Buying Settings,Lass uns einige Einkaufseinstellungen durchgehen,
+Level (BOM),Ebene (Stückliste),
+Limit timeslot for Stock Reposting,Zeitfenster für Bestandsumbuchung begrenzen,
+Limits don't apply on,Einschränkungen gelten nicht für,
+Link a new bank account,Neues Bankkonto verknüpfen,
+Link with Customer,Mit Kunde verknüpfen,
+Link with Supplier,Mit Lieferant verknüpfen,
+Linked with submitted documents,Verknüpft mit gebuchten Dokumenten,
+Linking Failed,Verknüpfung fehlgeschlagen,
+Linking to Customer Failed. Please try again.,Verknüpfung mit Kunde fehlgeschlagen. Bitte versuchen Sie es erneut.,
+Linking to Supplier Failed. Please try again.,Verknüpfung mit Lieferant fehlgeschlagen. Bitte versuchen Sie es erneut.,
+Links,Verknüpfungen,
+Loading import file...,Importdatei wird geladen ...,
+Locked,Gesperrt,
+Log Entries,Protokolleinträge,
+Log the selling and buying rate of an Item,Protokollieren Sie den Verkaufs- und Kaufkurs eines Artikels,
+Lost Reasons are required in case opportunity is Lost.,Bei verloren Chancen sind Gründe für Verlust erforderlich.,
+Machine Type,Maschinentyp,
+Main Cost Center,Hauptkostenstelle,
+Main Cost Center {0} cannot be entered in the child table,Hauptkostenstelle {0} kann nicht in die untergeordnete Tabelle eingegeben werden,
+Maintain Asset,Vermögensgegenstand warten,
+Maintenance Details,Wartungsdetails,
+Make ,Erstellen ,
+Make Asset Movement,Vermögensgegenstand-Bewegung erstellen,
+Make Quotation,Angebot erstellen,
+Make Return Entry,Retoure erstellen,
+Make Serial No / Batch from Work Order,Seriennummer / Charge aus Arbeitsauftrag herstellen,
+Make {0} Variant,{0} Variante erstellen,
+Make {0} Variants,{0} Varianten erstellen,
+Making Journal Entries against advance accounts: {0} is not recommended. These Journals won't be available for Reconciliation.,"Es wird nicht empfohlen, Buchungssätze gegen Vorschusskonten vorzunehmen: {0}. Diese Buchungssätze sind für die Abstimmungen nicht verfügbar.",
+Manage,Verwalten,
+Manage Sales Tax Templates,Umsatzsteuervorlagen verwalten,
+Manage Stock Movements,Lagerbewegungen verwalten,
+Mandatory Accounting Dimension,Obligatorische Buchhaltungsdimension,
+Mandatory Depends On,Bedingung für Pflichtfeld,
+Mandatory Field,Pflichtfeld,
+Mandatory Section,Obligatorischer Abschnitt,
+Manual Inspection,Manuelle Inspektion,
+Manufacturing Type,Fertigungstyp,
+Manufacturing module is all set up!,Das Fertigungsmodul ist fertig eingerichtet!,
+Mapping Purchase Receipt ...,Zuordnung des Eingangsbelegs...,
+Mapping Subcontracting Order ...,Zuordnung des Unterauftrags...,
+Mapping {0} ...,Zuordnung von {0}...,
+Margin View,Margenansicht,
+Mark As Closed,Als geschlossen markieren,
+Material Returned from WIP,Aus WIP zurückgegebenes Material,
+Material Transfer (In Transit),Materialtransfer (In Transit),
+Materials are already received against the {0} {1},Materialien sind bereits gegen {0} {1} eingegangen,
+Max Qty (As Per Stock UOM),Maximale Menge (gemäß Lager-ME),
+Maximum Net Rate,Maximaler Nettopreis,
+Maximum Payment Amount,Maximaler Zahlungsbetrag,
+Maximum Value,Maximalwert,
+Maximum quantity scanned for item {0}.,Maximale Menge für Artikel {0} gescannt.,
+Meeting,Treffen,
+Mention if non-standard Receivable account,"Festlegen, falls nicht das Standard-Forderungskonto verwendet werden soll",
+Merge Invoices Based On,Rechnungen zusammenführen auf Basis von,
+Merge Progress,Fortschritt der Zusammenführung,
+Merge Similar Account Heads,Ähnliche Bezeichnung der Konten zusammenführen,
+Merge taxes from multiple documents,Steuern aus mehreren Dokumenten zusammenführen,
+Merged,Zusammengeführt,
+"Merging is only possible if following properties are same in both records. Is Group, Root Type, Company and Account Currency","Zusammenführen ist nur möglich, wenn die folgenden Eigenschaften in beiden Datensätzen gleich sind: Ist Gruppe, Root-Typ, Unternehmen und Kontowährung",
+Merging {0} of {1},{0} von {1} wird zusammengeführt,
+Min Qty (As Per Stock UOM),Mindestmenge (gemäß Lager-ME),
+Minimum Net Rate,Mindestnettopreis,
+Minimum Payment Amount,Mindestzahlungsbetrag,
+Minimum Value,Minimalwert,
+Mismatch,Keine Übereinstimmung,
+Missing,Fehlt,
+Missing Asset,Fehlender Vermögensgegenstand,
+Missing Cost Center,Fehlende Kostenstelle,
+Missing Finance Book,Fehlendes Finanzbuch,
+Missing Finished Good,Fehlendes Fertigerzeugnis,
+Missing Formula,Fehlende Formel,
+Missing Items,Fehlende Artikel,
+Missing Payments App,Fehlende Zahlungs-App,
+Missing Serial No Bundle,Fehlendes Seriennr.-Bündel,
+Missing value,Fehlender Wert,
+Modified By,Geändert von,
+Modified On,Geändert am,
+Module Settings,Moduleinstellungen,
+Monitor for Last 'X' days,Letzte 'X' Tage überwachen,
+More columns found than expected. Please compare the uploaded file with standard template,Es wurden mehr Spalten gefunden als erwartet. Bitte vergleichen Sie die hochgeladene Datei mit der Standardvorlage,
+Move Stock,Lagerbestand verschieben,
+Move to Cart,Zum Warenkorb bewegen,
+Movement,Bewegung,
+Moving up in tree ...,Aufsteigen im Baum ...,
+Multi-level BOM Creator,Mehrstufiger Stücklistenersteller,
+Multiple Loyalty Programs found for Customer {}. Please select manually.,Für den Kunden {} wurden mehrere Treueprogramme gefunden. Bitte manuell auswählen.,
+Multiple Warehouse Accounts,Mehrere Lager-Konten,
+Multiple items cannot be marked as finished item,Mehrere Artikel können nicht als fertiger Artikel markiert werden,
+Must be a publicly accessible Google Sheets URL and adding Bank Account column is necessary for importing via Google Sheets,Es muss sich um eine öffentlich zugängliche Google Sheets URL handeln und das Hinzufügen der Spalte Bankkonto ist für den Import über Google Sheets erforderlich,
+Named Place,Benannter Ort,
+Naming Series and Price Defaults,Nummernkreis und Preisvorgaben,
+New Balance In Account Currency,Neuer Saldo in Kontowährung,
+New Event,Neues Event,
+New Note,Neue Notiz,
+New Task,Neue Aufgabe,
+New Version,Neue Version,
+No,Nein,
+No Answer,Keine Antwort,
+No Customers found with selected options.,Keine Kunden mit ausgewählten Optionen gefunden.,
+No Items selected for transfer.,Keine Artikel zur Übertragung ausgewählt.,
+No Matching Bank Transactions Found,Keine übereinstimmenden Banktransaktionen gefunden,
+No Notes,Keine Notizen,
+No Outstanding Invoices found for this party,Für diese Partei wurden keine ausstehenden Rechnungen gefunden,
+No POS Profile found. Please create a New POS Profile first,Kein POS-Profil gefunden. Bitte erstellen Sie zunächst ein neues POS-Profil,
+No Records for these settings.,Keine Datensätze für diese Einstellungen.,
+No Serial / Batches are available for return,Es sind keine Serien / Chargen zur Rückgabe verfügbar,
+No Summary,Keine Zusammenfassung,
+No Tax Withholding data found for the current posting date.,Für das aktuelle Buchungsdatum wurden keine Quellensteuerdaten gefunden.,
+No Terms,Keine Bedingungen,
+No Unreconciled Invoices and Payments found for this party and account,Für diese Partei und dieses Konto wurden keine nicht abgeglichenen Rechnungen und Zahlungen gefunden,
+No Unreconciled Payments found for this party,Für diese Partei wurden keine nicht abgestimmten Zahlungen gefunden,
+No Work Orders were created,Es wurden keine Arbeitsaufträge erstellt,
+No additional fields available,Keine zusätzlichen Felder verfügbar,
+No billing email found for customer: {0},Keine Rechnungs-E-Mail für den Kunden gefunden: {0},
+No data found. Seems like you uploaded a blank file,"Keine Daten gefunden. Es scheint, als hätten Sie eine leere Datei hochgeladen",
+No employee was scheduled for call popup,Es war kein Mitarbeiter für das Anruf-Popup eingeplant,
+No failed logs,Keine fehlgeschlagenen Protokolle,
+No item available for transfer.,Kein Artikel zur Übertragung verfügbar.,
+No items are available in sales orders {0} for production,In Kundenaufträgen {0} sind keine Artikel für die Produktion verfügbar,
+No items are available in the sales order {0} for production,Im Kundenauftrag {0} sind keine Artikel für die Produktion verfügbar,
+No items in cart,Keine Artikel im Warenkorb,
+No matches occurred via auto reconciliation,Keine Treffer beim automatischen Abgleich,
+No more children on Left,Keine Unterknoten mehr auf der linken Seite,
+No more children on Right,Keine Unterpunkte auf der rechten Seite,
+No of Docs,Anzahl der Dokumente,
+No of Months (Expense),Anzahl der Monate (Ausgaben),
+No of Months (Revenue),Anzahl der Monate (Einnahmen),
+No open event,Kein offenes Ereignis,
+No open task,Keine offene Aufgabe,
+No primary email found for customer: {0},Keine primäre E-Mail-Adresse für den Kunden gefunden: {0},
+No records found in Allocation table,Keine Datensätze in der Zuteilungstabelle gefunden,
+No records found in the Invoices table,Keine Datensätze in der Tabelle Rechnungen gefunden,
+No records found in the Payments table,Keine Datensätze in der Zahlungstabelle gefunden,
+No stock transactions can be created or modified before this date.,Vor diesem Datum können keine Lagervorgänge erstellt oder geändert werden.,
+No {0} Accounts found for this company.,Keine {0} Konten für dieses Unternehmen gefunden.,
+No.,Nr.,
+No. of Employees,Anzahl Mitarbeiter,
+No. of parallel job cards which can be allowed on this workstation. Example: 2 would mean this workstation can process production for two Work Orders at a time.,"Anzahl der parallelen Auftragskarten, die an diesem Arbeitsplatz erlaubt sind. Beispiel: 2 würde bedeuten, dass dieser Arbeitsplatz die Produktion von zwei Arbeitsaufträgen gleichzeitig verarbeiten kann.",
+Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>,Hinweis: Die automatische Löschung von Protokollen gilt nur für Protokolle des Typs <i>Update Cost</i>,
+"Note: To merge the items, create a separate Stock Reconciliation for the old item {0}","Hinweis: Um die Artikel zusammenzuführen, erstellen Sie eine separate Bestandsabstimmung für den alten Artikel {0}",
+Notes HTML,Notizen HTML,
+Number of Days,Anzahl der Tage,
+Numeric,Numerisch,
+Numeric Inspection,Numerische Prüfung,
+Off,aus,
+Offsetting Account,Verrechnungskonto,
+On Paid Amount,Auf bezahlten Betrag,
+On This Date,An diesem Datum,
+On Track,Auf Kurs,
+On enabling this cancellation entries will be posted on the actual cancellation date and reports will consider cancelled entries as well,"Wenn Sie diese Option aktivieren, werden die Stornobuchungen am tatsächlichen Stornodatum gebucht und die Berichte berücksichtigen auch stornierte Einträge",
+"On submission of the stock transaction, system will auto create the Serial and Batch Bundle based on the Serial No / Batch fields.",Bei der Buchung der Bestandstransaktion erstellt das System automatisch das Serien- und Chargenbündel auf der Grundlage der Felder Seriennummer/Chargennummer.,
+Once the Work Order is Closed. It can't be resumed.,"Sobald der Arbeitsauftrag abgeschlossen ist, kann er nicht wiederaufgenommen werden.",
+Only 'Payment Entries' made against this advance account are supported.,"Es werden nur 'Zahlungsbuchungen' unterstützt, die gegen dieses Vorschusskonto vorgenommen werden.",
+Only CSV and Excel files can be used to for importing data. Please check the file format you are trying to upload,"Nur CSV- und Excel-Dateien können für den Datenimport verwendet werden. Bitte überprüfen Sie das Format der Datei, die Sie hochladen möchten",
+Only Parent can be of type {0},Nur das übergeordnete Element kann vom Typ {0} sein,
+Only existing assets,Nur bestehende Vermögensgegenstände,
+"Only one Subcontracting Order can be created against a Purchase Order, cancel the existing Subcontracting Order to create a new one.","Zu einer Einkaufsbestellung kann nur ein Unterauftrag erstellt werden. Um einen neuen zu erstellen, müssen Sie den vorhandenen Unterauftrag stornieren.",
+Only {0} are supported,Es werden nur {0} unterstützt,
+Open Activities HTML,Alle Aktivitäten HTML,
+Open Call Log,Anrufprotokoll öffnen,
+Open Event,Offenes Event,
+Open Events,Offene Events,
+Open Sales Orders,Offene Kundenaufträge,
+Open Task,Aufgabe erstellen,
+Open Tasks,Offene Aufgaben,
+Open Work Order {0},Offener Arbeitsauftrag {0},
+Opening & Closing,Öffnen & Schließen,
+Operating Cost Per BOM Quantity,Betriebskosten pro Stücklistenmenge,
+Operation time does not depend on quantity to produce,Die Vorgangsdauer hängt nicht von der zu produzierenden Menge ab,
+Opportunity Amount (Company Currency),Chance Betrag (Währung des Unternehmens),
+Opportunity Owner,Chancen-Inhaber,
+Opportunity Source,Quelle der Chance,
+Opportunity Summary by Sales Stage,Chance Zusammenfassung nach Verkaufsstufe,
+Opportunity Summary by Sales Stage ,Chance Zusammenfassung nach Verkaufsstufe ,
+Opportunity Value,Wert,
+Other Info,Sonstiges,
+Out of stock,Nicht auf Lager,
+Over Receipt,Mehreingang,
+Over Receipt/Delivery of {0} {1} ignored for item {2} because you have {3} role.,"Überhöhte Annahme bzw. Lieferung von Artikel {2} mit {0} {1} wurde ignoriert, weil Sie die Rolle {3} haben.",
+Overbilling of {0} {1} ignored for item {2} because you have {3} role.,"Überhöhte Abrechnung von Artikel {2} mit {0} {1} wurde ignoriert, weil Sie die Rolle {3} haben.",
+Overdue Payment,Überfällige Zahlung,
+Overdue Payments,Überfällige Zahlungen,
+Overdue Tasks,Überfällige Aufgaben,
+Overview,Übersicht,
+PDF Name,PDF-Name,
+POS Closing Failed,POS Abschluss fehlgeschlagen,
+POS Closing failed while running in a background process. You can resolve the {0} and retry the process again.,POS Abschluss ist während der Ausführung in einem Hintergrundprozess fehlgeschlagen. Sie können {0} beheben und den Vorgang erneut versuchen.,
+POS Invoices will be consolidated in a background process,POS Rechnungen werden in einem Hintergrundprozess konsolidiert,
+POS Invoices will be unconsolidated in a background process,POS Rechnungen werden in einem Hintergrundprozess gelöst,
+POS Profile {} contains Mode of Payment {}. Please remove them to disable this mode.,"Das POS-Profil {} enthält die Zahlungsweise {}. Bitte entfernen Sie diese erst dort, bevor Sie sie deaktivieren.",
+POS Search Fields,POS-Suchfelder,
+POS Setting,POS-Einstellungen,
+Package No(s) already in use. Try from Package No {0},Paketnummer(n) werden bereits verwendet. Versuchen Sie es mit Paketnummern ab {0},
+Packaging Slip From Delivery Note,Packzettel aus Lieferschein,
+Packed Items cannot be transferred internally,Verpackte Artikel können nicht intern transferiert werden,
+Packed Qty,Verpackte Menge,
+Page Break After Each SoA,Seitenumbruch nach jeder Kontoabrechnung,
+Paid Amount After Tax,Gezahlter Betrag nach Steuern,
+Paid Amount After Tax (Company Currency),Gezahlter Betrag nach Steuern (Währung des Unternehmens),
+Paid From Account Type,Bezahlt von Kontotyp,
+Paid To Account Type,Bezahlt an Kontotyp,
+Pallets,Paletten,
+Parameter Group,Parametergruppe,
+Parameter Group Name,Name der Parametergruppe,
+Parcel Template,Paketvorlage,
+Parcel Template Name,Paketvorlagenname,
+Parcel weight cannot be 0,Paketgewicht kann nicht 0 sein,
+Parcels,Pakete,
+Parent Account Missing,Übergeordnetes Konto fehlt,
+Parent Document,Übergeordnetes Dokument,
+Parent Item {0} must not be a Fixed Asset,Der übergeordnete Artikel {0} darf kein Anlagevermögen sein,
+Parent Row No,Übergeordnete Zeilennr,
+Parent Task {0} is not a Template Task,Übergeordnete Aufgabe {0} ist keine Vorlage,
+Partial Material Transferred,Material teilweise übertragen,
+Partial Stock Reservation,Teilbestandsreservierung,
+Partial Success,Teilerfolg,
+"Partial stock can be reserved. For example, If you have a Sales Order of 100 units and the Available Stock is 90 units then a Stock Reservation Entry will be created for 90 units. ","Teilbestände können reserviert werden. Wenn Sie beispielsweise einen Verkaufsauftrag über 100 Einheiten haben und der verfügbare Bestand 90 Einheiten beträgt, wird eine Bestandsreservierung für 90 Einheiten erstellt. ",
+Partially Delivered,Teilweise geliefert,
+Partially Reconciled,Teilweise abgeglichen,
+Partially Reserved,Teilweise reserviert,
+Partnership,GbR,
+Party Account No. (Bank Statement),Konto-Nr. der Partei (Kontoauszug),
+Party Account {0} currency ({1}) and document currency ({2}) should be same,Die Währung des Kontos {0} ({1}) und die des Dokuments ({2}) müssen identisch sein,
+Party IBAN (Bank Statement),IBAN der Partei (Kontoauszug),
+Party Item Code,Beteiligter Artikel Code,
+Party Name/Account Holder (Bank Statement),Name der Partei/Kontoinhaber (Kontoauszug),
+Party can only be one of {0},Die Partei kann nur eine von {0} sein,
+Passport Details,Angaben zum Reisepass,
+Pause Job,Job pausieren,
+Paused,Pausiert,
+Payable Account: {0} must be in Company default currency: {1},Verbindlichkeitskonto: {0} muss in der Standardwährung des Unternehmens sein: {1},
+"Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice.","Zahlungseintrag {0} ist mit Bestellung {1} verknüpft. Prüfen Sie, ob er in dieser Rechnung als Vorauszahlung ausgewiesen werden soll.",
+Payment Ledger,Zahlungsbuch,
+Payment Ledger Balance,Saldo des Zahlungsbuchs,
+Payment Limit,Zahlungslimit,
+Payment Reconciliations,Zahlungsabgleich,
+Payment Terms from orders will be fetched into the invoices as is,Zahlungsbedingungen aus Aufträgen werden eins zu eins in Rechnungen übernommen,
+Payment Unlink Error,Fehler beim Aufheben der Zahlungsverknüpfung,
+Payment of {0} received successfully.,Zahlung von {0} erfolgreich erhalten.,
+Payment of {0} received successfully. Waiting for other requests to complete...,Zahlung von {0} erfolgreich erhalten. Warte auf die Fertigstellung anderer Anfragen...,
+Payment request failed,Die Zahlungsanforderung ist fehlgeschlagen,
+Payment term {0} not used in {1},Zahlungsbedingung {0} nicht verwendet in {1},
+Pending processing,Ausstehende Verarbeitung,
+Per Received,% Empfangen,
+Percentage (%),Prozentsatz (%),
+Percentage you are allowed to order beyond the Blanket Order quantity.,"Prozentsatz, den Sie über die Rahmenaustragsmenge hinaus bestellen dürfen.",
+Percentage you are allowed to sell beyond the Blanket Order quantity.,"Prozentsatz, den Sie über die Rahmenbestellmenge hinaus verkaufen dürfen.",
+Period Closed,Zeitraum geschlossen,
+Period Closing Settings,Periodenabschlusseinstellungen,
+Period Details,Periode Details,
+Period To Date,Enddatum des Zeitraums,
+Period_from_date,Startdatum des Zeitraums,
+Pick List Incomplete,Pickliste unvollständig,
+Pick Manually,Manuell auswählen,
+Pick Serial / Batch Based On,Serien- / Chargennummer auswählen basierend auf,
+Pick Serial / Batch No,Serien- / Chargennummer auswählen,
+Picked Qty (in Stock UOM),Kommissionierte Menge (in Lager ME),
+Pickup,Abholung,
+Pickup Contact Person,Abholung Kontaktperson,
+Pickup Date,Abholdatum,
+Pickup Date cannot be before this day,Das Abholdatum kann nicht vor diesem Tag liegen,
+Pickup From,Abholung von,
+Pickup To time should be greater than Pickup From time,Die Zeit „Abholung bis“ sollte größer sein als die Zeit „Abholung von“,
+Pickup Type,Abholart,
+Pickup from,Abholung von,
+Pickup to,Abholung bis,
+Plaid Link Failed,Plaid-Link fehlgeschlagen,
+Plaid Link Refresh Required,Aktualisierung des Plaid-Links erforderlich,
+Plaid Link Updated,Plaid-Link aktualisiert,
+Plant Dashboard,Werk Dashboard,
+Plant Floor,Werkshalle,
+Please Set Priority,Bitte Priorität festlegen,
+Please Specify Account,Bitte Konto angeben,
+Please add 'Supplier' role to user {0}.,Bitte fügen Sie dem Benutzer {0} die Rolle „Lieferant“ hinzu.,
+Please add Request for Quotation to the sidebar in Portal Settings.,Bitte fügen Sie „Angebotsanfrage“ zur Seitenleiste in den Portaleinstellungen hinzu.,
+Please add Root Account for - {0},Bitte fügen Sie ein Root-Konto für - {0} hinzu,
+Please add atleast one Serial No / Batch No,Bitte fügen Sie mindestens eine Serien-/Chargennummer hinzu,
+Please add the Bank Account column,Bitte fügen Sie die Spalte „Bankkonto“ hinzu,
+Please add the account to root level Company - {0},Bitte fügen Sie das Konto zur Muttergesellschaft hinzu - {0},
+Please add {1} role to user {0}.,Bitte fügen Sie dem Benutzer {0} die Rolle {1} hinzu.,
+Please adjust the qty or edit {0} to proceed.,"Bitte passen Sie die Menge an oder bearbeiten Sie {0}, um fortzufahren.",
+Please attach CSV file,Bitte CSV-Datei anhängen,
+Please cancel and amend the Payment Entry,Bitte stornieren und berichtigen Sie die Zahlung,
+Please cancel payment entry manually first,Bitte stornieren Sie die Zahlung zunächst manuell,
+Please cancel related transaction.,Bitte stornieren Sie die entsprechende Transaktion.,
+Please check Process Deferred Accounting {0} and submit manually after resolving errors.,"Bitte überprüfen Sie ""Rechnungsabgrenzung verarbeiten"" {0} und buchen Sie den Vorgang nach Behebung der Fehler manuell.",
+Please check your email to confirm the appointment,"Bitte überprüfen Sie Ihre E-Mails, um den Termin zu bestätigen",
+Please contact any of the following users to extend the credit limits for {0}: {1},"Bitte kontaktieren Sie einen der folgenden Benutzer, um die Kreditlimits für {0} zu erweitern: {1}",
+Please contact any of the following users to {} this transaction.,"Bitte kontaktieren Sie einen der folgenden Benutzer, um diese Transaktion zu {}.",
+Please contact your administrator to extend the credit limits for {0}.,"Bitte wenden Sie sich an Ihren Administrator, um die Kreditlimits für {0} zu erweitern.",
+Please create a new Accounting Dimension if required.,Bitte erstellen Sie bei Bedarf eine neue Buchhaltungsdimension.,
+Please create purchase from internal sale or delivery document itself,Bitte erstellen Sie den Kauf aus dem internen Verkaufs- oder Lieferbeleg selbst,
+"Please delete Product Bundle {0}, before merging {1} into {2}","Bitte löschen Sie das Produktbündel {0}, bevor Sie {1} mit {2} zusammenführen",
+Please do not book expense of multiple assets against one single Asset.,Bitte buchen Sie die Ausgaben für mehrere Vermögensgegenstände nicht auf einen einzigen Vermögensgegenstand.,
+Please enable only if the understand the effects of enabling this.,"Bitte aktivieren Sie diese Option nur, wenn Sie die Auswirkungen verstehen.",
+Please enable {0} in the {1}.,Bitte aktivieren Sie {0} in {1}.,
+Please enable {} in {} to allow same item in multiple rows,"Bitte aktivieren Sie {} in {}, um denselben Artikel in mehreren Zeilen zuzulassen",
+Please ensure {} account is a Balance Sheet account.,"Bitte stellen Sie sicher, dass das Konto {} ein Bilanzkonto ist.",
+Please ensure {} account {} is a Payable account. Change the account type to Payable or select a different account.,"Bitte stellen Sie sicher, dass {} Konto {} ein Verbindlichkeiten-Konto ist. Bitte ändern Sie die Kontoart oder wählen Sie ein anderes Konto.",
+Please ensure {} account {} is a Receivable account.,"Bitte stellen Sie sicher, dass {} Konto {} ein Forderungskonto ist.",
+Please enter Root Type for account- {0},Bitte geben Sie den Root-Typ für das Konto ein: {0},
+Please enter Serial Nos,Bitte Seriennummern eingeben,
+Please enter Shipment Parcel information,Bitte geben Sie die Paketinformationen für die Sendung ein,
+Please enter Stock Items consumed during the Repair.,Bitte geben Sie die während der Reparatur verbrauchten Lagerartikel ein.,
+Please enter mobile number first.,Bitte geben Sie zuerst Ihre Handynummer ein.,
+Please enter quantity for item {0},Bitte geben Sie die Anzahl für den Artikel {0} ein,
+Please enter serial nos,Bitte geben Sie die Seriennummern ein,
+"Please first set Last Name, Email and Phone for the user","Bitte geben Sie zunächst Nachname, E-Mail und Telefonnummer des Benutzers ein",
+Please fix overlapping time slots for {0},Bitte korrigieren Sie sich überschneidende Zeitfenster für {0},
+Please fix overlapping time slots for {0}.,Bitte korrigieren Sie sich überschneidende Zeitfenster für {0}.,
+Please import accounts against parent company or enable {} in company master.,Bitte importieren Sie Konten gegen die Muttergesellschaft oder aktivieren Sie {} in den Unternehmensstammdaten.,
+Please make sure the file you are using has 'Parent Account' column present in the header.,"Bitte vergewissern Sie sich, dass die von Ihnen verwendete Datei in der Kopfzeile die Spalte 'Parent Account' enthält.",
+Please mention 'Weight UOM' along with Weight.,Bitte geben Sie neben dem Gewicht auch die entsprechende Mengeneinheit an.,
+Please mention the Current and New BOM for replacement.,Bitte geben Sie die aktuelle und die neue Stückliste für den Ersatz an.,
+Please rectify and try again.,Bitte korrigieren Sie den Fehler und versuchen Sie es erneut.,
+Please refresh or reset the Plaid linking of the Bank {}.,Bitte aktualisieren oder setzen Sie die Plaid-Verknüpfung der Bank {} zurück.,
+Please save before proceeding.,"Bitte speichern Sie, bevor Sie fortfahren.",
+Please select Bank Account,Bitte wählen Sie ein Bankkonto,
+Please select Finished Good Item for Service Item {0},Bitte wählen Sie ein Fertigprodukt für Serviceartikel {0},
+Please select Serial/Batch Nos to reserve or change Reservation Based On to Qty.,Wählen Sie zum Reservieren Serien-/Chargennummern aus oder ändern Sie „Reservierung basierend auf“ in „Menge“.,
+Please select Subcontracting Order instead of Purchase Order {0},"Bitte wählen Sie ""Unterauftrag"" anstatt ""Bestellung"" {0}",
+Please select a Subcontracting Purchase Order.,Bitte wählen Sie eine Unterauftragsbestellung aus.,
+Please select a Warehouse,Bitte wählen Sie ein Lager,
+Please select a Work Order first.,Bitte wählen Sie zuerst einen Arbeitsauftrag aus.,
+Please select a customer for fetching payments.,"Bitte wählen Sie einen Kunden aus, um Zahlungen abzurufen.",
+Please select a date,Bitte wählen Sie ein Datum,
+Please select a date and time,Bitte wählen Sie ein Datum und eine Uhrzeit,
+Please select a row to create a Reposting Entry,"Bitte wählen Sie eine Zeile aus, um einen Umbuchungseintrag zu erstellen",
+Please select a supplier for fetching payments.,"Bitte wählen Sie einen Lieferanten aus, um Zahlungen abzurufen.",
+Please select a valid Purchase Order that has Service Items.,Bitte wählen Sie einen gültigen Lieferantenauftrag mit Serviceartikeln.,
+Please select a valid Purchase Order that is configured for Subcontracting.,"Bitte wählen Sie einen gültigen Lieferantenauftrag, der für die Vergabe von Unteraufträgen konfiguriert ist.",
+Please select an item code before setting the warehouse.,"Bitte wählen Sie einen Artikelcode aus, bevor Sie das Lager festlegen.",
+Please select either the Item or Warehouse or Warehouse Type filter to generate the report.,"Bitte wählen Sie entweder den Filter „Artikel“, „Lager“ oder „Lagertyp“ aus, um den Bericht zu generieren.",
+Please select items,Bitte Artikel auswählen,
+Please select items to reserve.,"Bitte wählen Sie die Artikel aus, die Sie reservieren möchten.",
+Please select items to unreserve.,"Bitte wählen Sie Artikel aus, deren Reservierung aufgehoben werden soll.",
+Please select only one row to create a Reposting Entry,"Bitte wählen Sie nur eine Zeile aus, um einen Umbuchungseintrag zu erstellen",
+Please select rows to create Reposting Entries,"Bitte wählen Sie Zeilen aus, um Umbuchungseinträge zu erstellen",
+Please select the required filters,Bitte wählen Sie die gewünschten Filter aus,
+Please select valid document type.,Bitte wählen Sie einen gültigen Dokumententyp aus.,
+Please set Account,Bitte legen Sie ein Konto fest,
+Please set Accounting Dimension {} in {},Bitte legen Sie die Buchhaltungsdimension {} in {} fest,
+Please set Email/Phone for the contact,Bitte legen Sie E-Mail/Telefon für den Kontakt fest,
+Please set Fiscal Code for the customer '%s',Bitte setzen Sie den Steuercode für den Kunden '%s',
+Please set Fiscal Code for the public administration '%s',Bitte setzen Sie den Steuercode für die öffentliche Verwaltung '%s',
+Please set Root Type,Bitte Root-Typ setzen,
+Please set Tax ID for the customer '%s',Bitte legen Sie die Steuernummer für den Kunden „%s“ fest,
+Please set VAT Accounts in {0},Bitte legen Sie die Umsatzsteuerkonten in {0} fest,
+Please set a Cost Center for the Asset or set an Asset Depreciation Cost Center for the Company {},Bitte legen Sie eine Kostenstelle für den Vermögensgegenstand oder eine Standard-Kostenstelle für die Abschreibung von Vermögensgegenständen für das Unternehmen {} fest,
+Please set a default Holiday List for Company {0},Bitte legen Sie eine Standardliste der arbeitsfreien Tage für Unternehmen {0} fest,
+Please set an Address on the Company '%s',Bitte geben Sie eine Adresse für das Unternehmen „%s“ ein,
+Please set an Expense Account in the Items table,Bitte legen Sie in der Artikeltabelle ein Aufwandskonto fest,
+Please set default Exchange Gain/Loss Account in Company {},Bitte legen Sie im Unternehmen {} das Standardkonto für Wechselkursgewinne/-verluste fest,
+Please set filters,Bitte Filter einstellen,
+Please set one of the following:,Bitte stellen Sie eine der folgenden Optionen ein:,
+Please set the cost center field in {0} or setup a default Cost Center for the Company.,Legen Sie das Feld Kostenstelle in {0} fest oder richten Sie eine Standardkostenstelle für das Unternehmen ein.,
+Please set {0} in BOM Creator {1},Bitte setzen Sie {0} im Stücklistenersteller {1},
+Please setup and enable a group account with the Account Type - {0} for the company {1},Bitte richten Sie ein Gruppenkonto mit dem Kontotyp - {0} für die Firma {1} ein und aktivieren Sie es,
+Please share this email with your support team so that they can find and fix the issue.,"Bitte teilen Sie diese E-Mail mit Ihrem Support-Team, damit es das Problem finden und beheben kann.",
+Please specify a {0},Bitte geben Sie eine {0} an,
+Please try again in an hour.,Bitte versuchen Sie es in einer Stunde erneut.,
+Please update Repair Status.,Bitte aktualisieren Sie den Reparaturstatus.,
+Point-of-Sale Profile,Verkaufsstellen-Profil,POS Profile
+Portal User,Portal-Benutzer,
+Portal Users,Portal-Benutzer,
+Posting Datetime,Buchungszeitpunkt,
+"Previous Year is not closed, please close it first","Das vorherige Jahr ist noch nicht abgeschlossen, bitte schließen Sie es zuerst",
+Price ({0}),Preis ({0}),
+Price List Defaults,Preislistenvorgaben,
+Price Per Unit ({0}),Preis pro Einheit ({0}),
+Primary Contact,Hauptkontakt,
+Primary Party,Primäre Partei,
+Primary Role,Hauptrolle,
+Print Format Builder,Programm zum Erstellen von Druckformaten,
+Printing,Druck,
+Priority cannot be lesser than 1.,Die Priorität kann nicht kleiner als 1 sein.,
+Priority is mandatory,Priorität ist erforderlich,
+Probability,Warscheinlichkeit,
+Process Loss,Prozessverlust,
+Process Loss Percentage cannot be greater than 100,Der Prozentsatz der Prozessverluste kann nicht größer als 100 sein,
+Process Loss Qty,Prozessverlustmenge,
+Process Loss Report,Prozessverlust-Bericht,
+Process Loss Value,Prozessverlustwert,
+Process Payment Reconciliation,Zahlungsabgleich verarbeiten,
+Process Subscription,Abonnement verarbeiten,
+Process in Single Transaction,Verarbeitung in einer einzigen Transaktion,
+Processed BOMs,Verarbeitete Stücklisten,
+Processing Sales! Please Wait...,Verkauf wird verarbeitet! Bitte warten...,
+Produced / Received Qty,Produziert / Erhaltene Menge,
+Product Price ID,Produktpreis-ID,
+Production Plan Already Submitted,Produktionsplan bereits gebucht,
+Production Plan Item Reference,Produktionsplanartikelreferenz,
+Production Plan Qty,Produktionsplan Menge,
+Production Plan Sub Assembly Item,Produktionsplan-Unterbaugruppenartikel,
+Production Plan Sub-assembly Item,Produktionsplan-Unterbaugruppenartikel,
+Production Plan Summary,Produktionsplan Zusammenfassung,
+Production Planning,Produktionsplanung,
+"Products, Purchases, Analysis, and more.","Produkte, Einkäufe, Analysen und mehr.",
+"Products, Raw Materials, BOM, Work Order, and more.","Produkte, Rohmaterialien, Stücklisten, Arbeitsaufträge und mehr.",
+"Products, Sales, Analysis, and more.","Produkte, Vertrieb, Analyse und mehr.",
+Profit and Loss Summary,Gewinn und Verlust Zusammenfassung,
+Progress,Fortschritt,
+Progress (%),Fortschritt (%),
+Project Progress:,Projektfortschritt:,
+Prospect,Potenzieller Kunde,
+Prospect Lead,Lead beim potenziellen Kunde,
+Prospect Opportunity,Chance beim potenziellen Kunde,
+Prospect Owner,Verantwortliche Person,
+Prospect {0} already exists,Potenzieller Kunde {0} existiert bereits,
+Purchase Orders {0} are un-linked,Bestellungen {0} sind nicht verlinkt,
+Purchase Receipt (Draft) will be auto-created on submission of Subcontracting Receipt.,"Der Eingangsbeleg (Entwurf) wird automatisch erstellt, wenn der Unterauftragsbeleg gebucht wird.",
+Purchase Receipt {0} created.,Eingangsbeleg {0} erstellt.,
+Purchase Value,Einkaufswert,
+Purchase an Asset,Vermögensgegenstand kaufen,
+Purchase an Asset Item,Vermögensgegenstand-Artikel kaufen,
+Purchases,Käufe,
+Purposes Required,Gründe erforderlich,
+Putaway Rule already exists for Item {0} in Warehouse {1}.,Für Artikel {0} im Lager {1} ist bereits eine Einlagerungsregel vorhanden.,
+Qty ,Menge ,
+Qty After Transaction,Menge nach Transaktion,
+Qty As Per BOM,Menge gemäß Stückliste,
+Qty Change,Mengenänderung,
+Qty In Stock,Menge auf Lager,
+Qty Per Unit,Menge pro Einheit,
+"Qty To Manufacture ({0}) cannot be a fraction for the UOM {2}. To allow this, disable '{1}' in the UOM {2}.","Die Herzustellende Menge ({0}) kann nicht ein Bruchteil der Maßeinheit {2} sein. Um dies zu ermöglichen, deaktivieren Sie '{1}' in der Maßeinheit {2}.",
+Qty To Produce,Zu produzierende Menge,
+Qty and Rate,Menge und Einzelpreis,
+Qty as Per Stock UOM,Menge in Lagermaßeinheit,
+Qty in Stock UOM,Menge in Lagermaßeinheit,
+Qty of Finished Goods Item should be greater than 0.,Die Menge des Fertigwarenartikels sollte größer als 0 sein.,
+Qty to Be Consumed,Zu verbrauchende Menge,
+Qty to Build,Zu produzierende Menge,
+Qty to Fetch,Abzurufende Menge,
+Qty to Produce,Zu produzierende Menge,
+Qualified,Qualifiziert,
+Quality Inspection Parameter,Qualitätsprüfparameter,
+Quality Inspection Parameter Group,Qualitätsprüfungsparametergruppe,
+Quality Inspection Settings,Einstellungen für die Qualitätsprüfung,
+Quality Inspection(s),Qualitätsprüfung(en),
+Quantity is required,Menge ist erforderlich,
+"Quantity must be greater than zero, and less or equal to {0}",Die Menge muss größer als Null und kleiner oder gleich {0} sein,
+Quantity to Produce should be greater than zero.,Die zu produzierende Menge sollte größer als Null sein.,
+Quantity to Scan,Zu scannende Menge,
+Quarter {0} {1},Quartal {0} {1},
+Quoted Amount,Angebotsbetrag,
+Rate Difference with Purchase Invoice,Kursdifferenz zur Eingangsrechnung,
+Ratios,Verhältnisse,
+Raw Material Cost Per Qty,Rohstoffkosten pro Menge,
+Raw Material Item,Rohmaterial Artikel,
+Raw Material Value,Rohmaterial Wert,
+Raw Materials Warehouse,Rohstofflager,
+Reached Root,Oberste Ebene erreicht,
+Reading Value,Abgelesener Wert,
+Reason for hold:,Grund für die Sperre:,
+Rebuild Tree,Baum neu aufbauen,
+Receivable/Payable Account,Forderungen-/Verbindlichkeiten-Konto,
+Received Amount After Tax,Erhaltener Betrag nach Steuern,
+Received Amount After Tax (Company Currency),Erhaltener Betrag nach Steuern (Währung des Unternehmens),
+Received Qty in Stock UOM,Erhaltene Menge in Lager-ME,
+Recent Orders,Letzte Bestellungen,
+Recent Transactions,Kürzliche Transaktionen,
+Reconcile the Bank Transaction,Banktransaktion abgleichen,
+Reconciled Entries,Abgestimmte Posten,
+Reconciliation Error Log,Abstimmungsfehlerprotokoll,
+Reconciliation Logs,Abstimmungsprotokolle,
+Reconciliation Progress,Abstimmungsfortschritt,
+Recording HTML,HTML aufzeichnen,
+Reference Exchange Rate,Referenzwechselkurs,
+Reference No,Referenznummer,
+Reference number of the invoice from the previous system,Referenznummer der Rechnung aus dem vorherigen System,
+References to Sales Invoices are Incomplete,Verweise auf Ausgangsrechnungen sind unvollständig,
+References to Sales Orders are Incomplete,Referenzen zu Kundenaufträgen sind unvollständig,
+Refresh Google Sheet,Google Sheet aktualisieren,
+Refresh Plaid Link,Plaid Link aktualisieren,
+Regenerate Closing Stock Balance,Schlussbestand neu generieren,
+Rejected Serial and Batch Bundle,Abgelehntes Serien- und Chargenbündel,
+Repair,Reparieren,
+Repair Asset,Vermögensgegenstand reparieren,
+Repair Details,Reparaturdetails,
+"Replace a particular BOM in all other BOMs where it is used. It will replace the old BOM link, update cost and regenerate ""BOM Explosion Item"" table as per new BOM.
+It also updates latest price in all the BOMs.","Ersetzen Sie eine bestimmte Stückliste in allen anderen Stücklisten, in denen sie verwendet wird. Dadurch wird der alte Stücklistenlink ersetzt, die Kosten werden aktualisiert und die Tabelle „Position der aufgelösten Stückliste“ gemäß der neuen Stückliste neu erstellt.
+Außerdem wird der neueste Preis in allen Stücklisten aktualisiert.",
+Report Error,Fehler melden,
+Report Filters,Berichtsfilter,
+Report View,Berichtsansicht,
+Repost Error Log,Fehlerprotokoll für Umbuchungen,
+Represents a Financial Year. All accounting entries and other major transactions are tracked against the Fiscal Year.,Stellt ein Geschäftsjahr dar. Alle Buchhaltungsbeiträge und andere wichtige Transaktionen werden gegen das Geschäftsjahr verfolgt.,
+Request Parameters,Anfrageparameter,
+Request Timeout,Zeitüberschreitung der Anfrage,
+Reservation Based On,Reservierung basierend auf,
+Reserve,Reservieren,
+Reserve Stock,Reservierter Bestand,
+"Reserved Qty ({0}) cannot be a fraction. To allow this, disable '{1}' in UOM {3}.","Die reservierte Menge ({0}) darf kein Bruchteil sein. Um dies zu ermöglichen, deaktivieren Sie '{1}' in UOM {3}.",
+Reserved Qty for Production Plan,Reservierte Menge für Produktionsplan,
+Reserved Qty for Subcontract,Reservierte Menge für Unterauftrag,
+Reserved Qty should be greater than Delivered Qty.,Die reservierte Menge sollte größer sein als die gelieferte Menge.,
+Reserved Serial No.,Reservierte Seriennr.,
+Reserved Stock,Reservierter Bestand,
+Reserved Stock for Batch,Reservierter Bestand für Charge,
+Reserved for POS Transactions,Für Kassentransaktionen reserviert,
+Reserved for Production,Für die Produktion reserviert,
+Reserved for Production Plan,Für Produktionsplan reserviert,
+Reserved for Sub Contracting,Für Unteraufträge reserviert,
+Reserving Stock...,Bestand reservieren...,
+Reset Plaid Link,Plaid-Link zurücksetzen,
+Resolution Due,Auflösung fällig,
+Response and Resolution,Antwort und Auflösung,
+Restart,Neustart,
+Restore Asset,Vermögensgegenstand wiederherstellen,
+Restrict,Einschränken,
+Result Key,Ergebnisschlüssel,
+Resume Job,Auftrag fortsetzen,
+Retried,Erneut versucht,
+Retry,Wiederholen,
+Retry Failed Transactions,Fehlgeschlagene Transaktionen wiederholen,
+Return Against,Korrektur von,
+Return Issued,Rückgabe ausgestellt,
+Return Qty,Rückgabemenge,
+Return Qty from Rejected Warehouse,Rückgabemenge aus Ausschusslager,
+Return of Components,Rückgabe von Komponenten,
+Returned,Zurückgeschickt,
+Returned Qty ,Zurückgegebene Menge ,
+Returned Qty in Stock UOM,Zurückgegebene Menge in Lager-ME,
+Revenue,Umsatz,
+Reversal Of,Umkehrung von,
+Review Chart of Accounts,Prüfung des Kontenplans,
+Review Fixed Asset Accounts,Konten für Vermögensgegenstände überprüfen,
+Review Stock Settings,Lagereinstellungen überprüfen,
+Right Child,Rechter Unterknoten,
+Role Allowed to Create/Edit Back-dated Transactions,"Rolle, die rückdatierte Transaktionen erstellen/bearbeiten darf",
+Role Allowed to Override Stop Action,"Rolle, die die Stopp-Aktion übergehen darf",
+Role allowed to bypass Credit Limit,"Rolle, die das Kreditlimit umgehen darf",
+"Root Type for {0} must be one of the Asset, Liability, Income, Expense and Equity","Root-Typ für {0} muss einer der folgenden sein: Vermögenswert, Verbindlichkeit, Einkommen, Aufwand und Eigenkapital",
+Row #,Zeile #,
+Row # {0}:,Zeile # {0}:,
+Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}.,Zeile #{0}: Für das Lager {1} mit dem Nachbestellungstyp {2} ist bereits ein Nachbestellungseintrag vorhanden.,
+Row #{0}: Acceptance Criteria Formula is incorrect.,Zeile #{0}: Die Formel für die Akzeptanzkriterien ist falsch.,
+Row #{0}: Acceptance Criteria Formula is required.,Zeile #{0}: Die Formel für die Akzeptanzkriterien ist erforderlich.,
+Row #{0}: Accepted Warehouse and Rejected Warehouse cannot be same,Zeile #{0}: Annahme- und Ablehnungslager dürfen nicht identisch sein,
+Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1},Zeile #{0}: Annahmelager ist obligatorisch für den angenommenen Artikel {1},
+Row #{0}: Allocated amount:{1} is greater than outstanding amount:{2} for Payment Term {3},Zeile #{0}: Zugewiesener Betrag:{1} ist größer als der ausstehende Betrag:{2} für Zahlungsfrist {3},
+Row #{0}: Amount must be a positive number,Zeile #{0}: Betrag muss eine positive Zahl sein,
+Row #{0}: BOM is not specified for subcontracting item {0},Zeile #{0}: Stückliste ist für Unterauftragsgegenstand {0} nicht spezifiziert,
+Row #{0}: Batch No {1} is already selected.,Zeile #{0}: Die Chargennummer {1} ist bereits ausgewählt.,
+Row #{0}: Cannot transfer more than Required Qty {1} for Item {2} against Job Card {3},Zeile #{0}: Es kann nicht mehr als die erforderliche Menge {1} für Artikel {2} gegen Auftragskarte {3} übertragen werden,
+Row #{0}: Consumed Asset {1} cannot be Draft,Zeile #{0}: verbrauchter Vermögensgegenstand {1} darf nicht im Entwurfsstatus sein,
+Row #{0}: Consumed Asset {1} cannot be cancelled,Zeile #{0}: verbrauchter Vermögensgegenstand {1} darf nicht storniert sein,
+Row #{0}: Consumed Asset {1} cannot be the same as the Target Asset,Zeile #{0}: verbrauchter Vermögensgegenstand {1} darf nicht identisch mit der Ziel-Vermögensgegenstand sein,
+Row #{0}: Consumed Asset {1} cannot be {2},Zeile #{0}: verbrauchter Vermögensgegenstand {1} darf nicht {2} sein,
+Row #{0}: Consumed Asset {1} does not belong to company {2},Zeile #{0}: verbrauchter Vermögensgegenstand {1} gehört nicht zu Unternehmen {2},
+Row #{0}: Cumulative threshold cannot be less than Single Transaction threshold,Zeile #{0}: Kumulativer Schwellenwert kann nicht kleiner sein als der Schwellenwert für Einzeltransaktionen,
+Row #{0}: Dates overlapping with other row,Zeile #{0}: Daten überlappen sich mit anderen Zeilen,
+Row #{0}: Default BOM not found for FG Item {1},Zeile #{0}: Standard-Stückliste für Fertigerzeugnis {1} nicht gefunden,
+Row #{0}: Expense Account not set for the Item {1}. {2},Zeile #{0}: Aufwandskonto für den Artikel nicht festgelegt {1}. {2},
+Row #{0}: Finished Good Item Qty can not be zero,Zeile #{0}: Menge für Fertigerzeugnis darf nicht Null sein,
+Row #{0}: Finished Good Item is not specified for service item {1},Zeile #{0}: Fertigerzeugnisartikel ist nicht für Dienstleistungsartikel {1} spezifiziert,
+Row #{0}: Finished Good Item {1} must be a sub-contracted item,Zeile #{0}: Fertigerzeugnisartikel {1} muss ein unterbeauftragter Artikel sein,
+Row #{0}: Finished Good reference is mandatory for Scrap Item {1}.,Zeile #{0}: Fertigerzeugnis-Referenz ist obligatorisch für Ausschussartikel {1}.,
+"Row #{0}: For {1}, you can select reference document only if account gets credited","Zeile #{0}: Für {1} können Sie den Referenzbeleg nur auswählen, wenn das Konto belastet wird",
+"Row #{0}: For {1}, you can select reference document only if account gets debited","Zeile #{0}: Für {1} können Sie den Referenzbeleg nur auswählen, wenn das Konto belastet wird",
+Row #{0}: From Date cannot be before To Date,Zeile #{0}: Von-Datum kann nicht vor Bis-Datum liegen,
+Row #{0}: Item {1} does not exist,Zeile #{0}: Artikel {1} existiert nicht,
+"Row #{0}: Item {1} has been picked, please reserve stock from the Pick List.","Zeile #{0}: Artikel {1} wurde kommissioniert, bitte reservieren Sie den Bestand aus der Pickliste.",
+Row #{0}: Item {1} is not a service item,Zeile #{0}: Artikel {1} ist kein Dienstleistungsartikel,
+Row #{0}: Item {1} is not a stock item,Zeile #{0}: Artikel {1} ist kein Lagerartikel,
+Row #{0}: Please select Item Code in Assembly Items,Zeile #{0}: Bitte wählen Sie den Artikelcode in den Baugruppenartikeln aus,
+Row #{0}: Please select the BOM No in Assembly Items,Zeile #{0}: Bitte wählen Sie die Stücklisten-Nr. in den Montageartikeln,
+Row #{0}: Please select the Sub Assembly Warehouse,Zeile #{0}: Bitte wählen Sie das Lager für Unterbaugruppen,
+Row #{0}: Qty increased by {1},Zeile #{0}: Menge erhöht um {1},
+Row #{0}: Qty must be a positive number,Zeile #{0}: Menge muss eine positive Zahl sein,
+Row #{0}: Qty should be less than or equal to Available Qty to Reserve (Actual Qty - Reserved Qty) {1} for Iem {2} against Batch {3} in Warehouse {4}.,Zeile #{0}: Die Menge sollte kleiner oder gleich der verfügbaren Menge zum Reservieren sein (Ist-Menge – reservierte Menge) {1} für Artikel {2} der Charge {3} im Lager {4}.,
+Row #{0}: Quantity to reserve for the Item {1} should be greater than 0.,Zeile #{0}: Die zu reservierende Menge für den Artikel {1} sollte größer als 0 sein.,
+Row #{0}: Rate must be same as {1}: {2} ({3} / {4}),Zeile #{0}: Einzelpreis muss gleich sein wie {1}: {2} ({3} / {4}),
+Row #{0}: Received Qty must be equal to Accepted + Rejected Qty for Item {1},Zeile #{0}: Die erhaltene Menge muss gleich der angenommenen + abgelehnten Menge für Artikel {1} sein,
+Row #{0}: Rejected Qty cannot be set for Scrap Item {1}.,Zeile #{0}: Die abgelehnte Menge kann nicht für den Ausschussartikel {1} festgelegt werden.,
+Row #{0}: Scrap Item Qty cannot be zero,Zeile #{0}: Die Menge des Ausschussartikels darf nicht Null sein,
+Row #{0}: Serial No {1} for Item {2} is not available in {3} {4} or might be reserved in another {5}.,Zeile #{0}: Seriennummer {1} für Artikel {2} ist in {3} {4} nicht verfügbar oder könnte in einem anderen {5} reserviert sein.,
+Row #{0}: Serial No {1} is already selected.,Zeile #{0}: Die Seriennummer {1} ist bereits ausgewählt.,
+Row #{0}: Start Time and End Time are required,Zeile #{0}: Startzeit und Endzeit sind erforderlich,
+Row #{0}: Start Time must be before End Time,Zeile #{0}: Startzeit muss vor Endzeit liegen,
+Row #{0}: Status is mandatory,Zeile #{0}: Status ist obligatorisch,
+Row #{0}: Stock cannot be reserved for Item {1} against a disabled Batch {2}.,Zeile #{0}: Der Bestand kann nicht für Artikel {1} für eine deaktivierte Charge {2} reserviert werden.,
+Row #{0}: Stock cannot be reserved for a non-stock Item {1},Zeile #{0}: Lagerbestand kann nicht für einen Artikel ohne Lagerhaltung reserviert werden {1},
+Row #{0}: Stock cannot be reserved in group warehouse {1}.,Zeile #{0}: Bestand kann nicht im Gruppenlager {1} reserviert werden.,
+Row #{0}: Stock is already reserved for the Item {1}.,Zeile #{0}: Für den Artikel {1} ist bereits ein Lagerbestand reserviert.,
+Row #{0}: Stock is reserved for item {1} in warehouse {2}.,Zeile #{0}: Der Bestand ist für den Artikel {1} im Lager {2} reserviert.,
+Row #{0}: Stock not available to reserve for Item {1} against Batch {2} in Warehouse {3}.,Zeile #{0}: Bestand nicht verfügbar für Artikel {1} von Charge {2} im Lager {3}.,
+Row #{0}: Stock not available to reserve for the Item {1} in Warehouse {2}.,Zeile #{0}: Kein Bestand für den Artikel {1} im Lager {2} verfügbar.,
+Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2},Zeile #{0}: Das Lager {1} ist kein untergeordnetes Lager eines Gruppenlagers {2},
+Row #{0}: You must select an Asset for Item {1}.,Zeile #{0}: Sie müssen einen Vermögensgegenstand für Artikel {1} auswählen.,
+Row #{0}: {1} of {2} should be {3}. Please update the {1} or select a different account.,Zeile #{0}: {1} von {2} sollte {3} sein. Bitte aktualisieren Sie die {1} oder wählen Sie ein anderes Konto.,
+Row #{1}: Warehouse is mandatory for stock Item {0},Zeile #{1}: Lager ist obligatorisch für Artikel {0},
+Row #{}: Finance Book should not be empty since you're using multiple.,"Zeile #{}: Das Finanzbuch sollte nicht leer sein, da Sie mehrere verwenden.",
+Row #{}: Original Invoice {} of return invoice {} is {}.,Zeile #{}: Originalrechnung {} der Rechnungskorrektur {} ist {}.,
+Row #{}: Please use a different Finance Book.,Zeile #{}: Bitte verwenden Sie ein anderes Finanzbuch.,
+Row #{}: item {} has been picked already.,Zeile #{}: Artikel {} wurde bereits kommissioniert.,
+Row #{}: {} {} doesn't belong to Company {}. Please select valid {}.,Zeile #{}: {} {} gehört nicht zur Firma {}. Bitte wählen Sie eine gültige {} aus.,
+Row No {0}: Warehouse is required. Please set a Default Warehouse for Item {1} and Company {2},Zeile Nr. {0}: Lager ist erforderlich. Bitte legen Sie ein Standardlager für Artikel {1} und Unternehmen {2} fest,
+Row Number,Zeilennummer,
+Row {0},Zeile {0},
+"Row {0} picked quantity is less than the required quantity, additional {1} {2} required.","Zeile {0} kommissionierte Menge ist kleiner als die erforderliche Menge, zusätzliche {1} {2} erforderlich.",
+Row {0}# Item {1} cannot be transferred more than {2} against {3} {4},Zeile {0}# Artikel {1} kann nicht mehr als {2} gegen {3} {4} übertragen werden,
+Row {0}# Item {1} not found in 'Raw Materials Supplied' table in {2} {3},Zeile {0}# Artikel {1} wurde in der Tabelle „Gelieferte Rohstoffe“ in {2} {3} nicht gefunden,
+Row {0}: Accepted Qty and Rejected Qty can't be zero at the same time.,Zeile {0}: Die akzeptierte Menge und die abgelehnte Menge können nicht gleichzeitig Null sein.,
+Row {0}: Account {1} and Party Type {2} have different account types,Zeile {0}: Konto {1} und Parteityp {2} haben unterschiedliche Kontotypen,
+Row {0}: Account {1} is a Group Account,Zeile {0}: Konto {1} ist eine Kontogruppe,
+Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2},Zeile {0}: Der zugewiesene Betrag {1} muss kleiner oder gleich dem ausstehenden Rechnungsbetrag {2} sein,
+Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2},Zeile {0}: Der zugewiesene Betrag {1} muss kleiner oder gleich dem verbleibenden Zahlungsbetrag {2} sein,
+Row {0}: Both Debit and Credit values cannot be zero,Zeile {0}: Sowohl Soll als auch Haben können nicht gleich Null sein,
+Row {0}: Cost Center {1} does not belong to Company {2},Zeile {0}: Die Kostenstelle {1} gehört nicht zum Unternehmen {2},
+Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.,"Zeile {0}: Entweder die Referenz zu einem ""Lieferschein-Artikel"" oder ""Verpackter Artikel"" ist obligatorisch.",
+Row {0}: From Warehouse is mandatory for internal transfers,Zeile {0}: Von Lager ist obligatorisch für interne Transfers,
+Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer,"Zeile {0}: Der Einzelpreis wurde gemäß dem Bewertungskurs aktualisiert, da es sich um eine interne Umlagerung handelt",
+Row {0}: Item {1} must be a stock item.,Zeile {0}: Artikel {1} muss ein Lagerartikel sein.,
+Row {0}: Packing Slip is already created for Item {1}.,Zeile {0}: Für den Artikel {1} wurde bereits ein Packzettel erstellt.,
+Row {0}: Payment Term is mandatory,Zeile {0}: Zahlungsbedingung ist obligatorisch,
+Row {0}: Please select a BOM for Item {1}.,Zeile {0}: Bitte wählen Sie eine Stückliste für Artikel {1}.,
+Row {0}: Please select an active BOM for Item {1}.,Zeile {0}: Bitte wählen Sie eine aktive Stückliste für Artikel {1}.,
+Row {0}: Please select an valid BOM for Item {1}.,Zeile {0}: Bitte wählen Sie eine gültige Stückliste für Artikel {1}.,
+Row {0}: Purchase Invoice {1} has no stock impact.,Zeile {0}: Eingangsrechnung {1} hat keine Auswirkungen auf den Bestand.,
+Row {0}: Qty cannot be greater than {1} for the Item {2}.,Zeile {0}: Die Menge darf für den Artikel {2} nicht größer als {1} sein.,
+Row {0}: Qty in Stock UOM can not be zero.,Zeile {0}: Menge in Lager-ME kann nicht Null sein.,
+Row {0}: Qty must be greater than 0.,Zeile {0}: Menge muss größer als 0 sein.,
+Row {0}: Shift cannot be changed since the depreciation has already been processed,"Zeile {0}: Schicht kann nicht geändert werden, da die Abschreibung bereits verarbeitet wurde",
+Row {0}: {2} Item {1} does not exist in {2} {3},Zeile {0}: {2} Artikel {1} existiert nicht in {2} {3},
+Rows: {0} have 'Payment Entry' as reference_type. This should not be set manually.,Zeilen: {0} haben „Zahlungseintrag“ als Referenztyp. Dies sollte nicht manuell festgelegt werden.,
+Rows: {0} in {1} section are Invalid. Reference Name should point to a valid Payment Entry or Journal Entry.,Zeilen: {0} im Abschnitt {1} sind ungültig. Der Referenzname sollte auf einen gültigen Zahlungseintrag oder Buchungssatz verweisen.,
+Run parallel job cards in a workstation,Parallele Jobkarten an einer Workstation ausführen,
+Running,Laufend,
+SLA Fulfilled On,SLA erfüllt am,
+SLA Paused On,SLA pausiert am,
+SLA will be applied on every {0},SLA wird alle {0} angewendet,
+STATEMENTS OF ACCOUNTS,KONTOAUSZÜGE,
+Salary Currency,Gehaltswährung,
+Sales Invoice {0} must be deleted before cancelling this Sales Order,Ausgangsrechnung {0} muss vor der Stornierung dieses Kundenauftrags gelöscht werden,
+Sales Order Reference,Kundenauftrag Referenz,
+Sales Order Status,Kundenauftrag Status,
+Sales Partner ,Vertriebspartner ,
+Sales Pipeline Analytics,Analyse der Vertriebspipeline,
+Sales Update Frequency in Company and Project,Häufigkeit der Umsatzaktualisierung in Unternehmen und Projekten,
+Sales Value,Verkaufswert,
+Salvage Value Percentage,Restwertanteil,
+Same item and warehouse combination already entered.,Dieselbe Artikel- und Lagerkombination wurde bereits eingegeben.,
+Savings,Einsparungen,
+Scan Batch No,Chargennummer scannen,
+Scan Mode,Scan-Modus,
+Scan Serial No,Seriennummer scannen,
+Scan barcode for item {0},Barcode für Artikel {0} scannen,
+"Scan mode enabled, existing quantity will not be fetched.","Scanmodus aktiviert, vorhandene Menge wird nicht abgerufen.",
+Scanned Quantity,Gescannte Menge,
+Scheduled Time Logs,Geplante Zeitprotokolle,
+Scheduler is Inactive. Can't trigger job now.,Der Planer ist inaktiv. Job kann derzeit nicht ausgelöst werden.,
+Scheduler is Inactive. Can't trigger jobs now.,Der Planer ist inaktiv. Jobs können derzeit nicht ausgelöst werden.,
+Scheduler is inactive. Cannot enqueue job.,Zeitplaner ist inaktiv. Aufgabe kann nicht eingereiht werden.,
+Scheduler is inactive. Cannot merge accounts.,Zeitplaner ist inaktiv. Konten können nicht zusammengeführt werden.,
+Scheduling,Zeitplan,
+Scrap & Process Loss,Ausschuss & Prozessverluste,
+Scrap Asset,Vermögensgegenstand verschrotten,
+Scrap Cost Per Qty,Ausschusskosten pro Menge,
+Scrap Item Code,Code für Ausschussartikel,
+Scrap Item Name,Name des Ausschussartikel,
+"Search by item code, serial number or barcode","Suche nach Artikelcode, Seriennummer oder Barcode",
+Select Batch No,Chargennummer auswählen,
+Select Finished Good,Fertigerzeugnis auswählen,
+Select Serial No,Seriennummer auswählen,
+Select Serial and Batch,Seriennummer und Charge auswählen,
+Select Time,Zeit auswählen,
+Select View,Ansicht auswählen,
+Select Vouchers to Match,Passende Belege auswählen,
+Select a Company this Employee belongs to.,"Wählen Sie ein Unternehmen, zu dem dieser Mitarbeiter gehört.",
+Select a Customer,Wählen Sie einen Kunden,
+Select an Item Group.,Wählen Sie eine Artikelgruppe.,
+Select the Default Workstation where the Operation will be performed. This will be fetched in BOMs and Work Orders.,"Wählen Sie den Standardarbeitsplatz aus, an dem der Vorgang ausgeführt wird. Dieser wird in Stücklisten und Arbeitsaufträgen abgerufen.",
+Select the Item to be manufactured.,"Wählen Sie den Artikel, der hergestellt werden soll.",
+"Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically.","Wählen Sie den Artikel, der hergestellt werden soll. Der Name des Artikels, die ME, das Unternehmen und die Währung werden automatisch abgerufen.",
+Select the Warehouse,Wählen Sie das Lager aus,
+Select the date and your timezone,Wählen Sie das Datum und Ihre Zeitzone,
+Select the raw materials (Items) required to manufacture the Item,"Wählen Sie die Rohstoffe (Artikel) aus, die zur Herstellung des Artikels benötigt werden",
+"Select whether to get items from a Sales Order or a Material Request. For now select <b>Sales Order</b>.
+ A Production Plan can also be created manually where you can select the Items to manufacture.","Wählen Sie, ob Sie Artikel aus einem Kundenauftrag oder einer Materialanforderung abrufen möchten. Wählen Sie erst einmal <b>Kundenauftrag</b>.
+ Ein Produktionsplan kann auch manuell erstellt werden, wobei Sie die zu produzierenden Artikel auswählen können.",
+Select your weekly off day,Wählen Sie einen wöchentlich freien Tag,
+Selected Vouchers,Ausgewählte Belege,
+Selected date is,Ausgewähltes Datum ist,
+Selected document must be in submitted state,Ausgewähltes Dokument muss in gebuchtem Zustand sein,
+Self delivery,Selbstanlieferung,
+Sell Asset,Vermögensgegenstand verkaufen,
+Send Attached Files,Angehängte Dateien senden,
+Send Document Print,Ausdruck der Anfrage senden,
+Send Emails,E-Mails senden,
+Sequential,Sequentiell,
+Serial & Batch Item,Serien- und Chargenartikel,
+Serial & Batch Item Settings,Einstellungen für Serien- und Chargenartikel,
+Serial / Batch No,Serien-/Chargennr,
+Serial / Batch Nos,Serien-/Chargennummern,
+Serial No and Batch for Finished Good,Serien- und Chargennummer für Fertigerzeugnis,
+Serial No is mandatory,Seriennummer ist obligatorisch,
+Serial No {0} already exists,Die Seriennummer {0} existiert bereits,
+Serial No {0} already scanned,Seriennummer {0} bereits gescannt,
+Serial No {0} does not exists,Seriennummer {0} existiert nicht,
+Serial No {0} is already added,Die Seriennummer {0} ist bereits hinzugefügt,
+Serial Nos,Seriennummern,
+Serial Nos / Batch Nos,Serien-/Chargennummern,
+Serial Nos Mismatch,Seriennummern stimmen nicht überein,
+Serial Nos are created successfully,Seriennummern wurden erfolgreich erstellt,
+"Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding.","Seriennummern sind bereits reserviert. Sie müssen die Reservierung aufheben, bevor Sie fortfahren.",
+Serial and Batch,Seriennummer und Charge,
+Serial and Batch Bundle,Serien- und Chargenbündel,
+Serial and Batch Bundle created,Serien- und Chargenbündel erstellt,
+Serial and Batch Bundle updated,Serien- und Chargenbündel aktualisiert,
+Serial and Batch Bundle {0} is already used in {1} {2}.,Serien- und Chargenbündel {0} wird bereits in {1} {2} verwendet.,
+Serial and Batch No,Serien- und Chargennummer,
+Serial and Batch Nos,Serien- und Chargennummern,
+Serial and Batch Nos will be auto-reserved based on <b>Pick Serial / Batch Based On</b>,Serien- und Chargennummern werden automatisch basierend auf <b>Serien- / Chargennummer auswählen basierend auf</b> reserviert,
+Serial and Batch Reservation,Serien- und Chargenreservierung,
+Serial and Batch Summary,Serien- und Chargenzusammenfassung,
+Service Item,Dienstleistungsartikel,
+Service Item Qty,Dienstleistungsartikel Menge,
+Service Item Qty / Finished Good Qty,Dienstleistungsartikel Menge / Fertigerzeugnis Menge,
+Service Item UOM,Dienstleistungsartikel ME,
+Service Item {0} is disabled.,Dienstleistungsartikel {0} ist deaktiviert.,
+Service Item {0} must be a non-stock item.,Dienstleistungsartikel {0} muss ein Artikel ohne Lagerhaltung sein.,
+Service Provider,Anbieter,
+Set Default Supplier,Standard-Lieferant festlegen,
+Set Operating Cost / Scrape Items From Sub-assemblies,Betriebskosten festlagen / Ausschuss aus Unterbaugruppen entfernen,
+Set Operating Cost Based On BOM Quantity,Betriebskosten auf Basis der Stücklistenmenge festlegen,
+Set Password,Passwort festlegen,
+Set Project Status,Projektstatus festlegen,
+Set Quantity,Anzahl festlegen,
+Set Up a Company,Unternehmen einrichten,
+Set Warehouse,Lager festlegen,
+Set default {0} account for non stock items,"Legen Sie das Standardkonto {0} für ""Artikel ohne Lagerhaltung"" fest",
+Set the status manually.,Status manuell setzen.,
+Set up your Warehouse,Ihr Lager einrichten,
+Set {0} in asset category {1} for company {2},Legen Sie {0} in die Vermögensgegenstand-Kategorie {1} für das Unternehmen {2} fest,
+Setting {} is required,Die Einstellung {} ist erforderlich,
+Setup Your Letterhead,Briefkopf einrichten,
+Setup a Warehouse,Richte ein Lager ein,
+Setup your organization,Unternehmensdaten einrichten,
+Shift,Schicht,
+Shift Factor,Schichtfaktor,
+Shift Name,Schichtname,
+Shipment,Sendung,
+Shipment Amount,Versandbetrag,
+Shipment Delivery Note,Lieferschein für die Sendung,
+Shipment ID,Sendungs-ID,
+Shipment Information,Sendungsinformationen,
+Shipment Parcel,Versandpaket,
+Shipment Parcel Template,Versandpaketvorlage,
+Shipment Type,Sendungstyp,
+Shipment details,Sendungsdetails,
+Shipping Address Details,Lieferadressendetails,
+Shipping Address Template,Vorlage Lieferadresse,
+Show Balances in Chart Of Accounts,Saldo in Kontenplan anzeigen,
+Show Barcode Field in Stock Transactions,Barcode-Feld in Lagerbewegungen anzeigen,
+Show Failed Logs,Fehlgeschlagene Protokolle anzeigen,
+Show Item Name,Artikelname anzeigen,
+Show Preview,Vorschau anzeigen,
+Show pending entries,Ausstehende Einträge anzeigen,
+"Simple Python Expression, Example: doc.status == 'Open' and doc.issue_type == 'Bug'","Einfacher Python-Ausdruck, Beispiel: doc.status == 'Open' und doc.issue_type == 'Bug'",
+"Simple Python formula applied on Reading fields.<br> Numeric eg. 1: <b>reading_1 &gt; 0.2 and reading_1 &lt; 0.5</b><br>
+Numeric eg. 2: <b>mean &gt; 3.5</b> (mean of populated fields)<br>
+Value based eg.:  <b>reading_value in (""A"", ""B"", ""C"")</b>","Einfache Python-Formel, die auf Ablesewert-Felder (reading) angewendet wird.<br> Numerisch z.B. 1: <b>reading_1 &gt; 0.2 und reading_1 &lt; 0.5</b><br>
+Numerisch z.B. 2: <b>mean &gt; 3.5</b> (Mittelwert der ausgefüllten Felder)<br>
+Wertbasiert z.B.: <b>reading_value in (""A"", ""B"", ""C"")</b>",
+Simultaneous,Gleichzeitig,
+Skipped,Übersprungen,
+"Skipping {0} of {1}, {2}","Überspringe {0} von {1}, {2}",
+Sold by,Verkauft von,
+Source Exchange Rate,Quellwechselkurs,
+Spacer,Abstandshalter,
+Split Asset,Vermögensgegenstand aufspalten,
+Split Early Payment Discount Loss into Income and Tax Loss,Skontobetrag in Aufwand und Umsatzsteuerkorrektur aufteilen,
+Split From,Abspalten von,
+Split Qty,Abgespaltene Menge,
+Stage,Stufe,
+Standard Description,Standardbeschreibung,
+Start / Resume,Start / Fortsetzen,
+Start Import,Starten Sie den Import,
+Start Job,Auftrag starten,
+Start Merge,Zusammenführung starten,
+Status Details,Statusdetails,
+Status Illustration,Statusdarstellung,
+Stock Ledger report contains every submitted stock transaction. You can use filter to narrow down ledger entries.,"Der Lagerbuchbericht enthält alle gebuchten Lagertransaktionen. Sie können Filter verwenden, um die angezeigten Einträge einzugrenzen.",
+Stock UOM Quantity,Lager-ME Menge,
+Stock and Manufacturing,Lager und Fertigung,
+Stock cannot be reserved in group warehouse {0}.,In der Lager-Gruppe {0} kann kein Bestand reserviert werden.,
+Stock cannot be reserved in the group warehouse {0}.,In der Lager-Gruppe {0} kann kein Bestand reserviert werden.,
+Stock not available for Item {0} in Warehouse {1}.,Der Artikel {0} ist in Lager {1} nicht vorrätig.,
+Stock transactions that are older than the mentioned days cannot be modified.,"Lagerbewegungen, die älter als die genannten Tage sind, können nicht geändert werden.",
+Stock will be reserved on submission of <b>Purchase Receipt</b> created against Material Request for Sales Order.,"Der Bestand wird mit der Buchung des <b>Eingangsbelegs</b> reserviert, der gegen eine Materialanfrage für einen Verkaufsauftrag erstellt wurde.",
+Sub Assemblies & Raw Materials,Unterbaugruppen & Rohmaterialien,
+Sub Assembly Item,Artikel der Unterbaugruppe,
+Sub Assembly Item Code,Artikelcode der Unterbaugruppe,
+Sub Assembly Items,Artikel der Unterbaugruppe,
+Sub Assembly Warehouse,Unterbaugruppe Lager,
+Subcontract BOM,Stückliste für Untervergabe,
+Subcontract Order,Unterauftrag,
+Subcontracting BOM,Stückliste für Untervergabe,
+Subcontracting Order,Unterauftrag,
+Subcontracting Order (Draft) will be auto-created on submission of Purchase Order.,Unterauftrag (Entwurf) wird automatisch bei der Buchung der Lieferantenbestellung erstellt.,
+Subcontracting Order Item,Position im Unterauftrag,
+Subcontracting Purchase Order,Unterauftragsbestellung,
+Subcontracting Receipt,Unterauftragsbeleg,
+Subcontracting Settings,Untervergabe-Einstellungen,
+Submit Action Failed,Aktion Buchen fehlgeschlagen,
+Submit After Import,Nach dem Import buchen,
+Submit ERR Journals?,ERR-Journale buchen?,
+Submit Generated Invoices,Generierte Rechnungen buchen,
+Submit your Quotation,Buchen Sie Ihr Angebot,
+Succeeded,Erfolgreich,
+Succeeded Entries,Erfolgreiche Einträge,
+"Successfully changed Stock UOM, please redefine conversion factors for new UOM.",Lager-ME erfolgreich geändert. Bitte passen Sie nun die Umrechnungsfaktoren an.,
+Successfully imported {0},Erfolgreich importiert {0},
+"Successfully imported {0} record out of {1}. Click on Export Errored Rows, fix the errors and import again.","{0} von {1} Datensätzen erfolgreich importiert. Klicken Sie auf „Fehlerhafte Zeilen exportieren“, beheben Sie die Fehler und importieren Sie erneut.",
+Successfully imported {0} record.,{0} Datensatz erfolgreich importiert.,
+"Successfully imported {0} records out of {1}. Click on Export Errored Rows, fix the errors and import again.","{0} von {1} Datensätzen erfolgreich importiert. Klicken Sie auf „Fehlerhafte Zeilen exportieren“, beheben Sie die Fehler und importieren Sie erneut.",
+Successfully imported {0} records.,{0} Datensätze erfolgreich importiert.,
+Successfully linked to Customer,Erfolgreich mit dem Kunden verknüpft,
+Successfully linked to Supplier,Erfolgreich mit dem Lieferanten verknüpft,
+Successfully merged {0} out of {1}.,{0} von {1} erfolgreich zusammengeführt.,
+Successfully updated {0},Erfolgreich aktualisiert {0},
+"Successfully updated {0} record out of {1}. Click on Export Errored Rows, fix the errors and import again.","{0} von {1} Datensätzen erfolgreich aktualisiert. Klicken Sie auf „Fehlerhafte Zeilen exportieren“, beheben Sie die Fehler und importieren Sie erneut.",
+Successfully updated {0} record.,{0} Datensatz erfolgreich aktualisiert.,
+"Successfully updated {0} records out of {1}. Click on Export Errored Rows, fix the errors and import again.","{0} von {1} Datensätzen erfolgreich aktualisiert. Klicken Sie auf „Fehlerhafte Zeilen exportieren“, beheben Sie die Fehler und importieren Sie erneut.",
+Successfully updated {0} records.,{0} Datensätze erfolgreich aktualisiert.,
+Sum of Repair Cost and Value of Consumed Stock Items.,Summe der Reparaturkosten und des Wertes der verbrauchten Lagerartikel.,
+Supplier Info,Lieferanteninfo,
+Supplier Invoice,Lieferantenrechnung,
+Supplier Item,Lieferantenartikel,
+Supplier Portal Users,Benutzer des Lieferantenportals,
+Sync Now,Jetzt synchronisieren,
+Sync Started,Synchronisierung gestartet,
+System will automatically create the serial numbers / batch for the Finished Good on submission of work order,"Falls aktiviert, erstellt das System bei der Buchung des Arbeitsauftrags automatisch Serien- bzw. Chargennummern für die Fertigerzeugnisse",
+TCS Amount,Quellensteuerbetrag (TCS),
+TCS Rate %,Quellensteuersatz (TCS) %,
+TDS Amount,Quellensteuerbetrag (TDS),
+TDS Payable,Fällige Quellensteuer (TDS),
+Take a quick walk-through of Accounts Settings,Machen Sie einen kurzen Rundgang durch die Kontoeinstellungen,
+Take a walk-through of Manufacturing Settings,Machen Sie einen Rundgang durch die Fertigungseinstellungen,
+Target Asset,Ziel-Vermögensgegenstand,
+Target Asset {0} cannot be cancelled,Ziel-Vermögensgegenstand {0} kann nicht storniert werden,
+Target Asset {0} cannot be submitted,Ziel-Vermögensgegenstand {0} kann nicht gebucht werden,
+Target Asset {0} cannot be {1},Ziel-Vermögensgegenstand {0} kann nicht {1} sein,
+Target Asset {0} does not belong to company {1},Ziel-Vermögensgegenstand {0} gehört nicht zum Unternehmen {1},
+Target Asset {0} needs to be composite asset,Ziel-Vermögensgegenstand {0} muss ein zusammengesetzter Vermögensgegenstand sein,
+Target Batch No,Ziel-Chargen-Nr,
+Target Exchange Rate,Zielwechselkurs,
+Target Has Batch No,Ziel hat Chargennummer,
+Target Has Serial No,Ziel hat Seriennummer,
+Target Is Fixed Asset,Ziel ist Anlagevermögen,
+Target Item Code,Ziel Artikelcode,
+Target Item Name,Ziel Artikelname,
+Target Item {0} is neither a Fixed Asset nor a Stock Item,Der Zielartikel {0} ist weder ein Vermögensgegenstand noch ein Lagerartikel,
+Target Item {0} must be a Fixed Asset item,Zielartikel {0} muss ein Vermögensgegenstand sein,
+Target Item {0} must be a Stock Item,Zielartikel {0} muss ein Lagerartikel sein,
+Target Qty must be a positive number,Zielmenge muss eine positive Zahl sein,
+Target Serial No,Ziel Seriennummer,
+Tax Amount,Steuerbetrag,
+Tax Masters,Steuer-Stammdaten,
+Tax Settings,Umsatzsteuer-Einstellungen,
+Telephony Call Type,Telefonie Anrufart,
+Template Options,Vorlagenoptionen,
+Template Task,Vorlage,
+Template Warnings,Vorlagenwarnungen,
+Terms & Conditions,Bedingungen & Konditionen,
+Terms and Conditions Template,Vorlage für Allgemeine Geschäftsbedingungen,
+The Accounts Module is all set up!,Das Buchhaltungsmodul ist fertig eingerichtet!,
+The Buying Module is all set up!,Das Einkaufsmodul ist fertig eingerichtet!,
+The CRM Module is all set up!,Das CRM-Modul ist fertig eingerichtet!,
+The Condition '{0}' is invalid,Der Zustand &#39;{0}&#39; ist ungültig,
+The Document Type {0} must have a Status field to configure Service Level Agreement,"Der Dokumenttyp {0} muss über ein Statusfeld verfügen, um das Service Level Agreement zu konfigurieren",
+"The GL Entries will be cancelled in the background, it can take a few minutes.","Die Hauptbucheinträge werden im Hintergrund storniert, dies kann einige Minuten dauern.",
+"The GL Entries will be processed in the background, it can take a few minutes.","Die Hauptbucheinträge werden im Hintergrund verarbeitet, dies kann einige Minuten dauern.",
+The Selling Module is all set up!,Das Vertriebsmodul ist fertig eingerichtet!,
+The Stock Module is all set up!,Das Lagermodul ist fertig eingerichtet!,
+The currency of invoice {} ({}) is different from the currency of this dunning ({}).,Die Währung der Rechnung {} ({}) unterscheidet sich von der Währung dieser Mahnung ({}).,
+The default BOM for that item will be fetched by the system. You can also change the BOM.,Die Standardstückliste für diesen Artikel wird vom System abgerufen. Sie können die Stückliste auch ändern.,
+"The following Items, having Putaway Rules, could not be accomodated:","Die folgenden Artikel, für die Einlagerungsregeln gelten, konnten nicht untergebracht werden:",
+The following assets have failed to automatically post depreciation entries: {0},Bei den folgenden Vermögensgegenständen wurden die Abschreibungen nicht automatisch gebucht: {0},
+The reserved stock will be released. Are you certain you wish to proceed?,"Der reservierte Bestand wird freigegeben. Sind Sie sicher, dass Sie fortfahren möchten?",
+The task has been enqueued as a background job.,Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt.,
+"The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage","Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt. Falls bei der Verarbeitung im Hintergrund ein Problem auftritt, fügt das System einen Kommentar über den Fehler bei dieser Bestandsabstimmung hinzu und kehrt zur Stufe Gebucht zurück",
+The warehouse where you store finished Items before they are shipped.,"Das Lager, in dem Sie fertige Artikel lagern, bevor sie versandt werden.",
+"The warehouse where you store your raw materials. Each required item can have a separate source warehouse. Group warehouse also can be selected as source warehouse. On submission of the Work Order, the raw materials will be reserved in these warehouses for production usage.","Das Lager, in dem Sie Ihre Rohmaterialien lagern. Jeder benötigte Artikel kann ein eigenes Quelllager haben. Auch ein Gruppenlager kann als Quelllager ausgewählt werden. Bei Buchung des Arbeitsauftrags werden die Rohstoffe in diesen Lagern für die Produktion reserviert.",
+The warehouse where your Items will be transferred when you begin production. Group Warehouse can also be selected as a Work in Progress warehouse.,"Das Lager, in das Ihre Artikel übertragen werden, wenn Sie mit der Produktion beginnen. Es kann auch eine Lager-Gruppe ausgewählt werden.",
+There are no Failed transactions,Es gibt keine fehlgeschlagenen Transaktionen,
+There are no slots available on this date,Für dieses Datum sind keine Plätze verfügbar,
+There aren't any item variants for the selected item,Für den ausgewählten Artikel sind keine Artikelvarianten vorhanden,
+There is already an active Subcontracting BOM {0} for the Finished Good {1}.,Es gibt bereits eine aktive Stückliste für Untervergabe {0} für das Fertigerzeugnis {1}.,
+There must be atleast 1 Finished Good in this Stock Entry,Es muss mindestens 1 Fertigerzeugnis in dieser Lagerbewegung vorhanden sein,
+There was an error creating Bank Account while linking with Plaid.,Bei der Verknüpfung mit Plaid ist ein Fehler beim Erstellen des Bankkontos aufgetreten.,
+There was an error syncing transactions.,Es ist ein Fehler bei der Synchronisierung von Transaktionen aufgetreten.,
+There was an error updating Bank Account {} while linking with Plaid.,Beim Verknüpfen mit Plaid ist beim Aktualisieren des Bankkontos {} ein Fehler aufgetreten.,
+There was an issue connecting to Plaid's authentication server. Check browser console for more information,Es gab ein Problem bei der Verbindung mit dem Authentifizierungsserver von Plaid. Prüfen Sie die Browser-Konsole für weitere Informationen,
+This Account has '0' balance in either Base Currency or Account Currency,Dieses Konto weist entweder in der Basiswährung oder in der Kontowährung einen Saldo von „0“ auf,
+This field is used to set the 'Customer'.,"Dieses Feld wird verwendet, um den „Kunden“ festzulegen.",
+This filter will be applied to Journal Entry.,Dieser Filter wird auf den Buchungssatz angewendet.,
+This is a Template BOM and will be used to make the work order for {0} of the item {1},"Dies ist eine Stücklistenvorlage und wird verwendet, um den Arbeitsauftrag für {0} des Artikels {1} zu erstellen",
+This is considered dangerous from accounting point of view.,Dies gilt aus buchhalterischer Sicht als gefährlich.,
+"This is for raw material Items that'll be used to create finished goods. If the Item is an additional service like 'washing' that'll be used in the BOM, keep this unchecked.","Dies gilt für ""Rohmaterial Artikel"", die zur Herstellung von Fertigprodukten verwendet werden. Wenn es sich bei dem Artikel um eine zusätzliche Dienstleistung wie „Waschen“ handelt, welcher in der Stückliste verwendet wird, lassen Sie dieses Kontrollkästchen deaktiviert.",
+This item filter has already been applied for the {0},Dieser Artikelfilter wurde bereits für {0} angewendet,
+This option can be checked to edit the 'Posting Date' and 'Posting Time' fields.,"Diese Option kann aktiviert werden, um die Felder 'Buchungsdatum' und 'Buchungszeit' zu bearbeiten.",
+This schedule was created when Asset {0} was adjusted through Asset Value Adjustment {1}.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} durch die Vermögenswertanpassung {1} angepasst wurde.",
+This schedule was created when Asset {0} was consumed through Asset Capitalization {1}.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} durch Vermögensgegenstand-Aktivierung {1} verbraucht wurde.",
+This schedule was created when Asset {0} was repaired through Asset Repair {1}.,"Dieser Zeitplan wurde erstellt, als Vermögensgegenstand {0} über Vermögensgegenstand-Reparatur {1} repariert wurde.",
+This schedule was created when Asset {0} was restored on Asset Capitalization {1}'s cancellation.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} nach der Stornierung der Vermögensgegenstand-Aktivierung {1} wiederhergestellt wurde.",
+This schedule was created when Asset {0} was restored.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} wiederhergestellt wurde.",
+This schedule was created when Asset {0} was returned through Sales Invoice {1}.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} über die Ausgangsrechnung {1} zurückgegeben wurde.",
+This schedule was created when Asset {0} was scrapped.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} verschrottet wurde.",
+This schedule was created when Asset {0} was sold through Sales Invoice {1}.,"Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} über die Ausgangsrechnung {1} verkauft wurde.",
+This schedule was created when Asset {0} was updated after being split into new Asset {1}.,"Dieser Zeitplan wurde erstellt, als Vermögensgegenstand {0} aktualisiert wurde, nachdem er in einen neuen Vermögensgegenstand {1} aufgeteilt wurde.",
+This schedule was created when Asset {0}'s Asset Repair {1} was cancelled.,"Dieser Zeitplan wurde erstellt, als die Reparatur {1} von Vermögensgegenstand {0} storniert wurde.",
+This schedule was created when Asset {0}'s Asset Value Adjustment {1} was cancelled.,"Dieser Zeitplan wurde erstellt, als die Vermögenswertanpassung {1} von Vermögensgegenstand {0} storniert wurde.",
+This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}.,"Dieser Zeitplan wurde erstellt, als die Schichten des Vermögensgegenstandes {0} durch die Vermögensgegenstand -Schichtzuordung {1} angepasst wurden.",
+This schedule was created when new Asset {0} was split from Asset {1}.,"Dieser Zeitplan wurde erstellt, als der neue Vermögensgegenstand {0} von dem Vermögensgegenstand {1} abgespalten wurde.",
+"This table is used to set details about the 'Item', 'Qty', 'Basic Rate', etc.","Diese Tabelle wird verwendet, um Details zu „Artikel“, „Menge“, „Einzelpreis“ usw. festzulegen.",
+This {} will be treated as material transfer.,Diese(r) {} wird als Materialtransfer behandelt.,
+Threshold for Suggestion (In Percentage),Schwellenwert für Vorschlag (in Prozent),
+Time Taken to Deliver,Lieferzeit,
+Time in mins,Zeit in Min,
+Time in mins.,Zeit in Min.,
+Time slot is not available,Zeitfenster ist nicht verfügbar,
+To Doctype,Bis Doctype,
+To be Delivered to Customer,An den Kunden zu liefern,
+"To enable Capital Work in Progress Accounting,","Um die Buchung von Anlagen im Bau zu ermöglichen,",
+To include non-stock items in the material request planning. i.e. Items for which 'Maintain Stock' checkbox is unticked.,"Um ""Artikel ohne Lagerhaltung"" in die Materialanforderungsplanung einzubeziehen. Das heißt Artikel, bei denen das Kontrollkästchen „Lager verwalten“ deaktiviert ist.",
+To submit the invoice without purchase order please set {0} as {1} in {2},"Um die Rechnung ohne Bestellung zu buchen, stellen Sie bitte {0} als {1} in {2} ein",
+To submit the invoice without purchase receipt please set {0} as {1} in {2},"Um die Rechnung ohne Eingangsbeleg zu buchen, stellen Sie bitte {0} als {1} in {2} ein",
+Total Active Items,Anzahl aktive Artikel,
+Total Billing Hours,Summe abgerechneter Stunden,
+Total Interest,Gesamtzins,
+Total Repair Cost,Gesamtreparaturkosten,
+Total Sales Amount,Gesamtumsatz,
+Total Stock Value,Gesamter Lagerwert,
+Total Supplied Qty,Insgesamt gelieferte Menge,
+Total Time (in Mins),Gesamtzeit (in Min.),
+Total Value,Gesamtwert,
+Total Value Difference (Incoming - Outgoing),Gesamtwertdifferenz (eingehend – ausgehend),
+Total Views,Gesamte Aufrufe,
+Total Warehouses,Anzahl Lager,
+Total percentage against cost centers should be 100,Der Gesamtprozentsatz für die Kostenstellen sollte 100 betragen,
+Track Material Request,Materialanforderung verfolgen,
+Tracking Status,Tracking-Status,
+Tracking Status Info,Tracking-Statusinformationen,
+Tracking URL,Tracking-URL,
+Transaction Settings,Transaktionseinstellungen,
+Transaction currency: {0} cannot be different from Bank Account({1}) currency: {2},Die Transaktionswährung: {0} darf sich nicht von der Währung des Bankkontos ({1}) unterscheiden: {2},
+Transactions against the Company already exist! Chart of Accounts can only be imported for a Company with no transactions.,Es gibt bereits Transaktionen für das Unternehmen! Kontenpläne können nur für ein Unternehmen ohne Transaktionen importiert werden.,
+Transfer Asset,Vermögensgegenstand übertragen,
+Transferring cannot be done to an Employee. Please enter location where Asset {0} has to be transferred,"Die Übertragung kann nicht an einen Mitarbeiter erfolgen. Bitte geben Sie den Ort ein, an den der Vermögensgegenstand {0} übertragen werden soll.",
+Tree of Procedures,Baum der Prozeduren,
+Type Of Call,Art des Anrufs,
+Type of Transaction,Art der Transaktion,
+UAE VAT 201,VAE VAT 201,
+UAE VAT Account,VAE VAT Konto,
+UAE VAT Accounts,VAE VAT Konten,
+UAE VAT Settings,VAE VAT Einstellungen,
+UOM conversion factor required for UOM: {0} in Item: {1},ME Umrechnungsfaktor erforderlich für ME: {0} in Artikel: {1},
+Unable to find variable:,Variable kann nicht gefunden werden:,
+"Under Working Hours table, you can add start and end times for a Workstation. For example, a Workstation may be active from 9 am to 1 pm, then 2 pm to 5 pm. You can also specify the working hours based on shifts. While scheduling a Work Order, the system will check for the availability of the Workstation based on the working hours specified.",In der Tabelle „Arbeitszeit“ können Sie Start- und Endzeiten für einen Arbeitsplatz hinzufügen. Eine Arbeitsstation kann beispielsweise von 9 bis 13 Uhr und dann von 14 bis 17 Uhr aktiv sein. Sie können die Arbeitszeiten auch basierend auf Schichten angeben. Beim Planen eines Arbeitsauftrags überprüft das System die Verfügbarkeit des Arbeitsplatzes basierend auf den angegebenen Arbeitszeiten.,
+Unit of Measure (UOM),Maßeinheit (ME),
+Unlinked,Nicht verknüpft,
+Unqualified,Nicht qualifiziert,
+Unreconcile Payment Entries,Zahlungsbuchungen rückgängig machen,
+Unreconciled Amount,Nicht abgestimmter Betrag,
+Unreserve,Reservierung aufheben,
+Unreserve Stock,Reservierung aufheben,
+Unreserving Stock...,Reservierung aufheben...,
+Up,Hoch,
+Update Billed Amount in Delivery Note,Abgerechneten Betrag im Lieferschein aktualisieren,
+Update Billed Amount in Purchase Order,Abgerechneter Betrag in Bestellung aktualisieren,
+Update Existing Records,Bestehende Datensätze aktualisieren,
+Update Outstanding for Self,Ausstehenden Betrag für dieses Dokument aktualisieren,
+Update Rate as per Last Purchase,Rate gemäß dem letzten Kauf aktualisieren,
+Update Stock Opening Balance,Lageranfangsbestand aktualisieren,
+Update frequency of Project,Aktualisierungshäufigkeit des Projekts,
+"Updating {0} of {1}, {2}","{0} von {1}, {2} wird aktualisiert",
+Upload Bank Statement,Kontoauszug hochladen,
+Use Batch-wise Valuation,Chargenweise Bewertung verwenden,
+Use Company default Cost Center for Round off,Standardkostenstelle des Unternehmens zum Abrunden verwenden,
+Use HTTP Protocol,HTTP-Protokoll verwenden,
+Use Serial / Batch Fields,Feld Seriennummer / Charge verwenden,
+Use Serial No / Batch Fields,Feld Seriennummer / Charge verwenden,
+Use Transaction Date Exchange Rate,Wechselkurs des Transaktionsdatums verwenden,
+Users with this role are allowed to over bill above the allowance percentage,"Roll, die mehr als den erlaubten Prozentsatz zusätzlich abrechnen darf",
+VAT Accounts,USt-Konten,
+VAT Audit Report,USt-Prüfbericht,
+Validate Negative Stock,Negativen Bestand validieren,
+Valuation rate for customer provided items has been set to zero.,Die Bewertungsrate für von Kunden beigestellte Artikel wurde auf Null gesetzt.,
+Value Change,Wertänderung,
+Value of Goods,Warenwert,
+Value of goods cannot be 0,Der Warenwert kann nicht 0 sein,
+View BOM Update Log,Stücklistenaktualisierungsprotokoll anzeigen,
+View Exchange Gain/Loss Journals,Anzeigen von Buchungen für Kursgewinne/-verluste,
+View General Ledger,Hauptbuch anzeigen,
+View Ledgers,Hauptbücher anzeigen,
+View Warehouses,Lager anzeigen,
+Visits,Besuche,
+Voice Call Settings,Sprachanruf-Einstellungen,
+Voucher,Beleg,
+Voucher Name,Beleg,
+Voucher No is mandatory,Beleg Nr. ist obligatorisch,
+Voucher Qty,Beleg Menge,
+Voucher Subtype,Beleg Untertyp,
+Waiting for payment...,Warte auf Zahlung...,
+Warehouse Capacity for Item '{0}' must be greater than the existing stock level of {1} {2}.,Die Lagerkapazität für Artikel '{0}' muss größer sein als der vorhandene Lagerbestand von {1} {2}.,
+Warehouse Details,Lagerdetails,
+Warehouse Disabled?,Lager deaktiviert?,
+Warehouse Settings,Lagereinstellungen,
+Warehouse Wise Stock Balance,Bestand nach Lager,
+Warehouse {0} does not belong to Company {1}.,Lager {0} gehört nicht zu Unternehmen {1}.,
+"Warehouse {0} is not linked to any account, please mention the account in the warehouse record or set default inventory account in company {1}.",Das Lager {0} ist mit keinem Konto verknüpft. Bitte geben Sie das Konto im Lagerdatensatz an oder legen Sie im Unternehmen {1} das Standardbestandskonto fest.,
+Warehouse's Stock Value has already been booked in the following accounts:,Der Lagerbestandswert wurde bereits auf den folgenden Konten gebucht:,
+Warning - Row {0}: Billing Hours are more than Actual Hours,Warnung - Zeile {0}: Abgerechnete Stunden sind mehr als tatsächliche Stunden,
+Warning!,Warnung!,
+Watch Video,Video ansehen,
+Week {0} {1},Woche {0} {1},
+Weekly Time to send,Wöchentliche Sendezeit,
+Weight (kg),Gewicht (Kg),
+"When a parent warehouse is chosen, the system conducts stock checks against the associated child warehouses","Wenn ein übergeordnetes Lager ausgewählt wird, führt das System Bestandsprüfungen mit den zugehörigen untergeordneten Lagern durch",
+"When creating an Item, entering a value for this field will automatically create an Item Price at the backend.","Wenn Sie bei der Erstellung eines Artikels einen Wert für dieses Feld eingeben, wird automatisch ein Artikelpreis erstellt.",
+"While making Purchase Invoice from Purchase Order, use Exchange Rate on Invoice's transaction date rather than inheriting it from Purchase Order. Only applies for Purchase Invoice.","Einzelpreis am Transaktionsdatum der Rechnung verwenden, anstatt ihn aus dem Lieferantenauftrag zu übernehmen. Gilt nur für Eingangsrechnungen.",
+Width (cm),Breite (cm),
+Withdrawal,Auszahlung,
+Work Order Consumed Materials,In Arbeitsauftrag verbrauchtes Material,
+Workstation Dashboard,Arbeitsplatz-Dashboard,
+Workstation Status,Arbeitsplatzstatus,
+Workstation Type,Arbeitsplatztyp,
+Workstations,Arbeitsplätze,
+Write Off Limit,Abschreibungsgrenze,
+Wrong Company,Falsches Unternehmen,
+Wrong Template,Falsche Vorlage,
+Yes,Ja,
+You are not authorized to make/edit Stock Transactions for Item {0} under warehouse {1} before this time.,"Sie sind nicht berechtigt, Lagertransaktionen für Artikel {0} im Lager {1} vor diesem Zeitpunkt durchzuführen/zu bearbeiten.",
+You are picking more than required quantity for the item {0}. Check if there is any other pick list created for the sales order {1}.,"Sie kommissionieren mehr als die erforderliche Menge für den Artikel {0}. Prüfen Sie, ob eine andere Pickliste für den Kundenauftrag erstellt wurde {1}.",
+"You can set it as a machine name or operation type. For example, stiching machine 12",Sie können es als Maschinenname oder Betriebsart festlegen. Zum Beispiel Nähmaschine 12,
+"You can set the filters to narrow the results, then click on Generate New Report to see the updated report.","Sie können Filter festlegen, um die Ergebnisse einzugrenzen. Klicken Sie auf „Neuen Bericht erstellen“, um den aktualisierten Bericht anzuzeigen.",
+You can't make any changes to Job Card since Work Order is closed.,"Sie können keine Änderungen an der Jobkarte vornehmen, da der Arbeitsauftrag geschlossen ist.",
+You cannot create/amend any accounting entries till this date.,Bis zu diesem Datum können Sie keine Buchungen erstellen/berichtigen.,
+You have entered a duplicate Delivery Note on Row,Sie haben mehrere Lieferscheine eingegeben,
+You haven't created a {0} yet,Sie haben noch kein(en) {0} erstellt,
+You're ready to start your journey with ERPNext,"Sie sind bereit, Ihre Reise mit ERPNext zu beginnen",
+Your Name (required),Ihr Name (erforderlich),
+Your email has been verified and your appointment has been scheduled,Ihre E-Mail wurde verifiziert und Ihr Termin wurde geplant,
+`Allow Negative rates for Items`,„Negative Preise für Artikel zulassen“,
+as a percentage of finished item quantity,als Prozentsatz der fertigen Artikelmenge,
+description,beschreibung,
+discount applied,Rabatt angewendet,
+fieldname,feldname,
+is already,ist bereits,
+out of 5,von 5,
+payments app is not installed. Please install it from {0} or {1},Die Zahlungs-App ist nicht installiert. Bitte installieren Sie sie von {0} oder {1},
+payments app is not installed. Please install it from {} or {},Die Zahlungs-App ist nicht installiert. Bitte installieren Sie sie von {0} oder {1},
+quotation_item,Angebotsposition,
+ratings,bewertungen,
+temporary name,vorläufiger Name,
+up to ,bis zu ,
+variance,abweichung,
+via BOM Update Tool,via Stücklisten-Update-Tool,
+will be,wird sein,
+{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue.,"{0} <b>{1}</b> hat Vermögensgegenstände gebucht. Entfernen Sie Artikel <b>{2}</b> aus der Tabelle, um fortzufahren.",
+{0} account is not of type {1},Konto {0} ist nicht vom Typ {1},
+{0} account not found while submitting purchase receipt,Konto {0} beim Buchen des Eingangsbelegs nicht gefunden,
+{0} and {1},{0} und {1},
+{0} cannot be used as a Main Cost Center because it has been used as child in Cost Center Allocation {1},"{0} kann nicht als Hauptkostenstelle verwendet werden, da sie als untergeordnete Kostenstelle in der Kostenstellenzuordnung {1} verwendet wurde",
+{0} currency must be same as company's default currency. Please select another account.,Die Währung {0} muss mit der Standardwährung des Unternehmens übereinstimmen. Bitte wählen Sie ein anderes Konto aus.,
+{0} is mandatory for account {1},{0} ist für Konto {1} obligatorisch,
+{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}.,Menge {0} des Artikels {1} wird im Lager {2} mit einer Kapazität von {3} empfangen.,
+{0} units of Item {1} is picked in another Pick List.,{0} Einheiten des Artikels {1} werden in einer anderen Pickliste kommissioniert.,
+{0} will be given as discount.,{0} wird als Rabatt gewährt.,
+{0} {1} Manually,{0} {1} manuell,
+{0} {1} Partially Reconciled,{0} {1} Teilweise abgeglichen,
+{0} {1} is allocated twice in this Bank Transaction,{0} {1} wird in dieser Banktransaktion zweimal zugeteilt,
+{0} {1} is not in any active Fiscal Year,{0} {1} befindet sich in keinem aktiven Geschäftsjahr,
+{0} {1} via CSV File,{0} {1} via CSV-Datei,
+{0} {1}: Account {2} is a Group Account and group accounts cannot be used in transactions,{0} {1}: Das Konto {2} ist ein Gruppenkonto und Gruppenkonten können nicht für Transaktionen verwendet werden,
+{0} {1}: Cost Center is required for 'Profit and Loss' account {2}.,{0} {1}: Kostenstelle ist für das GUV-Konto {2} erforderlich.,
+{0} {1}: Cost Center {2} is a group cost center and group cost centers cannot be used in transactions,{0} {1}: Die Kostenstelle {2} ist eine Gruppenkostenstelle und Gruppenkostenstellen können nicht für Transaktionen verwendet werden,
+{0}% of total invoice value will be given as discount.,{0}% des Gesamtrechnungswerts wird als Rabatt gewährt.,
+{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity}),Die Stichprobengröße von {item_name} ({sample_size}) darf nicht größer sein als die akzeptierte Menge ({accepted_quantity}),
+{range4}-Above,{range4}-oberhalb,
+{}  Available,{}  Verfügbar,
+{}  To Deliver,{}  Auszuliefern,
+{}  To Receive,{}  Zu empfangen,
+{} Assigned,{} Zugewiesen,
+{} Available,{} Verfügbar,
+{} Open,{} Offen,
+{} Pending,{} Ausstehend,
+{} To Bill,{} Abzurechnen,
+{} is a child company.,{} ist ein untergeordnetes Unternehmen.,
+{} {} is already linked with another {},{} {} ist bereits mit einem anderen {} verknüpft,
+{} {} is already linked with {} {},{} {} ist bereits mit {} {} verknüpft,


### PR DESCRIPTION
This PR backports translations in bulk for strings that

1. have a translation on the `develop` branch,
2. also occur in `version-15`, and
3. didn't have a translation in `version-15` yet.

Since we only add translations and don't change existing ones, this should be non-breaking.