### PR TITLE
fix: fetch payment term on doc creation from payment term connnections

### DIFF
--- a/erpnext/accounts/doctype/payment_term/payment_term.js
+++ b/erpnext/accounts/doctype/payment_term/payment_term.js
@@ -1,6 +1,28 @@
 // Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 frappe.ui.form.on("Payment Term", {
+	setup(frm) {
+		frm.make_methods = {
+			"Sales Invoice": () => {
+				open_form(frm, "Sales Invoice", "Payment Schedule", "payment_schedule");
+			},
+			"Sales Order": () => {
+				open_form(frm, "Sales Order", "Payment Schedule", "payment_schedule");
+			},
+			Quotation: () => {
+				open_form(frm, "Quotation", "Payment Schedule", "payment_schedule");
+			},
+			"Purchase Invoice": () => {
+				open_form(frm, "Purchase Invoice", "Payment Schedule", "payment_schedule");
+			},
+			"Purchase Order": () => {
+				open_form(frm, "Purchase Order", "Payment Schedule", "payment_schedule");
+			},
+			"Payment Terms Template": () => {
+				open_form(frm, "Payment Terms Template", "Payment Terms Template Detail", "terms");
+			},
+		};
+	},
 	onload(frm) {
 		frm.trigger("set_dynamic_description");
 	},
@@ -22,3 +44,18 @@ frappe.ui.form.on("Payment Term", {
 		}
 	},
 });
+
+function open_form(frm, doctype, child_doctype, parentfield) {
+	frappe.model.with_doctype(doctype, () => {
+		let new_doc = frappe.model.get_new_doc(doctype);
+		let new_child_doc = frappe.model.add_child(new_doc, child_doctype, parentfield);
+
+		frappe.run_serially([
+			() => frappe.ui.form.make_quick_entry(doctype, null, null, new_doc),
+			() => {
+				frappe.flags.ignore_company_party_validation = true;
+				frappe.model.set_value(child_doctype, new_child_doc.name, "payment_term", frm.doc.name);
+			},
+		]);
+	});
+}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1275,7 +1275,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return mappped_fields
 				.map((field) => item[field])
 				.filter(Boolean).length > 0;
-		} else if (this.frm.doc?.items) {
+		} else if (this.frm.doc?.items && this.frm.doc.items.length > 0) {
 			let first_row = this.frm.doc.items[0];
 			let mapped_rows = mappped_fields.filter(d => first_row[d])
 


### PR DESCRIPTION
When any transaction is created from connections of Payment Term. Payment Term was not set in the transaction.

![image](https://github.com/user-attachments/assets/0e133f23-349e-48d0-af65-2d1c157b11d8)


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/20494


