### PR TITLE
fix: show naming series only when needed

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -20,7 +20,11 @@ $.extend(erpnext, {
 	},
 
 	toggle_naming_series: function () {
-		if (cur_frm && cur_frm.fields_dict.naming_series) {
+		if (
+			cur_frm &&
+			cur_frm.fields_dict.naming_series &&
+			cur_frm.meta.naming_rule == 'By "Naming Series" field'
+		) {
 			cur_frm.toggle_display("naming_series", cur_frm.doc.__islocal ? true : false);
 		}
 	},


### PR DESCRIPTION
### Problem

Change the _Naming Rule_ of a sales transaction to "By Script". The form still shows the _Naming Series_ field, even if marked as _Hidden_ via **Customize Form**.

### Solution

Add `cur_frm.meta.naming_rule == 'By "Naming Series" field'` to the condition deciding whether to show the _Naming Series_ field.

### Notes

Not replacing the use of `cur_frm` in this PR because this would be a breaking change.

Backport to v14 + v15 after some time.