### PR TITLE
fix: ignore pricing rule while making DN from Pick List

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -941,6 +941,10 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 	}
 
 	def set_missing_values(source, target):
+		if kwargs.get("ignore_pricing_rule"):
+			# Skip pricing rule when the dn is creating from the pick list
+			target.ignore_pricing_rule = 1
+
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 		target.run_method("calculate_taxes_and_totals")

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -19,6 +19,7 @@
   "consider_rejected_warehouses",
   "get_item_locations",
   "pick_manually",
+  "ignore_pricing_rule",
   "section_break_6",
   "scan_barcode",
   "column_break_13",
@@ -200,11 +201,18 @@
    "fieldname": "pick_manually",
    "fieldtype": "Check",
    "label": "Pick Manually"
+  },
+  {
+   "default": "0",
+   "description": "If enabled then system won't apply the pricing rule on the delivery note which will be create from the pick list",
+   "fieldname": "ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 22:49:16.954637",
+ "modified": "2024-08-14 13:20:42.168827",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -50,6 +50,7 @@ class PickList(Document):
 		customer_name: DF.Data | None
 		for_qty: DF.Float
 		group_same_items: DF.Check
+		ignore_pricing_rule: DF.Check
 		locations: DF.Table[PickListItem]
 		material_request: DF.Link | None
 		naming_series: DF.Literal["STO-PICK-.YYYY.-"]
@@ -1144,7 +1145,7 @@ def create_dn_with_so(sales_dict, pick_list):
 	for customer in sales_dict:
 		for so in sales_dict[customer]:
 			delivery_note = None
-			kwargs = {"skip_item_mapping": True}
+			kwargs = {"skip_item_mapping": True, "ignore_pricing_rule": pick_list.ignore_pricing_rule}
 			delivery_note = create_delivery_note_from_sales_order(so, delivery_note, kwargs=kwargs)
 			break
 		if delivery_note:

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1205,3 +1205,64 @@ class TestPickList(FrappeTestCase):
 		pl_doc.submit()
 
 		frappe.db.set_single_value("Stock Settings", "over_picking_allowance", 0)
+
+	def test_ignore_pricing_rule_in_pick_list(self):
+		frappe.flags.print_stmt = False
+		warehouse = "_Test Warehouse - _TC"
+		item = make_item(
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"batch_number_series": "IPR-PICKLT-.######",
+				"create_new_batch": 1,
+			}
+		).name
+
+		make_stock_entry(
+			item=item,
+			to_warehouse=warehouse,
+			qty=2,
+			basic_rate=100,
+		)
+
+		pricing_rule = frappe.get_doc(
+			{
+				"doctype": "Pricing Rule",
+				"title": "Same Free Item",
+				"price_or_product_discount": "Product",
+				"selling": 1,
+				"apply_on": "Item Code",
+				"items": [
+					{
+						"item_code": item,
+					}
+				],
+				"same_item": 1,
+				"is_recursive": 1,
+				"recurse_for": 2,
+				"free_qty": 1,
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+			}
+		)
+
+		pricing_rule.save()
+		frappe.flags.print_stmt = True
+
+		so = make_sales_order(item_code=item, qty=2, rate=100, do_not_save=True)
+		so.set_warehouse = warehouse
+		so.submit()
+
+		self.assertEqual(len(so.items), 2)
+		self.assertTrue(so.items[1].is_free_item)
+
+		pl = create_pick_list(so.name)
+		pl.ignore_pricing_rule = 1
+		pl.save()
+		pl.submit()
+
+		self.assertEqual(len(pl.locations), 1)
+
+		delivery_note = create_delivery_note(pl.name)
+
+		self.assertEqual(len(delivery_note.items), 1)


### PR DESCRIPTION
**Issue**

- User has created pricing rule that on purchase of 2 quantity of Item A, they will get 1 free quantity of Item A
- User has create a sales order for 2 quantity of Item A, on which 1 free quantity of Item A has added in the SO
- User has created a pick list and he came to know that he has only 2 quantity of Item A available, so he has removed free item
- User has created Delivery Note and system has added 1 free item automatically which ideally was not picked

**Solution**

Added option in the pick list to Ignore the pricing rule
<img width="1340" alt="Screenshot 2024-08-14 at 1 24 16 PM" src="https://github.com/user-attachments/assets/cbd48d52-d2fe-463f-82af-1908e5775ac1">

