### PR TITLE
fix: Production plan pending qty is wrong for alternative UoMs

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
+				( flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) ) * item.conversion_factor
 			)
 
 		pi = frappe.qb.DocType("Packed Item")


### PR DESCRIPTION
If sales order item uom is different than the main uom, pending qty is wrong.

Sales Order
![image](https://github.com/user-attachments/assets/7eef58b8-5134-4af6-ad99-340325dc829a)

Before (Production Plan)
![image](https://github.com/user-attachments/assets/ce1ad0d3-f362-4284-a142-aa02c9fb0486)

After (Production Plan)
![image](https://github.com/user-attachments/assets/3bd8f7a4-7a3a-4a75-a967-e750f1e41173)


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
