### PR TITLE
fix: typerror on default_currency

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -658,7 +658,7 @@ frappe.ui.form.on("Payment Entry", {
 			frm.set_value("source_exchange_rate", 1);
 		} else if (frm.doc.paid_from) {
 			if (["Internal Transfer", "Pay"].includes(frm.doc.payment_type)) {
-				let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
+				let company_currency = frappe.get_doc(":Company", frm.doc.company)?.default_currency;
 				frappe.call({
 					method: "erpnext.setup.utils.get_exchange_rate",
 					args: {


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'default_currency')
  at paid_from_account_currency(payment_entry__js:661:69)
  at _handler(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at runner(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:109:16)
  at <anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:127:22)
```
Ref: https://support.frappe.io/helpdesk/tickets/20962