### PR TITLE
fix: SO link on PO and add in missing dashboard references on both

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
@@ -14,18 +14,31 @@ def get_data():
 			"Material Request": ["items", "material_request"],
 			"Supplier Quotation": ["items", "supplier_quotation"],
 			"Project": ["items", "project"],
+			"Sales Order": ["items", "sales_order"],
+			"BOM": ["items", "bom"],
+			"Production Plan": ["items", "production_plan"],
+			"Blanket Order": ["items", "blanket_order"],
 		},
 		"transactions": [
-			{"label": _("Related"), "items": ["Purchase Receipt", "Purchase Invoice"]},
-			{"label": _("Payment"), "items": ["Payment Entry", "Journal Entry", "Payment Request"]},
+			{
+				"label": _("Related"),
+				"items": ["Purchase Receipt", "Purchase Invoice", "Sales Order"]
+			},
+			{
+				"label": _("Payment"),
+				"items": ["Payment Entry", "Journal Entry", "Payment Request"]
+			},
 			{
 				"label": _("Reference"),
-				"items": ["Material Request", "Supplier Quotation", "Project", "Auto Repeat"],
+				"items": ["Supplier Quotation", "Project", "Auto Repeat"],
+			},
+			{
+				"label": _("Manufacturing"),
+				"items": ["Material Request", "BOM", "Production Plan", "Blanket Order"],
 			},
 			{
 				"label": _("Sub-contracting"),
 				"items": ["Subcontracting Order", "Subcontracting Receipt", "Stock Entry"],
 			},
-			{"label": _("Internal"), "items": ["Sales Order"]},
 		],
 	}

--- a/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
@@ -20,14 +20,8 @@ def get_data():
 			"Blanket Order": ["items", "blanket_order"],
 		},
 		"transactions": [
-			{
-				"label": _("Related"),
-				"items": ["Purchase Receipt", "Purchase Invoice", "Sales Order"]
-			},
-			{
-				"label": _("Payment"),
-				"items": ["Payment Entry", "Journal Entry", "Payment Request"]
-			},
+			{"label": _("Related"), "items": ["Purchase Receipt", "Purchase Invoice", "Sales Order"]},
+			{"label": _("Payment"), "items": ["Payment Entry", "Journal Entry", "Payment Request"]},
 			{
 				"label": _("Reference"),
 				"items": ["Supplier Quotation", "Project", "Auto Repeat"],

--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -15,6 +15,8 @@ def get_data():
 		},
 		"internal_links": {
 			"Quotation": ["items", "prevdoc_docname"],
+			"BOM": ["items", "bom_no"],
+			"Blanket Order": ["items", "blanket_order"],
 		},
 		"transactions": [
 			{
@@ -23,7 +25,7 @@ def get_data():
 			},
 			{"label": _("Purchasing"), "items": ["Material Request", "Purchase Order"]},
 			{"label": _("Projects"), "items": ["Project"]},
-			{"label": _("Manufacturing"), "items": ["Work Order"]},
+			{"label": _("Manufacturing"), "items": ["Work Order", "BOM", "Blanket Order"]},
 			{"label": _("Reference"), "items": ["Quotation", "Auto Repeat", "Stock Reservation Entry"]},
 			{"label": _("Payment"), "items": ["Payment Entry", "Payment Request", "Journal Entry"]},
 		],


### PR DESCRIPTION
The main fix is to the Purchase Order dashboard link back to the Sales Order which was incorrectly specified in the _dashboard.py file

Also adds in some missing links, mainly for Manufacturing for both documents.

no-docs
version-14-hotfix
version-15-hotfix
