### PR TITLE
fix(Process Statement Of Accounts): translatable strings in print

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -13,7 +13,7 @@
 		</div>
 		{% endif %}
 	</div>
-	<h2 class="text-center">{{ _("STATEMENTS OF ACCOUNTS") }}</h2>
+	<h2 class="text-center">{{ _("STATEMENT OF ACCOUNTS") }}</h2>
 	<div>
 		{% if filters.party[0] == filters.party_name[0] %}
 			<h5 style="float: left;">{{ _("Customer: ") }} <b>{{ filters.party_name[0] }}</b></h5>
@@ -22,11 +22,11 @@
 			<h5 style="float: left; margin-left:15px">{{ _("Customer Name: ") }} <b>{{filters.party_name[0] }}</b></h5>
 		{% endif %}
 		<h5 style="float: right;">
-			{{ _("Date: ") }}
-			<b>{{ frappe.format(filters.from_date, 'Date')}}
-			{{ _("to") }}
-			{{ frappe.format(filters.to_date, 'Date')}}</b>
-			</h5>
+			{{ _("Date: {0} to {1}").format(
+				frappe.format(filters.from_date, "Date"),
+				frappe.format(filters.to_date, 'Date')
+			) }}
+		</h5>
 	</div>
 	<br>
 
@@ -54,7 +54,7 @@
 						<br>
 					{% endif %}
 
