### PR TITLE
fix: quality inspection creation

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -245,6 +245,7 @@ class QualityInspection(Document):
 			for i in range(1, 11):
 				field = "reading_" + str(i)
 				if reading.get(field) is None:
+					data[field] = 0.0
 					continue
 
 				data[field] = parse_float(reading.get(field))


### PR DESCRIPTION
**Issue**

- Create the quality inspection template with "Formula Based Criteria" and formula as "(reading_1 + reading_2) > 3"
- Create the Purchase Receipt and after that click on Create > Quality Inspection 
- In the popup select the items and click on Create, you will get the below error

<img width="795" alt="Screenshot 2024-09-28 at 8 26 30 PM" src="https://github.com/user-attachments/assets/3f119a95-0bcb-439a-b630-a13ecd0c2a28">
