### PR TITLE
fix: cancel Journal Entry on cancellation of asset value adjustment

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -56,6 +56,7 @@ class AssetValueAdjustment(Document):
 		)
 
 	def on_cancel(self):
+		frappe.get_doc("Journal Entry", self.journal_entry).cancel()
 		self.update_asset(self.current_asset_value)
 		add_asset_activity(
 			self.asset,


### PR DESCRIPTION
On cancellation of Asset Value Adjustment system doesn't cancel linked Journal Entry.
Closes #42519 