### PR TITLE
fix: transaction exchange rate on GL's for Multi currency Journals

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1039,7 +1039,9 @@ class AccountsController(TransactionBase):
 		gl_dict.update(
 			{
 				"transaction_currency": self.get("currency") or self.company_currency,
-				"transaction_exchange_rate": self.get("conversion_rate", 1),
+				"transaction_exchange_rate": item.get("exchange_rate", 1)
+				if self.doctype == "Journal Entry" and item
+				else self.get("conversion_rate", 1),
 				"debit_in_transaction_currency": self.get_value_in_transaction_currency(
 					account_currency, gl_dict, "debit"
 				),


### PR DESCRIPTION
On Multi-Currency Journals, GL entries for all rows have the same exchange rate from the first row of the Journal. This is incorrect.