### PR TITLE
fix: 'NoneType' object has no attribute 'has_serial_no'

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -357,6 +357,9 @@ class StockController(AccountsController):
 
 	@frappe.request_cache
 	def is_serial_batch_item(self, item_code) -> bool:
+		if not frappe.db.exists("Item", item_code):
+			frappe.throw(_("Item {0} does not exist.").format(bold(item_code)))
+
 		item_details = frappe.db.get_value("Item", item_code, ["has_serial_no", "has_batch_no"], as_dict=1)
 
 		if item_details.has_serial_no or item_details.has_batch_no:


### PR DESCRIPTION
```
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 248, in make_bundle_for_sales_purchase_return
    self.make_bundle_for_non_rejected_qty(table_name)
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 303, in make_bundle_for_non_rejected_qty
    field, reference_ids = self.get_reference_ids(table_name)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 340, in get_reference_ids
    if not self.is_serial_batch_item(row.item_code):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/caching.py", line 59, in wrapper
    return_val = func(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 362, in is_serial_batch_item
    if item_details.has_serial_no or item_details.has_batch_no:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'has_serial_no'
```