### PR TITLE
fix: payment entry rounding

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
@@ -188,8 +188,8 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 
 		pe = get_payment_entry(si.doctype, si.name)
 		pe.paid_amount = 95
-		pe.source_exchange_rate = 84.211
 		pe.received_amount = 8000
+		pe.source_exchange_rate = pe.received_amount / pe.paid_amount
 		pe.references = []
 		pe.save().submit()
 
@@ -229,7 +229,7 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 		row = next(x for x in je.accounts if x.account == self.debtors_usd)
 		self.assertEqual(flt(row.credit_in_account_currency, precision), 5.0)  # in USD
 		row = next(x for x in je.accounts if x.account != self.debtors_usd)
-		self.assertEqual(flt(row.debit_in_account_currency, precision), 421.06)  # in INR
+		self.assertEqual(flt(row.debit_in_account_currency, precision), 421.05)  # in INR
 
 		# total_debit and total_credit will be 0.0, as JV is posting only to account currency fields
 		self.assertEqual(flt(je.total_debit, precision), 0.0)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1142,7 +1142,7 @@ frappe.ui.form.on("Payment Entry", {
 					frm.doc.target_exchange_rate;
 			}
 		}
-		frm.set_value("unallocated_amount", precision(unallocated_amount, "unallocated_amount"));
+		frm.set_value("unallocated_amount", flt(unallocated_amount, precision("unallocated_amount")));
 		frm.trigger("set_difference_amount");
 	},
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1142,7 +1142,7 @@ frappe.ui.form.on("Payment Entry", {
 					frm.doc.target_exchange_rate;
 			}
 		}
-		frm.set_value("unallocated_amount", unallocated_amount);
+		frm.set_value("unallocated_amount", precision(unallocated_amount, "unallocated_amount"));
 		frm.trigger("set_difference_amount");
 	},
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1096,12 +1096,10 @@ frappe.ui.form.on("Payment Entry", {
 		$.each(frm.doc.references || [], function (i, row) {
 			if (row.allocated_amount) {
 				total_allocated_amount += flt(row.allocated_amount);
-				base_total_allocated_amount += flt(
-					flt(row.allocated_amount) * flt(exchange_rate),
-					precision("base_paid_amount")
-				);
+				base_total_allocated_amount += flt(row.allocated_amount) * flt(exchange_rate);
 			}
 		});
+		base_total_allocated_amount = flt(base_total_allocated_amount, precision("base_paid_amount"));
 		frm.set_value("total_allocated_amount", Math.abs(total_allocated_amount));
 		frm.set_value("base_total_allocated_amount", Math.abs(base_total_allocated_amount));
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1124,6 +1124,7 @@ class PaymentEntry(AccountsController):
 					self.base_paid_amount - (total_deductions + self.base_total_allocated_amount)
 				) / self.target_exchange_rate
 				self.unallocated_amount -= included_taxes
+			self.unallocated_amount = flt(self.unallocated_amount, self.precision("unallocated_amount"))
 
 	def set_difference_amount(self):
 		base_unallocated_amount = flt(self.unallocated_amount) * (

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1883,8 +1883,9 @@ class TestPaymentEntry(FrappeTestCase):
 		pe.source_exchange_rate = 1.35
 		pe.save()
 
-		# 58,991.94 = (43,697.73 * 1.35) = 58,991.94
-		self.assertEqual(pe.base_paid_amount, pe.base_total_allocated_amount)
+		# 58,991.94 = (43,697.73 * 1.35)
+		self.assertEqual(pe.base_paid_amount, 58991.94)
+		self.assertEqual(pe.base_total_allocated_amount, 58991.94)
 		self.assertEqual(pe.unallocated_amount, 0)
 
 

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1335,7 +1335,11 @@ class TestPaymentReconciliation(FrappeTestCase):
 		pe.save().submit()
 
 		# unallocated_amount will have some rounding loss - 26.749950
-		self.assertNotEqual(pe.unallocated_amount, 26.75)
+		# Rounding issue fixed in #43037
+		self.assertEqual(pe.unallocated_amount, 26.75)
+
+		# Reset unalloacted amount to continue test for unrounded unallaocted_amounts before #43037
+		pe.unalloacted_amount = 26.749950
 
 		pr = frappe.get_doc("Payment Reconciliation")
 		pr.company = self.company

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1338,7 +1338,7 @@ class TestPaymentReconciliation(FrappeTestCase):
 		# Rounding issue fixed in #43037
 		self.assertEqual(pe.unallocated_amount, 26.75)
 
-		# Reset unalloacted amount to continue test for unrounded unallaocted_amounts before #43037
+		# Reset unallocated amount to continue test for unrounded unallocated_amount before #43037
 		pe.unalloacted_amount = 26.749950
 
 		pr = frappe.get_doc("Payment Reconciliation")


### PR DESCRIPTION
To prevent unwanted value getting posted to the ledger.

Before:
![image](https://github.com/user-attachments/assets/c628dee2-d9a8-4a6c-80a5-a535b4442af7)


After:
![image](https://github.com/user-attachments/assets/cfa1629f-7994-480e-9268-c8aec2047083)

## Notes to Maintainer
### Regards to rounding unallocated amount
[fix(test): correct pe.source_exchange rate based on provided paid_amount and received_amount](https://github.com/frappe/erpnext/pull/43037/commits/920acaf318a1341aec32274bdff7fbf5f545468a)
![image](https://github.com/user-attachments/assets/d8418e86-d081-4173-a4b4-5c637d25e90c)
Removed hard coded 84.211 exchange rate because 95 * 84.211 is not 8000 but 8000.045 so to actually post 8000 INR we need more precision in the exchange rate achieved by dividing the received amount (INR) by the paid amount (USD)
![image](https://github.com/user-attachments/assets/c22a41a6-fb5c-4cf7-994c-866d4e99c67c)

After the exchange revaluation is completed (See spreadsheet screenshot) the amount actually should be rounded down to 421.05
![image](https://github.com/user-attachments/assets/bce222b9-ad09-4d87-9a35-1d70b68e58f1)

### Regards to rounding base paid allocated amount
https://github.com/frappe/erpnext/pull/43037/commits/e3a12335156b250c49a4cba239e47fad72271977
Before this change rounding would happen in a loop while accumulating values. This doesn't work because adding or subtraction of floating points during the loop can still cause long precision. This change rounds after the addition or subtraction has finished.

