### PR TITLE
refactor: better UX on Bank Clearance tool

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.js
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.js
@@ -38,6 +38,11 @@ frappe.ui.form.on("Bank Clearance", {
 		frm.add_custom_button(__("Get Payment Entries"), () => frm.trigger("get_payment_entries"));
 
 		frm.change_custom_button_type(__("Get Payment Entries"), null, "primary");
+		if (frm.doc.payment_entries.length) {
+			frm.add_custom_button(__("Update Clearance Date"), () => frm.trigger("update_clearance_date"));
+			frm.change_custom_button_type(__("Get Payment Entries"), null, "default");
+			frm.change_custom_button_type(__("Update Clearance Date"), null, "primary");
+		}
 	},
 
 	update_clearance_date: function (frm) {
@@ -45,13 +50,7 @@ frappe.ui.form.on("Bank Clearance", {
 			method: "update_clearance_date",
 			doc: frm.doc,
 			callback: function (r, rt) {
-				frm.refresh_field("payment_entries");
-				frm.refresh_fields();
-
-				if (!frm.doc.payment_entries.length) {
-					frm.change_custom_button_type(__("Get Payment Entries"), null, "primary");
-					frm.change_custom_button_type(__("Update Clearance Date"), null, "default");
-				}
+				frm.refresh();
 			},
 		});
 	},
@@ -60,17 +59,8 @@ frappe.ui.form.on("Bank Clearance", {
 		return frappe.call({
 			method: "get_payment_entries",
 			doc: frm.doc,
-			callback: function (r, rt) {
-				frm.refresh_field("payment_entries");
-
-				if (frm.doc.payment_entries.length) {
-					frm.add_custom_button(__("Update Clearance Date"), () =>
-						frm.trigger("update_clearance_date")
-					);
-
-					frm.change_custom_button_type(__("Get Payment Entries"), null, "default");
-					frm.change_custom_button_type(__("Update Clearance Date"), null, "primary");
-				}
+			callback: function () {
+				frm.refresh();
 			},
 		});
 	},


### PR DESCRIPTION
## Issue
While updating Clearance date using Bank Clearance tool, if there were any errors, `Update Clearance Tool` button gets disabled, prohibiting further use. You have to reload the whole page, set filters (again) and pull payment entries (again), for the button be active again. This flow is unergonomic.

## Fix
Use `frm.refresh` to reload the entire form and move the button addition logic to the standard `refresh` function.

## Before

https://github.com/user-attachments/assets/0d0748a8-995e-41b0-a536-7e890e814a52



## After

https://github.com/user-attachments/assets/1f3cb193-1e48-481e-b11d-2ec234f0d6ef

