### PR TITLE
fix: check multi-currency on jv for common party accounting with foreign currency

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4045,6 +4045,7 @@ class TestSalesInvoice(FrappeTestCase):
 		self.assertEqual(len(actual), 4)
 		self.assertEqual(expected, actual)
 
+	@change_settings("Accounts Settings", {"enable_common_party_accounting": True})
 	def test_common_party_with_foreign_currency_jv(self):
 		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.accounts.doctype.opening_invoice_creation_tool.test_opening_invoice_creation_tool import (
@@ -4091,11 +4092,8 @@ class TestSalesInvoice(FrappeTestCase):
 		supp_doc.append("accounts", test_account_details)
 		supp_doc.save()
 
-		# enable common party accounting
-		frappe.db.set_single_value("Accounts Settings", "enable_common_party_accounting", 1)
-
 		# create a party link between customer & supplier
-		party_link = create_party_link("Supplier", supplier, customer)
+		create_party_link("Supplier", supplier, customer)
 
 		# create a sales invoice
 		si = create_sales_invoice(
@@ -4128,9 +4126,6 @@ class TestSalesInvoice(FrappeTestCase):
 		)
 		self.assertTrue(jv)
 		self.assertEqual(jv[0], si.grand_total)
-
-		party_link.delete()
-		frappe.db.set_single_value("Accounts Settings", "enable_common_party_accounting", 0)
 
 
 def set_advance_flag(company, flag, default_account):

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -51,7 +51,7 @@ class TestSalesInvoice(FrappeTestCase):
 		from erpnext.stock.doctype.stock_ledger_entry.test_stock_ledger_entry import create_items
 
 		create_items(["_Test Internal Transfer Item"], uoms=[{"uom": "Box", "conversion_factor": 10}])
-		# create_internal_parties()
+		create_internal_parties()
 		setup_accounts()
 		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2453,6 +2453,8 @@ class AccountsController(TransactionBase):
 
 		primary_account = get_party_account(primary_party_type, primary_party, self.company)
 		secondary_account = get_party_account(secondary_party_type, secondary_party, self.company)
+		primary_account_currency = get_account_currency(primary_account)
+		secondary_account_currency = get_account_currency(secondary_account)
 
 		jv = frappe.new_doc("Journal Entry")
 		jv.voucher_type = "Journal Entry"
@@ -2491,6 +2493,10 @@ class AccountsController(TransactionBase):
 		else:
 			advance_entry.credit_in_account_currency = self.outstanding_amount
 			reconcilation_entry.debit_in_account_currency = self.outstanding_amount
+
+		default_currency = erpnext.get_company_currency(self.company)
+		if primary_account_currency != default_currency or secondary_account_currency != default_currency:
+			jv.multi_currency = 1
 
 		jv.append("accounts", reconcilation_entry)
 		jv.append("accounts", advance_entry)


### PR DESCRIPTION
Issue:
When creating an invoice for the common party in foreign currency, it throws a multicurrency error while creating advance jv.
https://support.frappe.io/helpdesk/tickets/20825

Solution:
Enabling multi-currency check box based on account currency, while creating advance jv


![Screenshot from 2024-09-05 17-15-31](https://github.com/user-attachments/assets/c91fcc78-6e4f-44ba-91d7-24e7888686f6)

![image](https://github.com/user-attachments/assets/86cabd2d-d993-43f8-b12b-14a0bd33003a)
