### PR TITLE
feat: Add 'ABBR' variable to support company abbreviation in naming series

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1357,6 +1357,14 @@ def parse_naming_series_variable(doc, variable):
 			date = getdate()
 			company = None
 		return get_fiscal_year(date=date, company=company)[0]
+	
+	elif variable == "ABBR":
+		if doc:
+			company = doc.get("company") or frappe.defaults.get_default("company")
+		else:
+			company = frappe.defaults.get_default("company")
+
+		return frappe.db.get_value("Company", company, "abbr") if company else ""
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1360,9 +1360,9 @@ def parse_naming_series_variable(doc, variable):
 	
 	elif variable == "ABBR":
 		if doc:
-			company = doc.get("company") or frappe.defaults.get_default("company")
+			company = doc.get("company") or frappe.db.get_default('company')
 		else:
-			company = frappe.defaults.get_default("company")
+			company = frappe.db.get_default('company')
 
 		return frappe.db.get_value("Company", company, "abbr") if company else ""
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1357,12 +1357,12 @@ def parse_naming_series_variable(doc, variable):
 			date = getdate()
 			company = None
 		return get_fiscal_year(date=date, company=company)[0]
-	
+
 	elif variable == "ABBR":
 		if doc:
-			company = doc.get("company") or frappe.db.get_default('company')
+			company = doc.get("company") or frappe.db.get_default("company")
 		else:
-			company = frappe.db.get_default('company')
+			company = frappe.db.get_default("company")
 
 		return frappe.db.get_value("Company", company, "abbr") if company else ""
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -385,6 +385,7 @@ doc_events = {
 # function should expect the variable and doc as arguments
 naming_series_variables = {
 	"FY": "erpnext.accounts.utils.parse_naming_series_variable",
+	"ABBR": "erpnext.accounts.utils.parse_naming_series_variable",
 }
 
 # On cancel event Payment Entry will be exempted and all linked submittable doctype will get cancelled.


### PR DESCRIPTION
**Summary:**

This pull request adds support for the .ABBR. variable in naming series, allowing users to include the company abbreviation in document names.

**Changes Made:**

Modified erpnext/accounts/utils.py to handle the .ABBR. variable in the parse_naming_series_variable function.
Updated hooks.py to register the .ABBR. variable in naming_series_variables.

**Usage:**

Users can now include .ABBR. in their naming series patterns, which will be replaced with the company abbreviation.
```
Example:
INV-.YYYY.-.ABBR.-.#####
```

Related Pull Request:
[frappe#27809](https://github.com/frappe/frappe/pull/27809)

`no-docs`