### PR TITLE
fix: typeerror on Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -305,7 +305,7 @@ frappe.ui.form.on("Payment Entry", {
 
 	set_dynamic_labels: function (frm) {
 		var company_currency = frm.doc.company
-			? frappe.get_doc(":Company", frm.doc.company).default_currency
+			? frappe.get_doc(":Company", frm.doc.company)?.default_currency
 			: "";
 
 		frm.set_currency_labels(


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'default_currency')
  at set_dynamic_labels(payment_entry__js:306:49)
  at _handler(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at refresh(payment_entry__js:196:14)
  at _handler(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at runner(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:109:16)
  at <anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:127:22)
```

Internal Ref: [20966](https://support.frappe.io/helpdesk/tickets/20966)