### PR TITLE
fix: Write Off not working when paid_amount is greater than grand_total

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -156,9 +156,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 	}
 
 	change_amount() {
-		if (this.frm.doc.paid_amount > this.frm.doc.grand_total) {
-			this.calculate_write_off_amount();
-		} else {
+		if (this.frm.doc.paid_amount <= this.frm.doc.grand_total) {
 			this.frm.set_value("change_amount", 0.0);
 			this.frm.set_value("base_change_amount", 0.0);
 		}
@@ -180,7 +178,10 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 			this.frm.set_value(
 				"write_off_amount",
 				flt(
-					this.frm.doc.grand_total - this.frm.doc.paid_amount - this.frm.doc.total_advance,
+					this.frm.doc.grand_total -
+						this.frm.doc.paid_amount +
+						this.frm.doc.change_amount -
+						this.frm.doc.total_advance,
 					precision("write_off_amount")
 				)
 			);

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -174,6 +174,7 @@ class POSInvoiceMergeLog(Document):
 
 		rounding_adjustment, base_rounding_adjustment = 0, 0
 		rounded_total, base_rounded_total = 0, 0
+		base_write_off_amount, write_off_amount = 0, 0
 
 		loyalty_amount_sum, loyalty_points_sum, idx = 0, 0, 1
 
@@ -247,8 +248,10 @@ class POSInvoiceMergeLog(Document):
 
 			rounding_adjustment += doc.rounding_adjustment
 			rounded_total += doc.rounded_total
+			write_off_amount += doc.write_off_amount
 			base_rounding_adjustment += doc.base_rounding_adjustment
 			base_rounded_total += doc.base_rounded_total
+			base_write_off_amount += doc.base_write_off_amount
 
 		if loyalty_points_sum:
 			invoice.redeem_loyalty_points = 1
@@ -262,6 +265,8 @@ class POSInvoiceMergeLog(Document):
 		invoice.set("base_rounding_adjustment", base_rounding_adjustment)
 		invoice.set("rounded_total", rounded_total)
 		invoice.set("base_rounded_total", base_rounded_total)
+		invoice.set("write_off_amount", write_off_amount)
+		invoice.set("base_write_off_amount", base_write_off_amount)
 		invoice.additional_discount_percentage = 0
 		invoice.discount_amount = 0.0
 		invoice.taxes_and_charges = None

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -403,7 +403,10 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 			this.frm.set_value(
 				"write_off_amount",
 				flt(
-					this.frm.doc.grand_total - this.frm.doc.paid_amount - this.frm.doc.total_advance,
+					this.frm.doc.grand_total -
+						this.frm.doc.paid_amount +
+						this.frm.doc.change_amount -
+						this.frm.doc.total_advance,
 					precision("write_off_amount")
 				)
 			);
@@ -411,11 +414,6 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 		this.calculate_outstanding_amount(false);
 		this.frm.refresh_fields();
-	}
-
-	write_off_amount() {
-		this.set_in_company_currency(this.frm.doc, ["write_off_amount"]);
-		this.write_off_outstanding_amount_automatically();
 	}
 
 	items_add(doc, cdt, cdn) {
@@ -512,9 +510,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	}
 
 	change_amount() {
-		if (this.frm.doc.paid_amount > this.frm.doc.grand_total) {
-			this.calculate_write_off_amount();
-		} else {
+		if (this.frm.doc.paid_amount <= this.frm.doc.grand_total) {
 			this.frm.set_value("change_amount", 0.0);
 			this.frm.set_value("base_change_amount", 0.0);
 		}

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -853,7 +853,11 @@ class calculate_taxes_and_totals:
 				write_off_limit = flt(
 					frappe.db.get_value("POS Profile", self.doc.pos_profile, "write_off_limit")
 				)
-				if write_off_limit and abs(self.doc.outstanding_amount) <= write_off_limit:
+				if (
+					self.doc.outstanding_amount
+					and write_off_limit
+					and abs(self.doc.outstanding_amount) <= write_off_limit
+				):
 					self.doc.write_off_outstanding_amount_automatically = 1
 
 			if (
@@ -897,11 +901,13 @@ class calculate_taxes_and_totals:
 			and any(d.type == "Cash" for d in self.doc.payments)
 		):
 			self.doc.change_amount = flt(
-				self.doc.paid_amount - grand_total, self.doc.precision("change_amount")
+				self.doc.paid_amount - grand_total + self.doc.write_off_amount,
+				self.doc.precision("change_amount"),
 			)
 
 			self.doc.base_change_amount = flt(
-				self.doc.base_paid_amount - base_grand_total, self.doc.precision("base_change_amount")
+				self.doc.base_paid_amount - base_grand_total + self.doc.base_write_off_amount,
+				self.doc.precision("base_change_amount"),
 			)
 
 	def calculate_write_off_amount(self):

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -919,27 +919,38 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				var grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 				var base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
-				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total,
-					precision("change_amount"));
+				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total +
+					this.frm.doc.write_off_amount, precision("change_amount"));
 
 				this.frm.doc.base_change_amount = flt(this.frm.doc.base_paid_amount -
-					base_grand_total, precision("base_change_amount"));
+					base_grand_total + this.frm.doc.base_write_off_amount,
+					precision("base_change_amount"));
 			}
 		}
 	}
 
 	calculate_write_off_amount() {
-		if(this.frm.doc.write_off_outstanding_amount_automatically) {
-			this.frm.doc.write_off_amount = flt(this.frm.doc.outstanding_amount, precision("write_off_amount"));
-			this.frm.doc.base_write_off_amount = flt(this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
-				precision("base_write_off_amount"));
-
-			this.calculate_outstanding_amount(false);
+		if (this.frm.doc.paid_amount > this.frm.doc.grand_total){
+			this.frm.doc.write_off_amount = flt(this.frm.doc.grand_total - this.frm.doc.paid_amount
+				+ this.frm.doc.change_amount, precision("write_off_amount"));
 		}
+		else if(this.frm.doc.write_off_outstanding_amount_automatically) {
+			this.frm.doc.write_off_amount = flt(this.frm.doc.outstanding_amount, precision("write_off_amount"));
+		}
+		this.frm.doc.base_write_off_amount = flt(this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
+			precision("base_write_off_amount"));
+
+		this.calculate_outstanding_amount(false);
 
 	}
 
 	filtered_items() {
 		return this.frm.doc.items.filter(item => !item["is_alternative"]);
+	}
+
+
+	write_off_amount() {
+		this.set_in_company_currency(this.frm.doc, ["write_off_amount"]);
+		this.write_off_outstanding_amount_automatically();
 	}
 };


### PR DESCRIPTION
Write-Off amount is currently not working when the paid amount is greater than the grand_total.

To simulate, lets suppose that we're selling an item that costs $ 8.50, then we only give back $ 1.00 to the customer, and the customer says that we don't need to give back the $ 0.50 amount.

Item value: $ 8.50
Change amount: $ 1.00
Write-off: $ -0.50

This is how the system behaves before apply changes:

![Before](https://github.com/user-attachments/assets/0b131d70-f06e-4089-80e3-972b418b3b55)

This commit apply all changes necessary for make it works properly. This is how the system behaves after applying changes:

![After](https://github.com/user-attachments/assets/430a4337-8ff6-47ea-b05a-5f00a3124ef6)

I also changed POS Invoice Merge Log, cause after we make the POS Closing Entry, the write-off amounts are not summed in the consolidated Sales Invoice. 