### PR TITLE
feat: link purchase invoice item with open purchase order

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -129,7 +129,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			);
 		}
 
-		if (doc.docstatus === 0) {
+		if (doc.docstatus === 0 && !this.frm.is_new()) {
 			const cur_doc = this.frm.doc;
 			const invoice_items = cur_doc.items;
 


### PR DESCRIPTION
**This PR adds functionality to automatically link open Purchase Orders to a Purchase Invoice on FIFO bases, similar to the existing link between a Material Request and a Purchase Order.**

![image](https://github.com/user-attachments/assets/29af0d67-5620-4e12-abef-7b5ba7b9798f)

**Purchase Order linked with Purchase Invoice Item**
![image](https://github.com/user-attachments/assets/f8d2a939-099e-44de-836d-22b1bc416631)
