### PR TITLE
fix: correct garbage value on Razorpay Payments Page

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -258,19 +258,19 @@ class PaymentRequest(Document):
 		if hasattr(controller, "validate_minimum_transaction_amount"):
 			controller.validate_minimum_transaction_amount(self.currency, self.grand_total)
 
-		return controller.get_payment_url(
-			**{
-				"amount": flt(self.grand_total, self.precision("grand_total")),
-				"title": data.company.encode("utf-8"),
-				"description": self.subject.encode("utf-8"),
-				"reference_doctype": "Payment Request",
-				"reference_docname": self.name,
-				"payer_email": self.email_to or frappe.session.user,
-				"payer_name": frappe.safe_encode(data.customer_name),
-				"order_id": self.name,
-				"currency": self.currency,
-			}
-		)
+        return controller.get_payment_url(
+            **{
+                "amount": flt(self.grand_total, self.precision("grand_total")),
+                "title": data.company,
+                "description": self.subject,
+                "reference_doctype": "Payment Request",
+                "reference_docname": self.name,
+                "payer_email": self.email_to or frappe.session.user,
+                "payer_name": data.customer_name,
+                "order_id": self.name,
+                "currency": self.currency,
+            }
+        )
 
 	def set_as_paid(self):
 		if self.payment_channel == "Phone":


### PR DESCRIPTION
This PR addresses an issue in the payment_request.py where the encoding format conflicts with Razorpay Payments Page and getting garbage value instead of title and description like [ 10001, 000100, 00111, 0000011, 01111101 ]