### PR TITLE
fix: change dynamic link doctype fieldtype to data

### DIFF
--- a/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
+++ b/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
@@ -199,8 +199,7 @@ class General_Payment_Ledger_Comparison:
 			dict(
 				label=_("Voucher Type"),
 				fieldname="voucher_type",
-				fieldtype="Link",
-				options="DocType",
+				fieldtype="Data",
 				width="100",
 			)
 		)
@@ -219,8 +218,7 @@ class General_Payment_Ledger_Comparison:
 			dict(
 				label=_("Party Type"),
 				fieldname="party_type",
-				fieldtype="Link",
-				options="DocType",
+				fieldtype="Data",
 				width="100",
 			)
 		)


### PR DESCRIPTION
Issue:
Columns `voucher_type` and `party_type` are linked with DocType, since users won't have permission for DocType it throws an insufficient permission error
ref: [22230](https://support.frappe.io/helpdesk/tickets/22230)

Before:
![Screenshot from 2024-09-20 10-57-34](https://github.com/user-attachments/assets/a8fc8db1-4af7-4380-a7b2-951368c02205)

After:
![Screenshot from 2024-09-20 10-57-53](https://github.com/user-attachments/assets/6c7956e9-54c5-4bcf-bb0d-6154fef56e90)

Backport needed: v14 & v15

