### PR TITLE
fix: update clearance date in invoice payment table

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -108,8 +108,17 @@ class BankClearance(Document):
 				if not d.clearance_date:
 					d.clearance_date = None
 
-				payment_entry = frappe.get_doc(d.payment_document, d.payment_entry)
-				payment_entry.db_set("clearance_date", d.clearance_date)
+				if d.payment_document == "Sales Invoice":
+					frappe.db.set_value(
+						"Sales Invoice Payment",
+						{"parent": d.payment_entry, "account": self.get("account"), "amount": [">", 0]},
+						"clearance_date",
+						d.clearance_date,
+					)
+
+				else:
+					payment_entry = frappe.get_doc(d.payment_document, d.payment_entry)
+					payment_entry.db_set("clearance_date", d.clearance_date)
 
 				clearance_date_updated = True
 

--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -117,8 +117,9 @@ class BankClearance(Document):
 					)
 
 				else:
-					payment_entry = frappe.get_doc(d.payment_document, d.payment_entry)
-					payment_entry.db_set("clearance_date", d.clearance_date)
+					frappe.db.set_value(
+						d.payment_document, d.payment_entry, "clearance_date", d.clearance_date
+					)
 
 				clearance_date_updated = True
 

--- a/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
@@ -6,16 +6,29 @@ import unittest
 import frappe
 from frappe.utils import add_months, getdate
 
+from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.tests.utils import if_lending_app_installed, if_lending_app_not_installed
 
 
 class TestBankClearance(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
+		create_warehouse(
+			warehouse_name="_Test Warehouse",
+			properties={"parent_warehouse": "All Warehouses - _TC"},
+			company="_Test Company",
+		)
+		create_item("_Test Item")
+		create_cost_center(cost_center_name="_Test Cost Center", company="_Test Company")
+
 		clear_payment_entries()
 		clear_loan_transactions()
+		clear_pos_sales_invoices()
 		make_bank_account()
 		add_transactions()
 
@@ -83,9 +96,39 @@ class TestBankClearance(unittest.TestCase):
 		bank_clearance.get_payment_entries()
 		self.assertEqual(len(bank_clearance.payment_entries), 3)
 
+	def test_update_clearance_date_on_si(self):
+		sales_invoice = make_pos_sales_invoice()
+
+		date = getdate()
+		bank_clearance = frappe.get_doc("Bank Clearance")
+		bank_clearance.account = "_Test Bank Clearance - _TC"
+		bank_clearance.from_date = add_months(date, -1)
+		bank_clearance.to_date = date
+		bank_clearance.include_pos_transactions = 1
+		bank_clearance.get_payment_entries()
+
+		self.assertNotEqual(len(bank_clearance.payment_entries), 0)
+		for payment in bank_clearance.payment_entries:
+			if payment.payment_entry == sales_invoice.name:
+				payment.clearance_date = date
+
+		bank_clearance.update_clearance_date()
+
+		si_clearance_date = frappe.db.get_value(
+			"Sales Invoice Payment",
+			{"parent": sales_invoice.name, "account": bank_clearance.account},
+			"clearance_date",
+		)
+
+		self.assertEqual(si_clearance_date, date)
+
 
 def clear_payment_entries():
 	frappe.db.delete("Payment Entry")
+
+
+def clear_pos_sales_invoices():
+	frappe.db.delete("Sales Invoice", {"is_pos": 1})
 
 
 @if_lending_app_installed
@@ -115,9 +158,45 @@ def add_transactions():
 
 
 def make_payment_entry():
-	pi = make_purchase_invoice(supplier="_Test Supplier", qty=1, rate=690)
+	from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+
+	supplier = create_supplier(supplier_name="_Test Supplier")
+	pi = make_purchase_invoice(
+		supplier=supplier,
+		supplier_warehouse="_Test Warehouse - _TC",
+		expense_account="Cost of Goods Sold - _TC",
+		uom="Nos",
+		qty=1,
+		rate=690,
+	)
 	pe = get_payment_entry("Purchase Invoice", pi.name, bank_account="_Test Bank Clearance - _TC")
 	pe.reference_no = "Conrad Oct 18"
 	pe.reference_date = "2018-10-24"
 	pe.insert()
 	pe.submit()
+
+
+def make_pos_sales_invoice():
+	from erpnext.accounts.doctype.opening_invoice_creation_tool.test_opening_invoice_creation_tool import (
+		make_customer,
+	)
+
+	mode_of_payment = frappe.get_doc({"doctype": "Mode of Payment", "name": "Cash"})
+
+	if not frappe.db.get_value("Mode of Payment Account", {"company": "_Test Company", "parent": "Cash"}):
+		mode_of_payment.append(
+			"accounts", {"company": "_Test Company", "default_account": "_Test Bank Clearance - _TC"}
+		)
+		mode_of_payment.save()
+
+	customer = make_customer(customer="_Test Customer")
+
+	si = create_sales_invoice(customer=customer, item="_Test Item", is_pos=1, qty=1, rate=1000, do_not_save=1)
+	si.set("payments", [])
+	si.append(
+		"payments", {"mode_of_payment": "Cash", "account": "_Test Bank Clearance - _TC", "amount": 1000}
+	)
+	si.insert()
+	si.submit()
+
+	return si


### PR DESCRIPTION
Issue:
Unable to update clearance date for POS-invoices from bank clearance.
ref: [22212](https://support.frappe.io/helpdesk/tickets/22212)

Before:
[bank clearance issue.webm](https://github.com/user-attachments/assets/5a57f4d6-f931-4641-ab51-075fc2dffb84)

After:
[bank clearance issue fix.webm](https://github.com/user-attachments/assets/1ef48a38-864e-44dc-aee0-cebefe55734a)

Backport needed: v15
