### PR TITLE
fix: do not copy date fields in opportunity doctype

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -185,7 +185,8 @@
   {
    "fieldname": "expected_closing",
    "fieldtype": "Date",
-   "label": "Expected Closing Date"
+   "label": "Expected Closing Date",
+   "no_copy": 1
   },
   {
    "fieldname": "section_break_14",
@@ -357,6 +358,7 @@
    "fieldname": "transaction_date",
    "fieldtype": "Date",
    "label": "Opportunity Date",
+   "no_copy": 1,
    "oldfieldname": "transaction_date",
    "oldfieldtype": "Date",
    "reqd": 1,
@@ -388,6 +390,7 @@
    "fieldname": "first_response_time",
    "fieldtype": "Duration",
    "label": "First Response Time",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -622,7 +625,7 @@
  "icon": "fa fa-info-sign",
  "idx": 195,
  "links": [],
- "modified": "2024-03-27 13:10:07.008338",
+ "modified": "2024-08-20 04:12:29.095761",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Opportunity",


### PR DESCRIPTION
When duplicating an existing record, the opportunity date isn't being set to the current date. Instead, it's capturing the old record's date incorrectly. The standard function should update the opportunity date to the current date.



Frappe Internal Issue: https://support.frappe.io/app/hd-ticket/20028

