### PR TITLE
feat: :card_file_box: company field added to Quality Inspection

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.json
@@ -15,6 +15,7 @@
   "inspection_type",
   "reference_type",
   "reference_name",
+  "company",
   "section_break_7",
   "item_code",
   "item_serial_no",
@@ -238,6 +239,13 @@
    "fieldname": "manual_inspection",
    "fieldtype": "Check",
    "label": "Manual Inspection"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
   }
  ],
  "icon": "fa fa-search",
@@ -245,7 +253,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:28.680815",
+ "modified": "2024-08-01 16:31:27.363920",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection",


### PR DESCRIPTION
As a user, I want to enter my company directly into a "Quality Inspection", so that

- I can find my "Quality Inspection" of interest quickly
- the System Manager can restrict my access to a certain Company, along with the "Quality Inspection" (via "User Permissions")
- the System Manager can create company-specific "Document Naming Rule" for the "Quality Inspection", so that I don't have to take care about it

Please backport to version-14 & version-15 as well.
