### PR TITLE
chore: fix editorconfig for json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,4 +18,4 @@ max_line_length = 110
 [{*.json}]
 insert_final_newline = false
 indent_style = space
-indent_size = 2
+indent_size = 1

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ __pycache__
 *~
 .idea/
 .vscode/
+.helix/
 node_modules/
 .backportrc.json


### PR DESCRIPTION
The framework indents json by 1, only.

`.helix` is just a popular editor that some developers use, and local config is sometimes needed for best DevX.
