### PR TITLE
fix: get amount with taxes and charges from payment entry

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
@@ -154,8 +154,8 @@ def get_payment_entries(filters):
 		select
 			"Payment Entry" as payment_document, name as payment_entry,
 			reference_no, reference_date as ref_date,
-			if(paid_to=%(account)s, received_amount, 0) as debit,
-			if(paid_from=%(account)s, paid_amount, 0) as credit,
+			if(paid_to=%(account)s, received_amount_after_tax, 0) as debit,
+			if(paid_from=%(account)s, paid_amount_after_tax, 0) as credit,
 			posting_date, ifnull(party,if(paid_from=%(account)s,paid_to,paid_from)) as against_account, clearance_date,
 			if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency
 		from `tabPayment Entry`


### PR DESCRIPTION
The Bank Reconciliation Statement Report didn't include the taxes and charges amount from the payment entry
https://support.frappe.io/helpdesk/tickets/20341

![Screenshot from 2024-08-26 20-03-20](https://github.com/user-attachments/assets/a90fd0ff-831e-4fa8-bc25-c11bd0cc7201)

![Screenshot from 2024-08-26 20-03-50](https://github.com/user-attachments/assets/a6e0935e-b4fd-417c-9f70-ff55c1d28067)
