### PR TITLE
fix: set today in 'On This Date' in Available Batch Report

### DIFF
--- a/erpnext/stock/report/available_batch_report/available_batch_report.js
+++ b/erpnext/stock/report/available_batch_report/available_batch_report.js
@@ -17,7 +17,7 @@ frappe.query_reports["Available Batch Report"] = {
 			fieldtype: "Date",
 			width: "80",
 			reqd: 1,
-			default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
+			default: frappe.datetime.get_today(),
 		},
 		{
 			fieldname: "item_code",


### PR DESCRIPTION
version 15

fixes: #43113

- The default date of available batch reports is one month before Today(). Fixed it to show default as today.