### PR TITLE
feat: new DocType "Duty Tax Fee Type"

### DIFF
--- a/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
@@ -10,6 +10,7 @@
   "charge_type",
   "row_id",
   "account_head",
+  "duty_tax_fee_type",
   "col_break_1",
   "description",
   "included_in_paid_amount",
@@ -174,12 +175,18 @@
    "label": "Account Currency",
    "options": "Currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "duty_tax_fee_type",
+   "fieldtype": "Link",
+   "label": "Duty Tax Fee Type",
+   "options": "Duty Tax Fee Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:05:58.437605",
+ "modified": "2024-09-26 19:36:05.874214",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Advance Taxes and Charges",

--- a/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.py
@@ -26,6 +26,7 @@ class AdvanceTaxesandCharges(Document):
 		cost_center: DF.Link | None
 		currency: DF.Link | None
 		description: DF.SmallText
+		duty_tax_fee_type: DF.Link | None
 		included_in_paid_amount: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
@@ -10,6 +10,7 @@
   "category",
   "add_deduct_tax",
   "charge_type",
+  "duty_tax_fee_type",
   "row_id",
   "included_in_print_rate",
   "included_in_paid_amount",
@@ -233,12 +234,18 @@
    "fieldtype": "Check",
    "label": "Is Tax Withholding Account",
    "read_only": 1
+  },
+  {
+   "fieldname": "duty_tax_fee_type",
+   "fieldtype": "Link",
+   "label": "Duty Tax Fee Type",
+   "options": "Duty Tax Fee Type"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-08 19:51:36.678551",
+ "modified": "2024-09-26 19:37:54.566689",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges",

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
@@ -31,6 +31,7 @@ class PurchaseTaxesandCharges(Document):
 		]
 		cost_center: DF.Link | None
 		description: DF.SmallText
+		duty_tax_fee_type: DF.Link | None
 		included_in_paid_amount: DF.Check
 		included_in_print_rate: DF.Check
 		is_tax_withholding_account: DF.Check

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -9,6 +9,7 @@
   "charge_type",
   "row_id",
   "account_head",
+  "duty_tax_fee_type",
   "col_break_1",
   "description",
   "included_in_print_rate",
@@ -212,13 +213,19 @@
    "label": "Account Currency",
    "options": "Currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "duty_tax_fee_type",
+   "fieldtype": "Link",
+   "label": "Duty Tax Fee Type",
+   "options": "Duty Tax Fee Type"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:38.190993",
+ "modified": "2024-09-26 19:08:59.465056",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges",

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.py
@@ -30,6 +30,7 @@ class SalesTaxesandCharges(Document):
 		cost_center: DF.Link | None
 		description: DF.SmallText
 		dont_recompute_tax: DF.Check
+		duty_tax_fee_type: DF.Link | None
 		included_in_paid_amount: DF.Check
 		included_in_print_rate: DF.Check
 		item_wise_tax_detail: DF.Code | None

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -383,3 +383,4 @@ erpnext.patches.v15_0.set_standard_stock_entry_type
 erpnext.patches.v15_0.set_difference_amount_in_asset_value_adjustment
 erpnext.patches.v15_0.link_purchase_item_to_asset_doc
 erpnext.patches.v15_0.migrate_to_utm_analytics
+erpnext.patches.v14_0.create_duty_tax_fee_types

--- a/erpnext/patches/v14_0/create_duty_tax_fee_types.py
+++ b/erpnext/patches/v14_0/create_duty_tax_fee_types.py
@@ -1,0 +1,5 @@
+from erpnext.setup.doctype.duty_tax_fee_type.duty_tax_fee_type import create_duty_tax_fee_types
+
+
+def execute():
+	create_duty_tax_fee_types()

--- a/erpnext/setup/doctype/duty_tax_fee_type/README.md
+++ b/erpnext/setup/doctype/duty_tax_fee_type/README.md
@@ -1,0 +1,6 @@
+This doctype represents the "5153  Duty or tax or fee type name code" as
+specified by UN/EDIFACT in https://service.unece.org/trade/untdid/d19b/tred/tred5153.htm
+
+It is used in Sales Taxes and Charges / Purchase Taxes and Charges to specify
+the type of tax or fee. This is useful when generating or importing electronic
+invoices.

