### PR TITLE
fix(stock): Grab posting date/time from SABB

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1732,6 +1732,9 @@ def get_valuation_rate(
 
 	# Get moving average rate of a specific batch number
 	if warehouse and serial_and_batch_bundle:
+		sabb = frappe.db.get_value(
+			"Serial and Batch Bundle", serial_and_batch_bundle, ["posting_date", "posting_time"], as_dict=True
+		)
 		batch_obj = BatchNoValuation(
 			sle=frappe._dict(
 				{
@@ -1739,6 +1742,8 @@ def get_valuation_rate(
 					"warehouse": warehouse,
 					"actual_qty": -1,
 					"serial_and_batch_bundle": serial_and_batch_bundle,
+					"posting_date": sabb.posting_date,
+					"posting_time": sabb.posting_time,
 				}
 			)
 		)


### PR DESCRIPTION
## TypeError: combine() argument 1 must be datetime.date, not None

Hey :wave:, sorry to bother you.

I see in the code below that a "fake" Stock Ledger Entry is constructed. However, there are two missing keys, namely "posting_date" and "posting_date". Because, they are expected a little bit after, saving the Stock Entry fails.

I just wanted an expert's opinion: is this a typo, a small oversight? Or should I dig down more.
Please note that I did not try to reproduce the issue yet, just doing things on instinct.

```py
  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 1714, in get_valuation_rate
    batch_obj = BatchNoValuation(
			sle=frappe._dict(
				{
					"item_code": item_code,
					"warehouse": warehouse,
					"actual_qty": -1,
					"serial_and_batch_bundle": serial_and_batch_bundle,
#				-->	## Here there are missing keys: posting_date, posting_time
#				-->	## Let's just grab them from the SABB and call it a day
				}
			)
		)
```


---

<details><summary><h2>Stack trace</h2></summary>

```py
  File "apps/frappe/frappe/desk/form/save.py", line 39, in savedocs
    doc.save()
      doc = <StockEntry: MAT-STE-2024-XXXXX>
  File "apps/frappe/frappe/model/document.py", line 1136, in run_before_save_methods
    self.run_method("validate")
  File "apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 238, in validate
    self.calculate_rate_and_amount()
  File "apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 777, in calculate_rate_and_amount
    self.set_basic_rate(reset_outgoing_rate, raise_error_if_no_rate)
  File "apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 819, in set_basic_rate
    d.basic_rate = get_valuation_rate(
  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 1714, in get_valuation_rate
    batch_obj = BatchNoValuation(
			sle=frappe._dict(
				{
					"item_code": item_code,
					"warehouse": warehouse,
					"actual_qty": -1,
					"serial_and_batch_bundle": serial_and_batch_bundle,
					# HERE: Missing posting_date, posting_time
				}
			)
		)
  File "apps/erpnext/erpnext/stock/serial_batch_bundle.py", line 627, in __init__
    self.calculate_avg_rate()
  File "apps/erpnext/erpnext/stock/serial_batch_bundle.py", line 647, in calculate_avg_rate
    self.calculate_avg_rate_for_non_batchwise_valuation()
  File "apps/frappe/frappe/utils/deprecations.py", line 18, in wrapper
    return func(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/deprecated_serial_batch.py", line 158, in calculate_avg_rate_for_non_batchwise_valuation
    self.set_balance_value_for_non_batchwise_valuation_batches()
  File "apps/frappe/frappe/utils/deprecations.py", line 18, in wrapper
    return func(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/deprecated_serial_batch.py", line 190, in set_balance_value_for_non_batchwise_valuation_batches
    self.set_balance_value_from_sl_entries()
  File "apps/frappe/frappe/utils/deprecations.py", line 18, in wrapper
    return func(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/deprecated_serial_batch.py", line 200, in set_balance_value_from_sl_entries
    posting_datetime = get_combine_datetime(self.sle.posting_date, self.sle.posting_time)
      self = <erpnext.stock.serial_batch_bundle.BatchNoValuation object>
  File "apps/erpnext/erpnext/stock/utils.py", line 669, in get_combine_datetime
    return datetime.datetime.combine(posting_date, posting_time).replace(microsecond=0)
      posting_date = None
      posting_time = None
TypeError: combine() argument 1 must be datetime.date, not None
```

</details>