### PR TITLE
fix: recursion issue while submitting work order

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -249,11 +249,7 @@ class JobCard(Document):
 				if d.to_time and get_datetime(d.from_time) > get_datetime(d.to_time):
 					frappe.throw(_("Row {0}: From time must be less than to time").format(d.idx))
 
-				open_job_cards = []
-				if d.get("employee"):
-					open_job_cards = self.get_open_job_cards(d.get("employee"))
-
-				data = self.get_overlap_for(d, open_job_cards=open_job_cards)
+				data = self.get_overlap_for(d)
 				if data:
 					frappe.throw(
 						_("Row {0}: From Time and To Time of {1} is overlapping with {2}").format(
@@ -274,12 +270,12 @@ class JobCard(Document):
 		for row in self.sub_operations:
 			self.total_completed_qty += row.completed_qty
 
-	def get_overlap_for(self, args, open_job_cards=None):
+	def get_overlap_for(self, args):
 		time_logs = []
 
-		time_logs.extend(self.get_time_logs(args, "Job Card Time Log"))
+		time_logs.extend(self.get_time_logs(args, "Job Card Scheduled Time"))
 
-		time_logs.extend(self.get_time_logs(args, "Job Card Scheduled Time", open_job_cards=open_job_cards))
+		time_logs.extend(self.get_time_logs(args, "Job Card Time Log"))
 
 		if not time_logs:
 			return {}
@@ -304,7 +300,7 @@ class JobCard(Document):
 				self.workstation = workstation_time.get("workstation")
 				return workstation_time
 
-		return time_logs[0]
+		return time_logs[-1]
 
 	def has_overlap(self, production_capacity, time_logs):
 		overlap = False
@@ -343,7 +339,7 @@ class JobCard(Document):
 			return True
 		return overlap
 
-	def get_time_logs(self, args, doctype, open_job_cards=None):
+	def get_time_logs(self, args, doctype):
 		jc = frappe.qb.DocType("Job Card")
 		jctl = frappe.qb.DocType(doctype)
 
@@ -351,6 +347,7 @@ class JobCard(Document):
 			((jctl.from_time < args.from_time) & (jctl.to_time > args.from_time)),
 			((jctl.from_time < args.to_time) & (jctl.to_time > args.to_time)),
 			((jctl.from_time >= args.from_time) & (jctl.to_time <= args.to_time)),
+			((jctl.from_time >= args.from_time) & (jctl.to_time >= args.to_time)),
 		]
 
 		query = (
@@ -369,7 +366,6 @@ class JobCard(Document):
 				& (Criterion.any(time_conditions))
 				& (jctl.name != f"{args.name or 'No Name'}")
 				& (jc.name != f"{args.parent or 'No Name'}")
-				& (jc.docstatus < 2)
 			)
 			.orderby(jctl.to_time)
 		)
@@ -381,41 +377,17 @@ class JobCard(Document):
 			query = query.where(jc.workstation == self.workstation)
 
 		if args.get("employee"):
-			if not open_job_cards and doctype == "Job Card Scheduled Time":
-				return []
-
 			if doctype == "Job Card Time Log":
 				query = query.where(jctl.employee == args.get("employee"))
-			else:
-				query = query.where(jc.name.isin(open_job_cards))
 
-		if doctype != "Job Card Time Log":
-			query = query.where(jc.total_time_in_mins == 0)
+		if doctype == "Job Card Time Log":
+			query = query.where(jc.docstatus < 2)
+		else:
+			query = query.where((jc.docstatus == 0) & (jc.total_time_in_mins == 0))
 
 		time_logs = query.run(as_dict=True)
 
 		return time_logs
-
-	def get_open_job_cards(self, employee):
-		jc = frappe.qb.DocType("Job Card")
-		jctl = frappe.qb.DocType("Job Card Time Log")
-
-		query = (
-			frappe.qb.from_(jc)
-			.left_join(jctl)
-			.on(jc.name == jctl.parent)
-			.select(jc.name)
-			.where(
-				(jctl.parent == jc.name)
-				& (jc.workstation == self.workstation)
-				& (jctl.employee == employee)
-				& (jc.docstatus < 1)
-				& (jc.name != self.name)
-			)
-		)
-
-		jobs = query.run(as_dict=True)
-		return [job.get("name") for job in jobs] if jobs else []
 
 	def get_workstation_based_on_available_slot(self, existing_time_logs) -> dict:
 		workstations = get_workstations(self.workstation_type)
@@ -453,14 +425,14 @@ class JobCard(Document):
 			self.check_workstation_time(row)
 
 	def validate_overlap_for_workstation(self, args, row):
-		# get the last record based on the to time from the job card
-		data = self.get_overlap_for(args)
-
 		if not self.workstation:
 			workstations = get_workstations(self.workstation_type)
 			if workstations:
 				# Get the first workstation
 				self.workstation = workstations[0]
+
+		# get the last record based on the to time from the job card
+		data = self.get_overlap_for(args)
 
 		if not data:
 			row.planned_start_time = args.from_time


### PR DESCRIPTION
Issue

```
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 364, in get_value_sql
    return self.get_formatted_value(self.value, **kwargs)
      self = 
      kwargs = {'quote_char': '`', 'secondary_quote_char': "'", 'param_wrapper': , 'subcriterion': False, 'subquery': True, 'alias_quote_char': None, 'as_keyword': False, 'dialect': , 'with_namespace': True}
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 376, in get_formatted_value
    return cls.get_formatted_value(value.isoformat(), **kwargs)
      cls = 
      value = datetime.datetime(2024, 7, 23, 8, 25, 24, 555410)
      kwargs = {'quote_char': '`', 'secondary_quote_char': "'", 'param_wrapper': , 'subcriterion': False, 'subquery': True, 'alias_quote_char': None, 'as_keyword': False, 'dialect': , 'with_namespace': True}
      quote_char = "'"
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 373, in get_formatted_value
    if isinstance(value, Enum):
      cls = 
      value = '2024-07-23T08:25:24.555410'
      kwargs = {'quote_char': '`', 'secondary_quote_char': "'", 'param_wrapper': , 'subcriterion': False, 'subquery': True, 'alias_quote_char': None, 'as_keyword': False, 'dialect': , 'with_namespace': True}
      quote_char = "'"
builtins.RecursionError: maximum recursion depth exceeded while calling a Python object
```