### PR TITLE
fix: include parent item group in query

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -865,6 +865,7 @@ def get_item_group(pos_profile):
 	if pos_profile.get("item_groups"):
 		# Get items based on the item groups defined in the POS profile
 		for row in pos_profile.get("item_groups"):
+			item_groups.append(row.item_group)
 			item_groups.extend(get_descendants_of("Item Group", row.item_group))
 
 	return list(set(item_groups))


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/43257
include parent item group in query