### PR TITLE
fix: disable primary action button only when there are no active capitalization

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -188,11 +188,21 @@ frappe.ui.form.on("Asset", {
 			frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
 
 			if (frm.doc.is_composite_asset) {
-				$(".primary-action").prop("hidden", true);
-				$(".form-message").text("Capitalize this asset to confirm");
+				frappe.call({
+					method: "erpnext.assets.doctype.asset.asset.has_active_capitalization",
+					args: {
+						asset: frm.doc.name,
+					},
+					callback: function (r) {
+						if (!r.message) {
+							$(".primary-action").prop("hidden", true);
+							$(".form-message").text("Capitalize this asset to confirm");
 
-				frm.add_custom_button(__("Capitalize Asset"), function () {
-					frm.trigger("create_asset_capitalization");
+							frm.add_custom_button(__("Capitalize Asset"), function () {
+								frm.trigger("create_asset_capitalization");
+							});
+						}
+					},
 				});
 			}
 		}

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -221,7 +221,6 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:!doc.is_composite_asset",
    "fieldname": "gross_purchase_amount",
    "fieldtype": "Currency",
    "label": "Gross Purchase Amount",
@@ -580,7 +579,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-07-07 22:27:14.733839",
+ "modified": "2024-08-01 16:39:09.340973",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1037,6 +1037,14 @@ def get_asset_value_after_depreciation(asset_name, finance_book=None):
 
 
 @frappe.whitelist()
+def has_active_capitalization(asset):
+	active_capitalizations = frappe.db.count(
+		"Asset Capitalization", filters={"target_asset": asset, "docstatus": 1}
+	)
+	return active_capitalizations > 0
+
+
+@frappe.whitelist()
 def split_asset(asset_name, split_qty):
 	asset = frappe.get_doc("Asset", asset_name)
 	split_qty = cint(split_qty)


### PR DESCRIPTION
This PR addresses an issue in the Asset doctype where the primary action button got incorrectly disabled and showed the "Capitalize Aasset" button even when there were active capitalizations for the asset. The intended functionality was to perform these actions only when there were no active capitalizations for the asset