### PR TITLE
fix: set `party_type` null when `payment_type` is changed to `Internal Transfer`

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -385,7 +385,15 @@ frappe.ui.form.on("Payment Entry", {
 	payment_type: function (frm) {
 		if (frm.doc.payment_type == "Internal Transfer") {
 			$.each(
-				["party", "party_balance", "paid_from", "paid_to", "references", "total_allocated_amount"],
+				[
+					"party",
+					"party_type",
+					"party_balance",
+					"paid_from",
+					"paid_to",
+					"references",
+					"total_allocated_amount",
+				],
 				function (i, field) {
 					frm.set_value(field, null);
 				}


### PR DESCRIPTION
Issue while creating Payment Entry for Internal Transfer:

![image](https://github.com/user-attachments/assets/214752ff-75ae-435b-a694-e8f460460da3)

When the **Payment Type** is changed from **Pay** to **Internal Transfer**, the previously set **Party Type** is not set to null.

Video showing steps to replicate the issue:

https://github.com/user-attachments/assets/d865a29d-048c-4378-b4bf-6a93859079e8



