### PR TITLE
refactor: use hooks to extend bulk_transaction

### DIFF
--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -146,6 +146,11 @@ def task(doc_name, from_doctype, to_doctype):
 		},
 		"Purchase Receipt": {"Purchase Invoice": purchase_receipt.make_purchase_invoice},
 	}
+
+	hooks = frappe.get_hooks("bulk_transaction_task_mapper")
+	for hook in hooks:
+		mapper.update(frappe.get_attr(hook)())
+
 	frappe.flags.bulk_transaction = True
 	if to_doctype in ["Payment Entry"]:
 		obj = mapper[from_doctype][to_doctype](from_doctype, doc_name)


### PR DESCRIPTION
Bulk Transaction is very useful feature, but now it is really difficult to add more methods.

When creating a new app, there is a chance that the the new kind of bulk transaction is required. 

This PR move the mapper function inside a Doctype so it can be extened by super() in other app (I can't find a proper doctype other than Bulk Transaction Detail Log to place the get_mapper()).

I.e., I have a new app, and so I can do something like this with override_doctype_class.

```
from erpnext.bulk_transaction.doctype.bulk_transaction_log_detail.bulk_transaction_log_detail import BulkTransactionLogDetail


class BulkTransactionLogDetailThaiPayroll(BulkTransactionLogDetail):
    
    def get_mapper(self):
        from thai_payroll.custom import salary_slip
        mapper = super().get_mapper()
        mapper.update({
            "Salary Slip": {
		    	"Withholding Tax Cert Employee": salary_slip.make_withholding_tax_cert_employee,
		    },
        })
        return mapper
```

Note: IMHO, writing method within a class should be a preferred way to allow easier extension. Currently, in many case, I always need to do monkey patch and method overwrite (which is not good for upgrade).