### PR TITLE
fix: refine GLE deletion with against voucher check

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -363,10 +363,18 @@ class AccountsController(TransactionBase):
 				)
 			).run()
 			frappe.db.sql(
-				"delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name)
+				"""
+				delete from `tabGL Entry`
+				where(
+					(voucher_type=%s and voucher_no=%s) or
+					(ifnull(against_voucher_type, '')=%s and ifnull(against_voucher, '')=%s)
+				)
+				and is_cancelled=1
+				""",
+				(self.doctype, self.name, self.doctype, self.name),
 			)
 			frappe.db.sql(
-				"delete from `tabStock Ledger Entry` where voucher_type=%s and voucher_no=%s",
+				"delete from `tabStock Ledger Entry` where voucher_type=%s and voucher_no=%s and is_cancelled=1",
 				(self.doctype, self.name),
 			)
 


### PR DESCRIPTION
**Issue:**

- A user was unable to delete an asset record, even after enabling the 'Delete Accounting and Stock Ledger Entries on Deletion of Transaction' option.
- The error occurred because the asset was linked to the GL entry through the 'against voucher' field, with the voucher type being 'Journal Entry'.
- The deletion logic was only validating the 'voucher type' but did not account for the 'against voucher' field, leading to the error.

**Resolution:**

- Updated the deletion logic to also check the 'against voucher' field in addition to the 'voucher type'.

internal issue: [21449](https://support.frappe.io/helpdesk/tickets/21449)
