### PR TITLE
fix: Call super onload_post_render inside pos_invoice.js

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -44,6 +44,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 	}
 
 	onload_post_render(frm) {
+		super.onload_post_render();
 		this.pos_profile(frm);
 	}
 


### PR DESCRIPTION
super.onload_post_render() was not being called from pos_invoice.js.

It causes mistakes, for example, add multiples button was not showing.

![pr-screenshot1](https://github.com/user-attachments/assets/47dcd13c-87e5-44a8-a0e6-701eada5810d)
