### PR TITLE
fix: A project without tasks should be able to complete

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -213,6 +213,13 @@ class Project(Document):
 		frappe.db.set_value("Sales Order", {"project": self.name}, "project", "")
 
 	def update_percent_complete(self):
+		if self.status == "Completed":
+			if (
+				len(frappe.get_all("Task", dict(project=self.name))) == 0
+			):  # A project without tasks should be able to complete
+				self.percent_complete_method = "Manual"
+				self.percent_complete = 100
+
 		if self.percent_complete_method == "Manual":
 			if self.status == "Completed":
 				self.percent_complete = 100

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -199,6 +199,34 @@ class TestProject(FrappeTestCase):
 			if not pt.is_group:
 				self.assertIsNotNone(pt.parent_task)
 
+	def test_project_having_no_tasks_complete(self):
+		project_name = "Test Project - No Tasks Completion"
+		frappe.db.sql(""" delete from tabTask where project = %s """, project_name)
+		frappe.delete_doc("Project", project_name)
+
+		project = frappe.get_doc(
+			dict(
+				doctype="Project",
+				project_name=project_name,
+				status="Open",
+				expected_start_date=nowdate(),
+				company="_Test Company",
+			)
+		).insert()
+
+		tasks = frappe.get_all(
+			"Task",
+			["subject", "exp_end_date", "depends_on_tasks", "name", "parent_task"],
+			dict(project=project.name),
+			order_by="creation asc",
+		)
+
+		self.assertEqual(project.status, "Open")
+		self.assertEqual(len(tasks), 0)
+		project.status = "Completed"
+		project.save()
+		self.assertEqual(project.status, "Completed")
+
 
 def get_project(name, template):
 	project = frappe.get_doc(

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -205,13 +205,13 @@ class TestProject(FrappeTestCase):
 		frappe.delete_doc("Project", project_name)
 
 		project = frappe.get_doc(
-			dict(
-				doctype="Project",
-				project_name=project_name,
-				status="Open",
-				expected_start_date=nowdate(),
-				company="_Test Company",
-			)
+			{
+				"doctype": "Project",
+				"project_name": project_name,
+				"status": "Open",
+				"expected_start_date": nowdate(),
+				"company": "_Test Company",
+			}
 		).insert()
 
 		tasks = frappe.get_all(


### PR DESCRIPTION
This fix solves a bug where, when completing a project without tasks, it will fail to close.

- If a project without tasks is set to "Completed", either through setting the project status directly or with the "set_project_status" function, the status is not changed but reverted back to "Open".

- The reason for this behaviour is, that since there are no tasks to provide a completion percentage erpnext will not accept the "Completed" status.

- While failing the bug does not throw an error or warning message to the user, hence I am assuming the behaviour is unintentional and needs to be fixed.

- This fix solves the bug by changing the completion type to manual on completing the project if there are no tasks within the project
