### PR TITLE
fix: handle NaN values in payment term details

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2409,13 +2409,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		const doc = this.frm.doc;
 		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note') {
 			var posting_date = doc.posting_date || doc.transaction_date;
+
+			const grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total
+			const base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total
+
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_terms",
 				args: {
 					terms_template: doc.payment_terms_template,
 					posting_date: posting_date,
-					grand_total: doc.rounded_total || doc.grand_total,
-					base_grand_total: doc.base_rounded_total || doc.base_grand_total,
+					grand_total: isNaN(grand_total) ? 0 : grand_total,
+					base_grand_total: isNaN(base_grand_total) ? 0 : base_grand_total,
 					bill_date: doc.bill_date
 				},
 				callback: function(r) {
@@ -2433,14 +2437,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		const me = this;
 		var row = locals[cdt][cdn];
 		if(row.payment_term) {
+			const grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total
+			const base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total
+
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_term_details",
 				args: {
 					term: row.payment_term,
 					bill_date: this.frm.doc.bill_date,
 					posting_date: this.frm.doc.posting_date || this.frm.doc.transaction_date,
-					grand_total: this.frm.doc.rounded_total || this.frm.doc.grand_total,
-					base_grand_total: this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total
+					grand_total: isNaN(grand_total) ? 0 : grand_total,
+					base_grand_total: isNaN(base_grand_total) ? 0 : base_grand_total
 				},
 				callback: function(r) {
 					if(r.message && !r.exc) {


### PR DESCRIPTION
Issue: the Payment Term Template cannot be set in the document due to nan values.

Origin of Issue: Such issues can arise out of improper customisations.

Traceback:
```

Unable to parse reponse text request.js:340:14
{"message":[{"payment_term":"7","description":null,"invoice_portion":100.0,"payment_amount":NaN,"base_payment_amount":NaN,"discount_type":"Percentage","discount":0.0,"outstanding":NaN,"mode_of_payment":null,"due_date":"2024-08-28","discount_date":"2024-08-21"}]} request.js:341:14
SyntaxError: JSON.parse: unexpected character at line 1 column 93 of the JSON data
    call request.js:338
    jQuery 6
    call request.js:279
    call request.js:109
    payment_terms_template transaction.js:2412
    runner script_manager.js:106
    trigger script_manager.js:136
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    trigger script_manager.js:141
    watch_model_updates form.js:302
    enqueue_events model.js:604
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    trigger model.js:622
    set_value model.js:565
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    set_value model.js:574
    set_model_value base_control.js:271
    set base_control.js:233
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    set base_control.js:231
    validate_and_set_in_model base_control.js:251
    promise callback*validate_and_set_in_model base_control.js:251
    parse_validate_and_set_in_model link.js:122
    setup_awesomeplete link.js:396
    jQuery 2
    fire awesomplete.js:504
    select awesomplete.js:282
    item link.js:224
    jQuery 8
    item link.js:223
    evaluate awesomplete.js:323
    evaluate awesomplete.js:322
    set list awesomplete.js:167
    callback link.js:328
    callback request.js:85
    200 request.js:133
    call request.js:305
    jQuery 5
        fire
        fireWith
        done
        callback
        send
request.js:342:14
Unable to handle failed response request.js:362:12

```


Frappe Support Issue:  https://support.frappe.io/app/hd-ticket/20456

