### PR TITLE
fix: text color in sales funnel report based on theme

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -248,7 +248,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		context.fill();
 
 		// draw text
-		context.fillStyle = "black";
+		context.fillStyle = getComputedStyle(document.body).getPropertyValue("--text-color");
 		context.textBaseline = "middle";
 		context.font = "1.1em sans-serif";
 		context.fillText(__(title), width + 20, y_mid);


### PR DESCRIPTION
Issue: Text cannot be seen in dark mode
fix: Text color based on the theme.
Before:
![image](https://github.com/user-attachments/assets/b9593b9c-3d3e-47ea-95db-7ce77ac1e8e9)


After:
![image](https://github.com/user-attachments/assets/9169ffcd-d2fb-41ad-b87d-5b8f31ad1e91)

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/19154

