### PR TITLE
fix: Reset Value Conditionally Based on Merge Taxes

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1048,7 +1048,7 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 			},
 			"Sales Taxes and Charges": {
 				"doctype": "Sales Taxes and Charges",
-				"reset_value": True,
+				"reset_value": not (args and args.get("merge_taxes")),
 				"ignore": args.get("merge_taxes") if args else 0,
 			},
 			"Sales Team": {

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1205,7 +1205,7 @@ def make_purchase_invoice(source_name, target_doc=None, args=None):
 			},
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",
-				"reset_value": True,
+				"reset_value": not (args and args.get("merge_taxes")),
 				"ignore": args.get("merge_taxes") if args else 0,
 			},
 		},


### PR DESCRIPTION
**Issue:**

- In some of the Doctypes there is an option to merge the taxes from the selected documents.

![image](https://github.com/user-attachments/assets/e8c2fa37-f3b9-4d18-8326-e0e58113c451)


- So the functionality of `reset value` has to be changed considering that `merge taxes` is selected or not.