### PR TITLE
fix: bump pycountry version in ERPNext to be compatible with the frappe one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # Core dependencies
-    "pycountry~=22.3.5",
     "Unidecode~=1.3.6",
     "barcodenumber~=0.5.0",
     "rapidfuzz~=2.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # Core dependencies
+    "pycountry~=24.6.1",
     "Unidecode~=1.3.6",
     "barcodenumber~=0.5.0",
     "rapidfuzz~=2.15.0",


### PR DESCRIPTION
Actual result of 
**bench setup requirements** failed on develop branch (frappe and ERPNext)

```
/workspace/development/frappe-bench$ bench setup requirements
$ /workspace/development/frappe-bench/env/bin/python -m pip install --quiet --upgrade pip
Installing 4 applications...
Installing frappe
$ /workspace/development/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /workspace/development/frappe-bench/apps/frappe 

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
erpnext 16.0.0.dev0 requires pycountry~=22.3.5, but you have pycountry 24.6.1 which is incompatible.

```

Since [https://github.com/frappe/frappe/commit/81b8b84b](https://github.com/frappe/frappe/commit/81b8b84b) commit (ping @barredterra) the version is 24.6.1 in frappe

May be a another fix can be to remove this dependencies in ERPNext as it is already provided by Frappe ?