### PR TITLE
fix: Production Plan, pending qty is wrong if alternative UoM is used

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -339,6 +339,7 @@ class ProductionPlan(Document):
 		items = items_query.run(as_dict=True)
 
 		for item in items:
+			#Calculate the pending qty with respect to conversion factor.
 			item.pending_qty = (
 				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
 			)

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,9 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			# Calculate the pending qty with respect to conversion factor.
-			item.pending_qty = (
-				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
-			)
+			item.pending_qty = (flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
 
 		pi = frappe.qb.DocType("Packed Item")
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
+				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
 			)
 
 		pi = frappe.qb.DocType("Packed Item")

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
+				( flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) ) * item.conversion_factor
 			)
 
 		pi = frappe.qb.DocType("Packed Item")

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,9 @@ class ProductionPlan(Document):
 
 		for item in items:
 			# Calculate the pending qty with respect to conversion factor.
-			item.pending_qty = (flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
+			item.pending_qty = (
+				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)
+			) * item.conversion_factor
 
 		pi = frappe.qb.DocType("Packed Item")
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
+				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
 			)
 
 		pi = frappe.qb.DocType("Packed Item")

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -340,7 +340,7 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				( flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) ) * item.conversion_factor
+				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
 			)
 
 		pi = frappe.qb.DocType("Packed Item")

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -339,7 +339,7 @@ class ProductionPlan(Document):
 		items = items_query.run(as_dict=True)
 
 		for item in items:
-			#Calculate the pending qty with respect to conversion factor.
+			# Calculate the pending qty with respect to conversion factor.
 			item.pending_qty = (
 				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)) * item.conversion_factor
 			)

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -341,8 +341,9 @@ class ProductionPlan(Document):
 		for item in items:
 			# Calculate the pending qty with respect to conversion factor.
 			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)
-			) * item.conversion_factor
+				(flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0))
+			* item.conversion_factor
+			)
 
 		pi = frappe.qb.DocType("Packed Item")
 


### PR DESCRIPTION
Production plan incorrectly calculates pending qty if uom is not main uom in sales order.

Sales Order:
![image](https://github.com/user-attachments/assets/534c5451-6423-479e-bf4f-1a40a60d2af9)

Before (Production Plan,  Assembly Items ):
![image](https://github.com/user-attachments/assets/9b2f5c66-b0f4-4781-a495-c7bf54c95b40)


After (Production Plan,  Assembly Items ):
![image](https://github.com/user-attachments/assets/e3c398f1-086c-426d-9b0d-8c7a32cfd196)

PS1: It's now calculates the pending qty with respect to conversion factor in sales order.
PS2: I only corrected Sales Order part. Material Request handle the calculation in the database and it seems correct.
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
