### PR TITLE
fix: typeerror on payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -230,7 +230,7 @@ frappe.ui.form.on("Payment Entry", {
 
 	hide_unhide_fields: function (frm) {
 		var company_currency = frm.doc.company
-			? frappe.get_doc(":Company", frm.doc.company).default_currency
+			? frappe.get_doc(":Company", frm.doc.company)?.default_currency
 			: "";
 
 		frm.toggle_display(


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'default_currency')
  at hide_unhide_fields(payment_entry__js:222:49)
  at _handler(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at set_difference_amount(payment_entry__js:1201:14)
  at _handler(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at runner(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:109:16)
  at <anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:127:22)
```

Internal Ref: https://support.frappe.io/helpdesk/tickets/20002