### PR TITLE
fix: add delivered status filter in warranty claim serial no field

### DIFF
--- a/erpnext/support/doctype/warranty_claim/warranty_claim.js
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.js
@@ -12,7 +12,7 @@ frappe.ui.form.on("Warranty Claim", {
 		frm.set_query("serial_no", () => {
 			let filters = {
 				company: frm.doc.company,
-				status: ["in",["Delivered"]],
+				status: ["in", ["Delivered"]],
 			};
 
 			if (frm.doc.item_code) {

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.js
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.js
@@ -12,6 +12,7 @@ frappe.ui.form.on("Warranty Claim", {
 		frm.set_query("serial_no", () => {
 			let filters = {
 				company: frm.doc.company,
+				status: ["in",["Delivered"]],
 			};
 
 			if (frm.doc.item_code) {


### PR DESCRIPTION
Before - In Warranty Claim No status filter for serial no field
Now - Add delivered status filter for serial no field.
There is no need to show an active serial no for warranty claim