### PR TITLE
fix: incorrect outstanding on non-pos invoice with write_off_account

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -338,6 +338,7 @@ class SalesInvoice(SellingController):
 		if self.redeem_loyalty_points and self.loyalty_points and not self.is_consolidated:
 			validate_loyalty_points(self, self.loyalty_points)
 
+		self.allow_write_off_only_on_pos()
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
 
 	def validate_accounts(self):
@@ -1030,6 +1031,10 @@ class SalesInvoice(SellingController):
 					comma_and(notes)
 				),
 			)
+
+	def allow_write_off_only_on_pos(self):
+		if not self.is_pos and self.write_off_account:
+			self.write_off_account = None
 
 	def validate_write_off_account(self):
 		if flt(self.write_off_amount) and not self.write_off_account:


### PR DESCRIPTION
# Issue
`write_off_account` is auto set based on the POS Profile when user marks the Invoice as POS - 'Is Pos' checbox.

When `write_off_account` is set, invoice's Outstanding Amount is not updated. But, if you set and unset 'Is Pos' checkbox, `write_off_account` is still set, due to which the Outstanding Amount field is not updated even though it is a normal invoice.

This is more pronounced in Sales Return (Credit Note), as the outstanding amount is not even updated in draft status due to which it always shows '0', even if 'Update Outstanding for Self' is enabled.

# Fix
If Invoice is not POS, write_off_account will be cleared.

Internal Ref: [20369](https://support.frappe.io/helpdesk/tickets/20369)