### PR TITLE
fix: create Account Closing Balance even though there are no transaction in period

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -392,8 +392,7 @@ def process_closing_entries(gl_entries, closing_entries, voucher_name, company, 
 	)
 
 	try:
-		if gl_entries + closing_entries:
-			make_closing_entries(gl_entries + closing_entries, voucher_name, company, closing_date)
+		make_closing_entries(gl_entries + closing_entries, voucher_name, company, closing_date)
 	except Exception as e:
 		frappe.db.rollback()
 		frappe.log_error(e)


### PR DESCRIPTION
Issue-: If there are no transactions in a period, Account Closing Balances are not created. This gives incorrect opening balance for the following period.

Fix: Allow creating closing entries even if there are no GL entries or period closing voucher entries.

![image](https://github.com/user-attachments/assets/3b7aaa9e-2026-4137-97a1-a528d42c4862)


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/22654
