### PR TITLE
fix: deduct advances adjusted for threshold check for tcs

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -327,7 +327,7 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 			tax_amount = 0
 		else:
 			#  if no TCS has been charged in FY,
-			# then chargeable value is "prev invoices + advances" value which cross the threshold
+			# then chargeable value is "prev invoices + advances - advance_adjusted" value which cross the threshold
 			tax_amount = get_tcs_amount(parties, inv, tax_details, vouchers, advance_vouchers)
 
 	if cint(tax_details.round_off_tax_amount):
@@ -631,15 +631,26 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 	)
 
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
+	advance_adjusted = get_advance_adjusted_in_invoice(inv)
 
 	current_invoice_total = get_invoice_total_without_tcs(inv, tax_details)
-	total_invoiced_amt = current_invoice_total + invoiced_amt + advance_amt - credit_note_amt
+	total_invoiced_amt = (
+		current_invoice_total + invoiced_amt + advance_amt - credit_note_amt - advance_adjusted
+	)
 
 	if cumulative_threshold and total_invoiced_amt >= cumulative_threshold:
 		chargeable_amt = total_invoiced_amt - cumulative_threshold
 		tcs_amount = chargeable_amt * tax_details.rate / 100 if chargeable_amt > 0 else 0
 
 	return tcs_amount
+
+
+def get_advance_adjusted_in_invoice(inv):
+	advances_adjusted = 0
+	for row in inv.get("advances", []):
+		advances_adjusted += row.allocated_amount
+
+	return advances_adjusted
 
 
 def get_invoice_total_without_tcs(inv, tax_details):


### PR DESCRIPTION
TCS is deducting twice in sales invoice if advance payment is received from a customer and then the sales invoice is booked separately.

The typical use case is 
Sales Invoice - 400
Advance Payment Entry = 300
Advance Payment Entry Adjusted - 100
Threshhold - 500

Before
Chargeble Amount =  400+300 -500 = 200

After
Chargeble Amount = 400+300-100-500 = 100

closes: https://github.com/frappe/erpnext/issues/42001
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/20142