### PR TITLE
fix: error message in coa importer

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -47,9 +47,11 @@ def validate_columns(data):
 
 	no_of_columns = max([len(d) for d in data])
 
-	if no_of_columns > 8:
+	if no_of_columns != 8:
 		frappe.throw(
-			_("More columns found than expected. Please compare the uploaded file with standard template"),
+			_(
+				"Columns are not according to template. Please compare the uploaded file with standard template"
+			),
 			title=(_("Wrong Template")),
 		)
 


### PR DESCRIPTION
The current validation process only checks for rows with more than 8 columns. This limited check does not account for less than 8 columns, which can cause issues.

Frappe Internal Issue: https://support.frappe.io/app/hd-ticket/19638

### Traceback
```

Traceback (most recent call last):

  File "apps/frappe/frappe/app.py", line 114, in application

    response = frappe.api.handle(request)

               ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/api/__init__.py", line 49, in handle

    data = endpoint(**arguments)

           ^^^^^^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call

    return frappe.handler.handle()

           ^^^^^^^^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/handler.py", line 49, in handle

    data = execute_cmd(cmd)

           ^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd

    return frappe.call(method, **frappe.form_dict)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/__init__.py", line 1768, in call

    return fn(*args, **newargs)

           ^^^^^^^^^^^^^^^^^^^^

  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper

    return func(*args, **kwargs)

           ^^^^^^^^^^^^^^^^^^^^^

  File "apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 175, in get_coa

    forest = build_forest(data)

             ^^^^^^^^^^^^^^^^^^

  File "apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 239, in build_forest

    (

ValueError: not enough values to unpack (expected 8, got 6)```


```

Before:
![image](https://github.com/user-attachments/assets/9e7e5e43-cf36-4fae-8b0c-26f8adecf6e2)


After:
![image](https://github.com/user-attachments/assets/7967fcde-b4a1-4248-9b5c-aca72f41531e)
