### PR TITLE
refactor: Loosen account currency validation on groups

### DIFF
--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -42,7 +42,6 @@ class CustomerGroup(NestedSet):
 
 	def validate_currency_for_receivable_and_advance_account(self):
 		for x in self.accounts:
-			company_default_currency = frappe.get_cached_value("Company", x.company, "default_currency")
 			receivable_account_currency = None
 			advance_account_currency = None
 
@@ -54,21 +53,6 @@ class CustomerGroup(NestedSet):
 			if x.advance_account:
 				advance_account_currency = frappe.get_cached_value(
 					"Account", x.advance_account, "account_currency"
-				)
-
-			if receivable_account_currency and receivable_account_currency != company_default_currency:
-				frappe.throw(
-					_("Receivable Account: {0} must be in Company default currency: {1}").format(
-						frappe.bold(x.account),
-						frappe.bold(company_default_currency),
-					)
-				)
-
-			if advance_account_currency and advance_account_currency != company_default_currency:
-				frappe.throw(
-					_("Advance Account: {0} must be in Company default currency: {1}").format(
-						frappe.bold(x.advance_account), frappe.bold(company_default_currency)
-					)
 				)
 
 			if (

--- a/erpnext/setup/doctype/supplier_group/supplier_group.py
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.py
@@ -37,7 +37,6 @@ class SupplierGroup(NestedSet):
 
 	def validate_currency_for_payable_and_advance_account(self):
 		for x in self.accounts:
-			company_default_currency = frappe.get_cached_value("Company", x.company, "default_currency")
 			payable_account_currency = None
 			advance_account_currency = None
 
@@ -47,21 +46,6 @@ class SupplierGroup(NestedSet):
 			if x.advance_account:
 				advance_account_currency = frappe.get_cached_value(
 					"Account", x.advance_account, "account_currency"
-				)
-
-			if payable_account_currency and payable_account_currency != company_default_currency:
-				frappe.throw(
-					_("Payable Account: {0} must be in Company default currency: {1}").format(
-						frappe.bold(x.account),
-						frappe.bold(company_default_currency),
-					)
-				)
-
-			if advance_account_currency and advance_account_currency != company_default_currency:
-				frappe.throw(
-					_("Advance Account: {0} must be in Company default currency: {1}").format(
-						frappe.bold(x.advance_account), frappe.bold(company_default_currency)
-					)
 				)
 
 			if (


### PR DESCRIPTION
Loosen the accounts validation to allow foreign currency default accounts for receivable / payable accounts and advances in Customer / Supplier Group.

Both the accounts should be of the same currency. That validation stays.