-					<br>{{ _("Remarks") }}: {{ row.remarks }}
+					<br>{{ _("Remarks:") }} {{ row.remarks }}
 					{% if row.bill_no %}
 						<br>{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
 					{% endif %}
@@ -83,17 +83,20 @@
 	</table>
 	<br>
 	{% if ageing %}
-	<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
-		{{ _("up to " ) }}  {{ frappe.format(filters.to_date, 'Date')}}
+	<h4 class="text-center">
+		{{ _("Ageing Report based on {0} up to {1}").format(
+			ageing.ageing_based_on,
+			frappe.format(filters.to_date, "Date")
+		) }}
 	</h4>
 	<table class="table table-bordered">
 		<thead>
 			<tr>
-				<th style="width: 20%">0 - 30 Days</th>
-				<th style="width: 20%">30 - 60 Days</th>
-				<th style="width: 20%">60 - 90 Days</th>
-				<th style="width: 20%">90 - 120 Days</th>
-				<th style="width: 20%">Above 120 Days</th>
+				<th style="width: 20%">{{ _("0 - 30 Days") }}</th>
+				<th style="width: 20%">{{ _("30 - 60 Days") }}</th>
+				<th style="width: 20%">{{ _("60 - 90 Days") }}</th>
+				<th style="width: 20%">{{ _("90 - 120 Days") }}</th>
+				<th style="width: 20%">{{ _("Above 120 Days") }}</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -6,228 +6,301 @@
 	.print-format td {
 		vertical-align:middle !important;
 	}
-	</style>
+</style>
 
-	<div id="header-html" class="hidden-pdf">
-		{% if letter_head.content %}
-		<div class="letter-head text-center">{{ letter_head.content }}</div>
-		<hr style="height:2px;border-width:0;color:black;background-color:black;">
-		{% endif %}
-	</div>
-	<div id="footer-html" class="visible-pdf">
-		{% if letter_head.footer %}
-		<div class="letter-head-footer">
-			<hr style="border-width:0;color:black;background-color:black;padding-bottom:2px;">
-			{{ letter_head.footer }}
-		</div>
-		{% endif %}
-	</div>
-
-	<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
-	<h4 class="text-center">
-		{{ filters.customer_name }}
-	</h4>
-	<h6 class="text-center">
-		{% if (filters.tax_id) %}
-		{{ _("Tax Id: ") }}{{ filters.tax_id }}
-		{% endif %}
-	</h6>
-	<h5 class="text-center">
-		{{ _(filters.ageing_based_on) }}
-		{{ _("Until") }}
-		{{ frappe.format(filters.report_date, 'Date') }}
-	</h5>
-
-	<div class="clearfix">
-		<div class="pull-left">
-		{% if(filters.payment_terms) %}
-			<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
-		{% endif %}
-		</div>
-		<div class="pull-right">
-		{% if(filters.credit_limit) %}
-			<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
-		{% endif %}
-		</div>
-	</div>
-
-	{% if(filters.show_future_payments) %}
-		{% set balance_row = data.slice(-1).pop() %}
-		{% for i in report.columns %}
-			{% if i.fieldname == 'age' %}
-				{% set elem = i %}
-			{% endif %}
-		{% endfor %}
-		{% set start = report.columns.findIndex(elem) %}
-		{% set range1 = report.columns[start].label %}
-		{% set range2 = report.columns[start+1].label %}
-		{% set range3 = report.columns[start+2].label %}
-		{% set range4 = report.columns[start+3].label %}
-		{% set range5 = report.columns[start+4].label %}
-		{% set range6 = report.columns[start+5].label %}
-
-		{% if(balance_row) %}
-		<table class="table table-bordered table-condensed">
-			<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
-				<colgroup>
-					<col style="width: 30mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-					<col style="width: 18mm;">
-				</colgroup>
-
-			<thead>
-				<tr>
-					<th>{{ _(" ") }}</th>
-					<th>{{ _(range1) }}</th>
-					<th>{{ _(range2) }}</th>
-					<th>{{ _(range3) }}</th>
-					<th>{{ _(range4) }}</th>
-					<th>{{ _(range5) }}</th>
-					<th>{{ _(range6) }}</th>
-					<th>{{ _("Total") }}</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>{{ _("Total Outstanding") }}</td>
-					<td class="text-right">
-						{{ format_number(balance_row["age"], null, 2) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range1"], data[data.length-1]["currency"]) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range2"], data[data.length-1]["currency"]) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range3"], data[data.length-1]["currency"]) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range4"], data[data.length-1]["currency"]) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range5"], data[data.length-1]["currency"]) }}
-					</td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) }}
-					</td>
-				</tr>
-					<td>{{ _("Future Payments") }}</td>
-					<td></td>
-					<td></td>
-					<td></td>
-					<td></td>
-					<td></td>
-					<td></td>
-					<td class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) }}
-					</td>
-				<tr class="cvs-footer">
-					<th class="text-left">{{ _("Cheques Required") }}</th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) }}</th>
-				</tr>
-			</tbody>
-
-		</table>
-		{% endif %}
+<div id="header-html" class="hidden-pdf">
+	{% if letter_head.content %}
+	<div class="letter-head text-center">{{ letter_head.content }}</div>
+	<hr style="height:2px;border-width:0;color:black;background-color:black;">
 	{% endif %}
-	<table class="table table-bordered">
+</div>
+<div id="footer-html" class="visible-pdf">
+	{% if letter_head.footer %}
+	<div class="letter-head-footer">
+		<hr style="border-width:0;color:black;background-color:black;padding-bottom:2px;">
+		{{ letter_head.footer }}
+	</div>
+	{% endif %}
+</div>
+
+<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
+<h4 class="text-center">
+	{{ filters.customer_name }}
+</h4>
+<h6 class="text-center">
+	{% if (filters.tax_id) %}
+	{{ _("Tax Id: ") }}{{ filters.tax_id }}
+	{% endif %}
+</h6>
+<h5 class="text-center">
+	{{ _(filters.ageing_based_on) }}
+	{{ _("Until") }}
+	{{ frappe.format(filters.report_date, 'Date') }}
+</h5>
+
+<div class="clearfix">
+	<div class="pull-left">
+	{% if(filters.payment_terms) %}
+		<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
+	{% endif %}
+	</div>
+	<div class="pull-right">
+	{% if(filters.credit_limit) %}
+		<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
+	{% endif %}
+	</div>
+</div>
+
+{% if(filters.show_future_payments) %}
+	{% set balance_row = data.slice(-1).pop() %}
+	{% for i in report.columns %}
+		{% if i.fieldname == 'age' %}
+			{% set elem = i %}
+		{% endif %}
+	{% endfor %}
+	{% set start = report.columns.findIndex(elem) %}
+	{% set range1 = report.columns[start].label %}
+	{% set range2 = report.columns[start+1].label %}
+	{% set range3 = report.columns[start+2].label %}
+	{% set range4 = report.columns[start+3].label %}
+	{% set range5 = report.columns[start+4].label %}
+	{% set range6 = report.columns[start+5].label %}
+
+	{% if(balance_row) %}
+	<table class="table table-bordered table-condensed">
+		<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
+			<colgroup>
+				<col style="width: 30mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+				<col style="width: 18mm;">
+			</colgroup>
+
 		<thead>
 			<tr>
