### PR TITLE
fix: do not include advances for tds vouchers

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -414,6 +414,9 @@ def get_advance_vouchers(parties, company=None, from_date=None, to_date=None, pa
 	Use Payment Ledger to fetch unallocated Advance Payments
 	"""
 
+	if party_type == "Supplier":
+		return []
+
 	ple = qb.DocType("Payment Ledger Entry")
 
 	conditions = []


### PR DESCRIPTION
Issue: TDS is getting deducted even though the threshold has not been breached.

Steps To Replicate:
- Create a Journal Entry for the supplier by debiting the supplier account and crediting tds account.
- Now create a purchase invoice with `apply_tds` enabled and tds_category.
- TDS will get deducted even though the threshold has not been breached.

Solution:
Only include vouchers with the same `tax_withholding_category` for checking if tds is deducted earlier.

Notes :
- Since we are already checking for payment entry separately advances will be checked automatically.
- Advances are still required for TCS(sales workflow) because `tax_withholding_category` field is not present in sales invoice.


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/17255