### PR TITLE
feat: add extractor for setup wizard txt files

### DIFF
--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,2 +1,3 @@
 **/setup/setup_wizard/data/uom_data.json,erpnext.gettext.extractors.uom_data.extract
 **/setup/doctype/incoterm/incoterms.csv,erpnext.gettext.extractors.incoterms.extract
+**/setup/setup_wizard/data/*.txt,erpnext.gettext.extractors.lines_from_txt_file.extract

--- a/erpnext/gettext/extractors/lines_from_txt_file.py
+++ b/erpnext/gettext/extractors/lines_from_txt_file.py
@@ -1,0 +1,4 @@
+def extract(fileobj, *args, **kwargs):
+	"""Split file into lines and yield one translation unit per line."""
+	for line_no, line in enumerate(fileobj.readlines()):
+		yield line_no + 1, "_", line.decode().strip(), []


### PR DESCRIPTION
In `epnext/setup/setup_wizard/data/` we store some `.txt`-files with record names that are created by the setup wizard. The respective DocTypes have "Translate Link Fields" enabled. We need to extract these record names so people can translate them. Extraction is done by just splitting these `.txt`-files line by line, where each line becomes a translatable string.

> no-docs