### PR TITLE
fix: Fix API endpoint for Frankfurter

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -109,7 +109,7 @@ def get_api_endpoint(service_provider: str | None = None, use_http: bool = False
 		if service_provider == "exchangerate.host":
 			api = "api.exchangerate.host/convert"
 		elif service_provider == "frankfurter.app":
-			api = "frankfurter.app/{transaction_date}"
+			api = "api.frankfurter.app/{transaction_date}"
 
 		protocol = "https://"
 		if use_http:

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -68,9 +68,9 @@ def patched_requests_get(*args, **kwargs):
 		if kwargs["params"].get("date") and kwargs["params"].get("from") and kwargs["params"].get("to"):
 			if test_exchange_values.get(kwargs["params"]["date"]):
 				return PatchResponse({"result": test_exchange_values[kwargs["params"]["date"]]}, 200)
-	elif args[0].startswith("https://frankfurter.app") and kwargs.get("params"):
+	elif args[0].startswith("https://api.frankfurter.app") and kwargs.get("params"):
 		if kwargs["params"].get("base") and kwargs["params"].get("symbols"):
-			date = args[0].replace("https://frankfurter.app/", "")
+			date = args[0].replace("https://api.frankfurter.app/", "")
 			if test_exchange_values.get(date):
 				return PatchResponse(
 					{"rates": {kwargs["params"].get("symbols"): test_exchange_values.get(date)}}, 200

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -84,7 +84,7 @@ def setup_currency_exchange():
 		ces.set("result_key", [])
 		ces.set("req_params", [])
 
-		ces.api_endpoint = "https://frankfurter.app/{transaction_date}"
+		ces.api_endpoint = "https://api.frankfurter.app/{transaction_date}"
 		ces.append("result_key", {"key": "rates"})
 		ces.append("result_key", {"key": "{to_currency}"})
 		ces.append("req_params", {"key": "base", "value": "{from_currency}"})


### PR DESCRIPTION
Frankfurter just passed a **breaking change** which breaks the "frankfurter.app" endpoint for API calls. The new endpoint is "api.frankfurter.app".

re: https://github.com/frappe/erpnext/pull/43472