### PR TITLE
fix: add parenttype condition for item table in Purchase Register Report

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -311,6 +311,7 @@ def get_account_columns(invoice_list, include_payments):
 			"""select distinct expense_account
 			from `tabPurchase Invoice Item` where docstatus = 1
 			and (expense_account is not null and expense_account != '')
+			and parenttype='Purchase Invoice'
 			and parent in (%s) order by expense_account"""
 			% ", ".join(["%s"] * len(invoice_list)),
 			tuple([inv.name for inv in invoice_list]),
@@ -451,7 +452,7 @@ def get_invoice_expense_map(invoice_list):
 		"""
 		select parent, expense_account, sum(base_net_amount) as amount
 		from `tabPurchase Invoice Item`
-		where parent in (%s)
+		where parent in (%s) and parenttype='Purchase Invoice'
 		group by parent, expense_account
 	"""
 		% ", ".join(["%s"] * len(invoice_list)),
@@ -522,7 +523,7 @@ def get_invoice_po_pr_map(invoice_list):
 		"""
 		select parent, purchase_order, purchase_receipt, po_detail, project
 		from `tabPurchase Invoice Item`
-		where parent in (%s)
+		where parent in (%s) and parenttype='Purchase Invoice'
 	"""
 		% ", ".join(["%s"] * len(invoice_list)),
 		tuple(inv.name for inv in invoice_list),

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -326,6 +326,7 @@ def apply_common_conditions(filters, query, doctype, child_doctype=None, payment
 
 	if join_required:
 		query = query.inner_join(child_doc).on(parent_doc.name == child_doc.parent)
+		query = query.where(child_doc.parenttype == doctype)
 		query = query.distinct()
 
 	if parent_doc.get_table_name() != "tabJournal Entry":


### PR DESCRIPTION
If a child table is used in some other table it can cause an issue with the data.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/21111
Purchase Invoice Item table was used in custom doctype which caused the issues for them.
