### PR TITLE
Fix(POS): selling bundle not reduce the items associate with it    

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -721,31 +721,45 @@ import frappe
 
 @frappe.whitelist(allow_guest=True)
 def get_total_qty_for_item_bundles(item_code):
+    debug_info = {}
+
     # Step 1: Fetch all bundles associated with the specified item
-    associated_bundles = frappe.get_all("Product Bundle Item", filters={"item_code": item_code}, fields=["parent", "qty"])
-    bundle_qty_map = {bundle["parent"]: bundle["qty"] for bundle in associated_bundles}
+    associated_bundles = frappe.get_all("Product Bundle Item", filters={"item_code": item_code}, fields=["parent"])
+    associated_bundle_names = [bundle["parent"] for bundle in associated_bundles]
+    debug_info['associated_bundles'] = associated_bundles
+    debug_info['associated_bundle_names'] = associated_bundle_names
+    print(f"Associated bundles: {associated_bundles}")
+    print(f"Associated bundle names: {associated_bundle_names}")
 
-    # If no associated bundles are found, return 0
-    if not bundle_qty_map:
-        return 0
-
-    # Step 2: Fetch and filter records from POS Invoice Item directly in the query
+    # Step 2: Fetch all records from POS Invoice Item
     p_item = frappe.qb.DocType("POS Invoice Item")
+    p_inv = frappe.qb.DocType("POS Invoice")
+
     all_items = (
         frappe.qb.from_(p_item)
-        .select(p_item.star)
-        .where(p_item.item_code.isin(list(bundle_qty_map.keys())))
+        .join(p_inv).on(p_item.parent == p_inv.name)
+        .select(p_item.star, p_inv.consolidated_invoice)
+        .where(
+            (IfNull(p_inv.consolidated_invoice, "") == "") &
+            (p_item.docstatus == 1) &
+            (p_inv.docstatus == 1) &
+            (p_item.item_code.isin(associated_bundle_names)) 
+        )
     ).run(as_dict=True)
+    debug_info['all_items'] = all_items
+    print(f"All items: {all_items}")
 
     # Step 3: Calculate the total quantity for the associated bundles
     total_qty = 0
     for item in all_items:
-        bundle_name = item.get('item_code')
-        bundle_qty = item.get('qty', 0)
-        item_qty_in_bundle = bundle_qty_map.get(bundle_name, 0)
-        total_qty += bundle_qty * item_qty_in_bundle
+        if item.get('item_code') in associated_bundle_names:
+            total_qty += item.get('qty', 0)
+            print(f"Processing item: {item}, total_qty: {total_qty}")
 
-    return total_qty
+    debug_info['total_qty'] = total_qty
+    print(f"Total quantity: {total_qty}")
+
+    return debug_info
 
 @frappe.whitelist(allow_guest=True)
 def get_stock_availability(item_code, warehouse):


### PR DESCRIPTION
Bundles have no effect on items in the POS system, so the number of bundles sold will not make a difference in the individual items themselves tell close the shift so you need to make a return

**bundle item is bundle product consists of one unit each of item1 and item2**

![366335621-df0acb80-6db9-4bb4-b8ce-0f62c1e795ae](https://github.com/user-attachments/assets/0b5f674a-fb2a-4434-beb7-a93986d9599d)

version-15-hotfix
version-14-hotfix
fix #43167 