### PR TITLE
fix: override indicator color for  "Draft"

### DIFF
--- a/erpnext/accounts/doctype/invoice_discounting/invoice_discounting_list.js
+++ b/erpnext/accounts/doctype/invoice_discounting/invoice_discounting_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["Invoice Discounting"] = {
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status == "Draft") {
 			return [__("Draft"), "red", "status,=,Draft"];

--- a/erpnext/accounts/doctype/payment_request/payment_request_list.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["Payment Request"] = {
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status == "Draft") {
 			return [__("Draft"), "gray", "status,=,Draft"];

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry_list.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry_list.js
@@ -3,6 +3,7 @@
 
 // render
 frappe.listview_settings["POS Closing Entry"] = {
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		var status_color = {
 			Draft: "red",

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice_list.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice_list.js
@@ -13,6 +13,7 @@ frappe.listview_settings["POS Invoice"] = {
 		"currency",
 		"is_return",
 	],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		var status_color = {
 			Draft: "red",

--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry_list.js
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry_list.js
@@ -3,6 +3,7 @@
 
 // render
 frappe.listview_settings["POS Opening Entry"] = {
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		var status_color = {
 			Draft: "red",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
@@ -13,6 +13,7 @@ frappe.listview_settings["Sales Invoice"] = {
 		"currency",
 		"is_return",
 	],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		const status_colors = {
 			Draft: "grey",

--- a/erpnext/assets/doctype/asset/asset_list.js
+++ b/erpnext/assets/doctype/asset/asset_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["Asset"] = {
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status === "Fully Depreciated") {
 			return [__("Fully Depreciated"), "green", "status,=,Fully Depreciated"];

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator_list.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["BOM Creator"] = {
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status === "Draft") {
 			return [__("Draft"), "red", "status,=,Draft"];

--- a/erpnext/manufacturing/doctype/production_plan/production_plan_list.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan_list.js
@@ -1,6 +1,7 @@
 frappe.listview_settings["Production Plan"] = {
 	hide_name_column: true,
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	filters: [["status", "!=", "Closed"]],
 	get_indicator: function (doc) {
 		if (doc.status === "Submitted") {

--- a/erpnext/manufacturing/doctype/work_order/work_order_list.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order_list.js
@@ -9,6 +9,7 @@ frappe.listview_settings["Work Order"] = {
 		"planned_start_date",
 		"planned_end_date",
 	],
+	has_indicator_for_draft: 1,
 	filters: [["status", "!=", "Stopped"]],
 	get_indicator: function (doc) {
 		if (doc.status === "Submitted") {

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip_list.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["Delivery Trip"] = {
 	add_fields: ["status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (["Cancelled", "Draft"].includes(doc.status)) {
 			return [__(doc.status), "red", "status,=," + doc.status];

--- a/erpnext/stock/doctype/pick_list/pick_list_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list_list.js
@@ -2,6 +2,7 @@
 // For license information, please see license.txt
 
 frappe.listview_settings["Pick List"] = {
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		const status_colors = {
 			Draft: "grey",

--- a/erpnext/stock/doctype/stock_entry/stock_entry_list.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_list.js
@@ -7,6 +7,7 @@ frappe.listview_settings["Stock Entry"] = {
 		"`tabStock Entry`.`bom_no`",
 		"`tabStock Entry`.`is_return`",
 	],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.is_return === 1 && doc.purpose === "Material Transfer for Manufacture") {
 			return [

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry_list.js
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry_list.js
@@ -2,6 +2,7 @@
 // For license information, please see license.txt
 
 frappe.listview_settings["Stock Reservation Entry"] = {
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		const status_colors = {
 			Draft: "red",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt_list.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt_list.js
@@ -2,6 +2,7 @@
 // For license information, please see license.txt
 
 frappe.listview_settings["Subcontracting Receipt"] = {
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		const status_colors = {
 			Draft: "grey",


### PR DESCRIPTION
indicator colour was not overridden because `has_indicator_for_draft` was not set.

Before:
![image](https://github.com/user-attachments/assets/07b9aa08-55db-446e-aac4-feb154a849b7)

After:
![image](https://github.com/user-attachments/assets/97b3bc9b-fd5f-4b6a-9e4e-21123c1b1369)


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/22685