-				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
-					<th style="width: 10%">{{ _("Date") }}</th>
-					<th style="width: 4%">{{ _("Age (Days)") }}</th>
-
-					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
-						<th style="width: 14%">{{ _("Reference") }}</th>
-						<th style="width: 10%">{{ _("Sales Person") }}</th>
-					{% else %}
-						<th style="width: 24%">{{ _("Reference") }}</th>
-					{% endif %}
-					{% if not(filters.show_future_payments) %}
-						<th style="width: 20%">
-						{% if (filters.customer or filters.supplier or filters.customer_name) %}
-							{{ _("Remarks") }}
-						{% else %}
-							{{ _("Party") }}
-						{% endif %}
-						</th>
-					{% endif %}
-					<th style="width: 10%; text-align: right">{{ _("Invoiced Amount") }}</th>
-					{% if not(filters.show_future_payments) %}
-						<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
-						<th style="width: 10%; text-align: right">
-							{% if report.report_name == "Accounts Receivable" %}
-								{{ _('Credit Note') }}
-							{% else %}
-								{{ _('Debit Note') }}
-							{% endif %}
-						</th>
-					{% endif %}
-					<th style="width: 10%; text-align: right">{{ _("Outstanding Amount") }}</th>
-					{% if(filters.show_future_payments) %}
-						{% if(report.report_name == "Accounts Receivable") %}
-							<th style="width: 12%">{{ _("Customer LPO No.") }}</th>
-						{% endif %}
-						<th style="width: 10%">{{ _("Future Payment Ref") }}</th>
-						<th style="width: 10%">{{ _("Future Payment Amount") }}</th>
-						<th style="width: 10%">{{ _("Remaining Balance") }}</th>
-					{% endif %}
-				{% else %}
-					<th style="width: 40%">
-						{% if (filters.customer or filters.supplier or filters.customer_name) %}
-							{{ _("Remarks")}}
-						{% else %}
-							{{ _("Party") }}
-						{% endif %}
-					</th>
-					<th style="width: 15%">{{ _("Total Invoiced Amount") }}</th>
-					<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
-					<th style="width: 15%">
-						{% if report.report_name == "Accounts Receivable Summary" %}
-							{{ _('Credit Note Amount') }}
-						{% else %}
-							{{ _('Debit Note Amount') }}
-						{% endif %}
-					</th>
-					<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
-				{% endif %}
+				<th>{{ _(" ") }}</th>
+				<th>{{ _(range1) }}</th>
+				<th>{{ _(range2) }}</th>
+				<th>{{ _(range3) }}</th>
+				<th>{{ _(range4) }}</th>
+				<th>{{ _(range5) }}</th>
+				<th>{{ _(range6) }}</th>
+				<th>{{ _("Total") }}</th>
 			</tr>
 		</thead>
 		<tbody>
