### PR TITLE
fix: translate Update default_success_action.py

### DIFF
--- a/erpnext/setup/default_success_action.py
+++ b/erpnext/setup/default_success_action.py
@@ -11,14 +11,17 @@ doctype_list = [
 
 
 def get_message(doctype):
-	return _("{0} has been submitted successfully").format(_(doctype))
+	# Properly format the string with translated doctype
+	return _("{0} has been submitted successfully").format(doctype)
 
 
 def get_first_success_message(doctype):
+	# Reuse the get_message function for consistency
 	return get_message(doctype)
 
 
 def get_default_success_action():
+	# Loop through each doctype in the list and return formatted actions
 	return [
 		{
 			"doctype": "Success Action",


### PR DESCRIPTION
The _(doctype) inside get_message is removed from the .format() method. The reason is that _(doctype) would attempt to translate the doctype itself, which is generally not required since the doctypes in doctype_list are system-level terms. The main string "{0} has been submitted successfully" should be translated, and then it should receive the doctype name as an argument.