### PR TITLE
fix: read only filters in multidialog fields

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -935,6 +935,7 @@ erpnext.utils.map_current_doc = function (opts) {
 			target: opts.target,
 			date_field: opts.date_field || undefined,
 			setters: opts.setters,
+			read_only_setters: opts.read_only_setters,
 			data_fields: data_fields,
 			get_query: opts.get_query,
 			add_filters_group: 1,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -447,9 +447,11 @@ frappe.ui.form.on("Stock Entry", {
 						source_doctype: "Stock Entry",
 						target: frm,
 						date_field: "posting_date",
+						read_only_setters: ["stock_entry_type", "purpose", "add_to_transit"],
 						setters: {
 							stock_entry_type: "Material Transfer",
 							purpose: "Material Transfer",
+							add_to_transit: 1,
 						},
 						get_query_filters: {
 							docstatus: 1,


### PR DESCRIPTION
**Issue**

Goto Stock Entry -> Get Items From -> Transit Entry -> Users able to change Stock Entry Type

<img width="661" alt="image" src="https://github.com/user-attachments/assets/1289a1d4-3033-41fc-8937-f3af9f58b00d">


**After Fix**

Do not allow to change the filters in the multidialog

<img width="910" alt="Screenshot 2024-10-06 at 10 02 25 AM" src="https://github.com/user-attachments/assets/9a1493f2-0370-45d6-89bc-333ce734783a">