-			{% for i in range(data|length) %}
-				<tr>
-				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
-					{% if(data[i]["party"]) %}
-						<td>{{ (data[i]["posting_date"]) }}</td>
-						<td style="text-align: right">{{ data[i]["age"] }}</td>
-						<td>
-							{% if not(filters.show_future_payments) %}
-								{{ data[i]["voucher_type"] }}
-								<br>
-							{% endif %}
-							{{ data[i]["voucher_no"] }}
-						</td>
+			<tr>
+				<td>{{ _("Total Outstanding") }}</td>
+				<td class="text-right">
+					{{ format_number(balance_row["age"], null, 2) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(balance_row["range1"], data[data.length-1]["currency"]) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(balance_row["range2"], data[data.length-1]["currency"]) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(balance_row["range3"], data[data.length-1]["currency"]) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(balance_row["range4"], data[data.length-1]["currency"]) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(balance_row["range5"], data[data.length-1]["currency"]) }}
+				</td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) }}
+				</td>
+			</tr>
+				<td>{{ _("Future Payments") }}</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td class="text-right">
+					{{ frappe.utils.fmt_money(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) }}
+				</td>
+			<tr class="cvs-footer">
+				<th class="text-left">{{ _("Cheques Required") }}</th>
+				<th></th>
+				<th></th>
+				<th></th>
+				<th></th>
+				<th></th>
+				<th></th>
+				<th class="text-right">
+					{{ frappe.utils.fmt_money(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) }}</th>
+			</tr>
+		</tbody>
 
