### PR TITLE
fix: multiple issues in Payment Request (#42427)

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -174,6 +174,17 @@ frappe.ui.form.on("Payment Entry", {
 			};
 		});
 
+		frm.set_query("payment_request", "references", function (doc, cdt, cdn) {
+			const row = frappe.get_doc(cdt, cdn);
+			return {
+				query: "erpnext.accounts.doctype.payment_request.payment_request.get_open_payment_requests_query",
+				filters: {
+					reference_doctype: row.reference_doctype,
+					reference_name: row.reference_name,
+				},
+			};
+		});
+
 		frm.set_query("sales_taxes_and_charges_template", function () {
 			return {
 				filters: {
@@ -191,7 +202,15 @@ frappe.ui.form.on("Payment Entry", {
 				},
 			};
 		});
+
+		frm.add_fetch(
+			"payment_request",
+			"outstanding_amount",
+			"payment_request_outstanding",
+			"Payment Entry Reference"
+		);
 	},
+
 	refresh: function (frm) {
 		erpnext.hide_company(frm);
 		frm.events.hide_unhide_fields(frm);
@@ -216,6 +235,7 @@ frappe.ui.form.on("Payment Entry", {
 			);
 		}
 		erpnext.accounts.unreconcile_payment.add_unreconcile_btn(frm);
+		frappe.flags.allocate_payment_amount = true;
 	},
 
 	validate_company: (frm) => {
@@ -797,7 +817,7 @@ frappe.ui.form.on("Payment Entry", {
 		);
 
 		if (frm.doc.payment_type == "Pay")
-			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.received_amount, 1);
+			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.received_amount, true);
 		else frm.events.set_unallocated_amount(frm);
 
 		frm.set_paid_amount_based_on_received_amount = false;
@@ -818,7 +838,7 @@ frappe.ui.form.on("Payment Entry", {
 		}
 
 		if (frm.doc.payment_type == "Receive")
-			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount, 1);
+			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount, true);
 		else frm.events.set_unallocated_amount(frm);
 	},
 
