### PR TITLE
fix: show chart tool tip in report currency

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -95,7 +95,7 @@ def execute(filters=None):
 		filters.periodicity, period_list, filters.accumulated_values, company=filters.company
 	)
 
-	chart = get_chart_data(filters, columns, asset, liability, equity)
+	chart = get_chart_data(filters, columns, asset, liability, equity, currency)
 
 	report_summary, primitive_summary = get_report_summary(
 		period_list, asset, liability, equity, provisional_profit_loss, currency, filters
@@ -221,7 +221,7 @@ def get_report_summary(
 	], (net_asset - net_liability + net_equity)
 
 
-def get_chart_data(filters, columns, asset, liability, equity):
+def get_chart_data(filters, columns, asset, liability, equity, currency):
 	labels = [d.get("label") for d in columns[2:]]
 
 	asset_data, liability_data, equity_data = [], [], []
@@ -248,5 +248,9 @@ def get_chart_data(filters, columns, asset, liability, equity):
 		chart["type"] = "bar"
 	else:
 		chart["type"] = "line"
+
+	chart["fieldtype"] = "Currency"
+	chart["options"] = "currency"
+	chart["currency"] = currency
 
 	return chart

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -120,7 +120,7 @@ def execute(filters=None):
 	)
 	columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company, True)
 
-	chart = get_chart_data(columns, data)
+	chart = get_chart_data(columns, data, company_currency)
 
 	report_summary = get_report_summary(summary_data, company_currency)
 
@@ -261,7 +261,7 @@ def get_report_summary(summary_data, currency):
 	return report_summary
 
 
-def get_chart_data(columns, data):
+def get_chart_data(columns, data, currency):
 	labels = [d.get("label") for d in columns[2:]]
 	print(data)
 	datasets = [
@@ -277,5 +277,7 @@ def get_chart_data(columns, data):
 	chart = {"data": {"labels": labels, "datasets": datasets}, "type": "bar"}
 
 	chart["fieldtype"] = "Currency"
+	chart["options"] = "currency"
+	chart["currency"] = currency
 
 	return chart

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -115,7 +115,7 @@ def get_balance_sheet_data(fiscal_year, companies, columns, filters):
 		True,
 	)
 
-	chart = get_chart_data(filters, columns, asset, liability, equity)
+	chart = get_chart_data(filters, columns, asset, liability, equity, company_currency)
 
 	return data, message, chart, report_summary
 
@@ -173,7 +173,7 @@ def get_profit_loss_data(fiscal_year, companies, columns, filters):
 	if net_profit_loss:
 		data.append(net_profit_loss)
 
-	chart = get_pl_chart_data(filters, columns, income, expense, net_profit_loss)
+	chart = get_pl_chart_data(filters, columns, income, expense, net_profit_loss, company_currency)
 
 	report_summary, primitive_summary = get_pl_summary(
 		companies, "", income, expense, net_profit_loss, company_currency, filters, True

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -59,11 +59,11 @@ def execute(filters=None):
 
 	columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 
-	chart = get_chart_data(filters, columns, income, expense, net_profit_loss)
-
 	currency = filters.presentation_currency or frappe.get_cached_value(
 		"Company", filters.company, "default_currency"
 	)
+	chart = get_chart_data(filters, columns, income, expense, net_profit_loss, currency)
+
 	report_summary, primitive_summary = get_report_summary(
 		period_list, filters.periodicity, income, expense, net_profit_loss, currency, filters
 	)
@@ -152,7 +152,7 @@ def get_net_profit_loss(income, expense, period_list, company, currency=None, co
 		return net_profit_loss
 
 
-def get_chart_data(filters, columns, income, expense, net_profit_loss):
+def get_chart_data(filters, columns, income, expense, net_profit_loss, currency):
 	labels = [d.get("label") for d in columns[2:]]
 
 	income_data, expense_data, net_profit = [], [], []
@@ -181,5 +181,7 @@ def get_chart_data(filters, columns, income, expense, net_profit_loss):
 		chart["type"] = "line"
 
 	chart["fieldtype"] = "Currency"
+	chart["options"] = "currency"
+	chart["currency"] = currency
 
 	return chart


### PR DESCRIPTION
Issue: When there are multiple companies with different currencies, the report chart tooltip shows the global default currency instead of the report currency
ref: [21723](https://support.frappe.io/helpdesk/tickets/21723)

Before: 
![tooltip-issue](https://github.com/user-attachments/assets/e65df244-2955-4d72-b339-fe6f66cf14ef)

After:
![tooltip-fix](https://github.com/user-attachments/assets/1ffb11e2-a58a-4b57-91c8-b1d432f9a77a)

Backport needed: v14 & v15