### PR TITLE
fix: add company filter in Warehouse wise Item Balance Age and Value

### DIFF
--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
@@ -4,6 +4,15 @@
 frappe.query_reports["Warehouse wise Item Balance Age and Value"] = {
 	filters: [
 		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			width: "80",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
+		},
+		{
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
@@ -39,6 +48,12 @@ frappe.query_reports["Warehouse wise Item Balance Age and Value"] = {
 			fieldtype: "Link",
 			width: "80",
 			options: "Warehouse",
+			get_query: function () {
+				const company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: { company: company },
+				};
+			},
 		},
 		{
 			fieldname: "filter_total_zero_qty",

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
@@ -109,8 +109,6 @@ def validate_filters(filters):
 		sle_count = flt(frappe.qb.from_("Stock Ledger Entry").select(Count("name")).run()[0][0])
 		if sle_count > 500000:
 			frappe.throw(_("Please set filter based on Item or Warehouse"))
-	if not filters.get("company"):
-		filters["company"] = frappe.defaults.get_user_default("Company")
 
 
 def get_warehouse_list(filters):


### PR DESCRIPTION
Version 15

fixes: #43443

**Before:**

- Report is fetching and filtering company from session defaults and showing stock only for selected company, it's difficult for user.

https://github.com/user-attachments/assets/c6f7601b-6e68-4cf6-935f-ba97caeaa6a7


<br>

**After:**

- Adding the company filter, removing unnecessary conditions from the report, and displaying warehouse by company.

https://github.com/user-attachments/assets/92cdc47f-f449-4fca-955d-258256ffd69c

