### PR TITLE
fix: update develop_version in hooks

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -20,7 +20,7 @@ add_to_apps_screen = [
 	}
 ]
 
-develop_version = "14.x.x-develop"
+develop_version = "15.x.x-develop"
 
 app_include_js = "erpnext.bundle.js"
 app_include_css = "erpnext.bundle.css"


### PR DESCRIPTION
fixes: #42995

- update develop_version in hooks `14.x.x-develop` -> `15.x.x-develop`