### PR TITLE
fix: map rows on journal entry by validating account, party, debit and credit value

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -195,6 +195,11 @@ class JournalEntry(AccountsController):
 		self.update_booked_depreciation()
 
 	def on_update_after_submit(self):
+		# Flag will be set on Reconciliation
+		# Reconciliation tool will anyways repost ledger entries. So, no need to check and do implicit repost.
+		if self.flags.get("ignore_reposting_on_reconciliation"):
+			return
+
 		self.needs_repost = self.check_if_fields_updated(fields_to_check=[], child_tables={"accounts": []})
 		if self.needs_repost:
 			self.validate_for_repost()

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import qb
 from frappe.tests.utils import FrappeTestCase, change_settings
-from frappe.utils import add_days, flt, getdate, nowdate, today
+from frappe.utils import add_days, add_years, flt, getdate, nowdate, today
 
 from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
@@ -1847,14 +1847,10 @@ class TestPaymentReconciliation(FrappeTestCase):
 		self.assertEqual(len(pr.payments), 1)
 
 	def test_reconciliation_on_closed_period_payment(self):
-		from erpnext.accounts.doctype.account.test_account import create_account
-
-		# Get current fiscal year
-		current_fy_start_date = get_fiscal_year(today())[1]
-
 		# create backdated fiscal year
-		prev_fy_start_date = add_days(current_fy_start_date, -366)
-		prev_fy_end_date = add_days(current_fy_start_date, -1)
+		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, "min(year_start_date)")
+		prev_fy_start_date = add_years(first_fy_start_date, -1)
+		prev_fy_end_date = add_days(first_fy_start_date, -1)
 		create_fiscal_year(
 			company=self.company, year_start_date=prev_fy_start_date, year_end_date=prev_fy_end_date
 		)

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1996,7 +1996,7 @@ def make_period_closing_voucher(company, cost_center, posting_date=None, submit=
 			"transaction_date": posting_date or today(),
 			"posting_date": posting_date or today(),
 			"company": company,
-			"fiscal_year": get_fiscal_year(today(), company=company)[0],
+			"fiscal_year": get_fiscal_year(posting_date or today(), company=company)[0],
 			"cost_center": cost_center,
 			"closing_account_head": surplus_account,
 			"remarks": "test",

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -685,6 +685,8 @@ def update_reference_in_journal_entry(d, journal_entry, do_not_save=False):
 
 	# will work as update after submit
 	journal_entry.flags.ignore_validate_update_after_submit = True
+	# Ledgers will be reposted by Reconciliation tool
+	journal_entry.flags.ignore_reposting_on_reconciliation = True
 	if not do_not_save:
 		journal_entry.save(ignore_permissions=True)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3570,6 +3570,13 @@ def check_if_child_table_updated(child_table_before_update, child_table_after_up
 
 	# Check if any field affecting accounting entry is altered
 	for index, item in enumerate(child_table_before_update):
+		if item.parenttype == "Journal Entry" and any(
+			[
+				child_table_after_update[index].get(i) != item.get(i)
+				for i in ["account", "party_type", "party", "debit", "credit"]
+			]
+		):
+			continue
 		for field in fields_to_check:
 			if child_table_after_update[index].get(field) != item.get(field):
 				return True

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3570,13 +3570,6 @@ def check_if_child_table_updated(child_table_before_update, child_table_after_up
 
 	# Check if any field affecting accounting entry is altered
 	for index, item in enumerate(child_table_before_update):
-		if item.parenttype == "Journal Entry" and any(
-			[
-				child_table_after_update[index].get(i) != item.get(i)
-				for i in ["account", "party_type", "party", "debit", "credit"]
-			]
-		):
-			continue
 		for field in fields_to_check:
 			if child_table_after_update[index].get(field) != item.get(field):
 				return True


### PR DESCRIPTION
Issue: Unable to reconcile payment journal entry from closed fiscal year
https://support.frappe.io/helpdesk/tickets/21665

Before:
![Payment Reconciliation Issue](https://github.com/user-attachments/assets/3932bb37-0651-44e5-9834-a56ceaea4703)

After:
![Payment Reconciliation Fix](https://github.com/user-attachments/assets/818a7fda-a49e-4c74-8218-bdd4b4a01557)

backport needed for v15
