### PR TITLE
fix(ux): set amount based on account currency while adding new row

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -360,21 +360,23 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 
 	accounts_add(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
+		row.exchange_rate = 1;
 		$.each(doc.accounts, function (i, d) {
 			if (d.account && d.party && d.party_type) {
 				row.account = d.account;
 				row.party = d.party;
 				row.party_type = d.party_type;
+				row.exchange_rate = d.exchange_rate;
 			}
 		});
 
 		// set difference
 		if (doc.difference) {
 			if (doc.difference > 0) {
-				row.credit_in_account_currency = doc.difference;
+				row.credit_in_account_currency = doc.difference / row.exchange_rate;
 				row.credit = doc.difference;
 			} else {
-				row.debit_in_account_currency = -doc.difference;
+				row.debit_in_account_currency = -doc.difference / row.exchange_rate;
 				row.debit = -doc.difference;
 			}
 		}


### PR DESCRIPTION
Issue: While creating journal entry on foreign currency with party, adding a new row fetch amount in company currency. 

Before:
[jv.party.account.currecny.issue.webm](https://github.com/user-attachments/assets/8e7059d8-f69d-4285-8046-a3fb4411231e)

After:
[jv.party.account.currecny.fix.webm](https://github.com/user-attachments/assets/b0348d94-8915-4a3b-a4dc-c15b839d92a5)

backport needed for v15
