### PR TITLE
fix!: don't round unduly

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -514,7 +514,7 @@ class calculate_taxes_and_totals:
 			if tax.item_wise_tax_detail.get(key):
 				item_wise_tax_amount += tax.item_wise_tax_detail[key][1]
 
-			tax.item_wise_tax_detail[key] = [tax_rate, flt(item_wise_tax_amount)]
+			tax.item_wise_tax_detail[key] = [tax_rate, item_wise_tax_amount]
 
 	def round_off_totals(self, tax):
 		if tax.account_head in frappe.flags.round_off_applicable_accounts:


### PR DESCRIPTION
BREAKING: If you previously relied on the undue rounding of the tax
amount within the item wise tax detail, revise your code and config.
