### PR TITLE
fix: remove unnecessary condition on 'voucher_no'

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1838,7 +1838,7 @@ def get_outstanding_reference_documents(args, validate=False):
 				d["bill_no"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "bill_no")
 
 		# Get negative outstanding sales /purchase invoices
-		if args.get("party_type") != "Employee" and not args.get("voucher_no"):
+		if args.get("party_type") != "Employee":
 			negative_outstanding_invoices = get_negative_outstanding_invoices(
 				args.get("party_type"),
 				args.get("party"),


### PR DESCRIPTION
https://github.com/frappe/erpnext/blob/520db864b5a70c84255456032f355e5366b6ef03/erpnext/accounts/doctype/payment_entry/payment_entry.py#L1841