### PR TITLE
fix: incorrect Received Qty Amount in Purchase Order Analysis

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -40,6 +40,7 @@ def get_data(filters):
 	po = frappe.qb.DocType("Purchase Order")
 	po_item = frappe.qb.DocType("Purchase Order Item")
 	pi_item = frappe.qb.DocType("Purchase Invoice Item")
+	pr_item = frappe.qb.DocType("Purchase Receipt Item")
 
 	query = (
 		frappe.qb.from_(po)
@@ -47,6 +48,8 @@ def get_data(filters):
 		.on(po_item.parent == po.name)
 		.left_join(pi_item)
 		.on((pi_item.po_detail == po_item.name) & (pi_item.docstatus == 1))
+		.left_join(pr_item)
+		.on((pr_item.purchase_order_item == po_item.name) & (pr_item.docstatus == 1))
 		.select(
 			po.transaction_date.as_("date"),
 			po_item.schedule_date.as_("required_date"),
@@ -60,7 +63,7 @@ def get_data(filters):
 			(po_item.qty - po_item.received_qty).as_("pending_qty"),
 			Sum(IfNull(pi_item.qty, 0)).as_("billed_qty"),
 			po_item.base_amount.as_("amount"),
-			(po_item.received_qty * po_item.base_rate).as_("received_qty_amount"),
+			(pr_item.base_amount).as_("received_qty_amount"),
 			(po_item.billed_amt * IfNull(po.conversion_rate, 1)).as_("billed_amount"),
 			(po_item.base_amount - (po_item.billed_amt * IfNull(po.conversion_rate, 1))).as_(
 				"pending_amount"


### PR DESCRIPTION
**Issue**

PO amount 2000 -> purchase receipt with amount 2200 -> purchase invoice with amount 2200

In the Purchase Order Analysis report, PO and PI amount is correct but purchase receipt amount is incorrect
<img width="1314" alt="Screenshot 2024-08-21 at 2 27 07 PM" src="https://github.com/user-attachments/assets/d6a47d7d-9a5b-4285-af36-359ce4607ea8">



**After Fix**
<img width="1352" alt="Screenshot 2024-08-21 at 2 36 33 PM" src="https://github.com/user-attachments/assets/20753f33-cae6-4110-b981-a7262955c949">

