### PR TITLE
fix: custom stock entry type issue

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -376,3 +376,4 @@ erpnext.patches.v15_0.update_asset_repair_field_in_stock_entry
 erpnext.patches.v15_0.update_total_number_of_booked_depreciations
 erpnext.patches.v15_0.do_not_use_batchwise_valuation
 erpnext.patches.v15_0.drop_index_posting_datetime_from_sle
+erpnext.patches.v15_0.set_standard_stock_entry_type

--- a/erpnext/patches/v15_0/set_standard_stock_entry_type.py
+++ b/erpnext/patches/v15_0/set_standard_stock_entry_type.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	for stock_entry_type in [
+		"Material Issue",
+		"Material Receipt",
+		"Material Transfer",
+		"Material Transfer for Manufacture",
+		"Material Consumption for Manufacture",
+		"Manufacture",
+		"Repack",
+		"Send to Subcontractor",
+	]:
+		if frappe.db.exists("Stock Entry Type", stock_entry_type):
+			frappe.db.set_value("Stock Entry Type", stock_entry_type, "is_standard", 1)

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -66,29 +66,53 @@ def install(country=None):
 			"parent_item_group": _("All Item Groups"),
 		},
 		# Stock Entry Type
-		{"doctype": "Stock Entry Type", "name": "Material Issue", "purpose": "Material Issue"},
-		{"doctype": "Stock Entry Type", "name": "Material Receipt", "purpose": "Material Receipt"},
+		{
+			"doctype": "Stock Entry Type",
+			"name": "Material Issue",
+			"purpose": "Material Issue",
+			"is_standard": 1,
+		},
+		{
+			"doctype": "Stock Entry Type",
+			"name": "Material Receipt",
+			"purpose": "Material Receipt",
+			"is_standard": 1,
+		},
 		{
 			"doctype": "Stock Entry Type",
 			"name": "Material Transfer",
 			"purpose": "Material Transfer",
+			"is_standard": 1,
 		},
-		{"doctype": "Stock Entry Type", "name": "Manufacture", "purpose": "Manufacture"},
-		{"doctype": "Stock Entry Type", "name": "Repack", "purpose": "Repack"},
+		{
+			"doctype": "Stock Entry Type",
+			"name": "Manufacture",
+			"purpose": "Manufacture",
+			"is_standard": 1,
+		},
+		{
+			"doctype": "Stock Entry Type",
+			"name": "Repack",
+			"purpose": "Repack",
+			"is_standard": 1,
+		},
 		{
 			"doctype": "Stock Entry Type",
 			"name": "Send to Subcontractor",
 			"purpose": "Send to Subcontractor",
+			"is_standard": 1,
 		},
 		{
 			"doctype": "Stock Entry Type",
 			"name": "Material Transfer for Manufacture",
 			"purpose": "Material Transfer for Manufacture",
+			"is_standard": 1,
 		},
 		{
 			"doctype": "Stock Entry Type",
 			"name": "Material Consumption for Manufacture",
 			"purpose": "Material Consumption for Manufacture",
+			"is_standard": 1,
 		},
 		# territory: with two default territories, one for home country and one named Rest of the World
 		{

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1000,7 +1000,7 @@ class StockEntry(StockController):
 	def set_stock_entry_type(self):
 		if self.purpose:
 			self.stock_entry_type = frappe.get_cached_value(
-				"Stock Entry Type", {"purpose": self.purpose}, "name"
+				"Stock Entry Type", {"purpose": self.purpose, "is_standard": 1}, "name"
 			)
 
 	def set_purpose_for_stock_entry(self):

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "purpose",
-  "add_to_transit"
+  "add_to_transit",
+  "is_standard"
  ],
  "fields": [
   {
@@ -26,10 +27,17 @@
    "fieldname": "add_to_transit",
    "fieldtype": "Check",
    "label": "Add to Transit"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_standard",
+   "fieldtype": "Check",
+   "label": "Is Standard",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2024-07-08 08:41:19.385020",
+ "modified": "2024-08-20 15:35:45.696958",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Type",

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -19,6 +19,7 @@ class StockEntryType(Document):
 		from frappe.types import DF
 
 		add_to_transit: DF.Check
+		is_standard: DF.Check
 		purpose: DF.Literal[
 			"",
 			"Material Issue",
@@ -33,8 +34,22 @@ class StockEntryType(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_standard_type()
 		if self.add_to_transit and self.purpose != "Material Transfer":
 			self.add_to_transit = 0
+
+	def validate_standard_type(self):
+		if self.is_standard and self.name not in [
+			"Material Issue",
+			"Material Receipt",
+			"Material Transfer",
+			"Material Transfer for Manufacture",
+			"Material Consumption for Manufacture",
+			"Manufacture",
+			"Repack",
+			"Send to Subcontractor",
+		]:
+			frappe.throw(f"Stock Entry Type {self.name} cannot be set as standard")
 
 
 class ManufactureEntry:

--- a/erpnext/stock/doctype/stock_entry_type/test_stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/test_stock_entry_type.py
@@ -3,6 +3,33 @@
 
 import unittest
 
+import frappe
+
 
 class TestStockEntryType(unittest.TestCase):
-	pass
+	def test_stock_entry_type_non_standard(self):
+		stock_entry_type = "Test Manufacturing"
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "Stock Entry Type",
+				"__newname": stock_entry_type,
+				"purpose": "Manufacture",
+				"is_standard": 1,
+			}
+		)
+
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_stock_entry_type_is_standard(self):
+		for stock_entry_type in [
+			"Material Issue",
+			"Material Receipt",
+			"Material Transfer",
+			"Material Transfer for Manufacture",
+			"Material Consumption for Manufacture",
+			"Manufacture",
+			"Repack",
+			"Send to Subcontractor",
+		]:
+			self.assertTrue(frappe.db.get_value("Stock Entry Type", stock_entry_type, "is_standard"))


### PR DESCRIPTION
**Issue**

- Create a new stock entry type 'Recycle' with Purpose Manufacture.

- Create a work order and make a manufacture stock entry

- The system fetches Stock Entry Type as Recycle instead of Manufacture.

**Solution**

Added Is Standard checkbox in the stock entry type to identify standard stock entry types.