### PR TITLE
fix: incorrect amount in bank clearance

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -155,7 +155,7 @@ def get_payment_entries_for_bank_clearance(
 				"Payment Entry" as payment_document, name as payment_entry,
 				reference_no as cheque_number, reference_date as cheque_date,
 				if(paid_from=%(account)s, paid_amount + total_taxes_and_charges, 0) as credit,
-				if(paid_from=%(account)s, 0, received_amount) as debit,
+				if(paid_from=%(account)s, 0, received_amount + total_taxes_and_charges) as debit,
 				posting_date, ifnull(party,if(paid_from=%(account)s,paid_to,paid_from)) as against_account, clearance_date,
 				if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency
 			from `tabPayment Entry`


### PR DESCRIPTION
Payment Entries with tax amount received from customer should include tax amount
See the below screenshot for reference

Transaction with Tax amount
![1095-LBA-24-0150](https://github.com/user-attachments/assets/3ac32be3-455a-4a2a-ba86-f47caded9656)


General Ledger
![General-Ledger](https://github.com/user-attachments/assets/63fd980a-13b1-44ac-b461-327b2ffbca73)


Bank Clearance
![Bank-Clearance](https://github.com/user-attachments/assets/7108696f-01f4-4e3e-bfe0-471ff41d9a5d)

