### PR TITLE
Garbage Value for title, description and payer_name on Razorpay Payme…

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -261,12 +261,12 @@ class PaymentRequest(Document):
 		return controller.get_payment_url(
 			**{
 				"amount": flt(self.grand_total, self.precision("grand_total")),
-				"title": data.company.encode("utf-8"),
-				"description": self.subject.encode("utf-8"),
+				"title": data.company,
+				"description": self.subject,
 				"reference_doctype": "Payment Request",
 				"reference_docname": self.name,
 				"payer_email": self.email_to or frappe.session.user,
-				"payer_name": frappe.safe_encode(data.customer_name),
+				"payer_name": data.customer_name,
 				"order_id": self.name,
 				"currency": self.currency,
 			}


### PR DESCRIPTION

Information about bug
Garbage Value for title, description and payer_name on Razorpay Payments Page

How to reproduce :
Make Payment Request with method/type Razorpay
After Save, Submit open payment url in browser you will see garbage values like [0010 0010 00011 001001] instead of description and title.

Module
accounts

Version
Frappe 15.30.0
ERPNext 15.30.0

Installation method
manual install

Relevant log output / Stack trace / Full Error Message. Getting Garbage Value on Razorpay Payments UI Page


