### PR TITLE
fix/sales order status updater

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -8,10 +8,11 @@ from frappe.model.document import Document
 from frappe.utils.data import cint
 
 from erpnext.assets.doctype.asset.depreciation import get_disposal_account_and_cost_center
+from erpnext.controllers.updates_caster import ItemCastUpdates
 from erpnext.stock.doctype.serial_no.serial_no import get_delivery_note_serial_no, get_serial_nos
 
 
-class SalesInvoiceItem(Document):
+class SalesInvoiceItem(Document, ItemCastUpdates):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -39,32 +39,6 @@ status_map = {
 		["Ordered", "is_fully_ordered"],
 		["Cancelled", "eval:self.docstatus==2"],
 	],
-	"Sales Order": [
-		["Draft", None],
-		[
-			"To Deliver and Bill",
-			"eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1",
-		],
-		[
-			"To Bill",
-			"eval:(self.per_delivered >= 100 or self.skip_delivery_note) and self.per_billed < 100 and self.docstatus == 1",
-		],
-		[
-			"To Deliver",
-			"eval:self.per_delivered < 100 and self.per_billed >= 100 and self.docstatus == 1 and not self.skip_delivery_note",
-		],
-		[
-			"To Pay",
-			"eval:self.advance_payment_status == 'Requested' and self.docstatus == 1",
-		],
-		[
-			"Completed",
-			"eval:(self.per_delivered >= 100 or self.skip_delivery_note) and self.per_billed >= 100 and self.docstatus == 1",
-		],
-		["Cancelled", "eval:self.docstatus==2"],
-		["Closed", "eval:self.status=='Closed' and self.docstatus != 2"],
-		["On Hold", "eval:self.status=='On Hold'"],
-	],
 	"Purchase Order": [
 		["Draft", None],
 		["To Bill", "eval:self.per_received >= 100 and self.per_billed < 100 and self.docstatus == 1"],

--- a/erpnext/controllers/updates_caster.py
+++ b/erpnext/controllers/updates_caster.py
@@ -1,0 +1,108 @@
+from typing import Any, ClassVar
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class ItemCastUpdates:
+	"""
+	A mixin class for item doctypes that need to cast updates to other related doctypes.
+
+	This class provides a framework for fetching updates from one doctype and applying them to another.
+	It defines methods for casting updates onto target doctypes and receiving updates from source doctypes.
+
+	To use this class:
+	1. Inherit it in your item doctype class.
+	2. Implement the _cast_update_from_<source_doctype> method to define how updates are applied.
+
+	Examples:
+	 class SalesOrderItem(Document, ItemCastUpdates):
+	         def _cast_update_from_sales_invoice_item(self, item: Document) -> dict[str, Any]:
+	                 return {
+	                        "billed_amt": item.amount,
+	                 }
+	"""
+
+	# Class dictionary to map source doctype to target doctype field
+	ITEM_CAST_UPDATES_DOCTYPE_FIELD_MAP: ClassVar[dict[str, str]] = {}
+
+	def cast_updates_onto(self, target_doctype: str) -> dict[str, Any]:
+		link_field: str | None = self.ITEM_CAST_UPDATES_DOCTYPE_FIELD_MAP.get(target_doctype)
+
+		if not link_field:
+			frappe.throw(f"Mapping not found for {self.doctype} to {target_doctype}")
+
+		target_item: Document = frappe.get_doc(target_doctype, self.get(link_field))
+		assert isinstance(target_item, ItemCastUpdates), f"{target_item} must inherit ItemCastUpdates"
+		return target_item.cast_updates_from(self)
+
+	def cast_updates_from(self, item: Document) -> dict[str, Any]:
+		method_name: str = f"_cast_update_from_{frappe.scrub(item.doctype)}"
+		if hasattr(self, method_name):
+			return getattr(self, method_name)(item)
+		else:
+			frappe.throw(f"Method {method_name} not implemented for {self.doctype}")
+
+
+class CastUpdates:
+	"""
+	A class for managing updates across multiple items in a document.
+
+	This class is designed to work with documents that contain multiple items,
+	each of which may need to cast updates onto a target doctype. It aggregates
+	updates from all items and performs a unified database update for efficiency.
+
+	Usage:
+	1. Inherit this class in your main document class.
+	2. Ensure that the items in your document inherit from ItemCastUpdates.
+	3. Call the cast_updates_onto method with the target doctype when you need to propagate updates.
+
+	Attributes:
+	        None
+
+	Methods:
+	        cast_updates_onto(target_doctype): Casts updates from all items onto the specified target doctype.
+	"""
+
+	def cast_updates_onto(self, target_doctype: str) -> None:
+		"""
+		Casts updates from all items onto the specified target doctype.
+
+		This method iterates through all items in the document, collects their updates,
+		and performs a unified database update. It also updates the modified timestamp
+		for all affected documents in the target doctype.
+
+		Args:
+		        target_doctype (str): The name of the target doctype to receive updates.
+
+		Returns:
+		        None
+		"""
+		updates: dict[str, dict[str, Any]] = {}
+		for item in self.get("items", []):
+			assert isinstance(item, ItemCastUpdates), f"{item} must inherit ItemCastUpdates"
+			item_updates: dict[str, Any] = item.cast_updates_onto(target_doctype)
+			updates.setdefault(item.get(item.ITEM_CAST_UPDATES_DOCTYPE_FIELD_MAP[target_doctype]), {}).update(
+				item_updates
+			)
+
+		if not updates:
+			return
+
+		# Perform a unified update to the database
+		for name, data in updates.items():
+			frappe.db.set_value(target_doctype, name, data, update_modified=False)
+
+		# Update the status and modified timestamp for the entire document
+		for name in updates.keys():
+			doc = frappe.get_doc(target_doctype, name)
+			if hasattr(doc, "get_status"):
+				status = doc.get_status()
+			if doc.docstatus.is_submitted() and doc.status != status["status"]:
+				doc.add_comment("Label", _(status["status"]), comment_by=self.name)
+			doc.db_set(
+				{"modified": frappe.utils.now(), "modified_by": self.name, **status},
+				update_modified=False,
+				notify=True,
+			)

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -422,6 +422,8 @@ class SalesOrder(SellingController):
 		if self.get("reserve_stock"):
 			self.create_stock_reservation_entries()
 
+		self.set_status(update=True)
+
 	def on_cancel(self):
 		self.ignore_linked_doctypes = (
 			"GL Entry",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -5,8 +5,10 @@
 import frappe
 from frappe.model.document import Document
 
+from erpnext.controllers.updates_caster import ItemCastUpdates
 
-class SalesOrderItem(Document):
+
+class SalesOrderItem(Document, ItemCastUpdates):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
@@ -92,7 +94,11 @@ class SalesOrderItem(Document):
 		work_order_qty: DF.Float
 	# end: auto-generated types
 
-	pass
+	def _cast_update_from_sales_invoice_item(self, source):
+		return {"billed_amt": source.amount}
+
+	def _cast_update_from_delivery_note_item(self, source):
+		return {"delivered_qty": source.qty}
 
 
 def on_doctype_update():

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
@@ -4,8 +4,10 @@
 
 from frappe.model.document import Document
 
+from erpnext.controllers.updates_caster import ItemCastUpdates
 
-class DeliveryNoteItem(Document):
+
+class DeliveryNoteItem(Document, ItemCastUpdates):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 


### PR DESCRIPTION
- fix: Refactor set_status function in SalesOrder
- feat: Add set_status method to SalesOrder class
- feat: add updates_caster.py with CastUpdates and ItemCastUpdates classes
- wip: dead end

@ruthra-kumar I tried to give your suggestion a try and reached a dead end.

This logic is too entangled to organize properly, especially the presence of a 
"second condition" where delivery status can be determined by either a DN or a
SI with update_stock = 1, for example.

Here's how far I got, maybe some ideas can be useful.

I'll continue on the other PR to narrowly fix the update lifecycle and hotfix my use case.