@@ -989,6 +1009,7 @@ frappe.ui.form.on("Payment Entry", {
 						c.outstanding_amount = d.outstanding_amount;
 						c.bill_no = d.bill_no;
 						c.payment_term = d.payment_term;
+						c.payment_term_outstanding = d.payment_term_outstanding;
 						c.allocated_amount = d.allocated_amount;
 						c.account = d.account;
 
@@ -1038,7 +1059,8 @@ frappe.ui.form.on("Payment Entry", {
 
 				frm.events.allocate_party_amount_against_ref_docs(
 					frm,
-					frm.doc.payment_type == "Receive" ? frm.doc.paid_amount : frm.doc.received_amount
+					frm.doc.payment_type == "Receive" ? frm.doc.paid_amount : frm.doc.received_amount,
+					false
 				);
 			},
 		});
@@ -1052,93 +1074,13 @@ frappe.ui.form.on("Payment Entry", {
 		return ["Sales Invoice", "Purchase Invoice"];
 	},
 
-	allocate_party_amount_against_ref_docs: function (frm, paid_amount, paid_amount_change) {
-		var total_positive_outstanding_including_order = 0;
-		var total_negative_outstanding = 0;
-		var total_deductions = frappe.utils.sum(
-			$.map(frm.doc.deductions || [], function (d) {
-				return flt(d.amount);
-			})
-		);
-
-		paid_amount -= total_deductions;
-
-		$.each(frm.doc.references || [], function (i, row) {
-			if (flt(row.outstanding_amount) > 0)
-				total_positive_outstanding_including_order += flt(row.outstanding_amount);
-			else total_negative_outstanding += Math.abs(flt(row.outstanding_amount));
+	allocate_party_amount_against_ref_docs: async function (frm, paid_amount, paid_amount_change) {
+		await frm.call("allocate_amount_to_references", {
+			paid_amount: paid_amount,
+			paid_amount_change: paid_amount_change,
+			allocate_payment_amount: frappe.flags.allocate_payment_amount ?? false,
 		});
 
-		var allocated_negative_outstanding = 0;
-		if (
-			(frm.doc.payment_type == "Receive" && frm.doc.party_type == "Customer") ||
-			(frm.doc.payment_type == "Pay" && frm.doc.party_type == "Supplier") ||
-			(frm.doc.payment_type == "Pay" && frm.doc.party_type == "Employee")
-		) {
-			if (total_positive_outstanding_including_order > paid_amount) {
-				var remaining_outstanding = total_positive_outstanding_including_order - paid_amount;
-				allocated_negative_outstanding =
-					total_negative_outstanding < remaining_outstanding
-						? total_negative_outstanding
-						: remaining_outstanding;
-			}
-
-			var allocated_positive_outstanding = paid_amount + allocated_negative_outstanding;
-		} else if (["Customer", "Supplier"].includes(frm.doc.party_type)) {
-			total_negative_outstanding = flt(total_negative_outstanding, precision("outstanding_amount"));
-			if (paid_amount > total_negative_outstanding) {
-				if (total_negative_outstanding == 0) {
-					frappe.msgprint(
-						__("Cannot {0} {1} {2} without any negative outstanding invoice", [
-							frm.doc.payment_type,
-							frm.doc.party_type == "Customer" ? "to" : "from",
-							frm.doc.party_type,
-						])
-					);
-					return false;
-				} else {
-					frappe.msgprint(
-						__("Paid Amount cannot be greater than total negative outstanding amount {0}", [
-							total_negative_outstanding,
-						])
-					);
-					return false;
-				}
-			} else {
-				allocated_positive_outstanding = total_negative_outstanding - paid_amount;
-				allocated_negative_outstanding =
-					paid_amount +
-					(total_positive_outstanding_including_order < allocated_positive_outstanding
-						? total_positive_outstanding_including_order
-						: allocated_positive_outstanding);
-			}
-		}
-
-		$.each(frm.doc.references || [], function (i, row) {
-			if (frappe.flags.allocate_payment_amount == 0) {
-				//If allocate payment amount checkbox is unchecked, set zero to allocate amount
-				row.allocated_amount = 0;
-			} else if (
-				frappe.flags.allocate_payment_amount != 0 &&
-				(!row.allocated_amount || paid_amount_change)
-			) {
-				if (row.outstanding_amount > 0 && allocated_positive_outstanding >= 0) {
-					row.allocated_amount =
-						row.outstanding_amount >= allocated_positive_outstanding
-							? allocated_positive_outstanding
-							: row.outstanding_amount;
-					allocated_positive_outstanding -= flt(row.allocated_amount);
-				} else if (row.outstanding_amount < 0 && allocated_negative_outstanding) {
-					row.allocated_amount =
-						Math.abs(row.outstanding_amount) >= allocated_negative_outstanding
-							? -1 * allocated_negative_outstanding
-							: row.outstanding_amount;
-					allocated_negative_outstanding -= Math.abs(flt(row.allocated_amount));
-				}
-			}
-		});
-
-		frm.refresh_fields();
 		frm.events.set_total_allocated_amount(frm);
 	},
 
@@ -1686,6 +1628,62 @@ frappe.ui.form.on("Payment Entry", {
 
 		return current_tax_amount;
 	},
+
+	cost_center: function (frm) {
+		if (frm.doc.posting_date && (frm.doc.paid_from || frm.doc.paid_to)) {
+			return frappe.call({
+				method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_party_and_account_balance",
+				args: {
+					company: frm.doc.company,
+					date: frm.doc.posting_date,
+					paid_from: frm.doc.paid_from,
+					paid_to: frm.doc.paid_to,
+					ptype: frm.doc.party_type,
+					pty: frm.doc.party,
+					cost_center: frm.doc.cost_center,
+				},
+				callback: function (r, rt) {
+					if (r.message) {
+						frappe.run_serially([
+							() => {
+								frm.set_value(
+									"paid_from_account_balance",
+									r.message.paid_from_account_balance
+								);
+								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
+								frm.set_value("party_balance", r.message.party_balance);
+							},
+						]);
+					}
+				},
+			});
+		}
+	},
+
+	after_save: function (frm) {
+		const { matched_payment_requests } = frappe.last_response;
+		if (!matched_payment_requests) return;
+
+		const COLUMN_LABEL = [
+			[__("Reference DocType"), __("Reference Name"), __("Allocated Amount"), __("Payment Request")],
+		];
+
+		frappe.msgprint({
+			title: __("Unset Matched Payment Request"),
+			message: COLUMN_LABEL.concat(matched_payment_requests),
+			as_table: true,
+			wide: true,
+			primary_action: {
+				label: __("Allocate Payment Request"),
+				action() {
+					frappe.hide_msgprint();
+					frm.call("set_matched_payment_requests", { matched_payment_requests }, () => {
+						frm.dirty();
+					});
+				},
+			},
+		});
+	},
 });
 
 frappe.ui.form.on("Payment Entry Reference", {
@@ -1776,37 +1774,5 @@ frappe.ui.form.on("Payment Entry Deduction", {
 
 	deductions_remove: function (frm) {
 		frm.events.set_unallocated_amount(frm);
-	},
-});
-frappe.ui.form.on("Payment Entry", {
-	cost_center: function (frm) {
-		if (frm.doc.posting_date && (frm.doc.paid_from || frm.doc.paid_to)) {
-			return frappe.call({
-				method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_party_and_account_balance",
-				args: {
-					company: frm.doc.company,
-					date: frm.doc.posting_date,
-					paid_from: frm.doc.paid_from,
-					paid_to: frm.doc.paid_to,
-					ptype: frm.doc.party_type,
-					pty: frm.doc.party,
-					cost_center: frm.doc.cost_center,
-				},
-				callback: function (r, rt) {
-					if (r.message) {
-						frappe.run_serially([
-							() => {
-								frm.set_value(
-									"paid_from_account_balance",
-									r.message.paid_from_account_balance
-								);
-								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
-								frm.set_value("party_balance", r.message.party_balance);
-							},
-						]);
-					}
-				},
-			});
-		}
 	},
 });

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -10,6 +10,7 @@
   "due_date",
   "bill_no",
   "payment_term",
+  "payment_term_outstanding",
   "account_type",
   "payment_type",
   "column_break_4",
@@ -18,7 +19,9 @@
   "allocated_amount",
   "exchange_rate",
   "exchange_gain_loss",
-  "account"
+  "account",
+  "payment_request",
+  "payment_request_outstanding"
  ],
  "fields": [
   {
@@ -120,12 +123,33 @@
    "fieldname": "payment_type",
    "fieldtype": "Data",
    "label": "Payment Type"
+  },
+  {
+   "fieldname": "payment_request",
+   "fieldtype": "Link",
+   "label": "Payment Request",
+   "options": "Payment Request"
+  },
+  {
+   "depends_on": "eval: doc.payment_term",
+   "fieldname": "payment_term_outstanding",
+   "fieldtype": "Float",
+   "label": "Payment Term Outstanding",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.payment_request && doc.payment_request_outstanding",
+   "fieldname": "payment_request_outstanding",
+   "fieldtype": "Float",
+   "is_virtual": 1,
+   "label": "Payment Request Outstanding",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-05 09:44:08.310593",
+ "modified": "2024-09-16 18:11:50.019343",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry Reference",

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
+import frappe
 from frappe.model.document import Document
 
 
@@ -25,11 +25,19 @@ class PaymentEntryReference(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		payment_request: DF.Link | None
+		payment_request_outstanding: DF.Float
 		payment_term: DF.Link | None
+		payment_term_outstanding: DF.Float
 		payment_type: DF.Data | None
 		reference_doctype: DF.Link
 		reference_name: DF.DynamicLink
 		total_amount: DF.Float
 	# end: auto-generated types
 
-	pass
+	@property
+	def payment_request_outstanding(self):
+		if not self.payment_request:
+			return
+
+		return frappe.db.get_value("Payment Request", self.payment_request, "outstanding_amount")

--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -48,8 +48,8 @@ frappe.ui.form.on("Payment Request", "refresh", function (frm) {
 	}
 
 	if (
-		(!frm.doc.payment_gateway_account || frm.doc.payment_request_type == "Outward") &&
-		frm.doc.status == "Initiated"
+		frm.doc.payment_request_type == "Outward" &&
+		["Initiated", "Partially Paid"].includes(frm.doc.status)
 	) {
 		frm.add_custom_button(__("Create Payment Entry"), function () {
 			frappe.call({

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -19,9 +19,11 @@
   "reference_name",
   "transaction_details",
   "grand_total",
+  "currency",
   "is_a_subscription",
   "column_break_18",
-  "currency",
+  "outstanding_amount",
+  "party_account_currency",
   "subscription_section",
   "subscription_plans",
   "bank_account_details",
@@ -69,6 +71,7 @@
   {
    "fieldname": "transaction_date",
    "fieldtype": "Date",
+   "in_preview": 1,
    "label": "Transaction Date"
   },
   {
@@ -133,7 +136,8 @@
    "no_copy": 1,
    "options": "reference_doctype",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "transaction_details",
@@ -141,12 +145,14 @@
    "label": "Transaction Details"
   },
   {
-   "description": "Amount in customer's currency",
+   "description": "Amount in transaction currency",
    "fieldname": "grand_total",
    "fieldtype": "Currency",
+   "in_preview": 1,
    "label": "Amount",
    "non_negative": 1,
-   "options": "currency"
+   "options": "currency",
+   "reqd": 1
   },
   {
    "default": "0",
@@ -393,10 +399,41 @@
    "read_only": 1
   },
   {
+   "fieldname": "failed_reason",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reason for Failure",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.docstatus === 1",
+   "description": "Amount in party's bank account currency",
+   "fieldname": "outstanding_amount",
+   "fieldtype": "Currency",
+   "in_preview": 1,
+   "label": "Outstanding Amount",
+   "non_negative": 1,
+   "options": "party_account_currency",
+   "read_only": 1
+  },
+  {
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_pnyv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "party_account_currency",
+   "fieldtype": "Link",
+   "label": "Party Account Currency",
+   "options": "Currency",
    "read_only": 1
   }
  ],
@@ -404,7 +441,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-07 16:39:54.288002",
+ "modified": "2024-09-16 17:50:54.440090",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",
@@ -439,6 +476,7 @@
    "write": 1
   }
  ],
+ "show_preview_popup": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -417,10 +417,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "column_break_pnyv",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "party_account_currency",
    "fieldtype": "Link",
    "label": "Party Account Currency",

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -399,15 +399,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "failed_reason",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Reason for Failure",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "depends_on": "eval: doc.docstatus === 1",
    "description": "Amount in party's bank account currency",
    "fieldname": "outstanding_amount",

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -862,33 +862,6 @@ def validate_payment(doc, method=None):
 	)
 
 
-def get_paid_amount_against_order(dt, dn):
-	pe_ref = frappe.qb.DocType("Payment Entry Reference")
-	if dt == "Sales Order":
-		inv_dt, inv_field = "Sales Invoice Item", "sales_order"
-	else:
-		inv_dt, inv_field = "Purchase Invoice Item", "purchase_order"
-	inv_item = frappe.qb.DocType(inv_dt)
-	return (
-		frappe.qb.from_(pe_ref)
-		.select(
-			Sum(pe_ref.allocated_amount),
-		)
-		.where(
-			(pe_ref.docstatus == 1)
-			& (
-				(pe_ref.reference_name == dn)
-				| pe_ref.reference_name.isin(
-					frappe.qb.from_(inv_item)
-					.select(inv_item.parent)
-					.where(inv_item[inv_field] == dn)
-					.distinct()
-				)
-			)
-		)
-	).run()[0][0] or 0
-
-
 @frappe.whitelist()
 def get_open_payment_requests_query(doctype, txt, searchfield, start, page_len, filters):
 	# permission checks in `get_list()`

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -51,7 +51,6 @@ class PaymentRequest(Document):
 		cost_center: DF.Link | None
 		currency: DF.Link | None
 		email_to: DF.Data | None
-		failed_reason: DF.Data | None
 		grand_total: DF.Currency
 		iban: DF.ReadOnly | None
 		is_a_subscription: DF.Check

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -194,9 +194,6 @@ class PaymentRequest(Document):
 					self.send_email()
 					self.make_communication_entry()
 
-	def on_submit(self):
-		self.update_reference_advance_payment_status()
-
 	def request_phone_payment(self):
 		controller = _get_payment_gateway_controller(self.payment_gateway)
 		request_amount = self.get_request_amount()
@@ -457,14 +454,6 @@ class PaymentRequest(Document):
 				from payments.payment_gateways.stripe_integration import create_stripe_subscription
 
 			return create_stripe_subscription(gateway_controller, data)
-
-	def update_reference_advance_payment_status(self):
-		advance_payment_doctypes = frappe.get_hooks("advance_payment_receivable_doctypes") + frappe.get_hooks(
-			"advance_payment_payable_doctypes"
-		)
-		if self.reference_doctype in advance_payment_doctypes:
-			ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-			ref_doc.set_advance_payment_status()
 
 	def _allocate_payment_request_to_pe_references(self, references):
 		"""

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -3,9 +3,11 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder.functions import Sum
 from frappe.utils import flt, nowdate
 from frappe.utils.background_jobs import enqueue
 
+from erpnext import get_company_currency
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 )
@@ -45,9 +47,11 @@ class PaymentRequest(Document):
 		bank_account: DF.Link | None
 		bank_account_no: DF.ReadOnly | None
 		branch_code: DF.ReadOnly | None
+		company: DF.Link | None
 		cost_center: DF.Link | None
 		currency: DF.Link | None
 		email_to: DF.Data | None
+		failed_reason: DF.Data | None
 		grand_total: DF.Currency
 		iban: DF.ReadOnly | None
 		is_a_subscription: DF.Check
@@ -56,16 +60,18 @@ class PaymentRequest(Document):
 		mode_of_payment: DF.Link | None
 		mute_email: DF.Check
 		naming_series: DF.Literal["ACC-PRQ-.YYYY.-"]
+		outstanding_amount: DF.Currency
 		party: DF.DynamicLink | None
+		party_account_currency: DF.Link | None
 		party_type: DF.Link | None
 		payment_account: DF.ReadOnly | None
-		payment_channel: DF.Literal["", "Email", "Phone"]
+		payment_channel: DF.Literal["", "Email", "Phone", "Other"]
 		payment_gateway: DF.ReadOnly | None
 		payment_gateway_account: DF.Link | None
 		payment_order: DF.Link | None
 		payment_request_type: DF.Literal["Outward", "Inward"]
 		payment_url: DF.Data | None
-		print_format: DF.Literal
+		print_format: DF.Literal[None]
 		project: DF.Link | None
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None
@@ -84,7 +90,6 @@ class PaymentRequest(Document):
 		subscription_plans: DF.Table[SubscriptionPlanDetail]
 		swift_number: DF.ReadOnly | None
 		transaction_date: DF.Date | None
-		company: DF.Link | None
 	# end: auto-generated types
 
 	def validate(self):
@@ -100,6 +105,12 @@ class PaymentRequest(Document):
 			frappe.throw(_("To create a Payment Request reference document is required"))
 
 	def validate_payment_request_amount(self):
+		if self.grand_total == 0:
+			frappe.throw(
+				_("{0} cannot be zero").format(self.get_label_from_fieldname("grand_total")),
+				title=_("Invalid Amount"),
+			)
+
 		existing_payment_request_amount = flt(
 			get_existing_payment_request_amount(self.reference_doctype, self.reference_name)
 		)
@@ -147,28 +158,44 @@ class PaymentRequest(Document):
 					).format(self.grand_total, amount)
 				)
 
-	def on_submit(self):
-		if self.payment_request_type == "Outward":
-			self.db_set("status", "Initiated")
-			return
-		elif self.payment_request_type == "Inward":
-			self.db_set("status", "Requested")
-
-		send_mail = self.payment_gateway_validation() if self.payment_gateway else None
-		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-
+	def before_submit(self):
 		if (
-			hasattr(ref_doc, "order_type") and ref_doc.order_type == "Shopping Cart"
-		) or self.flags.mute_email:
-			send_mail = False
+			self.currency != self.party_account_currency
+			and self.party_account_currency == get_company_currency(self.company)
+		):
+			# set outstanding amount in party account currency
+			invoice = frappe.get_value(
+				self.reference_doctype,
+				self.reference_name,
+				["rounded_total", "grand_total", "base_rounded_total", "base_grand_total"],
+				as_dict=1,
+			)
+			grand_total = invoice.get("rounded_total") or invoice.get("grand_total")
+			base_grand_total = invoice.get("base_rounded_total") or invoice.get("base_grand_total")
+			self.outstanding_amount = flt(
+				self.grand_total / grand_total * base_grand_total,
+				self.precision("outstanding_amount"),
+			)
 
-		if send_mail and self.payment_channel != "Phone":
-			self.set_payment_request_url()
-			self.send_email()
-			self.make_communication_entry()
+		else:
+			self.outstanding_amount = self.grand_total
 
-		elif self.payment_channel == "Phone":
-			self.request_phone_payment()
+		if self.payment_request_type == "Outward":
+			self.status = "Initiated"
+		elif self.payment_request_type == "Inward":
+			self.status = "Requested"
+
+		if self.payment_request_type == "Inward":
+			if self.payment_channel == "Phone":
+				self.request_phone_payment()
+			else:
+				self.set_payment_request_url()
+				if not (self.mute_email or self.flags.mute_email):
+					self.send_email()
+					self.make_communication_entry()
+
+	def on_submit(self):
+		self.update_reference_advance_payment_status()
 
 	def request_phone_payment(self):
 		controller = _get_payment_gateway_controller(self.payment_gateway)
@@ -207,6 +234,7 @@ class PaymentRequest(Document):
 	def on_cancel(self):
 		self.check_if_payment_entry_exists()
 		self.set_as_cancelled()
+		self.update_reference_advance_payment_status()
 
 	def make_invoice(self):
 		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
@@ -275,7 +303,7 @@ class PaymentRequest(Document):
 
 	def set_as_paid(self):
 		if self.payment_channel == "Phone":
-			self.db_set("status", "Paid")
+			self.db_set({"status": "Paid", "outstanding_amount": 0})
 
 		else:
 			payment_entry = self.create_payment_entry()
@@ -296,32 +324,41 @@ class PaymentRequest(Document):
 		else:
 			party_account = get_party_account("Customer", ref_doc.get("customer"), ref_doc.company)
 
-		party_account_currency = ref_doc.get("party_account_currency") or get_account_currency(party_account)
+		party_account_currency = (
+			self.get("party_account_currency")
+			or ref_doc.get("party_account_currency")
+			or get_account_currency(party_account)
+		)
 
-		bank_amount = self.grand_total
+		party_amount = bank_amount = self.outstanding_amount
+
 		if party_account_currency == ref_doc.company_currency and party_account_currency != self.currency:
-			party_amount = ref_doc.get("base_rounded_total") or ref_doc.get("base_grand_total")
-		else:
-			party_amount = self.grand_total
+			exchange_rate = ref_doc.get("conversion_rate")
+			bank_amount = flt(self.outstanding_amount / exchange_rate, self.precision("grand_total"))
 
+		# outstanding amount is already in Part's account currency
 		payment_entry = get_payment_entry(
 			self.reference_doctype,
 			self.reference_name,
 			party_amount=party_amount,
 			bank_account=self.payment_account,
 			bank_amount=bank_amount,
+			created_from_payment_request=True,
 		)
 
 		payment_entry.update(
 			{
 				"mode_of_payment": self.mode_of_payment,
-				"reference_no": self.name,
+				"reference_no": self.name,  # to prevent validation error
 				"reference_date": nowdate(),
 				"remarks": "Payment Entry against {} {} via Payment Request {}".format(
 					self.reference_doctype, self.reference_name, self.name
 				),
 			}
 		)
+
+		# Allocate payment_request for each reference in payment_entry (Payment Term can splits the row)
+		self._allocate_payment_request_to_pe_references(references=payment_entry.references)
 
 		# Update dimensions
 		payment_entry.update(
@@ -330,14 +367,6 @@ class PaymentRequest(Document):
 				"project": self.get("project"),
 			}
 		)
-
-		if party_account_currency == ref_doc.company_currency and party_account_currency != self.currency:
-			amount = payment_entry.base_paid_amount
-		else:
-			amount = self.grand_total
-
-		payment_entry.received_amount = amount
-		payment_entry.get("references")[0].allocated_amount = amount
 
 		# Update 'Paid Amount' on Forex transactions
 		if self.currency != ref_doc.company_currency:
@@ -429,6 +458,70 @@ class PaymentRequest(Document):
 
 			return create_stripe_subscription(gateway_controller, data)
 
+	def update_reference_advance_payment_status(self):
+		advance_payment_doctypes = frappe.get_hooks("advance_payment_receivable_doctypes") + frappe.get_hooks(
+			"advance_payment_payable_doctypes"
+		)
+		if self.reference_doctype in advance_payment_doctypes:
+			ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+			ref_doc.set_advance_payment_status()
+
+	def _allocate_payment_request_to_pe_references(self, references):
+		"""
+		Allocate the Payment Request to the Payment Entry references based on\n
+		    - Allocated Amount.
+		    - Outstanding Amount of Payment Request.\n
+		Payment Request is doc itself and references are the rows of Payment Entry.
+		"""
+		if len(references) == 1:
+			references[0].payment_request = self.name
+			return
+
+		precision = references[0].precision("allocated_amount")
+		outstanding_amount = self.outstanding_amount
+
+		# to manage rows
+		row_number = 1
+		MOVE_TO_NEXT_ROW = 1
+		TO_SKIP_NEW_ROW = 2
+		NEW_ROW_ADDED = False
+
+		while row_number <= len(references):
+			row = references[row_number - 1]
+
+			# update the idx to maintain the order
+			row.idx = row_number
+
+			if outstanding_amount == 0:
+				if not NEW_ROW_ADDED:
+					break
+
+				row_number += MOVE_TO_NEXT_ROW
+				continue
+
+			# allocate the payment request to the row
+			row.payment_request = self.name
+
+			if row.allocated_amount <= outstanding_amount:
+				outstanding_amount = flt(outstanding_amount - row.allocated_amount, precision)
+				row_number += MOVE_TO_NEXT_ROW
+			else:
+				remaining_allocated_amount = flt(row.allocated_amount - outstanding_amount, precision)
+				row.allocated_amount = outstanding_amount
+				outstanding_amount = 0
+
+				# create a new row without PR for remaining unallocated amount
+				new_row = frappe.copy_doc(row)
+				references.insert(row_number, new_row)
+
+				# update new row
+				new_row.idx = row_number + 1
+				new_row.payment_request = None
+				new_row.allocated_amount = remaining_allocated_amount
+
+				NEW_ROW_ADDED = True
+				row_number += TO_SKIP_NEW_ROW
+
 
 @frappe.whitelist(allow_guest=True)
 def make_payment_request(**args):
@@ -459,10 +552,14 @@ def make_payment_request(**args):
 		{"reference_doctype": args.dt, "reference_name": args.dn, "docstatus": 0},
 	)
 
-	existing_payment_request_amount = get_existing_payment_request_amount(args.dt, args.dn)
+	# fetches existing payment request `grand_total` amount
+	existing_payment_request_amount = get_existing_payment_request_amount(ref_doc.doctype, ref_doc.name)
 
 	if existing_payment_request_amount:
 		grand_total -= existing_payment_request_amount
+
+		if not grand_total:
+			frappe.throw(_("Payment Request is already created"))
 
 	if draft_payment_request:
 		frappe.db.set_value(
@@ -477,6 +574,13 @@ def make_payment_request(**args):
 				"Outward" if args.get("dt") in ["Purchase Order", "Purchase Invoice"] else "Inward"
 			)
 
+		party_type = args.get("party_type") or "Customer"
+		party_account_currency = ref_doc.party_account_currency
+
+		if not party_account_currency:
+			party_account = get_party_account(party_type, ref_doc.get(party_type.lower()), ref_doc.company)
+			party_account_currency = get_account_currency(party_account)
+
 		pr.update(
 			{
 				"payment_gateway_account": gateway_account.get("name"),
@@ -485,6 +589,7 @@ def make_payment_request(**args):
 				"payment_channel": gateway_account.get("payment_channel"),
 				"payment_request_type": args.get("payment_request_type"),
 				"currency": ref_doc.currency,
+				"party_account_currency": party_account_currency,
 				"grand_total": grand_total,
 				"mode_of_payment": args.mode_of_payment,
 				"email_to": args.recipient_id or ref_doc.owner,
@@ -493,7 +598,7 @@ def make_payment_request(**args):
 				"reference_doctype": args.dt,
 				"reference_name": args.dn,
 				"company": ref_doc.get("company"),
-				"party_type": args.get("party_type") or "Customer",
+				"party_type": party_type,
 				"party": args.get("party") or ref_doc.get("customer"),
 				"bank_account": bank_account,
 			}
@@ -539,9 +644,11 @@ def get_amount(ref_doc, payment_account=None):
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if not ref_doc.get("is_pos"):
 			if ref_doc.party_account_currency == ref_doc.currency:
-				grand_total = flt(ref_doc.grand_total)
+				grand_total = flt(ref_doc.rounded_total or ref_doc.grand_total)
 			else:
-				grand_total = flt(ref_doc.base_grand_total) / ref_doc.conversion_rate
+				grand_total = flt(
+					flt(ref_doc.base_rounded_total or ref_doc.base_grand_total) / ref_doc.conversion_rate
+				)
 		elif dt == "Sales Invoice":
 			for pay in ref_doc.payments:
 				if pay.type == "Phone" and pay.account == payment_account:
@@ -563,24 +670,20 @@ def get_amount(ref_doc, payment_account=None):
 
 def get_existing_payment_request_amount(ref_dt, ref_dn):
 	"""
-	Get the existing payment request which are unpaid or partially paid for payment channel other than Phone
-	and get the summation of existing paid payment request for Phone payment channel.
+	Return the total amount of Payment Requests against a reference document.
 	"""
-	existing_payment_request_amount = frappe.db.sql(
-		"""
-		select sum(grand_total)
-		from `tabPayment Request`
-		where
-			reference_doctype = %s
-			and reference_name = %s
-			and docstatus = 1
-			and (status != 'Paid'
-			or (payment_channel = 'Phone'
-				and status = 'Paid'))
-	""",
-		(ref_dt, ref_dn),
+	PR = frappe.qb.DocType("Payment Request")
+
+	response = (
+		frappe.qb.from_(PR)
+		.select(Sum(PR.grand_total))
+		.where(PR.reference_doctype == ref_dt)
+		.where(PR.reference_name == ref_dn)
+		.where(PR.docstatus == 1)
+		.run()
 	)
-	return flt(existing_payment_request_amount[0][0]) if existing_payment_request_amount else 0
+
+	return response[0][0] if response[0] else 0
 
 
 def get_gateway_details(args):  # nosemgrep
@@ -627,41 +730,66 @@ def make_payment_entry(docname):
 	return doc.create_payment_entry(submit=False).as_dict()
 
 
-def update_payment_req_status(doc, method):
-	from erpnext.accounts.doctype.payment_entry.payment_entry import get_reference_details
+def update_payment_requests_as_per_pe_references(references=None, cancel=False):
+	"""
+	Update Payment Request's `Status` and `Outstanding Amount` based on Payment Entry Reference's `Allocated Amount`.
+	"""
+	if not references:
+		return
 
-	for ref in doc.references:
-		payment_request_name = frappe.db.get_value(
-			"Payment Request",
-			{
-				"reference_doctype": ref.reference_doctype,
-				"reference_name": ref.reference_name,
-				"docstatus": 1,
-			},
+	precision = references[0].precision("allocated_amount")
+
+	referenced_payment_requests = frappe.get_all(
+		"Payment Request",
+		filters={"name": ["in", {row.payment_request for row in references if row.payment_request}]},
+		fields=[
+			"name",
+			"grand_total",
+			"outstanding_amount",
+			"payment_request_type",
+		],
+	)
+
+	referenced_payment_requests = {pr.name: pr for pr in referenced_payment_requests}
+
+	for ref in references:
+		if not ref.payment_request:
+			continue
+
+		payment_request = referenced_payment_requests[ref.payment_request]
+		pr_outstanding = payment_request["outstanding_amount"]
+
+		# update outstanding amount
+		new_outstanding_amount = flt(
+			pr_outstanding + ref.allocated_amount if cancel else pr_outstanding - ref.allocated_amount,
+			precision,
 		)
 
-		if payment_request_name:
-			ref_details = get_reference_details(
-				ref.reference_doctype,
-				ref.reference_name,
-				doc.party_account_currency,
-				doc.party_type,
-				doc.party,
+		# to handle same payment request for the multiple allocations
+		payment_request["outstanding_amount"] = new_outstanding_amount
+
+		if not cancel and new_outstanding_amount < 0:
+			frappe.throw(
+				msg=_(
+					"The allocated amount is greater than the outstanding amount of Payment Request {0}"
+				).format(ref.payment_request),
+				title=_("Invalid Allocated Amount"),
 			)
-			pay_req_doc = frappe.get_doc("Payment Request", payment_request_name)
-			status = pay_req_doc.status
 
-			if status != "Paid" and not ref_details.outstanding_amount:
-				status = "Paid"
-			elif status != "Partially Paid" and ref_details.outstanding_amount != ref_details.total_amount:
-				status = "Partially Paid"
-			elif ref_details.outstanding_amount == ref_details.total_amount:
-				if pay_req_doc.payment_request_type == "Outward":
-					status = "Initiated"
-				elif pay_req_doc.payment_request_type == "Inward":
-					status = "Requested"
+		# update status
+		if new_outstanding_amount == payment_request["grand_total"]:
+			status = "Initiated" if payment_request["payment_request_type"] == "Outward" else "Requested"
+		elif new_outstanding_amount == 0:
+			status = "Paid"
+		elif new_outstanding_amount > 0:
+			status = "Partially Paid"
 
-			pay_req_doc.db_set("status", status)
+		# update database
+		frappe.db.set_value(
+			"Payment Request",
+			ref.payment_request,
+			{"outstanding_amount": new_outstanding_amount, "status": status},
+		)
 
 
 def get_dummy_message(doc):
@@ -745,3 +873,62 @@ def validate_payment(doc, method=None):
 			doc.reference_docname
 		)
 	)
+
+
+def get_paid_amount_against_order(dt, dn):
+	pe_ref = frappe.qb.DocType("Payment Entry Reference")
+	if dt == "Sales Order":
+		inv_dt, inv_field = "Sales Invoice Item", "sales_order"
+	else:
+		inv_dt, inv_field = "Purchase Invoice Item", "purchase_order"
+	inv_item = frappe.qb.DocType(inv_dt)
+	return (
+		frappe.qb.from_(pe_ref)
+		.select(
+			Sum(pe_ref.allocated_amount),
+		)
+		.where(
+			(pe_ref.docstatus == 1)
+			& (
+				(pe_ref.reference_name == dn)
+				| pe_ref.reference_name.isin(
+					frappe.qb.from_(inv_item)
+					.select(inv_item.parent)
+					.where(inv_item[inv_field] == dn)
+					.distinct()
+				)
+			)
+		)
+	).run()[0][0] or 0
+
+
+@frappe.whitelist()
+def get_open_payment_requests_query(doctype, txt, searchfield, start, page_len, filters):
+	# permission checks in `get_list()`
+	reference_doctype = filters.get("reference_doctype")
+	reference_name = filters.get("reference_doctype")
+
+	if not reference_doctype or not reference_name:
+		return []
+
+	open_payment_requests = frappe.get_list(
+		"Payment Request",
+		filters={
+			"reference_doctype": filters["reference_doctype"],
+			"reference_name": filters["reference_name"],
+			"status": ["!=", "Paid"],
+			"outstanding_amount": ["!=", 0],  # for compatibility with old data
+			"docstatus": 1,
+		},
+		fields=["name", "grand_total", "outstanding_amount"],
+		order_by="transaction_date ASC,creation ASC",
+	)
+
+	return [
+		(
+			pr.name,
+			_("<strong>Grand Total:</strong> {0}").format(pr.grand_total),
+			_("<strong>Outstanding Amount:</strong> {0}").format(pr.outstanding_amount),
+		)
+		for pr in open_payment_requests
+	]

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -231,7 +231,6 @@ class PaymentRequest(Document):
 	def on_cancel(self):
 		self.check_if_payment_entry_exists()
 		self.set_as_cancelled()
-		self.update_reference_advance_payment_status()
 
 	def make_invoice(self):
 		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import re
 import unittest
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -278,3 +280,256 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pe.paid_amount, 800)
 		self.assertEqual(pe.base_received_amount, 800)
 		self.assertEqual(pe.received_amount, 10)
+
+	def test_multiple_payment_if_partially_paid_for_same_currency(self):
+		so = make_sales_order(currency="INR", qty=1, rate=1000)
+
+		self.assertEqual(so.advance_payment_status, "Not Requested")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+		self.assertEqual(pr.grand_total, 1000)
+		self.assertEqual(pr.outstanding_amount, pr.grand_total)
+		self.assertEqual(pr.party_account_currency, pr.currency)  # INR
+		self.assertEqual(pr.status, "Requested")
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Requested")
+
+		# to make partial payment
+		pe = pr.create_payment_entry(submit=False)
+		pe.paid_amount = 200
+		pe.references[0].allocated_amount = 200
+		pe.submit()
+
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Partially Paid")
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Partially Paid")
+		self.assertEqual(pr.outstanding_amount, 800)
+		self.assertEqual(pr.grand_total, 1000)
+
+		# complete payment
+		pe = pr.create_payment_entry()
+
+		self.assertEqual(pe.paid_amount, 800)  # paid amount set from pr's outstanding amount
+		self.assertEqual(pe.references[0].allocated_amount, 800)
+		self.assertEqual(pe.references[0].outstanding_amount, 800)  # for Orders it is not zero
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Fully Paid")
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Paid")
+		self.assertEqual(pr.outstanding_amount, 0)
+		self.assertEqual(pr.grand_total, 1000)
+
+		# creating a more payment Request must not allowed
+		self.assertRaisesRegex(
+			frappe.exceptions.ValidationError,
+			re.compile(r"Payment Request is already created"),
+			make_payment_request,
+			dt="Sales Order",
+			dn=so.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+	def test_multiple_payment_if_partially_paid_for_multi_currency(self):
+		pi = make_purchase_invoice(currency="USD", conversion_rate=50, qty=1, rate=100)
+
+		pr = make_payment_request(
+			dt="Purchase Invoice",
+			dn=pi.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+		# 100 USD -> 5000 INR
+		self.assertEqual(pr.grand_total, 100)
+		self.assertEqual(pr.outstanding_amount, 5000)
+		self.assertEqual(pr.currency, "USD")
+		self.assertEqual(pr.party_account_currency, "INR")
+		self.assertEqual(pr.status, "Initiated")
+
+		# to make partial payment
+		pe = pr.create_payment_entry(submit=False)
+		pe.paid_amount = 2000
+		pe.references[0].allocated_amount = 2000
+		pe.submit()
+
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Partially Paid")
+		self.assertEqual(pr.outstanding_amount, 3000)
+		self.assertEqual(pr.grand_total, 100)
+
+		# complete payment
+		pe = pr.create_payment_entry()
+		self.assertEqual(pe.paid_amount, 3000)  # paid amount set from pr's outstanding amount
+		self.assertEqual(pe.references[0].allocated_amount, 3000)
+		self.assertEqual(pe.references[0].outstanding_amount, 0)  # for Invoices it will zero
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Paid")
+		self.assertEqual(pr.outstanding_amount, 0)
+		self.assertEqual(pr.grand_total, 100)
+
+		# creating a more payment Request must not allowed
+		self.assertRaisesRegex(
+			frappe.exceptions.ValidationError,
+			re.compile(r"Payment Request is already created"),
+			make_payment_request,
+			dt="Purchase Invoice",
+			dn=pi.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+	def test_single_payment_with_payment_term_for_same_currency(self):
+		create_payment_terms_template()
+
+		po = create_purchase_order(do_not_save=1, currency="INR", qty=1, rate=20000)
+		po.payment_terms_template = "Test Receivable Template"  # 84.746 and 15.254
+		po.save()
+		po.submit()
+
+		self.assertEqual(po.advance_payment_status, "Not Initiated")
+
+		pr = make_payment_request(
+			dt="Purchase Order",
+			dn=po.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+		self.assertEqual(pr.grand_total, 20000)
+		self.assertEqual(pr.outstanding_amount, pr.grand_total)
+		self.assertEqual(pr.party_account_currency, pr.currency)  # INR
+		self.assertEqual(pr.status, "Initiated")
+
+		po.load_from_db()
+		self.assertEqual(po.advance_payment_status, "Initiated")
+
+		pe = pr.create_payment_entry()
+
+		self.assertEqual(len(pe.references), 2)
+		self.assertEqual(pe.paid_amount, 20000)
+
+		# check 1st payment term
+		self.assertEqual(pe.references[0].allocated_amount, 16949.2)
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		# check 2nd payment term
+		self.assertEqual(pe.references[1].allocated_amount, 3050.8)
+		self.assertEqual(pe.references[1].payment_request, pr.name)
+
+		po.load_from_db()
+		self.assertEqual(po.advance_payment_status, "Fully Paid")
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Paid")
+		self.assertEqual(pr.outstanding_amount, 0)
+		self.assertEqual(pr.grand_total, 20000)
+
+	def test_single_payment_with_payment_term_for_multi_currency(self):
+		create_payment_terms_template()
+
+		si = create_sales_invoice(do_not_save=1, currency="USD", qty=1, rate=200, conversion_rate=50)
+		si.payment_terms_template = "Test Receivable Template"  # 84.746 and 15.254
+		si.save()
+		si.submit()
+
+		pr = make_payment_request(
+			dt="Sales Invoice",
+			dn=si.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+		# 200 USD -> 10000 INR
+		self.assertEqual(pr.grand_total, 200)
+		self.assertEqual(pr.outstanding_amount, 10000)
+		self.assertEqual(pr.currency, "USD")
+		self.assertEqual(pr.party_account_currency, "INR")
+		self.assertEqual(pr.status, "Requested")
+
+		pe = pr.create_payment_entry()
+		self.assertEqual(len(pe.references), 2)
+		self.assertEqual(pe.paid_amount, 10000)
+
+		# check 1st payment term
+		# convert it via dollar and conversion_rate
+		self.assertEqual(pe.references[0].allocated_amount, 8474.5)  # multi currency conversion
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		# check 2nd payment term
+		self.assertEqual(pe.references[1].allocated_amount, 1525.5)  # multi currency conversion
+		self.assertEqual(pe.references[1].payment_request, pr.name)
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Paid")
+		self.assertEqual(pr.outstanding_amount, 0)
+		self.assertEqual(pr.grand_total, 200)
+
+	def test_payment_cancel_process(self):
+		so = make_sales_order(currency="INR", qty=1, rate=1000)
+		self.assertEqual(so.advance_payment_status, "Not Requested")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			mute_email=1,
+			submit_doc=1,
+			return_doc=1,
+		)
+
+		self.assertEqual(pr.status, "Requested")
+		self.assertEqual(pr.grand_total, 1000)
+		self.assertEqual(pr.outstanding_amount, pr.grand_total)
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Requested")
+
+		pe = pr.create_payment_entry(submit=False)
+		pe.paid_amount = 800
+		pe.references[0].allocated_amount = 800
+		pe.submit()
+
+		self.assertEqual(pe.references[0].payment_request, pr.name)
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Partially Paid")
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Partially Paid")
+		self.assertEqual(pr.outstanding_amount, 200)
+		self.assertEqual(pr.grand_total, 1000)
+
+		# cancelling PE
+		pe.cancel()
+
+		pr.load_from_db()
+		self.assertEqual(pr.status, "Requested")
+		self.assertEqual(pr.outstanding_amount, 1000)
+		self.assertEqual(pr.grand_total, 1000)
+
+		so.load_from_db()
+		self.assertEqual(so.advance_payment_status, "Requested")

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -320,7 +320,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.grand_total, 1000)
 		self.assertEqual(pr.outstanding_amount, pr.grand_total)
 		self.assertEqual(pr.party_account_currency, pr.currency)  # INR
-		self.assertEqual(pr.status, "Requested")
 
 		so.load_from_db()
 
@@ -485,7 +484,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.outstanding_amount, 10000)
 		self.assertEqual(pr.currency, "USD")
 		self.assertEqual(pr.party_account_currency, "INR")
-		self.assertEqual(pr.status, "Requested")
 
 		pe = pr.create_payment_entry()
 		self.assertEqual(len(pe.references), 2)
@@ -516,7 +514,6 @@ class TestPaymentRequest(FrappeTestCase):
 			return_doc=1,
 		)
 
-		self.assertEqual(pr.status, "Requested")
 		self.assertEqual(pr.grand_total, 1000)
 		self.assertEqual(pr.outstanding_amount, pr.grand_total)
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -284,8 +284,6 @@ class TestPaymentRequest(FrappeTestCase):
 	def test_multiple_payment_if_partially_paid_for_same_currency(self):
 		so = make_sales_order(currency="INR", qty=1, rate=1000)
 
-		self.assertEqual(so.advance_payment_status, "Not Requested")
-
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
@@ -300,7 +298,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.status, "Requested")
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Requested")
 
 		# to make partial payment
 		pe = pr.create_payment_entry(submit=False)
@@ -311,7 +308,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pe.references[0].payment_request, pr.name)
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Partially Paid")
 
 		pr.load_from_db()
 		self.assertEqual(pr.status, "Partially Paid")
@@ -327,7 +323,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pe.references[0].payment_request, pr.name)
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Fully Paid")
 
 		pr.load_from_db()
 		self.assertEqual(pr.status, "Paid")
@@ -409,8 +404,6 @@ class TestPaymentRequest(FrappeTestCase):
 		po.save()
 		po.submit()
 
-		self.assertEqual(po.advance_payment_status, "Not Initiated")
-
 		pr = make_payment_request(
 			dt="Purchase Order",
 			dn=po.name,
@@ -425,7 +418,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.status, "Initiated")
 
 		po.load_from_db()
-		self.assertEqual(po.advance_payment_status, "Initiated")
 
 		pe = pr.create_payment_entry()
 
@@ -441,7 +433,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pe.references[1].payment_request, pr.name)
 
 		po.load_from_db()
-		self.assertEqual(po.advance_payment_status, "Fully Paid")
 
 		pr.load_from_db()
 		self.assertEqual(pr.status, "Paid")
@@ -491,7 +482,6 @@ class TestPaymentRequest(FrappeTestCase):
 
 	def test_payment_cancel_process(self):
 		so = make_sales_order(currency="INR", qty=1, rate=1000)
-		self.assertEqual(so.advance_payment_status, "Not Requested")
 
 		pr = make_payment_request(
 			dt="Sales Order",
@@ -506,7 +496,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.outstanding_amount, pr.grand_total)
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Requested")
 
 		pe = pr.create_payment_entry(submit=False)
 		pe.paid_amount = 800
@@ -516,7 +505,6 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pe.references[0].payment_request, pr.name)
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Partially Paid")
 
 		pr.load_from_db()
 		self.assertEqual(pr.status, "Partially Paid")
@@ -532,4 +520,3 @@ class TestPaymentRequest(FrappeTestCase):
 		self.assertEqual(pr.grand_total, 1000)
 
 		so.load_from_db()
-		self.assertEqual(so.advance_payment_status, "Requested")

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -3,7 +3,6 @@
 
 import re
 import unittest
-from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -18,7 +17,6 @@ from erpnext.setup.utils import get_exchange_rate
 
 test_dependencies = ["Currency Exchange", "Journal Entry", "Contact", "Address"]
 
-PAYMENT_URL = "https://example.com/payment"
 
 payment_gateway = {"doctype": "Payment Gateway", "gateway": "_Test Gateway"}
 
@@ -51,28 +49,6 @@ class TestPaymentRequest(FrappeTestCase):
 				"name",
 			):
 				frappe.get_doc(method).insert(ignore_permissions=True)
-
-		send_email = patch(
-			"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email",
-			return_value=None,
-		)
-		self.send_email = send_email.start()
-		self.addCleanup(send_email.stop)
-		get_payment_url = patch(
-			# this also shadows one (1) call to _get_payment_gateway_controller
-			"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.get_payment_url",
-			return_value=PAYMENT_URL,
-		)
-		self.get_payment_url = get_payment_url.start()
-		self.addCleanup(get_payment_url.stop)
-		_get_payment_gateway_controller = patch(
-			"erpnext.accounts.doctype.payment_request.payment_request._get_payment_gateway_controller",
-		)
-		self._get_payment_gateway_controller = _get_payment_gateway_controller.start()
-		self.addCleanup(_get_payment_gateway_controller.stop)
-
-	def tearDown(self):
-		frappe.db.rollback()
 
 	def test_payment_request_linkings(self):
 		so_inr = make_sales_order(currency="INR", do_not_save=True)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1966,7 +1966,38 @@ class AccountsController(TransactionBase):
 					).format(formatted_advance_paid, self.name, formatted_order_total)
 				)
 
-			frappe.db.set_value(self.doctype, self.name, "advance_paid", advance_paid)
+			self.db_set("advance_paid", advance_paid)
+
+		self.set_advance_payment_status()
+
+	def set_advance_payment_status(self):
+		new_status = None
+
+		paid_amount = frappe.get_value(
+			doctype="Payment Request",
+			filters={
+				"reference_doctype": self.doctype,
+				"reference_name": self.name,
+				"docstatus": 1,
+			},
+			fieldname="sum(grand_total - outstanding_amount)",
+		)
+
+		if not paid_amount:
+			if self.doctype in frappe.get_hooks("advance_payment_receivable_doctypes"):
+				new_status = "Not Requested" if paid_amount is None else "Requested"
+			elif self.doctype in frappe.get_hooks("advance_payment_payable_doctypes"):
+				new_status = "Not Initiated" if paid_amount is None else "Initiated"
+		else:
+			total_amount = self.get("rounded_total") or self.get("grand_total")
+			new_status = "Fully Paid" if paid_amount == total_amount else "Partially Paid"
+
+		if new_status == self.advance_payment_status:
+			return
+
+		self.db_set("advance_payment_status", new_status, update_modified=False)
+		self.set_status(update=True)
+		self.notify_update()
 
 	@property
 	def company_abbr(self):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1968,37 +1968,6 @@ class AccountsController(TransactionBase):
 
 			self.db_set("advance_paid", advance_paid)
 
-		self.set_advance_payment_status()
-
-	def set_advance_payment_status(self):
-		new_status = None
-
-		paid_amount = frappe.get_value(
-			doctype="Payment Request",
-			filters={
-				"reference_doctype": self.doctype,
-				"reference_name": self.name,
-				"docstatus": 1,
-			},
-			fieldname="sum(grand_total - outstanding_amount)",
-		)
-
-		if not paid_amount:
-			if self.doctype in frappe.get_hooks("advance_payment_receivable_doctypes"):
-				new_status = "Not Requested" if paid_amount is None else "Requested"
-			elif self.doctype in frappe.get_hooks("advance_payment_payable_doctypes"):
-				new_status = "Not Initiated" if paid_amount is None else "Initiated"
-		else:
-			total_amount = self.get("rounded_total") or self.get("grand_total")
-			new_status = "Fully Paid" if paid_amount == total_amount else "Partially Paid"
-
-		if new_status == self.advance_payment_status:
-			return
-
-		self.db_set("advance_payment_status", new_status, update_modified=False)
-		self.set_status(update=True)
-		self.notify_update()
-
 	@property
 	def company_abbr(self):
 		if not hasattr(self, "_abbr"):

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -365,7 +365,6 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
-			"erpnext.accounts.doctype.payment_request.payment_request.update_payment_req_status",
 			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning",
 		],
 		"on_cancel": ["erpnext.accounts.doctype.dunning.dunning.resolve_dunning"],


### PR DESCRIPTION
* fix: multiple issues in Payment Request

* chore: minor changes

* fix: remove  bug

* fix: replace `round` with `flt`

* fix: changes as per review

* refactor: replace sql query of `matched_payment_requests` to query builder

* fix: replace `locals` with `get_doc` in set_query

* fix: changes during review

* fix: minor review changes

* fix: remove unnecessary code for setting payment entry received amount

* fix: logic for set payment_request if PE made from transaction

* fix: Use rounded total to make Payment Request from `Sales Invoice` or `Purchase Invoice`

* refactor: enhance logic of `set_open_payment_requests_to_references`

* fix: added one optional arg `created_from_payment_request`

* fix: handle multiple allocation of PR at PE's reference

* fix: logic for PR if outstanding docs fetch

* fix: formatted Link field for `Payment Request` for PE's references

* fix: replace `get_all()` with `get_list()` for getting Payment Request for Link field

* chore: format `payment_entry.js` file

* style: Show preview popup of `Payment Request`

* fix: remove minor bug

* fix: add virtual field for Payment Term and Request `outstanding_amount` in PE's reference

* fix: get outstanding amount in PE's reference on realtime

* fix: move allocation of allocated_amount to server side (no change)

* fix: some minor changes to allocation

* fix: Split `Payment Request` if PE is created from PR and there are `Payment Terms`

* fix: minor logic changes

* fix: Allocation of allocated_amount if `paid_amount` is changes

* fix: improve logic of allocation

* fix: set matched payment request if unset

* fix: minor changes

* fix: Allocate single Payment Request if PE created from PR

* fix: improve code logic

* fix: Removed duplication code

* fix: proper message title

* refactor: Rename method of Allocation Amount to References

* refactor: Changing `grand_total` description based on `party_type`

* refactor: update Payment Request

* fix: Remove virtual property of payment_term_outstanding from references

* fix: fetch party account currency for creating payment request

* fix: use transaction currency as base in payment request

* fix: party amount for creating payment entry

* fix: allow for proportional amount paid by bank

* fix: Changed field order in Payment Request

* fix: Minor refactor in Payment Entry Reference table data

* test: Added test cases for allow Payment at `Partially Paid` status for PR

* test: Update partial paid status test case

* test: Update test case for same currency PR

* refactor: Wider the `msgprint` dialog for after save PE

* test: Update PR test cases

* chore: Remove dirty lines

* fix: formatting update

* fix: Use `flt` where doing subtraction

* test: PR test case with Payment Term for same currency

* fix: remove redundant `flt`

* test: Add test cases for PR