### PR TITLE
Improvement in Stock Balance Report Accuracy

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -217,7 +217,10 @@ class StockBalanceReport:
 				qty_dict.in_val += value_diff
 			else:
 				qty_dict.out_qty += abs(qty_diff)
-				qty_dict.out_val += abs(value_diff)
+				if value_diff > 0:
+					qty_dict.in_val += value_diff
+				else:
+					qty_dict.out_val += abs(value_diff)
 
 		qty_dict.val_rate = entry.valuation_rate
 		qty_dict.bal_qty += qty_diff


### PR DESCRIPTION
I found an issue with stock balance report where the totals were incorrect because negative quantities could still show positive changes in values in stock reconciliation. This was causing errors in the 'in' and 'out' values.

After reviewing the code and report, I fixed the problem by adding the condition. Now, the report totals are accurate, and both the opening and closing balances, as well as the 'in' and 'out' values, are correct.

This change will greatly improve the accuracy of the stock balance report.