### PR TITLE
perf: asset creation from purchase receipt

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -905,7 +905,7 @@ def transfer_asset(args):
 
 @frappe.whitelist()
 def get_item_details(item_code, asset_category, gross_purchase_amount):
-	asset_category_doc = frappe.get_doc("Asset Category", asset_category)
+	asset_category_doc = frappe.get_cached_doc("Asset Category", asset_category)
 	books = []
 	for d in asset_category_doc.finance_books:
 		books.append(


### PR DESCRIPTION
The function get_item_details was originally using frappe.get_doc("Asset Category", asset_category) to retrieve the "Asset Category" document. This method retrieves the document from the database every time it is called, which was a time-consuming operation.
Fix: The fix was to replace frappe.get_doc("Asset Category", asset_category) with frappe.get_cached_doc("Asset Category", asset_category)

<img width="655" alt="Screenshot 2024-08-20 at 12 01 17 PM" src="https://github.com/user-attachments/assets/7c4eecfe-84ef-4db5-a3c9-edb5f7b1875f">

<img width="718" alt="Screenshot 2024-08-20 at 12 02 45 PM" src="https://github.com/user-attachments/assets/3fe88b7b-58e5-4ed1-a96b-a5ec72a08a32">

