### PR TITLE
FIX: Production Plan -> Stock Qty from SO Item instead of Qty

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -312,7 +312,7 @@ class ProductionPlan(Document):
 				so_item.parent,
 				so_item.item_code,
 				so_item.warehouse,
-				so_item.qty,
+				so_item.stock_qty,
 				so_item.work_order_qty,
 				so_item.delivered_qty,
 				so_item.conversion_factor,


### PR DESCRIPTION
When building a production plan from a Sales Order, by default ERPNext take into account the `so_item.qty` field, this covers 90% of the good scenarios, but, if an Item have an different selling uom, it will raise an issue on manufacturing.

For instance, let's consider an Ice Cream factory!

For Ice Cream, the Stock Unit is Mililitre

![Sorvete-Sabor-Creme-Sorvete-Sabor-Creme-09-26-2024_03_09_PM](https://github.com/user-attachments/assets/1e0b4063-10f6-4e31-8664-1dad59f72aec)

The Standard Selling Unit is 1 Litre Package

![Sorvete-Sabor-Creme-Sorvete-Sabor-Creme-09-26-2024_03_10_PM](https://github.com/user-attachments/assets/324c3b36-2ea6-45ac-b34f-fe81f192a2da)

So, let's consider a Sales of 2000 Litres

![image](https://github.com/user-attachments/assets/88b68bc0-ae2b-424c-843c-a7763f42968c)

On the Sales Order Item, ERPNext calculate properly the expected Stock Qty **2.000.000 Mililitres**

But, when fetching the Sales Order on the Production Plan we have

![image](https://github.com/user-attachments/assets/b2938c16-d665-43c6-899d-2e63a5948121)

So all the Raw Materials get wrong

![image](https://github.com/user-attachments/assets/5fb9f349-9a83-47c5-9331-0656dff5d7fc)

But with a manual fix

![image](https://github.com/user-attachments/assets/94a46a17-5313-44fb-acce-5b31b5551bf7)

We get the right raw materials

![image](https://github.com/user-attachments/assets/9a394bbe-7519-4856-9835-d350e5dccb09)

Prooving that ERPNext is fetching the wrong value