-						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
-						<td>{{ data[i]["sales_person"] }}</td>
+	</table>
+	{% endif %}
+{% endif %}
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+				<th style="width: 10%">{{ _("Date") }}</th>
+				<th style="width: 4%">{{ _("Age (Days)") }}</th>
+
+				{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+					<th style="width: 14%">{{ _("Reference") }}</th>
+					<th style="width: 10%">{{ _("Sales Person") }}</th>
+				{% else %}
+					<th style="width: 24%">{{ _("Reference") }}</th>
+				{% endif %}
+				{% if not(filters.show_future_payments) %}
+					<th style="width: 20%">
+					{% if (filters.customer or filters.supplier or filters.customer_name) %}
+						{{ _("Remarks") }}
+					{% else %}
+						{{ _("Party") }}
+					{% endif %}
+					</th>
+				{% endif %}
+				<th style="width: 10%; text-align: right">{{ _("Invoiced Amount") }}</th>
+				{% if not(filters.show_future_payments) %}
+					<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
+					<th style="width: 10%; text-align: right">
+						{% if report.report_name == "Accounts Receivable" %}
+							{{ _('Credit Note') }}
+						{% else %}
+							{{ _('Debit Note') }}
 						{% endif %}
+					</th>
+				{% endif %}
+				<th style="width: 10%; text-align: right">{{ _("Outstanding Amount") }}</th>
+				{% if(filters.show_future_payments) %}
+					{% if(report.report_name == "Accounts Receivable") %}
+						<th style="width: 12%">{{ _("Customer LPO No.") }}</th>
+					{% endif %}
+					<th style="width: 10%">{{ _("Future Payment Ref") }}</th>
+					<th style="width: 10%">{{ _("Future Payment Amount") }}</th>
+					<th style="width: 10%">{{ _("Remaining Balance") }}</th>
+				{% endif %}
+			{% else %}
+				<th style="width: 40%">
+					{% if (filters.customer or filters.supplier or filters.customer_name) %}
+						{{ _("Remarks")}}
+					{% else %}
+						{{ _("Party") }}
+					{% endif %}
+				</th>
+				<th style="width: 15%">{{ _("Total Invoiced Amount") }}</th>
+				<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
+				<th style="width: 15%">
+					{% if report.report_name == "Accounts Receivable Summary" %}
+						{{ _('Credit Note Amount') }}
+					{% else %}
+						{{ _('Debit Note Amount') }}
+					{% endif %}
+				</th>
+				<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
+			{% endif %}
+		</tr>
+	</thead>
+	<tbody>
+		{% for i in range(data|length) %}
+			<tr>
+			{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+				{% if(data[i]["party"]) %}
+					<td>{{ (data[i]["posting_date"]) }}</td>
+					<td style="text-align: right">{{ data[i]["age"] }}</td>
+					<td>
+						{% if not(filters.show_future_payments) %}
+							{{ data[i]["voucher_type"] }}
+							<br>
+						{% endif %}
+						{{ data[i]["voucher_no"] }}
+					</td>
 
-						{% if not (filters.show_future_payments) %}
+					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+					<td>{{ data[i]["sales_person"] }}</td>
+					{% endif %}
+
+					{% if not (filters.show_future_payments) %}
+					<td>
+						{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
+							{{ data[i]["party"] }}
+							{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
+								<br> {{ data[i]["customer_name"] }}
+							{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
+								<br> {{ data[i]["supplier_name"] }}
+							{% endif %}
+						{% endif %}
+						<div>
+						{% if data[i]["remarks"] %}
+							{{ _("Remarks") }}:
+							{{ data[i]["remarks"] }}
+						{% endif %}
+						</div>
+					</td>
+					{% endif %}
+
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+
+					{% if not(filters.show_future_payments) %}
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+					{% endif %}
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+
+					{% if(filters.show_future_payments) %}
+						{% if(report.report_name == "Accounts Receivable") %}
+							<td style="text-align: right">
+								{{ data[i]["po_no"] }}</td>
+						{% endif %}
+						<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+					{% endif %}
+				{% else %}
+					<td></td>
+					{% if not(filters.show_future_payments) %}
+					<td></td>
+					{% endif %}
+					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+					<td></td>
+					{% endif %}
+					<td></td>
+					<td style="text-align: right"><b>{{ _("Total") }}</b></td>
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(data[i]["invoiced"], data[i]["currency"]) }}</td>
+
+					{% if not(filters.show_future_payments) %}
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }} </td>
+					{% endif %}
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+
+					{% if(filters.show_future_payments) %}
+						{% if(report.report_name == "Accounts Receivable") %}
+							<td style="text-align: right">
+								{{ data[i]["po_no"] }}</td>
+						{% endif %}
+						<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+					{% endif %}
+				{% endif %}
+			{% else %}
+				{% if(data[i]["party"] or "&nbsp;") %}
+					{% if not(data[i]["is_total_row"]) %}
 						<td>
-							{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
+							{% if(not(filters.customer | filters.supplier)) %}
 								{{ data[i]["party"] }}
 								{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
 									<br> {{ data[i]["customer_name"] }}
@@ -235,132 +308,59 @@
 									<br> {{ data[i]["supplier_name"] }}
 								{% endif %}
 							{% endif %}
-							<div>
-							{% if data[i]["remarks"] %}
-								{{ _("Remarks") }}:
-								{{ data[i]["remarks"] }}
-							{% endif %}
-							</div>
+							<br>{{ _("Remarks") }}:
+							{{ data[i]["remarks"] }}
 						</td>
-						{% endif %}
-
-						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
-
-						{% if not(filters.show_future_payments) %}
-							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
-						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
-
-						{% if(filters.show_future_payments) %}
-							{% if(report.report_name == "Accounts Receivable") %}
-								<td style="text-align: right">
-									{{ data[i]["po_no"] }}</td>
-							{% endif %}
-							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
 					{% else %}
-						<td></td>
-						{% if not(filters.show_future_payments) %}
-						<td></td>
-						{% endif %}
-						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
-						<td></td>
-						{% endif %}
-						<td></td>
-						<td style="text-align: right"><b>{{ _("Total") }}</b></td>
-						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["invoiced"], data[i]["currency"]) }}</td>
-
-						{% if not(filters.show_future_payments) %}
-							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }} </td>
-						{% endif %}
-						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
-
-						{% if(filters.show_future_payments) %}
-							{% if(report.report_name == "Accounts Receivable") %}
-								<td style="text-align: right">
-									{{ data[i]["po_no"] }}</td>
-							{% endif %}
-							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
+						<td><b>{{ _("Total") }}</b></td>
 					{% endif %}
