### PR TITLE
fix: retain date filter when redirecting in Profit and Loss report

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -114,6 +114,8 @@ erpnext.financial_statements = {
 	onload: function (report) {
 		// dropdown for links to other financial statements
 		erpnext.financial_statements.filters = get_filters();
+
+		let fiscal_year = erpnext.utils.get_fiscal_year(frappe.datetime.get_today());
 		var filters = report.get_values();
 
 		if (!filters.period_start_date || !filters.period_end_date) {

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -114,16 +114,17 @@ erpnext.financial_statements = {
 	onload: function (report) {
 		// dropdown for links to other financial statements
 		erpnext.financial_statements.filters = get_filters();
+		var filters = report.get_values();
 
-		let fiscal_year = erpnext.utils.get_fiscal_year(frappe.datetime.get_today());
-
-		frappe.model.with_doc("Fiscal Year", fiscal_year, function (r) {
-			var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-			frappe.query_report.set_filter_value({
-				period_start_date: fy.year_start_date,
-				period_end_date: fy.year_end_date,
+		if (!filters.period_start_date || !filters.period_end_date) {
+			frappe.model.with_doc("Fiscal Year", fiscal_year, function (r) {
+				var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
+				frappe.query_report.set_filter_value({
+					period_start_date: fy.year_start_date,
+					period_end_date: fy.year_end_date,
+				});
 			});
-		});
+		}
 
 		if (report.page) {
 			const views_menu = report.page.add_custom_button_group(__("Financial Statements"));


### PR DESCRIPTION
Previously, when redirecting to the Profit and Loss report, the date filter would unintentionally change, causing confusion for users expecting the original filter criteria to be retained. This fix ensures that the selected date filter remains consistent.

https://github.com/user-attachments/assets/b6890281-a0f3-4550-abc4-2c36d938c1c0


Changes:

- Modified the report redirection logic to preserve the existing date filter values.

This enhancement improves usability by maintaining the integrity of the user's filter selections.
