### PR TITLE
fix: fixed depreciation calculation as per income tax act

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -362,11 +362,14 @@ class Asset(AccountsController):
 		final_number_of_depreciations = cint(finance_book.total_number_of_depreciations) - cint(
 			self.number_of_depreciations_booked
 		)
-		has_pro_rata = self.check_is_pro_rata(finance_book)
+		for_income_tax = frappe.db.get_value("Finance Book", finance_book.finance_book, "for_income_tax")
+		has_pro_rata = False
+		if not for_income_tax:
+			has_pro_rata = self.check_is_pro_rata(finance_book)
 		depr_already_booked = any(
 			[d.journal_entry for d in self.get("schedules") if d.finance_book == finance_book.finance_book]
 		)
-		if has_pro_rata and not depr_already_booked:
+		if has_pro_rata and not depr_already_booked and not for_income_tax:
 			final_number_of_depreciations += 1
 
 		has_wdv_or_dd_non_yearly_pro_rata = False
@@ -517,10 +520,13 @@ class Asset(AccountsController):
 			)
 
 			# Adjust depreciation amount in the last period based on the expected value after useful life
-			if (
-				n == cint(final_number_of_depreciations) - 1
-				and flt(value_after_depreciation) != flt(finance_book.expected_value_after_useful_life)
-			) or flt(value_after_depreciation) < flt(finance_book.expected_value_after_useful_life):
+			if not for_income_tax and (
+				(
+					n == cint(final_number_of_depreciations) - 1
+					and flt(value_after_depreciation) != flt(finance_book.expected_value_after_useful_life)
+				)
+				or flt(value_after_depreciation) < flt(finance_book.expected_value_after_useful_life)
+			):
 				depreciation_amount += flt(value_after_depreciation) - flt(
 					finance_book.expected_value_after_useful_life
 				)

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -362,7 +362,9 @@ class Asset(AccountsController):
 		final_number_of_depreciations = cint(finance_book.total_number_of_depreciations) - cint(
 			self.number_of_depreciations_booked
 		)
-		for_income_tax = frappe.db.get_value("Finance Book", finance_book.finance_book, "for_income_tax")
+		for_income_tax = 0
+		if frappe.db.has_column("Finance Book", "for_income_tax"):
+			for_income_tax = frappe.db.get_value("Finance Book", finance_book.finance_book, "for_income_tax")
 		has_pro_rata = False
 		if not for_income_tax:
 			has_pro_rata = self.check_is_pro_rata(finance_book)

--- a/erpnext/crm/report/sales_pipeline_analytics/test_sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/test_sales_pipeline_analytics.py
@@ -1,19 +1,21 @@
 import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from erpnext.crm.report.sales_pipeline_analytics.sales_pipeline_analytics import execute
 
 
-class TestSalesPipelineAnalytics(unittest.TestCase):
-	@classmethod
-	def setUpClass(self):
+class TestSalesPipelineAnalytics(FrappeTestCase):
+	def setUp(self):
 		frappe.db.delete("Opportunity")
 		create_company()
 		create_customer()
 		create_opportunity()
 
 	def test_sales_pipeline_analytics(self):
+		self.from_date = "2021-01-01"
+		self.to_date = "2021-12-31"
 		self.check_for_monthly_and_number()
 		self.check_for_monthly_and_amount()
 		self.check_for_quarterly_and_number()
@@ -28,6 +30,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -43,6 +47,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -59,6 +65,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -74,6 +82,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -90,6 +100,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -105,6 +117,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -121,6 +135,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -136,6 +152,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"status": "Open",
 			"opportunity_type": "Sales",
 			"company": "Best Test",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)
@@ -153,8 +171,8 @@ class TestSalesPipelineAnalytics(unittest.TestCase):
 			"opportunity_type": "Sales",
 			"company": "Best Test",
 			"opportunity_source": "Cold Calling",
-			"from_date": "2021-08-01",
-			"to_date": "2021-08-31",
+			"from_date": self.from_date,
+			"to_date": self.to_date,
 		}
 
 		report = execute(filters)


### PR DESCRIPTION
This PR addresses the issue where, when the "for income tax" checkbox is enabled in ERPNext, the depreciation for the first year was incorrectly adjusted in the last year. The fix ensures that the depreciation of the first year is not adjusted in the last year when this checkbox is enabled.
Internal Issue 16828

