### PR TITLE
fix: set group_by condition to "Group by Voucher (Consolidated)" if `None` and voucher_no is set

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -35,6 +35,9 @@ def execute(filters=None):
 	if filters.get("party"):
 		filters.party = frappe.parse_json(filters.get("party"))
 
+	if filters.get("voucher_no") and not filters.get("group_by"):
+		filters.group_by = "Group by Voucher (Consolidated)"
+
 	validate_filters(filters, account_details)
 
 	validate_party(filters)


### PR DESCRIPTION
Issue: 

![image](https://github.com/user-attachments/assets/ab9fa3a9-7a3f-4eb3-b681-6316539f4446)

- Fix: To avoid thse double rows for opening and closing entries, setting the `group_by` filter as **Group by Voucher (Consolidated)** if `group_by` is not set and `voucher_no` is set,