### PR TITLE
chore: exempt draft prs from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,9 @@ exemptProjects: true
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true
 
+# Skip the stale action for draft PRs
+exemptDraftPr: true
+
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - hotfix


### PR DESCRIPTION
Hope this is fine with the general policy!

Closing draft PRs is really nasty and it's not a rare thing that a draft PR may simmer for months, for example to conduct extensive testing, etc.

Closing draft PR deters proper open source workflows.
