### PR TITLE
fix: shipping rule must match the company

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -15,10 +15,11 @@ erpnext.sales_common = {
 			onload() {
 				super.onload();
 				this.setup_queries();
-				this.frm.set_query("shipping_rule", function () {
+				this.frm.set_query("shipping_rule", function (doc) {
 					return {
 						filters: {
 							shipping_rule_type: "Selling",
+							company: doc.company,
 						},
 					};
 				});


### PR DESCRIPTION
We used to allow selecting **Shipping Rules** that belong to a different **Company**, which lead to errors due to using foreign income accounts. Now the **Shipping Rule** must belong to the same company as the corresponding sales transaction.