### PR TITLE
fix: Set "Accepted Qty in Stock UOM" in `calculate_item_values` in `taxes_and_totals.js`

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -132,6 +132,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				frappe.model.round_floats_in(item);
 				item.net_rate = item.rate;
 				item.qty = item.qty === undefined ? (me.frm.doc.is_return ? -1 : 1) : item.qty;
+				item.stock_qty = flt(item.qty * item.conversion_factor, precision("stock_qty", item));
 
 				if (!(me.frm.doc.is_return || me.frm.doc.is_debit_note)) {
 					item.net_amount = item.amount = flt(item.rate * item.qty, precision("amount", item));


### PR DESCRIPTION
Support Issue: https://support.frappe.io/app/hd-ticket/21240

Issue: Validation error while saving purchase invoice. The issue is replicable on the local site.

Video: https://drive.google.com/file/d/11hgAK-R-TBJ4J30uDt4rX08pDM8xuJNI/view?usp=sharing

Step to replicate:

1. Create a new purchase invoice.
2. Mention the Item Name manually(must not enter the <item> filed). UOM, Expense Account with the default Accept Quantity Save the record
3. The system shows a validation message. However, if we change the Accept Quantity to 2, the record gets saved.
![image](https://github.com/user-attachments/assets/5627936f-41cd-480f-a439-4015f77828b3)
![image](https://github.com/user-attachments/assets/2625e8f4-5c88-4702-aab3-58089b73464f)

Fix: Set default value for field  **Accepted Qty in Stock UOM** in `calculate_item_values` function in `taxes_and_totals.js`.
