### PR TITLE
feat: Removes the oblitation of having one default payment mode

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -141,8 +141,6 @@ class POSProfile(Document):
 			frappe.throw(_("Payment methods are mandatory. Please add at least one payment method."))
 
 		default_mode = [d.default for d in self.payments if d.default]
-		if not default_mode:
-			frappe.throw(_("Please select a default mode of payment"))
 
 		if len(default_mode) > 1:
 			frappe.throw(_("You can only select one mode of payment as default"))


### PR DESCRIPTION
Currently, inside POS Profile, it's required to mark some mode of payment as default. If we don't, the system doesn't allow the saving of the profile.

![image](https://github.com/user-attachments/assets/26efa7ed-635c-41db-8c6c-623687fb84c2)

There is not reason for this validation exists, I think it's better if it's better if it's up to the user. 

The advantage is that if the profile be configured without any default payment method, it will prevent situations which the sales user forgets to change the payment method, because the system will block submit and the user will be forced to choose the correct payment method.