### PR TITLE
fix: Maintain same rate on qty change on Quotation to Sales Order

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1263,6 +1263,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			"Sales Invoice Item": ["dn_detail", "so_detail", "sales_invoice_item"],
 			"Purchase Receipt Item": ["purchase_order_item", "purchase_invoice_item", "purchase_receipt_item"],
 			"Purchase Invoice Item": ["purchase_order_item", "pr_detail", "po_detail"],
+			"Sales Order Item": ["prevdoc_docname", "quotation_item"],
 		};
 		const mappped_fields = mapped_item_field_map[item.doctype] || [];
 


### PR DESCRIPTION
Scenario:
1. Create an Item Price for an Item
2. Make a Quotation with that Item
3. Update rate in Item price [1]
4. Make Sales Order from Quotation [2]
5. change qty

## current behavior
system fetches and updates the latest rate on sales order.

## expected behavior
rate should remain the same across quotation and sales order.