-				{% else %}
-					{% if(data[i]["party"] or "&nbsp;") %}
-						{% if not(data[i]["is_total_row"]) %}
-							<td>
-								{% if(not(filters.customer | filters.supplier)) %}
-									{{ data[i]["party"] }}
-									{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
-										<br> {{ data[i]["customer_name"] }}
-									{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
-										<br> {{ data[i]["supplier_name"] }}
-									{% endif %}
-								{% endif %}
-								<br>{{ _("Remarks") }}:
-								{{ data[i]["remarks"] }}
-							</td>
-						{% else %}
-							<td><b>{{ _("Total") }}</b></td>
-						{% endif %}
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
-					{% endif %}
+					<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+					<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+					<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+					<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
 				{% endif %}
-				</tr>
-			{% endfor %}
-			<td></td>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="paid"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="credit_note"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="outstanding"), currency=data[0]["currency"]) }}</b></td>
-		</tbody>
-	</table>
-	<br>
-	{% if ageing %}
-	<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
-		{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
-	</h4>
-	<table class="table table-bordered">
-		<thead>
-			<tr>
-				<th style="width: 25%">0 - 30 Days</th>
-				<th style="width: 25%">30 - 60 Days</th>
-				<th style="width: 25%">60 - 90 Days</th>
-				<th style="width: 25%">90 - 120 Days</th>
-				<th style="width: 20%">Above 120 Days</th>
+			{% endif %}
 			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>{{ frappe.utils.fmt_money(ageing.range1, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range2, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range3, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range4, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range5, currency=filters.presentation_currency) }}</td>
-			</tr>
-		</tbody>
-	</table>
-	{% endif %}
-	{% if terms_and_conditions %}
-	<div>
-		{{ terms_and_conditions }}
-	</div>
-	{% endif %}
-	<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>
+		{% endfor %}
+		<td></td>
+		<td></td>
+		<td></td>
+		<td></td>
+		<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>
+		<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="paid"), currency=data[0]["currency"]) }}</b></td>
+		<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="credit_note"), currency=data[0]["currency"]) }}</b></td>
+		<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="outstanding"), currency=data[0]["currency"]) }}</b></td>
+	</tbody>
+</table>
+<br>
+{% if ageing %}
+<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
+	{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
+</h4>
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<th style="width: 25%">0 - 30 Days</th>
+			<th style="width: 25%">30 - 60 Days</th>
+			<th style="width: 25%">60 - 90 Days</th>
+			<th style="width: 25%">90 - 120 Days</th>
+			<th style="width: 20%">Above 120 Days</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{ frappe.utils.fmt_money(ageing.range1, currency=data[0]["currency"]) }}</td>
+			<td>{{ frappe.utils.fmt_money(ageing.range2, currency=data[0]["currency"]) }}</td>
+			<td>{{ frappe.utils.fmt_money(ageing.range3, currency=data[0]["currency"]) }}</td>
+			<td>{{ frappe.utils.fmt_money(ageing.range4, currency=data[0]["currency"]) }}</td>
+			<td>{{ frappe.utils.fmt_money(ageing.range5, currency=filters.presentation_currency) }}</td>
+		</tr>
+	</tbody>
+</table>
+{% endif %}
+{% if terms_and_conditions %}
+<div>
+	{{ terms_and_conditions }}
+</div>
+{% endif %}
+<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -29,24 +29,25 @@
 </h4>
 <h6 class="text-center">
 	{% if (filters.tax_id) %}
-	{{ _("Tax Id: ") }}{{ filters.tax_id }}
+		{{ _("Tax Id: {0}").format(filters.tax_id) }}
 	{% endif %}
 </h6>
 <h5 class="text-center">
