### PR TITLE
fix : deffered revenue in tag version v14.61.2

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -384,45 +384,45 @@ def book_deferred_income_or_expense(doc, deferred_process, posting_date=None):
 			)
 
 		if not amount:
-			return
-
-		gl_posting_date = end_date
-		prev_posting_date = None
-		# check if books nor frozen till endate:
-		if accounts_frozen_upto and getdate(end_date) <= getdate(accounts_frozen_upto):
-			gl_posting_date = get_last_day(add_days(accounts_frozen_upto, 1))
 			prev_posting_date = end_date
-
-		if via_journal_entry:
-			book_revenue_via_journal_entry(
-				doc,
-				credit_account,
-				debit_account,
-				amount,
-				base_amount,
-				gl_posting_date,
-				project,
-				account_currency,
-				item.cost_center,
-				item,
-				deferred_process,
-				submit_journal_entry,
-			)
 		else:
-			make_gl_entries(
-				doc,
-				credit_account,
-				debit_account,
-				against,
-				amount,
-				base_amount,
-				gl_posting_date,
-				project,
-				account_currency,
-				item.cost_center,
-				item,
-				deferred_process,
-			)
+			gl_posting_date = end_date
+			prev_posting_date = None
+			# check if books nor frozen till endate:
+			if accounts_frozen_upto and getdate(end_date) <= getdate(accounts_frozen_upto):
+				gl_posting_date = get_last_day(add_days(accounts_frozen_upto, 1))
+				prev_posting_date = end_date
+
+			if via_journal_entry:
+				book_revenue_via_journal_entry(
+					doc,
+					credit_account,
+					debit_account,
+					amount,
+					base_amount,
+					gl_posting_date,
+					project,
+					account_currency,
+					item.cost_center,
+					item,
+					deferred_process,
+					submit_journal_entry,
+				)
+			else:
+				make_gl_entries(
+					doc,
+					credit_account,
+					debit_account,
+					against,
+					amount,
+					base_amount,
+					gl_posting_date,
+					project,
+					account_currency,
+					item.cost_center,
+					item,
+					deferred_process,
+				)
 
 		# Returned in case of any errors because it tries to submit the same record again and again in case of errors
 		if frappe.flags.deferred_accounting_error:


### PR DESCRIPTION
### Causes:
1. We found an anomaly: when the service start date is set at the end of the month (e.g., 30-05-2024 or 31-05-2024), the system fails to create the monthly deferred expense journal.
2. If we change the service start date to 29-05-2024, the amortization recognition journal for the end of May is created with a prorated calculation from 29-05-2024 to 31-05-2024. In the following month (e.g., 30 June), a full month’s expense recognition journal (30 days) is created.

### Findings:
Upon checking Frappe version 15, there appears to be an adjustment code for processing deferred accounting.