### PR TITLE
fix: `default_advance_account` field in Process Payment Reconciliation

### DIFF
--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.js
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.js
@@ -20,6 +20,17 @@ frappe.ui.form.on("Process Payment Reconciliation", {
 				},
 			};
 		});
+
+		frm.set_query("default_advance_account", function (doc) {
+			return {
+				filters: {
+					company: doc.company,
+					is_group: 0,
+					account_type: doc.party_type == "Customer" ? "Receivable" : "Payable",
+					root_type: doc.party_type == "Customer" ? "Liability" : "Asset",
+				},
+			};
+		});
 		frm.set_query("cost_center", function (doc) {
 			return {
 				filters: {
@@ -102,6 +113,7 @@ frappe.ui.form.on("Process Payment Reconciliation", {
 	company(frm) {
 		frm.set_value("party", "");
 		frm.set_value("receivable_payable_account", "");
+		frm.set_value("default_advance_account", "");
 	},
 	party_type(frm) {
 		frm.set_value("party", "");
@@ -109,6 +121,7 @@ frappe.ui.form.on("Process Payment Reconciliation", {
 
 	party(frm) {
 		frm.set_value("receivable_payable_account", "");
+		frm.set_value("default_advance_account", "");
 		if (!frm.doc.receivable_payable_account && frm.doc.party_type && frm.doc.party) {
 			return frappe.call({
 				method: "erpnext.accounts.party.get_party_account",
@@ -119,7 +132,12 @@ frappe.ui.form.on("Process Payment Reconciliation", {
 				},
 				callback: (r) => {
 					if (!r.exc && r.message) {
-						frm.set_value("receivable_payable_account", r.message);
+						if (typeof r.message === "string") {
+							frm.set_value("receivable_payable_account", r.message);
+						} else if (Array.isArray(r.message)) {
+							frm.set_value("receivable_payable_account", r.message[0]);
+							frm.set_value("default_advance_account", r.message[1]);
+						}
 					}
 					frm.refresh();
 				},

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.js
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.js
@@ -129,6 +129,7 @@ frappe.ui.form.on("Process Payment Reconciliation", {
 					company: frm.doc.company,
 					party_type: frm.doc.party_type,
 					party: frm.doc.party,
+					include_advance: 1,
 				},
 				callback: (r) => {
 					if (!r.exc && r.message) {

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.json
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.json
@@ -13,6 +13,7 @@
   "column_break_io6c",
   "party",
   "receivable_payable_account",
+  "default_advance_account",
   "filter_section",
   "from_invoice_date",
   "to_invoice_date",
@@ -141,12 +142,23 @@
   {
    "fieldname": "section_break_a8yx",
    "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.party",
+   "description": "Only 'Payment Entries' made against this advance account are supported.",
+   "documentation_url": "https://docs.erpnext.com/docs/user/manual/en/advance-in-separate-party-account",
+   "fieldname": "default_advance_account",
+   "fieldtype": "Link",
+   "label": "Default Advance Account",
+   "mandatory_depends_on": "doc.party_type",
+   "options": "Account",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:18.601732",
+ "modified": "2024-08-27 14:48:56.715320",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Payment Reconciliation",

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -23,6 +23,7 @@ class ProcessPaymentReconciliation(Document):
 		bank_cash_account: DF.Link | None
 		company: DF.Link
 		cost_center: DF.Link | None
+		default_advance_account: DF.Link
 		error_log: DF.LongText | None
 		from_invoice_date: DF.Date | None
 		from_payment_date: DF.Date | None
@@ -101,6 +102,7 @@ def get_pr_instance(doc: str):
 		"party_type",
 		"party",
 		"receivable_payable_account",
+		"default_advance_account",
 		"from_invoice_date",
 		"to_invoice_date",
 		"from_payment_date",


### PR DESCRIPTION
Default Advance account field in Process Payment Reconciliation

Before:
![image](https://github.com/user-attachments/assets/3bc40724-a238-45a4-816e-adeb25df132e)

After:
![image](https://github.com/user-attachments/assets/598b4c4f-954a-42eb-b46d-7de56f931717)


Frappe Support: https://support.frappe.io/app/hd-ticket/20813
