### PR TITLE
fix: new url for frankfurter.app, now use api.frankfurter.app

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -109,7 +109,7 @@ def get_api_endpoint(service_provider: str | None = None, use_http: bool = False
 		if service_provider == "exchangerate.host":
 			api = "api.exchangerate.host/convert"
 		elif service_provider == "frankfurter.app":
-			api = "frankfurter.app/{transaction_date}"
+			api = "api.frankfurter.app/{transaction_date}"
 
 		protocol = "https://"
 		if use_http:


### PR DESCRIPTION
frankfurter.app dosent work anymore, now we need to use "api.frankfurter.app":


old access: 
https://frankfurter.dev/2024-10-01?base=USD&symbols=INR

now:
https://api.frankfurter.app/2024-10-01?base=USD&symbols=INR


this is used on setup a new site, and get a stack on try to use frankfurter.app