### PR TITLE
 fix: get cost center allocation percentage only from the applicable allocation

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -180,50 +180,53 @@ def process_gl_map(gl_map, merge_entries=True, precision=None):
 
 
 def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None):
-	cost_center_allocation = get_cost_center_allocation_data(gl_map[0]["company"], gl_map[0]["posting_date"])
-	if not cost_center_allocation:
-		return gl_map
-
 	new_gl_map = []
 	for d in gl_map:
 		cost_center = d.get("cost_center")
 
 		# Validate budget against main cost center
 		validate_expense_against_budget(d, expense_amount=flt(d.debit, precision) - flt(d.credit, precision))
-
-		if cost_center and cost_center_allocation.get(cost_center):
-			for sub_cost_center, percentage in cost_center_allocation.get(cost_center, {}).items():
-				gle = copy.deepcopy(d)
-				gle.cost_center = sub_cost_center
-				for field in ("debit", "credit", "debit_in_account_currency", "credit_in_account_currency"):
-					gle[field] = flt(flt(d.get(field)) * percentage / 100, precision)
-				new_gl_map.append(gle)
-		else:
+		cost_center_allocation = get_cost_center_allocation_data(
+			gl_map[0]["company"], gl_map[0]["posting_date"], cost_center
+		)
+		if not cost_center_allocation:
 			new_gl_map.append(d)
+			continue
+
+		for sub_cost_center, percentage in cost_center_allocation:
+			gle = copy.deepcopy(d)
+			gle.cost_center = sub_cost_center
+			for field in ("debit", "credit", "debit_in_account_currency", "credit_in_account_currency"):
+				gle[field] = flt(flt(d.get(field)) * percentage / 100, precision)
+			new_gl_map.append(gle)
 
 	return new_gl_map
 
 
-def get_cost_center_allocation_data(company, posting_date):
-	par = frappe.qb.DocType("Cost Center Allocation")
-	child = frappe.qb.DocType("Cost Center Allocation Percentage")
+def get_cost_center_allocation_data(company, posting_date, cost_center):
+	cost_center_allocation = frappe.db.get_value(
+		"Cost Center Allocation",
+		{
+			"docstatus": 1,
+			"company": company,
+			"valid_from": ("<=", posting_date),
+			"main_cost_center": cost_center,
+		},
+		pluck="name",
+		order_by="valid_from desc",
+	)
 
-	records = (
-		frappe.qb.from_(par)
-		.inner_join(child)
-		.on(par.name == child.parent)
-		.select(par.main_cost_center, child.cost_center, child.percentage)
-		.where(par.docstatus == 1)
-		.where(par.company == company)
-		.where(par.valid_from <= posting_date)
-		.orderby(par.valid_from, order=frappe.qb.desc)
-	).run(as_dict=True)
+	if not cost_center_allocation:
+		return []
 
-	cc_allocation = frappe._dict()
-	for d in records:
-		cc_allocation.setdefault(d.main_cost_center, frappe._dict()).setdefault(d.cost_center, d.percentage)
+	records = frappe.db.get_all(
+		"Cost Center Allocation Percentage",
+		{"parent": cost_center_allocation},
+		["cost_center", "percentage"],
+		as_list=True,
+	)
 
-	return cc_allocation
+	return records
 
 
 def merge_similar_entries(gl_map, precision=None):


### PR DESCRIPTION
Issue:
sub cost center and percentage not fetching properly from Cost Center Allocation, when there are multiple allocation entries with different sets of sub cost centers
https://support.frappe.io/helpdesk/tickets/21870

Before:
https://github.com/user-attachments/assets/16f3a55b-4f4f-4e79-884c-a2e14ccca093

After:
https://github.com/user-attachments/assets/d275aca0-608b-4162-954c-6703ea2cf2e0

