### PR TITLE
Update default sales tax for Switzerland

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4171,8 +4171,8 @@
 
 	"Switzerland": {
 		"Switzerland normal VAT": {
-			"account_name": "VAT 7.7%",
-			"tax_rate": 7.70,
+			"account_name": "VAT 8.1%",
+			"tax_rate": 8.10,
 			"default": 1
 		},
 		"Switzerland reduced VAT": {

--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4176,12 +4176,12 @@
 			"default": 1
 		},
 		"Switzerland reduced VAT": {
-			"account_name": "VAT 2.5%",
-			"tax_rate": 2.50
+			"account_name": "VAT 2.6%",
+			"tax_rate": 2.60
 		},
 		"Switzerland lodging VAT": {
-			"account_name": "VAT 3.7%",
-			"tax_rate": 3.70
+			"account_name": "VAT 3.8%",
+			"tax_rate": 3.80
 		}
 	},
 


### PR DESCRIPTION
Sales tax has changed in Switzerland, as of 2024: https://www.estv.admin.ch/estv/en/home/value-added-tax/vat-rates-switzerland.html