### PR TITLE
refactor: filter to ignore system generated cr / dr reconciliation journals on general ledger

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -209,6 +209,11 @@ frappe.query_reports["General Ledger"] = {
 			label: __("Ignore Exchange Rate Revaluation Journals"),
 			fieldtype: "Check",
 		},
+		{
+			fieldname: "ignore_cr_dr_notes",
+			label: __("Ignore System Generated Credit / Debit Notes"),
+			fieldtype: "Check",
+		},
 	],
 };
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -236,6 +236,20 @@ def get_conditions(filters):
 		if err_journals:
 			filters.update({"voucher_no_not_in": [x[0] for x in err_journals]})
 
+	if filters.get("ignore_cr_dr_notes"):
+		system_generated_cr_dr_journals = frappe.db.get_all(
+			"Journal Entry",
+			filters={
+				"company": filters.get("company"),
+				"docstatus": 1,
+				"voucher_type": ("in", ["Credit Note", "Debit Note"]),
+				"is_system_generated": 1,
+			},
+			as_list=True,
+		)
+		if system_generated_cr_dr_journals:
+			filters.update({"voucher_no_not_in": [x[0] for x in system_generated_cr_dr_journals]})
+
 	if filters.get("voucher_no_not_in"):
 		conditions.append("voucher_no not in %(voucher_no_not_in)s")
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -230,6 +230,7 @@ def get_conditions(filters):
 				"company": filters.get("company"),
 				"docstatus": 1,
 				"voucher_type": ("in", ["Exchange Rate Revaluation", "Exchange Gain Or Loss"]),
+				"posting_date": ["between", [filters.get("from_date"), filters.get("to_date")]],
 			},
 			as_list=True,
 		)
@@ -244,6 +245,7 @@ def get_conditions(filters):
 				"docstatus": 1,
 				"voucher_type": ("in", ["Credit Note", "Debit Note"]),
 				"is_system_generated": 1,
+				"posting_date": ["between", [filters.get("from_date"), filters.get("to_date")]],
 			},
 			as_list=True,
 		)

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -2,6 +2,7 @@
 # MIT License. See license.txt
 
 import frappe
+from frappe import qb
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt, today
 
@@ -252,6 +253,10 @@ class TestGeneralLedger(FrappeTestCase):
 		self.assertIn(revaluation_jv.name, set([x.voucher_no for x in data]))
 
 	def test_ignore_cr_dr_notes_filter(self):
+		# Clear old data
+		sinv_doctype = qb.DocType("Sales Invoice")
+		qb.from_(sinv_doctype).delete().where(sinv_doctype.company.eq("_Test Company")).run()
+
 		si = create_sales_invoice()
 
 		cr_note = make_return_doc(si.doctype, si.name)

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -5,7 +5,9 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt, today
 
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.general_ledger.general_ledger import execute
+from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 
 class TestGeneralLedger(FrappeTestCase):
@@ -248,3 +250,73 @@ class TestGeneralLedger(FrappeTestCase):
 			)
 		)
 		self.assertIn(revaluation_jv.name, set([x.voucher_no for x in data]))
+
+	def test_ignore_cr_dr_notes_filter(self):
+		si = create_sales_invoice()
+
+		cr_note = make_return_doc(si.doctype, si.name)
+		cr_note.submit()
+
+		pr = frappe.get_doc("Payment Reconciliation")
+		pr.company = si.company
+		pr.party_type = "Customer"
+		pr.party = si.customer
+		pr.receivable_payable_account = si.debit_to
+
+		pr.get_unreconciled_entries()
+		self.assertEqual(len(pr.invoices), 1)
+		self.assertEqual(len(pr.payments), 1)
+
+		invoices = [invoice.as_dict() for invoice in pr.invoices]
+		payments = [payment.as_dict() for payment in pr.payments]
+		pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
+		pr.reconcile()
+
+		self.assertEqual(len(pr.invoices), 0)
+		self.assertEqual(len(pr.payments), 0)
+
+		system_generated_journal = frappe.db.get_all(
+			"Journal Entry",
+			filters={
+				"docstatus": 1,
+				"reference_type": si.doctype,
+				"reference_name": si.name,
+				"voucher_type": "Credit Note",
+				"is_system_generated": True,
+			},
+			fields=["name"],
+		)
+		self.assertEqual(len(system_generated_journal), 1)
+		expected = set([si.name, cr_note.name, system_generated_journal[0].name])
+		# Without ignore_cr_dr_notes
+		columns, data = execute(
+			frappe._dict(
+				{
+					"company": si.company,
+					"from_date": si.posting_date,
+					"to_date": si.posting_date,
+					"account": [si.debit_to],
+					"group_by": "Group by Voucher (Consolidated)",
+					"ignore_cr_dr_notes": False,
+				}
+			)
+		)
+		actual = set([x.voucher_no for x in data if x.voucher_no])
+		self.assertEqual(expected, actual)
+
+		# Without ignore_cr_dr_notes
+		expected = set([si.name, cr_note.name])
+		columns, data = execute(
+			frappe._dict(
+				{
+					"company": si.company,
+					"from_date": si.posting_date,
+					"to_date": si.posting_date,
+					"account": [si.debit_to],
+					"group_by": "Group by Voucher (Consolidated)",
+					"ignore_cr_dr_notes": True,
+				}
+			)
+		)
+		actual = set([x.voucher_no for x in data if x.voucher_no])
+		self.assertEqual(expected, actual)


### PR DESCRIPTION
Upon reconciling a Sales Return to a Sales Invoice, system always posts Journal Entries to adjust the amount. Few customers have requested an option to at least not include them in General Ledger report. A new filter - 'Ignore System Generated Credit / Debit Notes', is added for the same.
![Screenshot from 2024-08-02 15-56-52](https://github.com/user-attachments/assets/fc92904e-33cb-4975-b352-8abfb34f6e28)



Possible fix for https://github.com/frappe/erpnext/issues/39134