### PR TITLE
fix: closing amount reset to expected amount on save

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -194,7 +194,9 @@ function refresh_payments(d, frm) {
 		}
 		if (payment) {
 			payment.expected_amount += flt(p.amount);
-			payment.closing_amount = payment.expected_amount;
+			if (payment.closing_amount === 0) {
+				payment.closing_amount = payment.expected_amount;
+			}
 			payment.difference = payment.closing_amount - payment.expected_amount;
 		} else {
 			frm.add_child("payment_reconciliation", {


### PR DESCRIPTION
In ERPNext version 15, when entering and saving the POS closing amount in the POS Closing Entry Doctype, the closing amount is resetting to the expected amount. This results in the change amount not being saved correctly.

This fix ensures that the manually entered closing amount is saved properly without being overridden by the expected amount.

**Before:-** 
![POS Closing](https://github.com/user-attachments/assets/2e520ba1-3d5e-475a-9929-8478e94fe365)

**After:-**
![POS Closing fix](https://github.com/user-attachments/assets/1e0cda83-b527-4df1-b752-474afba6da9d)
