### PR TITLE
fix: Auto Create Serial and Batch Bundle For Outward

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -221,7 +221,15 @@ class SerialBatchBundle:
 			not self.sle.is_cancelled
 			and not self.sle.serial_and_batch_bundle
 			and self.item_details.has_batch_no == 1
-			and self.item_details.create_new_batch
+			and (
+				self.item_details.create_new_batch
+				or (
+					frappe.db.get_single_value(
+						"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+					)
+					and self.sle.actual_qty < 0
+				)
+			)
 		):
 			self.make_serial_batch_no_bundle()
 		elif not self.sle.is_cancelled:


### PR DESCRIPTION
**Steps to replicate issue**

- create batch item, enable has_batch_no and set batch_number_series and do not enable create_new_batch
- Create the purchase receipt with 10 quantity and single batch
- Enable "Auto Create Serial and Batch Bundle For Outward" in the Stock Settings
- Create the delivery note without batch selection, you will get the below error

<img width="649" alt="image" src="https://github.com/user-attachments/assets/63c4e127-f854-4c96-aa9a-fd4eb5b5a30c">
