### PR TITLE
feat: utility report to better diagnose incorrectly cleared Cheques and Deposits

### DIFF
--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
@@ -40,10 +40,5 @@ frappe.query_reports["Cheques and Deposits Incorrectly cleared"] = {
 			default: frappe.datetime.get_today(),
 			reqd: 1,
 		},
-		{
-			fieldname: "include_pos_transactions",
-			label: __("Include POS Transactions"),
-			fieldtype: "Check",
-		},
 	],
 };

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Cheques and Deposits Incorrectly cleared"] = {
+	filters: [],
+};

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js
@@ -2,5 +2,48 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Cheques and Deposits Incorrectly cleared"] = {
-	filters: [],
+	filters: [
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
+		},
+		{
+			fieldname: "account",
+			label: __("Bank Account"),
+			fieldtype: "Link",
+			options: "Account",
+			default: frappe.defaults.get_user_default("Company")
+				? locals[":Company"][frappe.defaults.get_user_default("Company")]["default_bank_account"]
+				: "",
+			reqd: 1,
+			get_query: function () {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					query: "erpnext.controllers.queries.get_account_list",
+					filters: [
+						["Account", "account_type", "in", "Bank, Cash"],
+						["Account", "is_group", "=", 0],
+						["Account", "disabled", "=", 0],
+						["Account", "company", "=", company],
+					],
+				};
+			},
+		},
+		{
+			fieldname: "report_date",
+			label: __("Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.get_today(),
+			reqd: 1,
+		},
+		{
+			fieldname: "include_pos_transactions",
+			label: __("Include POS Transactions"),
+			fieldtype: "Check",
+		},
+	],
 };

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.json
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.json
@@ -1,0 +1,29 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2024-07-30 17:20:07.570971",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2024-07-30 17:20:07.570971",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Cheques and Deposits Incorrectly cleared",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Payment Entry",
+ "report_name": "Cheques and Deposits Incorrectly cleared",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Accounts Manager"
+  }
+ ]
+}

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+
+
+def execute(filters=None):
+	columns, data = [], []
+	return columns, data

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
@@ -1,9 +1,44 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 
 
 def execute(filters=None):
 	columns, data = [], []
 	return columns, data
+
+
+def get_columns():
+	return [
+		{"fieldname": "posting_date", "label": _("Posting Date"), "fieldtype": "Date", "width": 90},
+		{
+			"fieldname": "payment_document",
+			"label": _("Payment Document Type"),
+			"fieldtype": "Data",
+			"width": 220,
+		},
+		{
+			"fieldname": "payment_entry",
+			"label": _("Payment Document"),
+			"fieldtype": "Dynamic Link",
+			"options": "payment_document",
+			"width": 220,
+		},
+		{
+			"fieldname": "debit",
+			"label": _("Debit"),
+			"fieldtype": "Currency",
+			"options": "account_currency",
+			"width": 120,
+		},
+		{
+			"fieldname": "credit",
+			"label": _("Credit"),
+			"fieldtype": "Currency",
+			"options": "account_currency",
+			"width": 120,
+		},
+		{"fieldname": "clearance_date", "label": _("Clearance Date"), "fieldtype": "Date", "width": 110},
+	]

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
@@ -2,12 +2,78 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe import _
+from frappe import _, qb
+from frappe.query_builder import CustomFunction
 
 
 def execute(filters=None):
-	columns, data = [], []
+	columns = get_columns()
+	data = build_data(filters)
 	return columns, data
+
+
+def build_data(filters):
+	vouchers = get_amounts_not_reflected_in_system_for_bank_reconciliation_statement(filters)
+	data = []
+	for x in vouchers:
+		data.append(
+			frappe._dict(
+				payment_document="Payment Entry",
+				payment_entry=x.name,
+				debit=x.amount,
+				credit=0,
+				posting_date=x.posting_date,
+				clearance_date=x.clearance_date,
+			)
+		)
+	return data
+
+
+def get_amounts_not_reflected_in_system_for_bank_reconciliation_statement(filters):
+	je = qb.DocType("Journal Entry")
+	jea = qb.DocType("Journal Entry Account")
+
+	journals = (
+		qb.from_(je)
+		.inner_join(jea)
+		.on(je.name == jea.parent)
+		.select(
+			je.name,
+			jea.debit_in_account_currency,
+			jea.credit_in_account_currency,
+			je.posting_date,
+			je.clearance_date,
+		)
+		.where(
+			je.docstatus.eq(1)
+			& jea.account.eq(filters.account)
+			& je.posting_date.gt(filters.report_date)
+			& je.clearance_date.lte(filters.report_date)
+			& (je.is_opening.isnull() | je.is_opening.eq("No"))
+		)
+		.run(as_dict=1)
+	)
+
+	ifelse = CustomFunction("IF", ["condition", "then", "else"])
+	pe = qb.DocType("Payment Entry")
+	payments = (
+		qb.from_(pe)
+		.select(
+			pe.name,
+			ifelse(pe.paid_from.eq(filters.account), pe.paid_amount, pe.received_amount).as_("amount"),
+			pe.posting_date,
+			pe.clearance_date,
+		)
+		.where(
+			pe.docstatus.eq(1)
+			& (pe.paid_from.eq(filters.account) | pe.paid_to.eq(filters.account))
+			& pe.posting_date.gt(filters.report_date)
+			& pe.clearance_date.lte(filters.report_date)
+		)
+		.run(as_dict=1)
+	)
+
+	return journals + payments
 
 
 def get_columns():
@@ -40,5 +106,6 @@ def get_columns():
 			"options": "account_currency",
 			"width": 120,
 		},
+		{"fieldname": "posting_date", "label": _("Posting Date"), "fieldtype": "Date", "width": 110},
 		{"fieldname": "clearance_date", "label": _("Clearance Date"), "fieldtype": "Date", "width": 110},
 	]

--- a/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
+++ b/erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py
@@ -102,7 +102,6 @@ def get_amounts_not_reflected_in_system_for_bank_reconciliation_statement(filter
 
 def get_columns():
 	return [
-		{"fieldname": "posting_date", "label": _("Posting Date"), "fieldtype": "Date", "width": 90},
 		{
 			"fieldname": "payment_document",
 			"label": _("Payment Document Type"),


### PR DESCRIPTION
Payment and Journal Entries whose Clearance date is lower than the posting date are considered as incorrectly cleared and reported as such in Bank Reconciliation Statement report.
![Screenshot from 2024-08-26 15-12-39](https://github.com/user-attachments/assets/61e163e2-3191-4563-ad9f-90c32149cd7a)

But, there is no clear and easy way to identify such entries without manually setting up filters in List / Report view. To address this, a new utility report: '**Cheques and Deposits Incorrectly cleared**' is introduced. This will report all such Payment / Journal entries with their Posting and Clearance dates.

![Screenshot from 2024-08-26 14-28-49](https://github.com/user-attachments/assets/6da762e6-3553-44ba-9171-a108d2c78cd3)

`no-docs`