### PR TITLE
feat: Allow unique Account number by root type (not unique for accros all Accounts) by allow_regional flags

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -101,14 +101,12 @@ class Account(NestedSet):
 		self.name = get_autoname_with_number(self.account_number, self.account_name, self.company)
 
 	def validate(self):
-		from erpnext.accounts.utils import validate_field_number
-
 		if frappe.local.flags.allow_unverified_charts:
 			return
 		self.validate_parent()
 		self.validate_parent_child_account_type()
 		self.validate_root_details()
-		validate_field_number("Account", self.name, self.account_number, self.company, "account_number")
+		validate_account_number(self.name, self.account_number, self.company, self.root_type)
 		self.validate_group_or_ledger()
 		self.set_root_and_report_type()
 		self.validate_mandatory()
@@ -462,7 +460,8 @@ def get_account_autoname(account_number, account_name, company):
 	return " - ".join(parts)
 
 
-def validate_account_number(name, account_number, company):
+@erpnext.allow_regional
+def validate_account_number(name, account_number, company, root_type):
 	if account_number:
 		account_with_same_number = frappe.db.get_value(
 			"Account", {"account_number": account_number, "company": company, "name": ["!=", name]}

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -460,9 +460,8 @@ def get_account_autoname(account_number, account_name, company):
 	return " - ".join(parts)
 
 
-@erpnext.allow_regional
 def validate_account_number(name, account_number, company, root_type):
-	if account_number:
+	if account_number and validate_regional_account_number(name, account_number, company, root_type) is None:
 		account_with_same_number = frappe.db.get_value(
 			"Account", {"account_number": account_number, "company": company, "name": ["!=", name]}
 		)
@@ -472,6 +471,11 @@ def validate_account_number(name, account_number, company, root_type):
 					account_number, account_with_same_number
 				)
 			)
+
+
+@erpnext.allow_regional
+def validate_regional_account_number(name, account_number, company, root_type):
+	return None
 
 
 @frappe.whitelist()
@@ -514,7 +518,7 @@ def update_account_number(name, account_name, account_number=None, from_descenda
 
 				frappe.throw(message, title=_("Rename Not Allowed"))
 
-	validate_account_number(name, account_number, account.company)
+	validate_account_number(name, account_number, account.company, account.root_type)
 	if account_number:
 		frappe.db.set_value("Account", name, "account_number", account_number.strip())
 	else:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Other suggested implementation of #42279

In France we have chart of account where the same Account number can be use as Liability or as Asset ( the root_type do not exists like that but in France, it imply other definition and meaning but we try to find a way to allow proper French accountancy in ERPNext)

We can understand that add root_type to the check the uniqueness of a Account number may not please all country accountancy rules.
So we can also change the PR to always send root_type as parameters and not use it for standard/core test of uniqueness but add @erpnext.allow_regional on the validate_account_number() function.
Like that we can override it in [ERPNext France](https://github.com/scopen-coop/erpnext_france) app

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR make two changes :

    Use the same method/function on Account creation as on Account update to check the validity of the account number
    Send root_type as parameters to validate_account_number() to check account number uniqueness by company and root_type

> no-docs