### PR TITLE
fix: AP filter to simulate employee advance as a ledger impacting voucher

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -162,6 +162,11 @@ frappe.query_reports["Accounts Payable"] = {
 			label: __("Group by Voucher"),
 			fieldtype: "Check",
 		},
+		{
+			fieldname: "handle_employee_advances",
+			label: __("Handle Employee Advances"),
+			fieldtype: "Check",
+		},
 	],
 
 	formatter: function (value, row, column, data, default_formatter) {

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -214,7 +214,11 @@ class ReceivablePayableReport:
 
 		# Build and use a separate row for Employee Advances.
 		# This allows Payments or Journals made against Emp Advance to be processed.
-		if not row and ple.against_voucher_type == "Employee Advance":
+		if (
+			not row
+			and ple.against_voucher_type == "Employee Advance"
+			and self.filters.handle_employee_advances
+		):
 			_d = self.build_voucher_dict(ple)
 			_d.voucher_type = ple.against_voucher_type
 			_d.voucher_no = ple.against_voucher_no

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -112,6 +112,26 @@ class ReceivablePayableReport:
 
 		self.build_data()
 
+	def build_voucher_dict(self, ple):
+		return frappe._dict(
+			voucher_type=ple.voucher_type,
+			voucher_no=ple.voucher_no,
+			party=ple.party,
+			party_account=ple.account,
+			posting_date=ple.posting_date,
+			account_currency=ple.account_currency,
+			remarks=ple.remarks,
+			invoiced=0.0,
+			paid=0.0,
+			credit_note=0.0,
+			outstanding=0.0,
+			invoiced_in_account_currency=0.0,
+			paid_in_account_currency=0.0,
+			credit_note_in_account_currency=0.0,
+			outstanding_in_account_currency=0.0,
+			cost_center=ple.cost_center,
+		)
+
 	def init_voucher_balance(self):
 		# build all keys, since we want to exclude vouchers beyond the report date
 		for ple in self.ple_entries:
@@ -123,24 +143,8 @@ class ReceivablePayableReport:
 				key = (ple.account, ple.voucher_type, ple.voucher_no, ple.party)
 
 			if key not in self.voucher_balance:
-				self.voucher_balance[key] = frappe._dict(
-					voucher_type=ple.voucher_type,
-					voucher_no=ple.voucher_no,
-					party=ple.party,
-					party_account=ple.account,
-					posting_date=ple.posting_date,
-					account_currency=ple.account_currency,
-					remarks=ple.remarks,
-					invoiced=0.0,
-					paid=0.0,
-					credit_note=0.0,
-					outstanding=0.0,
-					invoiced_in_account_currency=0.0,
-					paid_in_account_currency=0.0,
-					credit_note_in_account_currency=0.0,
-					outstanding_in_account_currency=0.0,
-					cost_center=ple.cost_center,
-				)
+				self.voucher_balance[key] = self.build_voucher_dict(ple)
+
 			self.get_invoices(ple)
 
 			if self.filters.get("group_by_party"):
@@ -207,6 +211,14 @@ class ReceivablePayableReport:
 						key = (ple.account, ple.against_voucher_type, return_against, ple.party)
 
 		row = self.voucher_balance.get(key)
+
+		# Build and use a separate row for Employee Advances.
+		# This allows Payments or Journals made against Emp Advance to be processed.
+		if not row and ple.against_voucher_type == "Employee Advance":
+			_d = self.build_voucher_dict(ple)
+			_d.voucher_type = ple.against_voucher_type
+			_d.voucher_no = ple.against_voucher_no
+			row = self.voucher_balance[key] = _d
 
 		if not row:
 			# no invoice, this is an invoice / stand-alone payment / credit note


### PR DESCRIPTION
## Issue
Expense Claims, Payment Entries and Journals allocated against Employee advance show up in Accounts Payable report as individual (unreconciled) entries. This is a known limitation in the system.

## Cause
Accounts Payable report relies on the Primary document having Ledger impact to work properly. Since, Employee Advances don't post any ledger entries, Exp Claims or Payments allocated against advances cannot be linked with each other and hence end up reported as unallocated.

## Workaround
AP report has a new filter 'Handle Employee Advances' to handle above scenario.