### PR TITLE
fix: get cost center allocation percentage only from the applicable allocation

### DIFF
--- a/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
+++ b/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
@@ -22,6 +22,7 @@ class TestCostCenterAllocation(unittest.TestCase):
 		cost_centers = [
 			"Main Cost Center 1",
 			"Main Cost Center 2",
+			"Main Cost Center 3",
 			"Sub Cost Center 1",
 			"Sub Cost Center 2",
 			"Sub Cost Center 3",
@@ -37,7 +38,7 @@ class TestCostCenterAllocation(unittest.TestCase):
 		)
 
 		jv = make_journal_entry(
-			"_Test Cash - _TC", "Sales - _TC", 100, cost_center="Main Cost Center 1 - _TC", submit=True
+			"Cash - _TC", "Sales - _TC", 100, cost_center="Main Cost Center 1 - _TC", submit=True
 		)
 
 		expected_values = [["Sub Cost Center 1 - _TC", 0.0, 60], ["Sub Cost Center 2 - _TC", 0.0, 40]]
@@ -121,7 +122,7 @@ class TestCostCenterAllocation(unittest.TestCase):
 	def test_valid_from_based_on_existing_gle(self):
 		# GLE posted against Sub Cost Center 1 on today
 		jv = make_journal_entry(
-			"_Test Cash - _TC",
+			"Cash - _TC",
 			"Sales - _TC",
 			100,
 			cost_center="Main Cost Center 1 - _TC",
@@ -143,16 +144,16 @@ class TestCostCenterAllocation(unittest.TestCase):
 		jv.cancel()
 
 	def test_multiple_cost_center_allocation_on_same_main_cost_center(self):
-		create_cost_center_allocation(
+		coa1 = create_cost_center_allocation(
 			"_Test Company",
-			"Main Cost Center 1 - _TC",
+			"Main Cost Center 3 - _TC",
 			{"Sub Cost Center 1 - _TC": 30, "Sub Cost Center 2 - _TC": 30, "Sub Cost Center 3 - _TC": 40},
 			valid_from=add_days(today(), -5),
 		)
 
-		create_cost_center_allocation(
+		coa2 = create_cost_center_allocation(
 			"_Test Company",
-			"Main Cost Center 1 - _TC",
+			"Main Cost Center 3 - _TC",
 			{"Sub Cost Center 1 - _TC": 50, "Sub Cost Center 2 - _TC": 50},
 			valid_from=add_days(today(), -1),
 		)
@@ -161,7 +162,7 @@ class TestCostCenterAllocation(unittest.TestCase):
 			"Cash - _TC",
 			"Sales - _TC",
 			100,
-			cost_center="Main Cost Center 1 - _TC",
+			cost_center="Main Cost Center 3 - _TC",
 			posting_date=today(),
 			submit=True,
 		)
@@ -184,6 +185,10 @@ class TestCostCenterAllocation(unittest.TestCase):
 			self.assertTrue(gle.cost_center in expected_values)
 			self.assertEqual(gle.debit, 0)
 			self.assertEqual(gle.credit, expected_values[gle.cost_center])
+
+		coa1.cancel()
+		coa2.cancel()
+		jv.cancel()
 
 
 def create_cost_center_allocation(

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -180,50 +180,53 @@ def process_gl_map(gl_map, merge_entries=True, precision=None):
 
 
 def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None):
-	cost_center_allocation = get_cost_center_allocation_data(gl_map[0]["company"], gl_map[0]["posting_date"])
-	if not cost_center_allocation:
-		return gl_map
-
 	new_gl_map = []
 	for d in gl_map:
 		cost_center = d.get("cost_center")
 
 		# Validate budget against main cost center
 		validate_expense_against_budget(d, expense_amount=flt(d.debit, precision) - flt(d.credit, precision))
-
-		if cost_center and cost_center_allocation.get(cost_center):
-			for sub_cost_center, percentage in cost_center_allocation.get(cost_center, {}).items():
-				gle = copy.deepcopy(d)
-				gle.cost_center = sub_cost_center
-				for field in ("debit", "credit", "debit_in_account_currency", "credit_in_account_currency"):
-					gle[field] = flt(flt(d.get(field)) * percentage / 100, precision)
-				new_gl_map.append(gle)
-		else:
+		cost_center_allocation = get_cost_center_allocation_data(
+			gl_map[0]["company"], gl_map[0]["posting_date"], cost_center
+		)
+		if not cost_center_allocation:
 			new_gl_map.append(d)
+			continue
+
+		for sub_cost_center, percentage in cost_center_allocation:
+			gle = copy.deepcopy(d)
+			gle.cost_center = sub_cost_center
+			for field in ("debit", "credit", "debit_in_account_currency", "credit_in_account_currency"):
+				gle[field] = flt(flt(d.get(field)) * percentage / 100, precision)
+			new_gl_map.append(gle)
 
 	return new_gl_map
 
 
-def get_cost_center_allocation_data(company, posting_date):
-	par = frappe.qb.DocType("Cost Center Allocation")
-	child = frappe.qb.DocType("Cost Center Allocation Percentage")
+def get_cost_center_allocation_data(company, posting_date, cost_center):
+	cost_center_allocation = frappe.db.get_value(
+		"Cost Center Allocation",
+		{
+			"docstatus": 1,
+			"company": company,
+			"valid_from": ("<=", posting_date),
+			"main_cost_center": cost_center,
+		},
+		pluck="name",
+		order_by="valid_from desc",
+	)
 
-	records = (
-		frappe.qb.from_(par)
-		.inner_join(child)
-		.on(par.name == child.parent)
-		.select(par.main_cost_center, child.cost_center, child.percentage)
-		.where(par.docstatus == 1)
-		.where(par.company == company)
-		.where(par.valid_from <= posting_date)
-		.orderby(par.valid_from, order=frappe.qb.desc)
-	).run(as_dict=True)
+	if not cost_center_allocation:
+		return []
 
-	cc_allocation = frappe._dict()
-	for d in records:
-		cc_allocation.setdefault(d.main_cost_center, frappe._dict()).setdefault(d.cost_center, d.percentage)
+	records = frappe.db.get_all(
+		"Cost Center Allocation Percentage",
+		{"parent": cost_center_allocation},
+		["cost_center", "percentage"],
+		as_list=True,
+	)
 
-	return cc_allocation
+	return records
 
 
 def merge_similar_entries(gl_map, precision=None):


### PR DESCRIPTION
Issue:
sub cost center and percentage not fetching properly from Cost Center Allocation, when there are multiple allocation entries with different sets of sub cost centers
https://support.frappe.io/helpdesk/tickets/21870

Before:
https://github.com/user-attachments/assets/16f3a55b-4f4f-4e79-884c-a2e14ccca093

After:
https://github.com/user-attachments/assets/d275aca0-608b-4162-954c-6703ea2cf2e0

backport needed for v14 and v15