### PR TITLE
fix: do not validate purchase document for composite asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -624,6 +624,9 @@ class Asset(AccountsController):
 		return records
 
 	def validate_make_gl_entry(self):
+		if self.is_composite_asset:
+			return True
+
 		purchase_document = self.get_purchase_document()
 		if not purchase_document:
 			return False


### PR DESCRIPTION
This PR modifies the `validate_make_gl_entry` method to skip the purchase document validation for capitalized assets, as they do not have associated purchase receipts or invoices.

`no-docs`