### PR TITLE
fix: invalid gp calculation

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -637,7 +637,7 @@ class SellingController(StockController):
 		if self.doctype in ["Sales Order", "Quotation"]:
 			for item in self.items:
 				item.gross_profit = flt(
-					((item.base_rate - flt(item.valuation_rate)) * item.stock_qty),
+					((flt(item.stock_uom_rate) - flt(item.valuation_rate)) * item.stock_qty),
 					self.precision("amount", item),
 				)
 


### PR DESCRIPTION
Initially, `base_rate` was used for calculation but this is wrong if a different UOM other that `stock_uom` is used for the transaction.