-	{{ _(filters.ageing_based_on) }}
-	{{ _("Until") }}
-	{{ frappe.format(filters.report_date, 'Date') }}
+	{{ _("{0} until {1}").format(
+		_(filters.ageing_based_on),
+		frappe.format(filters.report_date, 'Date')
+	) }}
 </h5>
 
 <div class="clearfix">
 	<div class="pull-left">
 	{% if(filters.payment_terms) %}
-		<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
+		<strong>{{ _("Payment Terms:") }}</strong> {{ filters.payment_terms }}
 	{% endif %}
 	</div>
 	<div class="pull-right">
 	{% if(filters.credit_limit) %}
-		<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
+		<strong>{{ _("Credit Limit:") }}</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
 	{% endif %}
 	</div>
 </div>
@@ -68,7 +69,7 @@
 
 	{% if(balance_row) %}
 	<table class="table table-bordered table-condensed">
-		<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
+		<caption class="text-right">{{ _("Amount in {0}").format(data[0]["currency"] ~ "") }}</caption>
 			<colgroup>
 				<col style="width: 30mm;">
 				<col style="width: 18mm;">
@@ -170,9 +171,9 @@
 					<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
 					<th style="width: 10%; text-align: right">
 						{% if report.report_name == "Accounts Receivable" %}
-							{{ _('Credit Note') }}
+							{{ _("Credit Note") }}
 						{% else %}
-							{{ _('Debit Note') }}
+							{{ _("Debit Note") }}
 						{% endif %}
 					</th>
 				{% endif %}
@@ -197,9 +198,9 @@
 				<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
 				<th style="width: 15%">
 					{% if report.report_name == "Accounts Receivable Summary" %}
-						{{ _('Credit Note Amount') }}
+						{{ _("Credit Note Amount") }}
 					{% else %}
-						{{ _('Debit Note Amount') }}
+						{{ _("Debit Note Amount") }}
 					{% endif %}
 				</th>
 				<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
@@ -334,17 +335,20 @@
 </table>
 <br>
 {% if ageing %}
-<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
-	{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
+<h4 class="text-center">
+	{{ _("Ageing Report based on {0} up to {1}").format(
+		ageing.ageing_based_on,
+		frappe.format(filters.report_date, "Date")
+	) }}
 </h4>
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			<th style="width: 25%">0 - 30 Days</th>
-			<th style="width: 25%">30 - 60 Days</th>
-			<th style="width: 25%">60 - 90 Days</th>
-			<th style="width: 25%">90 - 120 Days</th>
-			<th style="width: 20%">Above 120 Days</th>
+			<th style="width: 25%">{{ _("0 - 30 Days") }}</th>
+			<th style="width: 25%">{{ _("30 - 60 Days") }}</th>
+			<th style="width: 25%">{{ _("60 - 90 Days") }}</th>
+			<th style="width: 25%">{{ _("90 - 120 Days") }}</th>
+			<th style="width: 20%">{{ _("Above 120 Days") }}</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -363,4 +367,4 @@
 	{{ terms_and_conditions }}
 </div>
 {% endif %}
-<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>
+<p class="text-right text-muted">{{ _("Printed on {0}").format(frappe.utils.now()) }}</p>


### PR DESCRIPTION
> [!NOTE]
> Please hide whitespace changes to get a meaningful diff. (One file was over-indented.)

In some places, the missing translation function was added in.
In some places, strings were converted from `_("Clicked ") + n + _(" times")` to `_("Clicked {0} times").format(n)`.

Both print formats still work as expected:

![Bildschirmfoto 2024-08-08 um 13 06 39](https://github.com/user-attachments/assets/67bc7043-fe4f-477d-9d67-c2010365aee1)
![Bildschirmfoto 2024-08-08 um 13 06 16](https://github.com/user-attachments/assets/c9a27bf2-49ac-483c-8126-e0e0f5f0cff3)
