### PR TITLE
perf: data import with 99 stock entries

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -10,6 +10,7 @@ from frappe import _, scrub
 from frappe.model.meta import get_field_precision
 from frappe.query_builder.functions import Sum
 from frappe.utils import (
+	add_to_date,
 	cint,
 	cstr,
 	flt,
@@ -632,6 +633,7 @@ class update_entries_after:
 
 	def get_sle_against_current_voucher(self):
 		self.args["posting_datetime"] = get_combine_datetime(self.args.posting_date, self.args.posting_time)
+		self.args["updated_creation_time"] = add_to_date(self.args.creation, seconds=-2)
 
 		return frappe.db.sql(
 			"""
@@ -646,6 +648,7 @@ class update_entries_after:
 				and (
 					posting_datetime = %(posting_datetime)s
 				)
+				and creation >= %(updated_creation_time)s
 			order by
 				creation ASC
 			for update


### PR DESCRIPTION
System is taking 106 seconds to import 99 stock entries

process_sle method ran 4950 times for 99 stock entries which ideally should execute for 99 times 

<img width="795" alt="Screenshot 2024-08-08 at 11 42 58 PM" src="https://github.com/user-attachments/assets/59f5a3ff-c426-46c1-a6d1-ab38901a9757">


**After Fix**

22 seconds to complete 99 stock entries

<img width="713" alt="Screenshot 2024-08-09 at 1 44 49 AM" src="https://github.com/user-attachments/assets/14d9568c-8ecd-48ca-bbaf-92a6aede8379">

