### PR TITLE
fix: allow tax rule filter on tax category name with %

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -185,7 +185,7 @@ def get_tax_template(posting_date, args):
 		conditions.append("(from_date is null) and (to_date is null)")
 
 	conditions.append(
-		"ifnull(tax_category, '') = {}".format(frappe.db.escape(cstr(args.get("tax_category"))))
+		"ifnull(tax_category, '') = {}".format(frappe.db.escape(cstr(args.get("tax_category")), False))
 	)
 	if "tax_category" in args.keys():
 		del args["tax_category"]


### PR DESCRIPTION
Issue: 
When the tax category name has %, frappe.db.escape make it as %%. so the tax category name is not getting matched and sales taxes and charges template is not fetched from the tax rule
internal ref: [22418](https://support.frappe.io/helpdesk/tickets/22418)

Before:
[Tax Rule-Issue](https://github.com/user-attachments/assets/fa11c3b9-0e6e-451b-8a59-a9dbc360b950)

After:
[Tax Rule-Fix](https://github.com/user-attachments/assets/3f50f15c-b433-446d-a552-0e81ea6e9ee6)


Backport needed: v15