### PR TITLE
fix: duplicate items and outdated item price in POS

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -159,6 +159,8 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 	if not items_data:
 		return result
 
+	current_date = frappe.utils.today()
+
 	for item in items_data:
 		uoms = frappe.get_doc("Item", item.item_code).get("uoms", [])
 
@@ -167,12 +169,16 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 
 		item_price = frappe.get_all(
 			"Item Price",
-			fields=["price_list_rate", "currency", "uom", "batch_no"],
+			fields=["price_list_rate", "currency", "uom", "batch_no", "valid_from", "valid_upto"],
 			filters={
 				"price_list": price_list,
 				"item_code": item.item_code,
 				"selling": True,
+				"valid_from": ["<=", current_date],
+				"valid_upto": ["in", [None, "", current_date]],
 			},
+			order_by="valid_from desc",
+			limit=1
 		)
 
 		if not item_price:

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -178,7 +178,7 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 				"valid_upto": ["in", [None, "", current_date]],
 			},
 			order_by="valid_from desc",
-			limit=1
+			limit=1,
 		)
 
 		if not item_price:


### PR DESCRIPTION
version 15

fixes: #42935 & #44011

**Before:**
- Items with multiple price entries were displaying outdated prices on the POS screen. Specifically, if an item had multiple prices with different valid dates, the POS screen was showing a price that was no longer valid (i.e., past the Valid To date). This led to confusion as the POS invoice would correctly apply the most recent valid price, but the initial displayed price was incorrect.

https://github.com/user-attachments/assets/82b2b751-1eb9-44ef-ba7d-0511d0c76437

<br>


**After:**
- Issue was resolved by modifying the query logic to filter item prices based on both the Valid From and Valid Upto dates. The updated logic ensures that only the most recent price within the valid date range is displayed on the POS screen. This ensures consistency between the displayed price and the price applied when an item is added to the POS invoice.


https://github.com/user-attachments/assets/a3e9f3fb-b77f-45bc-a927-d28a3ba41e53