--- a/erpnext/setup/doctype/duty_tax_fee_type/data.csv
+++ b/erpnext/setup/doctype/duty_tax_fee_type/data.csv
@@ -1,0 +1,55 @@
+code,title,description
+AAA,Petroleum tax,A tax levied on the volume of petroleum being transacted.
+AAB,Provisional countervailing duty cash,Countervailing duty paid in cash prior to a formal finding of subsidization by Customs.
+AAC,Provisional countervailing duty bond,Countervailing duty paid by posting a bond during an investigation period prior to a formal decision on subsidization by Customs.
+AAD,Tobacco tax,A tax levied on tobacco products.
+AAE,Energy fee,General fee or tax for the use of energy.
+AAF,Coffee tax,A tax levied specifically on coffee products.
+AAG,"Harmonised sales tax, Canadian","A harmonized sales tax consisting of a goods and service tax, a Canadian provincial sales tax and, as applicable, a Quebec sales tax which is recoverable."
+AAH,Quebec sales tax,A sales tax charged within the Canadian province of Quebec which is recoverable.
+AAI,Canadian provincial sales tax,A sales tax charged within Canadian provinces which is non-recoverable.
+AAJ,Tax on replacement part,"A tax levied on a replacement part, where the original part is returned."
+AAK,Mineral oil tax,Tax that is levied specifically on products containing mineral oil.
+AAL,Special tax,To indicate a special type of tax.
+AAM,Insurance tax,A tax levied specifically on insurances.
+ADD,Anti-dumping duty,Duty applied to goods ruled to have been dumped in an import market at a price lower than that in the exporter's domestic market.
+BOL,Stamp duty (Imposta di Bollo),"Tax required in Italy, which may be fixed or graduated in various circumstances (e.g. VAT exempt documents or bank receipts)."
+CAP,Agricultural levy,Levy imposed on agricultural products where there is a difference between the selling price between trading countries.
+CAR,Car tax,A tax that is levied on the value of the automobile.
+COC,Paper consortium tax (Italy),Italian Paper consortium tax.
+CST,Commodity specific tax,"Tax related to a specified commodity, e.g. illuminants, salts."
+CUD,Customs duty,"Duties laid down in the Customs tariff, to which goods are liable on entering or leaving the Customs territory (CCC)."
+CVD,Countervailing duty,A duty on imported goods applied for compensate for subsidies granted to those goods in the exporting country.
+ENV,Environmental tax,Tax assessed for funding or assuring environmental protection or clean-up.
+EXC,Excise duty,"Customs or fiscal authorities code to identify a specific or ad valorem levy on a specific commodity, applied either domestically or at time of importation."
+EXP,Agricultural export rebate,Monetary rebate given to the seller in certain circumstances when agricultural products are exported.
+FET,Federal excise tax,Tax levied by the federal government on the manufacture of specific items.
+FRE,Free,No tax levied.
+GCN,General construction tax,General tax for construction.
+GST,Goods and services tax,Tax levied on the final consumption of goods and services throughout the production and distribution chain.
+ILL,Illuminants tax,Tax of illuminants.
+IMP,Import tax,Tax assessed on imports.
+IND,Individual tax,A tax levied based on an individual's ability to pay.
+LAC,Business license fee,Government assessed charge for permit to do business.
+LCN,Local construction tax,Local tax for construction.
+LDP,Light dues payable,Fee levied on a vessel to pay for port navigation lights.
+LOC,Local sales tax,"Assessment charges on sale of goods or services by city, borough country or other taxing authorities below state or provincial level."
+LST,Lust tax,Tax imposed for clean-up of leaky underground storage tanks.
+MCA,Monetary compensatory amount,Levy on Common Agricultural Policy (European Union) goods used to compensate for fluctuating currencies between member states.
+MCD,Miscellaneous cash deposit,"Duty paid and held on deposit, by Customs, during an investigation period prior to a final decision being made on any aspect related to imported goods (except valuation) by Customs."
+OTH,Other taxes,"Unspecified, miscellaneous tax charges."
+PDB,Provisional duty bond,Anti-dumping duty paid by posting a bond during an investigation period prior to a formal decision on dumping by Customs.
+PDC,Provisional duty cash,Anti-dumping duty paid in cash prior to a formal finding of dumping by Customs.
+PRF,Preference duty,"Duties laid down in the Customs tariff, to which goods are liable on entering or leaving the Customs territory falling under a preferential regime such as Generalised System of Preferences (GSP)."
+SCN,Special construction tax,Special tax for construction.
+SSS,Shifted social securities,Social securities share of the invoice amount to be paid directly to the social securities collector.
+STT,State/provincial sales tax,"All applicable sale taxes by authorities at the state or provincial level, below national level."
+SUP,Suspended duty,Duty suspended or deferred from payment.
+SUR,Surtax,A tax or duty applied on and in addition to existing duties and taxes.
+SWT,Shifted wage tax,Wage tax share of the invoice amount to be paid directly to the tax collector(s office).
+TAC,Alcohol mark tax,A tax levied based on the type of alcohol being obtained.
+TOT,Total,The summary amount of all taxes.
+TOX,Turnover tax,Tax levied on the total sales/turnover of a corporation.
+TTA,Tonnage taxes,Tax levied based on the vessel's net tonnage.
+VAD,Valuation deposit,"Duty paid and held on deposit, by Customs, during an investigation period prior to a formal decision on valuation of the goods being made."
+VAT,Value added tax,A tax on domestic or imported goods applied to the value added at each stage in the production/distribution cycle.

