### PR TITLE
fix: make party naming sequential when naming_by set as auto name

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -97,7 +97,7 @@ class Supplier(TransactionBase):
 		elif supp_master_name == "Naming Series":
 			set_name_by_naming_series(self)
 		else:
-			self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
+			set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def on_update(self):
 		self.create_primary_contact()

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -104,7 +104,7 @@ class Customer(TransactionBase):
 		elif cust_master_name == "Naming Series":
 			set_name_by_naming_series(self)
 		else:
-			self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
+			set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def get_customer_name(self):
 		if frappe.db.get_value("Customer", self.customer_name) and not frappe.flags.in_import:


### PR DESCRIPTION
When party naming by set to Auto Name in Buying/Selling Settings naming series counter skipping the next count.
https://support.frappe.io/helpdesk/tickets/20818

![Screenshot from 2024-08-26 19-37-32](https://github.com/user-attachments/assets/c147ea5e-87da-4c66-9e18-f57d1f5c3e71)

![Screenshot from 2024-08-26 19-38-10](https://github.com/user-attachments/assets/7ab01c11-6193-4d25-a4a6-c2eb4e04e5bc)
