### PR TITLE
fix: Translation for button SO to PO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1249,7 +1249,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					],
 				},
 			],
-			primary_action_label: "Create Purchase Order",
+			primary_action_label: __("Create Purchase Order"),
 			primary_action(args) {
 				if (!args) return;
 


### PR DESCRIPTION
Version 15 and 14

fixes: https://discuss.frappe.io/t/translation-for-button-create-purchase-order-in-so-not-working/133486

- Translation for button "Create Purchase Order" in SO