### PR TITLE
fix: disable apply tds field when tds category is set

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -361,7 +361,8 @@ class PurchaseInvoice(BuyingController):
 				)
 				.run()
 			)
-			self.set_onload("enable_apply_tds", True if po_with_tds else False)
+
+			self.set_onload("enable_apply_tds", True if (po_with_tds or not tds_category) else False)
 
 		super().set_missing_values(for_validate)
 


### PR DESCRIPTION
Apply TDS field is read-only in Purchase Invoice if it is unchecked in Purchase Order while creating PI from PO.