### PR TITLE
fix(holiday-list): use same date format for same holiday error message

### DIFF
--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -149,7 +149,11 @@ class HolidayList(Document):
 		unique_dates = []
 		for row in self.holidays:
 			if row.holiday_date in unique_dates:
-				frappe.throw(_("Holiday Date {0} added multiple times").format(frappe.bold(row.holiday_date)))
+				frappe.throw(_("Holiday Date {0} added multiple times").format(
+					frappe.bold(
+						formatdate(row.holiday_date)
+					)
+				))
 
 			unique_dates.append(row.holiday_date)
 

--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -149,11 +149,11 @@ class HolidayList(Document):
 		unique_dates = []
 		for row in self.holidays:
 			if row.holiday_date in unique_dates:
-				frappe.throw(_("Holiday Date {0} added multiple times").format(
-					frappe.bold(
-						formatdate(row.holiday_date)
+				frappe.throw(
+					_("Holiday Date {0} added multiple times").format(
+						frappe.bold(formatdate(row.holiday_date))
 					)
-				))
+				)
 
 			unique_dates.append(row.holiday_date)
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
Fix frappe/hrms#1847

> Please provide enough information so that others can review your pull request:

Fixes the issue where the date format in the error message doesn't adhere to the system settings for the date format.


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

The new patch uses the default system format for the error message too.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


Before:
![Screenshot 2024-08-02 at 9 58 58 PM](https://github.com/user-attachments/assets/6ad95f39-a6d4-4e8d-a0f0-c9ffffbac437)

After:
![Screenshot 2024-08-02 at 9 59 25 PM](https://github.com/user-attachments/assets/009a00be-8ece-44c8-84a0-06245744799a)
