### PR TITLE
fix: TDS workflow consistency in Purchase Order

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -652,8 +652,8 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	onload: function (frm) {
-		if (frm.doc.__onload && frm.is_new()) {
-			if (frm.doc.supplier) {
+		if (frm.doc.__onload && frm.doc.supplier) {
+			if (frm.is_new()) {
 				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
 			}
 			if (!frm.doc.__onload.supplier_tds) {

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -656,7 +656,7 @@ frappe.ui.form.on("Purchase Invoice", {
 			if (frm.doc.supplier) {
 				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
 			}
-			if (!frm.doc.__onload.enable_apply_tds) {
+			if (!frm.doc.__onload.supplier_tds) {
 				frm.set_df_property("apply_tds", "read_only", 1);
 			}
 		}

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -347,22 +347,6 @@ class PurchaseInvoice(BuyingController):
 			self.tax_withholding_category = tds_category
 			self.set_onload("supplier_tds", tds_category)
 
-		# If Linked Purchase Order has TDS applied, enable 'apply_tds' checkbox
-		if purchase_orders := [x.purchase_order for x in self.items if x.purchase_order]:
-			po = qb.DocType("Purchase Order")
-			po_with_tds = (
-				qb.from_(po)
-				.select(po.name)
-				.where(
-					po.docstatus.eq(1)
-					& (po.name.isin(purchase_orders))
-					& (po.apply_tds.eq(1))
-					& (po.tax_withholding_category.notnull())
-				)
-				.run()
-			)
-			self.set_onload("enable_apply_tds", True if po_with_tds else False)
-
 		super().set_missing_values(for_validate)
 
 	def validate_credit_to_acc(self):

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -133,8 +133,8 @@ frappe.ui.form.on("Purchase Order", {
 			frm.set_value("transaction_date", frappe.datetime.get_today());
 		}
 
-		if (frm.doc.__onload && frm.is_new()) {
-			if (frm.doc.supplier) {
+		if (frm.doc.__onload && frm.doc.supplier) {
+			if (frm.is_new()) {
 				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
 			}
 			if (!frm.doc.__onload.supplier_tds) {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -65,6 +65,33 @@ frappe.ui.form.on("Purchase Order", {
 		}
 	},
 
+	supplier: function (frm) {
+		// Do not update if inter company reference is there as the details will already be updated
+		if (frm.updating_party_details || frm.doc.inter_company_invoice_reference) return;
+
+		if (frm.doc.__onload && frm.doc.__onload.load_after_mapping) return;
+
+		erpnext.utils.get_party_details(
+			frm,
+			"erpnext.accounts.party.get_party_details",
+			{
+				posting_date: frm.doc.transaction_date,
+				bill_date: frm.doc.bill_date,
+				party: frm.doc.supplier,
+				party_type: "Supplier",
+				account: frm.doc.credit_to,
+				price_list: frm.doc.buying_price_list,
+				fetch_payment_terms_template: cint(!frm.doc.ignore_default_payment_terms_template),
+			},
+			function () {
+				frm.doc.apply_tds = frm.supplier_tds ? 1 : 0;
+				frm.doc.tax_withholding_category = frm.supplier_tds;
+				frm.set_df_property("apply_tds", "read_only", frm.supplier_tds ? 0 : 1);
+				frm.set_df_property("tax_withholding_category", "hidden", frm.supplier_tds ? 0 : 1);
+			}
+		);
+	},
+
 	get_materials_from_supplier: function (frm) {
 		let po_details = [];
 
@@ -106,6 +133,15 @@ frappe.ui.form.on("Purchase Order", {
 		set_schedule_date(frm);
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());
+		}
+
+		if (frm.doc.__onload && frm.is_new()) {
+			if (frm.doc.supplier) {
+				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
+			}
+			if (!frm.doc.__onload.supplier_tds) {
+				frm.set_df_property("apply_tds", "read_only", 1);
+			}
 		}
 
 		erpnext.queries.setup_queries(frm, "Warehouse", function () {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -84,8 +84,6 @@ frappe.ui.form.on("Purchase Order", {
 				fetch_payment_terms_template: cint(!frm.doc.ignore_default_payment_terms_template),
 			},
 			function () {
-				frm.doc.apply_tds = frm.supplier_tds ? 1 : 0;
-				frm.doc.tax_withholding_category = frm.supplier_tds;
 				frm.set_df_property("apply_tds", "read_only", frm.supplier_tds ? 0 : 1);
 				frm.set_df_property("tax_withholding_category", "hidden", frm.supplier_tds ? 0 : 1);
 			}

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -655,8 +655,6 @@ class PurchaseOrder(BuyingController):
 	def set_missing_values(self, for_validate=False):
 		tds_category = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
 		if tds_category and not for_validate:
-			self.apply_tds = 1
-			self.tax_withholding_category = tds_category
 			self.set_onload("supplier_tds", tds_category)
 
 		super().set_missing_values(for_validate)

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -659,6 +659,8 @@ class PurchaseOrder(BuyingController):
 			self.tax_withholding_category = tds_category
 			self.set_onload("supplier_tds", tds_category)
 
+		super().set_missing_values(for_validate)
+
 
 @frappe.request_cache
 def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=1.0):

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -773,6 +773,11 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 	def postprocess(source, target):
 		target.flags.ignore_permissions = ignore_permissions
 		set_missing_values(source, target)
+
+		# set tax_withholding_category from Purchase Order
+		if source.apply_tds and source.tax_withholding_category and target.apply_tds:
+			target.tax_withholding_category = source.tax_withholding_category
+
 		# Get the advance paid Journal Entries in Purchase Invoice Advance
 		if target.get("allocate_advances_automatically"):
 			target.set_advances()

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -652,6 +652,13 @@ class PurchaseOrder(BuyingController):
 			if sco:
 				update_sco_status(sco, "Closed" if self.status == "Closed" else None)
 
+	def set_missing_values(self, for_validate=False):
+		tds_category = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
+		if tds_category and not for_validate:
+			self.apply_tds = 1
+			self.tax_withholding_category = tds_category
+			self.set_onload("supplier_tds", tds_category)
+
 
 @frappe.request_cache
 def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=1.0):


### PR DESCRIPTION
- In Purchase Order and Purchase Invoice "Apply TDS" field "read_only" property based on Supplier Tax Withholding Category.
- While creating Purchase Invoice from Purchase Order if Tax withholding Category is set in Supplier than Tax withholding category will be copied from Purchase Order if it is set. 
- Consistency in "Apply TDS" field "read_only" property on refresh.