### PR TITLE
fix: delete exchange gain loss journal entry while deleting payment entry

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -346,12 +346,17 @@ class AccountsController(TransactionBase):
 					repost_doc.save(ignore_permissions=True)
 
 	def on_trash(self):
+		from erpnext.accounts.utils import delete_exchange_gain_loss_journal
+
 		self._remove_references_in_repost_doctypes()
 		self._remove_references_in_unreconcile()
 		self.remove_serial_and_batch_bundle()
 
 		# delete sl and gl entries on deletion of transaction
 		if frappe.db.get_single_value("Accounts Settings", "delete_linked_ledger_entries"):
+			# delete linked exchange gain/loss journal
+			delete_exchange_gain_loss_journal(self)
+
 			ple = frappe.qb.DocType("Payment Ledger Entry")
 			frappe.qb.from_(ple).delete().where(
 				(ple.voucher_type == self.doctype) & (ple.voucher_no == self.name)


### PR DESCRIPTION
Issue: while deleting the payment entry in foreign currency if it has exchange gain loss journal entry against it. Its not getting deleted.
https://support.frappe.io/helpdesk/tickets/20300


Before:
https://github.com/user-attachments/assets/92a6e320-2764-4ed5-a714-4b9083cdf25e

After:
https://github.com/user-attachments/assets/ae065d99-c42c-4c7b-861c-6785015f4558

backport needed for v15