### PR TITLE
fix: use get_last_day to get the correct date

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -729,10 +729,15 @@ def get_daily_depr_amount(asset, row, schedule_idx, amount):
 					)
 				),
 				add_days(
-					add_months(
-						row.depreciation_start_date,
-						(row.frequency_of_depreciation * (asset.opening_number_of_booked_depreciations + 1))
-						* -1,
+					get_last_day(
+						add_months(
+							row.depreciation_start_date,
+							(
+								row.frequency_of_depreciation
+								* (asset.opening_number_of_booked_depreciations + 1)
+							)
+							* -1,
+						),
 					),
 					1,
 				),


### PR DESCRIPTION
Used 'get_last_day' to ensures that the last day of any given month or year is accurately determined.
