### PR TITLE
feat: search attribute value in multiple variant creation dialog

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -554,18 +554,19 @@ $.extend(erpnext.item, {
 					fieldtype: "Data",
 					placeholder: "Search",
 					fieldname: `search_${frappe.scrub(name)}`,
-					onchange: function(e){
+					onchange: function (e) {
 						let value = e.target.value;
-						let result = attr_dict[name].filter(attr_value => attr_value.toString().toLowerCase().includes(value.toLowerCase()));
-						attr_dict[name].forEach((attr_value)=> {
+						let result = attr_dict[name].filter((attr_value) =>
+							attr_value.toString().toLowerCase().includes(value.toLowerCase())
+						);
+						attr_dict[name].forEach((attr_value) => {
 							if (result.includes(attr_value)) {
 								me.multiple_variant_dialog.set_df_property(attr_value, "hidden", 0);
-							}
-							else {
+							} else {
 								me.multiple_variant_dialog.set_df_property(attr_value, "hidden", 1);
 							}
-						})
-					}
+						});
+					},
 				});
 				attr_dict[name].forEach((value) => {
 					fields.push({
@@ -660,7 +661,10 @@ $.extend(erpnext.item, {
 			me.multiple_variant_dialog.disable_primary_action();
 			me.multiple_variant_dialog.clear();
 			me.multiple_variant_dialog.show();
-			me.multiple_variant_dialog.$wrapper.find("div[data-fieldname^='search_']").find(".clearfix").hide();
+			me.multiple_variant_dialog.$wrapper
+				.find("div[data-fieldname^='search_']")
+				.find(".clearfix")
+				.hide();
 		}
 
 		function get_selected_attributes() {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -550,6 +550,23 @@ $.extend(erpnext.item, {
 					fields.push({ fieldtype: "Section Break" });
 				}
 				fields.push({ fieldtype: "Column Break", label: name });
+				fields.push({
+					fieldtype: "Data",
+					placeholder: "Search",
+					fieldname: `search_${frappe.scrub(name)}`,
+					onchange: function(e){
+						let value = e.target.value;
+						let result = attr_dict[name].filter(attr_value => attr_value.toString().toLowerCase().includes(value.toLowerCase()));
+						attr_dict[name].forEach((attr_value)=> {
+							if (result.includes(attr_value)) {
+								me.multiple_variant_dialog.set_df_property(attr_value, "hidden", 0);
+							}
+							else {
+								me.multiple_variant_dialog.set_df_property(attr_value, "hidden", 1);
+							}
+						})
+					}
+				});
 				attr_dict[name].forEach((value) => {
 					fields.push({
 						fieldtype: "Check",
@@ -643,6 +660,7 @@ $.extend(erpnext.item, {
 			me.multiple_variant_dialog.disable_primary_action();
 			me.multiple_variant_dialog.clear();
 			me.multiple_variant_dialog.show();
+			me.multiple_variant_dialog.$wrapper.find("div[data-fieldname^='search_']").find(".clearfix").hide();
 		}
 
 		function get_selected_attributes() {


### PR DESCRIPTION
Added an search field in Item Multiple Variant Creation dialog to search attribute values. It will be helpful in case if we have a large amount of attribute values


https://github.com/user-attachments/assets/5ce0791d-f86d-4206-8d63-ab828e954efb




`no-docs`
