### PR TITLE
fix: unreconcile allocation child table redirect url voucher no issue

### DIFF
--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -69,7 +69,7 @@ erpnext.accounts.unreconcile_payment = {
 				{
 					label: __("Voucher Type"),
 					fieldname: "voucher_type",
-					fieldtype: "Dynamic Link",
+					fieldtype: "Link",
 					options: "DocType",
 					in_list_view: 1,
 					read_only: 1,
@@ -77,7 +77,7 @@ erpnext.accounts.unreconcile_payment = {
 				{
 					label: __("Voucher No"),
 					fieldname: "voucher_no",
-					fieldtype: "Link",
+					fieldtype: "Dynamic Link",
 					options: "voucher_type",
 					in_list_view: 1,
 					read_only: 1,


### PR DESCRIPTION
**Summery**
Once reconciled payment entry against invoice then redirection fails to redirect respective voucher type.

**Reference video**
**Before**
[Screencast from 04-09-24 05:11:47 PM IST.webm](https://github.com/user-attachments/assets/e813d52e-9447-47d4-81dd-d16cb935878b)
**After**
[Screencast from 04-09-24 05:13:47 PM IST.webm](https://github.com/user-attachments/assets/1352a66c-72f5-4638-b7e1-50e616fc4ff7)