--- a/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.js
+++ b/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Duty Tax Fee Type", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.json
+++ b/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "autoname": "prompt",
+ "creation": "2024-09-26 19:03:34.051250",
+ "description": "This doctype represents the \"5153  Duty or tax or fee type name code\" as specified by UN/EDIFACT in https://service.unece.org/trade/untdid/d19b/tred/tred5153.htm\n\nIt is used in Sales Taxes and Charges / Purchase Taxes and Charges to specify the type of tax or fee. This is useful when generating or importing electronic\ninvoices.",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  }
+ ],
+ "links": [],
+ "modified": "2024-09-26 19:34:06.068048",
+ "modified_by": "Administrator",
+ "module": "Setup",
+ "name": "Duty Tax Fee Type",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.json
+++ b/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.json
@@ -22,7 +22,7 @@
   }
  ],
  "links": [],
- "modified": "2024-09-26 19:34:06.068048",
+ "modified": "2024-09-26 20:05:34.716093",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Duty Tax Fee Type",
@@ -42,16 +42,8 @@
    "write": 1
   },
   {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
+   "role": "Desk User"
   }
  ],
  "sort_field": "creation",

--- a/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.py
+++ b/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.py
@@ -19,3 +19,17 @@ class DutyTaxFeeType(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def create_duty_tax_fee_types():
+	from csv import DictReader
+	from pathlib import Path
+
+	path = Path(__file__).parent / "data.csv"
+	with path.open() as file:
+		for row in DictReader(file):
+			doc = frappe.new_doc("Duty Tax Fee Type")
+			doc.name = row["code"]
+			doc.title = row["title"]
+			doc.description = row["description"]
+			doc.insert(ignore_if_duplicate=True)

--- a/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.py
+++ b/erpnext/setup/doctype/duty_tax_fee_type/duty_tax_fee_type.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class DutyTaxFeeType(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		description: DF.SmallText | None
+		title: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/erpnext/setup/doctype/duty_tax_fee_type/test_duty_tax_fee_type.py
+++ b/erpnext/setup/doctype/duty_tax_fee_type/test_duty_tax_fee_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDutyTaxFeeType(FrappeTestCase):
+	pass

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -9,6 +9,7 @@ from frappe.desk.page.setup_wizard.setup_wizard import add_all_roles_to
 from frappe.utils import cint
 
 from erpnext.setup.default_energy_point_rules import get_default_energy_point_rules
+from erpnext.setup.doctype.duty_tax_fee_type.duty_tax_fee_type import create_duty_tax_fee_types
 from erpnext.setup.doctype.incoterm.incoterm import create_incoterms
 
 from .default_success_action import get_default_success_action
@@ -28,6 +29,7 @@ def after_install():
 	create_default_success_action()
 	create_default_energy_point_rules()
 	create_incoterms()
+	create_duty_tax_fee_types()
 	create_default_role_profiles()
 	add_company_to_session_defaults()
 	add_standard_navbar_items()


### PR DESCRIPTION
- Added a new DocType **Duty Tax Fee Type**.

    This represents a standardized Code specifying a type of duty, tax or fee, as [defined by UN/EDIFACT](https://service.unece.org/trade/untdid/d19b/tred/tred5153.htm). 
    This is useful for generating or importing electronic invoices.

- Create **Duty Tax Fee Types** after install, for new sites.
- Create **Duty Tax Fee Types** via patch, for existing sites.
- Added a _Duty Tax Fee Type_ Link field to **Sales Taxes and Charges**.
- Added a _Duty Tax Fee Type_ Link field to  **Purchase Taxes and Charges**.
- Added a _Duty Tax Fee Type_ Link field to  **Advance Taxes and Charges**.

I wish to backport this because it's non-breaking and useful for e-invoice support in prior versions.