### PR TITLE
fix(test): broken test case due to missing status change

### DIFF
--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -198,6 +198,8 @@ class TestIssue(TestSetUp):
 		frappe.flags.current_time = get_datetime("2021-11-02 03:00")
 		create_communication(issue.name, "test@example.com", "Received", frappe.flags.current_time)
 		issue.reload()
+		issue.status = "Open"
+		issue.save()
 		# Since issue was Resolved, Resolution By should be increased by 5 hrs (3am - 10pm)
 		self.assertEqual(issue.total_hold_time, 3600 + 21600 + 18000)
 		# Resolution By should increase by 5 hrs


### PR DESCRIPTION
Regression: https://github.com/frappe/frappe/pull/27627


```
======================================================================
 FAIL  test_issue_open_after_closed (erpnext.support.doctype.issue.test_issue.TestIssue.test_issue_open_after_closed)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/support/doctype/issue/test_issue.py", line 202, in test_issue_open_after_closed
    self.assertEqual(issue.total_hold_time, 3600 + 21600 + 18000)
    issue = <Issue: ISS-2024-00033>
    self = <erpnext.support.doctype.issue.test_issue.TestIssue testMethod=test_issue_open_after_closed>
AssertionError: 25200.0 != 43200
```