### PR TITLE
fix: add currency in options for rate field in pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -419,7 +419,8 @@
    "depends_on": "eval:doc.rate_or_discount==\"Rate\"",
    "fieldname": "rate",
    "fieldtype": "Currency",
-   "label": "Rate"
+   "label": "Rate",
+   "options": "currency"
   },
   {
    "default": "0",
@@ -647,7 +648,7 @@
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2024-06-28 11:03:15.252701",
+ "modified": "2024-09-16 18:14:51.314765",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",


### PR DESCRIPTION
Issue:
Not showing appropriate currency symbol in rate field in pricing rule list view
https://support.frappe.io/helpdesk/tickets/22014

Before fix:
![Before fix](https://github.com/user-attachments/assets/e3db1103-c4ab-4d30-9aff-2178d0f21754)

After fix: 
![After fix](https://github.com/user-attachments/assets/baa44f1a-5f2f-4d33-b656-a2d09b2416ed)

Backport needed:
v15