### PR TITLE
fix: return type of `get_party_details`

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -68,7 +68,7 @@ def get_party_details(
 	pos_profile=None,
 ):
 	if not party:
-		return {}
+		return frappe._dict()
 	if not frappe.db.exists(party_type, party):
 		frappe.throw(_("{0}: {1} does not exists").format(party_type, party))
 	return _get_party_details(


### PR DESCRIPTION
`get_party_details` should always return a `frappe._dict`, otherwise it's prone to errors.