### PR TITLE
fix: Payment Ledger Report currency fieldtype fix

### DIFF
--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -210,7 +210,7 @@ class PaymentLedger:
 				)
 			)
 		self.columns.append(
-			dict(label=_("Currency"), fieldname="currency", fieldtype="Currency", hidden=True)
+			dict(label=_("Currency"), fieldname="currency", fieldtype="Link", options="Currency", hidden=True)
 		)
 
 	def run(self):


### PR DESCRIPTION
In the Payment Ledger Report "currency" field has the wrong fieldtype. As per the incoming data, it should be a Link field.

![image](https://github.com/user-attachments/assets/51c9375b-1577-49a1-b799-a9fbb5a8140c)

