### PR TITLE
fix: update 'Paid Amount' on forex payment request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -331,6 +331,17 @@ class PaymentRequest(Document):
 		payment_entry.received_amount = amount
 		payment_entry.get("references")[0].allocated_amount = amount
 
+		# Update 'Paid Amount' on Forex transactions
+		if self.currency != ref_doc.company_currency:
+			if (
+				self.payment_request_type == "Outward"
+				and payment_entry.paid_from_account_currency == ref_doc.company_currency
+				and payment_entry.paid_from_account_currency != payment_entry.paid_to_account_currency
+			):
+				payment_entry.paid_amount = payment_entry.base_paid_amount = (
+					payment_entry.target_exchange_rate * payment_entry.received_amount
+				)
+
 		for dimension in get_accounting_dimensions():
 			payment_entry.update({dimension: self.get(dimension)})
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -10,6 +10,7 @@ from frappe.tests.utils import FrappeTestCase
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.setup.utils import get_exchange_rate
 
@@ -398,3 +399,19 @@ class TestPaymentRequest(FrappeTestCase):
 		# Try to make Payment Request more than SO amount, should give validation
 		pr2.grand_total = 900
 		self.assertRaises(frappe.ValidationError, pr2.save)
+
+	def test_conversion_on_foreign_currency_accounts(self):
+		po_doc = create_purchase_order(supplier="_Test Supplier USD", currency="USD", do_not_submit=1)
+		po_doc.conversion_rate = 80
+		po_doc.items[0].qty = 1
+		po_doc.items[0].rate = 10
+		po_doc.save().submit()
+
+		pr = make_payment_request(dt=po_doc.doctype, dn=po_doc.name, recipient_id="nabin@erpnext.com")
+		pr = frappe.get_doc(pr).save().submit()
+
+		pe = pr.create_payment_entry()
+		self.assertEqual(pe.base_paid_amount, 800)
+		self.assertEqual(pe.paid_amount, 800)
+		self.assertEqual(pe.base_received_amount, 800)
+		self.assertEqual(pe.received_amount, 10)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
@@ -53,7 +54,7 @@ payment_method = [
 ]
 
 
-class TestPaymentRequest(unittest.TestCase):
+class TestPaymentRequest(FrappeTestCase):
 	def setUp(self):
 		for payment_gateway in payment_gateways:
 			if not frappe.db.get_value("Payment Gateway", payment_gateway["gateway"], "name"):
@@ -85,6 +86,9 @@ class TestPaymentRequest(unittest.TestCase):
 		)
 		self._get_payment_gateway_controller = _get_payment_gateway_controller.start()
 		self.addCleanup(_get_payment_gateway_controller.stop)
+
+	def tearDown(self):
+		frappe.db.rollback()
 
 	def test_payment_request_linkings(self):
 		so_inr = make_sales_order(currency="INR", do_not_save=True)


### PR DESCRIPTION
Payment Entry created from Payment Request have incorrect 'Paid amount' on forex transactions.

Ex:
Consider a Purchase Order of $20 grand total.
![Screenshot from 2024-08-08 10-39-21](https://github.com/user-attachments/assets/bf524f1a-2395-458c-adc0-8278c57a2ecc)
Now create a Payment Request for it.
![Screenshot from 2024-08-08 10-39-55](https://github.com/user-attachments/assets/e13930c6-63a4-4b3a-b5fd-13e76aa0ccc9)

## Without fix
Creating Payment Entry should've had Paid amount in company currency,
![Screenshot from 2024-08-08 10-40-28](https://github.com/user-attachments/assets/a5de95ec-cb3b-4c54-a035-ba73c71bcc2d)


## With fix
![Screenshot from 2024-08-08 10-40-12](https://github.com/user-attachments/assets/bdc3def1-386a-495a-a4ed-9cbed13c0bfc)

