### PR TITLE
fix: changed "valid_from" comparisons "<=" to ">=" in multiple files

### DIFF
--- a/erpnext/accounts/doctype/cost_center_allocation/cost_center_allocation.py
+++ b/erpnext/accounts/doctype/cost_center_allocation/cost_center_allocation.py
@@ -77,7 +77,7 @@ class CostCenterAllocation(Document):
 		)
 
 		if last_gle_date:
-			if getdate(self.valid_from) <= getdate(last_gle_date):
+			if getdate(self.valid_from) >= getdate(last_gle_date):
 				frappe.throw(
 					_(
 						"Valid From must be after {0} as last GL Entry against the cost center {1} posted on this date"

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -215,7 +215,7 @@ def get_cost_center_allocation_data(company, posting_date):
 		.select(par.main_cost_center, child.cost_center, child.percentage)
 		.where(par.docstatus == 1)
 		.where(par.company == company)
-		.where(par.valid_from <= posting_date)
+		.where(par.valid_from >= posting_date)
 		.orderby(par.valid_from, order=frappe.qb.desc)
 	).run(as_dict=True)
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2390,7 +2390,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		} else {
 			let filters = {
 				'item_code': item.item_code,
-				'valid_from': ["<=", doc.transaction_date || doc.bill_date || doc.posting_date],
+				'valid_from': [">=", doc.transaction_date || doc.bill_date || doc.posting_date],
 				'item_group': item.item_group,
 			}
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -607,7 +607,7 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 				# if supplier date is not present then posting date
 				validation_date = args.get("bill_date") or args.get("transaction_date")
 
-				if getdate(tax.valid_from) <= getdate(validation_date) and is_within_valid_range(args, tax):
+				if getdate(tax.valid_from) >= getdate(validation_date) and is_within_valid_range(args, tax):
 					taxes_with_validity.append(tax)
 			else:
 				taxes_with_no_validity.append(tax)


### PR DESCRIPTION
Updated the comparison logic for valid_from dates in multiple files. Previously, dates were compared using <=, which could lead to incorrect filtering.