### PR TITLE
fix: Get Entries not showing accounts with no gain or loss in Exchange Rate Revaluation issue fixed

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -74,6 +74,21 @@ class ExchangeRateRevaluation(Document):
 		if not (self.company and self.posting_date):
 			frappe.throw(_("Please select Company and Posting Date to getting entries"))
 
+	def on_submit(self):
+		self.remove_accounts_without_gain_loss()
+
+	def remove_accounts_without_gain_loss(self):
+		self.accounts = [account for account in self.accounts if account.gain_loss]
+
+		if not self.accounts:
+			frappe.throw(_("At least one account with exchange gain or loss is required"))
+
+		frappe.msgprint(
+			_("Removing rows without exchange gain or loss"),
+			alert=True,
+			indicator="yellow",
+		)
+
 	def on_cancel(self):
 		self.ignore_linked_doctypes = "GL Entry"
 
@@ -248,23 +263,23 @@ class ExchangeRateRevaluation(Document):
 				new_exchange_rate = get_exchange_rate(d.account_currency, company_currency, posting_date)
 				new_balance_in_base_currency = flt(d.balance_in_account_currency * new_exchange_rate)
 				gain_loss = flt(new_balance_in_base_currency, precision) - flt(d.balance, precision)
-				if gain_loss:
-					accounts.append(
-						{
-							"account": d.account,
-							"party_type": d.party_type,
-							"party": d.party,
-							"account_currency": d.account_currency,
-							"balance_in_base_currency": d.balance,
-							"balance_in_account_currency": d.balance_in_account_currency,
-							"zero_balance": d.zero_balance,
-							"current_exchange_rate": current_exchange_rate,
-							"new_exchange_rate": new_exchange_rate,
-							"new_balance_in_base_currency": new_balance_in_base_currency,
-							"new_balance_in_account_currency": d.balance_in_account_currency,
-							"gain_loss": gain_loss,
-						}
-					)
+
+				accounts.append(
+					{
+						"account": d.account,
+						"party_type": d.party_type,
+						"party": d.party,
+						"account_currency": d.account_currency,
+						"balance_in_base_currency": d.balance,
+						"balance_in_account_currency": d.balance_in_account_currency,
+						"zero_balance": d.zero_balance,
+						"current_exchange_rate": current_exchange_rate,
+						"new_exchange_rate": new_exchange_rate,
+						"new_balance_in_base_currency": new_balance_in_base_currency,
+						"new_balance_in_account_currency": d.balance_in_account_currency,
+						"gain_loss": gain_loss,
+					}
+				)
 
 			# Handle Accounts with '0' balance in Account/Base Currency
 			for d in [x for x in account_details if x.zero_balance]:
@@ -288,23 +303,22 @@ class ExchangeRateRevaluation(Document):
 						current_exchange_rate * d.balance_in_account_currency
 					)
 
-				if gain_loss:
-					accounts.append(
-						{
-							"account": d.account,
-							"party_type": d.party_type,
-							"party": d.party,
-							"account_currency": d.account_currency,
-							"balance_in_base_currency": d.balance,
-							"balance_in_account_currency": d.balance_in_account_currency,
-							"zero_balance": d.zero_balance,
-							"current_exchange_rate": current_exchange_rate,
-							"new_exchange_rate": new_exchange_rate,
-							"new_balance_in_base_currency": new_balance_in_base_currency,
-							"new_balance_in_account_currency": new_balance_in_account_currency,
-							"gain_loss": gain_loss,
-						}
-					)
+				accounts.append(
+					{
+						"account": d.account,
+						"party_type": d.party_type,
+						"party": d.party,
+						"account_currency": d.account_currency,
+						"balance_in_base_currency": d.balance,
+						"balance_in_account_currency": d.balance_in_account_currency,
+						"zero_balance": d.zero_balance,
+						"current_exchange_rate": current_exchange_rate,
+						"new_exchange_rate": new_exchange_rate,
+						"new_balance_in_base_currency": new_balance_in_base_currency,
+						"new_balance_in_account_currency": new_balance_in_account_currency,
+						"gain_loss": gain_loss,
+					}
+				)
 
 		return accounts
 

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -74,7 +74,7 @@ class ExchangeRateRevaluation(Document):
 		if not (self.company and self.posting_date):
 			frappe.throw(_("Please select Company and Posting Date to getting entries"))
 
-	def on_submit(self):
+	def before_submit(self):
 		self.remove_accounts_without_gain_loss()
 
 	def remove_accounts_without_gain_loss(self):


### PR DESCRIPTION
### Issue:
`Get Entries`  in Exchange Rate Revaluation is not fetching those entries where gain/loss is zero. User may want to set a different exchange rate manually.

![image](https://github.com/user-attachments/assets/befe19ce-1fe6-4abf-ab50-bf04ae55c8d3)

### Fix: 
Remove the condition `if_gain_loss` from `calculate_new_account_balance` method and instead remove the rows with zero gain/loss in `before_submit`. 

![image](https://github.com/user-attachments/assets/bc225323-870d-4d9a-b4ae-c155fff32db2)

