### PR TITLE
test: inherit from frappe.tests.IntegrationTestCase (treewide)

### DIFF
--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
 from frappe.tests.utils import make_test_records
+from frappe.tests import IntegrationTestCase
 from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.account.account import (
@@ -18,7 +17,7 @@ from erpnext.stock import get_company_default_inventory_account, get_warehouse_a
 test_dependencies = ["Company"]
 
 
-class TestAccount(unittest.TestCase):
+class TestAccount(IntegrationTestCase):
 	def test_rename_account(self):
 		if not frappe.db.exists("Account", "1210 - Debtors - _TC"):
 			acc = frappe.new_doc("Account")

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -11,7 +11,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 test_dependencies = ["Cost Center", "Location", "Warehouse", "Department"]
 
 
-class TestAccountingDimension(unittest.TestCase):
+class TestAccountingDimension(IntegrationTestCase):
 	def setUp(self):
 		create_dimension()
 

--- a/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
 	create_dimension,
@@ -15,7 +15,7 @@ from erpnext.exceptions import InvalidAccountDimensionError, MandatoryAccountDim
 test_dependencies = ["Location", "Cost Center", "Department"]
 
 
-class TestAccountingDimensionFilter(unittest.TestCase):
+class TestAccountingDimensionFilter(IntegrationTestCase):
 	def setUp(self):
 		create_dimension()
 		create_accounting_dimension_filter()

--- a/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_months, nowdate
 
 from erpnext.accounts.doctype.accounting_period.accounting_period import (
@@ -15,7 +15,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 test_dependencies = ["Item"]
 
 
-class TestAccountingPeriod(unittest.TestCase):
+class TestAccountingPeriod(IntegrationTestCase):
 	def test_overlap(self):
 		ap1 = create_accounting_period(
 			start_date="2018-04-01", end_date="2018-06-30", company="Wind Power LLC"

--- a/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/test_accounts_settings.py
@@ -1,9 +1,10 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestAccountsSettings(unittest.TestCase):
+class TestAccountsSettings(IntegrationTestCase):
 	def tearDown(self):
 		# Just in case `save` method succeeds, we need to take things back to default so that other tests
 		# don't break

--- a/erpnext/accounts/doctype/bank/test_bank.py
+++ b/erpnext/accounts/doctype/bank/test_bank.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBank(unittest.TestCase):
+
+class TestBank(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/bank_account/test_bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/test_bank_account.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
 from frappe import ValidationError
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Bank Account')
 
 
-class TestBankAccount(unittest.TestCase):
+class TestBankAccount(IntegrationTestCase):
 	def test_validate_iban(self):
 		valid_ibans = [
 			"GB82 WEST 1234 5698 7654 32",

--- a/erpnext/accounts/doctype/bank_account_subtype/test_bank_account_subtype.py
+++ b/erpnext/accounts/doctype/bank_account_subtype/test_bank_account_subtype.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBankAccountSubtype(unittest.TestCase):
+
+class TestBankAccountSubtype(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/bank_account_type/test_bank_account_type.py
+++ b/erpnext/accounts/doctype/bank_account_type/test_bank_account_type.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBankAccountType(unittest.TestCase):
+
+class TestBankAccountType(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_months, getdate
 
 from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
@@ -15,7 +15,7 @@ from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.tests.utils import if_lending_app_installed, if_lending_app_not_installed
 
 
-class TestBankClearance(unittest.TestCase):
+class TestBankClearance(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		create_warehouse(

--- a/erpnext/accounts/doctype/bank_guarantee/test_bank_guarantee.py
+++ b/erpnext/accounts/doctype/bank_guarantee/test_bank_guarantee.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBankGuarantee(unittest.TestCase):
+
+class TestBankGuarantee(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/bank_statement_import/test_bank_statement_import.py
+++ b/erpnext/accounts/doctype/bank_statement_import/test_bank_statement_import.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBankStatementImport(unittest.TestCase):
+
+class TestBankStatementImport(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import now_datetime, nowdate
 
 from erpnext.accounts.doctype.budget.budget import BudgetError, get_actual_expense
@@ -14,7 +14,7 @@ from erpnext.buying.doctype.purchase_order.test_purchase_order import create_pur
 test_dependencies = ["Monthly Distribution"]
 
 
-class TestBudget(unittest.TestCase):
+class TestBudget(IntegrationTestCase):
 	def test_monthly_budget_crossed_ignore(self):
 		set_total_expense_zero(nowdate(), "cost_center")
 

--- a/erpnext/accounts/doctype/cashier_closing/test_cashier_closing.py
+++ b/erpnext/accounts/doctype/cashier_closing/test_cashier_closing.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCashierClosing(unittest.TestCase):
+
+class TestCashierClosing(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestChartofAccountsImporter(unittest.TestCase):
+
+class TestChartofAccountsImporter(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/cheque_print_template/test_cheque_print_template.py
+++ b/erpnext/accounts/doctype/cheque_print_template/test_cheque_print_template.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Cheque Print Template')
 
 
-class TestChequePrintTemplate(unittest.TestCase):
+class TestChequePrintTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/cost_center/test_cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/test_cost_center.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Cost Center")
 
 
-class TestCostCenter(unittest.TestCase):
+class TestCostCenter(IntegrationTestCase):
 	def test_cost_center_creation_against_child_node(self):
 		if not frappe.db.get_value("Cost Center", {"name": "_Test Cost Center 2 - _TC"}):
 			frappe.get_doc(test_records[1]).insert()

--- a/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
+++ b/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, today
 
 from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
@@ -17,7 +17,7 @@ from erpnext.accounts.doctype.cost_center_allocation.cost_center_allocation impo
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 
 
-class TestCostCenterAllocation(unittest.TestCase):
+class TestCostCenterAllocation(IntegrationTestCase):
 	def setUp(self):
 		cost_centers = [
 			"Main Cost Center 1",

--- a/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
+++ b/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
@@ -110,7 +110,7 @@ def test_create_test_data():
 		coupon_code.insert()
 
 
-class TestCouponCode(unittest.TestCase):
+class TestCouponCode(IntegrationTestCase):
 	def setUp(self):
 		test_create_test_data()
 

--- a/erpnext/accounts/doctype/currency_exchange_settings/test_currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/test_currency_exchange_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Wahni Green Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCurrencyExchangeSettings(unittest.TestCase):
+
+class TestCurrencyExchangeSettings(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/dunning_type/test_dunning_type.py
+++ b/erpnext/accounts/doctype/dunning_type/test_dunning_type.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestDunningType(unittest.TestCase):
+
+class TestDunningType(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/finance_book/test_finance_book.py
+++ b/erpnext/accounts/doctype/finance_book/test_finance_book.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 
 
-class TestFinanceBook(unittest.TestCase):
+class TestFinanceBook(IntegrationTestCase):
 	def test_finance_book(self):
 		finance_book = create_finance_book()
 

--- a/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import now_datetime
 
 test_ignore = ["Company"]
 
 
-class TestFiscalYear(unittest.TestCase):
+class TestFiscalYear(IntegrationTestCase):
 	def test_extra_year(self):
 		if frappe.db.exists("Fiscal Year", "_Test Fiscal Year 2000"):
 			frappe.delete_doc("Fiscal Year", "_Test Fiscal Year 2000")

--- a/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
@@ -1,17 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
 from frappe.model.naming import parse_naming_series
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.gl_entry.gl_entry import rename_gle_sle_docs
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 
 
-class TestGLEntry(unittest.TestCase):
+class TestGLEntry(IntegrationTestCase):
 	def test_round_off_entry(self):
 		frappe.db.set_value("Company", "_Test Company", "round_off_account", "_Test Write Off - _TC")
 		frappe.db.set_value("Company", "_Test Company", "round_off_cost_center", "_Test Cost Center - _TC")

--- a/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
+++ b/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, flt, nowdate
 
 from erpnext.accounts.doctype.account.test_account import create_account
@@ -12,7 +12,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import get_gl_entries
 
 
-class TestInvoiceDiscounting(unittest.TestCase):
+class TestInvoiceDiscounting(IntegrationTestCase):
 	def setUp(self):
 		self.ar_credit = create_account(
 			account_name="_Test Accounts Receivable Credit",

--- a/erpnext/accounts/doctype/item_tax_template/test_item_tax_template.py
+++ b/erpnext/accounts/doctype/item_tax_template/test_item_tax_template.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestItemTaxTemplate(unittest.TestCase):
+
+class TestItemTaxTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/journal_entry_template/test_journal_entry_template.py
+++ b/erpnext/accounts/doctype/journal_entry_template/test_journal_entry_template.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestJournalEntryTemplate(unittest.TestCase):
+
+class TestJournalEntryTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/ledger_merge/test_ledger_merge.py
+++ b/erpnext/accounts/doctype/ledger_merge/test_ledger_merge.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2021, Wahni Green Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.ledger_merge.ledger_merge import start_merge
 
 
-class TestLedgerMerge(unittest.TestCase):
+class TestLedgerMerge(IntegrationTestCase):
 	def test_merge_success(self):
 		if not frappe.db.exists("Account", "Indirect Expenses - _TC"):
 			acc = frappe.new_doc("Account")

--- a/erpnext/accounts/doctype/loyalty_point_entry/test_loyalty_point_entry.py
+++ b/erpnext/accounts/doctype/loyalty_point_entry/test_loyalty_point_entry.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import today
 
 from erpnext.accounts.doctype.loyalty_program.test_loyalty_program import create_records
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 
 
-class TestLoyaltyPointEntry(unittest.TestCase):
+class TestLoyaltyPointEntry(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		# Create test records

--- a/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import cint, flt, getdate, today
 
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
@@ -13,7 +13,7 @@ from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
 from erpnext.accounts.party import get_dashboard_info
 
 
-class TestLoyaltyProgram(unittest.TestCase):
+class TestLoyaltyProgram(IntegrationTestCase):
 	@classmethod
 	def setUpClass(self):
 		# create relevant item, customer, loyalty program, etc

--- a/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
+++ b/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Mode of Payment')
 
 
-class TestModeofPayment(unittest.TestCase):
+class TestModeofPayment(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
+++ b/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Monthly Distribution")
 
 
-class TestMonthlyDistribution(unittest.TestCase):
+class TestMonthlyDistribution(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/party_link/test_party_link.py
+++ b/erpnext/accounts/doctype/party_link/test_party_link.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestPartyLink(unittest.TestCase):
+
+class TestPartyLink(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Payment Gateway Account')
 
 test_ignore = ["Payment Gateway"]
 
 
-class TestPaymentGatewayAccount(unittest.TestCase):
+class TestPaymentGatewayAccount(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/payment_term/test_payment_term.py
+++ b/erpnext/accounts/doctype/payment_term/test_payment_term.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestPaymentTerm(unittest.TestCase):
+
+class TestPaymentTerm(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/payment_terms_template/test_payment_terms_template.py
+++ b/erpnext/accounts/doctype/payment_terms_template/test_payment_terms_template.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestPaymentTermsTemplate(unittest.TestCase):
+class TestPaymentTermsTemplate(IntegrationTestCase):
 	def tearDown(self):
 		frappe.delete_doc("Payment Terms Template", "_Test Payment Terms Template For Test", force=1)
 

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import today
 
 from erpnext.accounts.doctype.finance_book.test_finance_book import create_finance_book
@@ -13,7 +12,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 from erpnext.accounts.utils import get_fiscal_year
 
 
-class TestPeriodClosingVoucher(unittest.TestCase):
+class TestPeriodClosingVoucher(IntegrationTestCase):
 	def test_closing_entry(self):
 		frappe.db.sql("delete from `tabGL Entry` where company='Test PCV Company'")
 		frappe.db.sql("delete from `tabPeriod Closing Voucher` where company='Test PCV Company'")

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
 	create_dimension,
@@ -24,7 +24,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 
-class TestPOSClosingEntry(unittest.TestCase):
+class TestPOSClosingEntry(IntegrationTestCase):
 	def setUp(self):
 		# Make stock available for POS Sales
 		make_stock_entry(target="_Test Warehouse - _TC", qty=2, basic_rate=100)

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import copy
 import unittest
 
 import frappe
 from frappe import _
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import make_sales_return
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
@@ -20,7 +20,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 
 
-class TestPOSInvoice(unittest.TestCase):
+class TestPOSInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import json
 
 import frappe

--- a/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestPOSOpeningEntry(unittest.TestCase):
+class TestPOSOpeningEntry(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.pos_profile.pos_profile import (
 	get_child_nodes,
@@ -13,7 +13,7 @@ from erpnext.stock.get_item_details import get_pos_profile
 test_dependencies = ["Item"]
 
 
-class TestPOSProfile(unittest.TestCase):
+class TestPOSProfile(IntegrationTestCase):
 	def test_pos_profile(self):
 		make_pos_profile()
 

--- a/erpnext/accounts/doctype/pos_profile_user/test_pos_profile_user.py
+++ b/erpnext/accounts/doctype/pos_profile_user/test_pos_profile_user.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestPOSProfileUser(unittest.TestCase):
+
+class TestPOSProfileUser(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/pos_settings/test_pos_settings.py
+++ b/erpnext/accounts/doctype/pos_settings/test_pos_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestPOSSettings(unittest.TestCase):
+
+class TestPOSSettings(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
+++ b/erpnext/accounts/doctype/process_deferred_accounting/test_process_deferred_accounting.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
@@ -13,7 +13,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 from erpnext.stock.doctype.item.test_item import create_item
 
 
-class TestProcessDeferredAccounting(unittest.TestCase):
+class TestProcessDeferredAccounting(IntegrationTestCase):
 	def test_creation_of_ledger_entry_on_submit(self):
 		"""test creation of gl entries on submission of document"""
 		change_acc_settings(acc_frozen_upto="2023-05-31", book_deferred_entries_based_on="Months")

--- a/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.promotional_scheme.promotional_scheme import TransactionExists
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
 
-class TestPromotionalScheme(unittest.TestCase):
+class TestPromotionalScheme(IntegrationTestCase):
 	def setUp(self):
 		if frappe.db.exists("Promotional Scheme", "_Test Scheme"):
 			frappe.delete_doc("Promotional Scheme", "_Test Scheme")

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Purchase Taxes and Charges Template')
 
 
-class TestPurchaseTaxesandChargesTemplate(unittest.TestCase):
+class TestPurchaseTaxesandChargesTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Sales Taxes and Charges Template")
 
 
-class TestSalesTaxesandChargesTemplate(unittest.TestCase):
+class TestSalesTaxesandChargesTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
+++ b/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.share_transfer.share_transfer import ShareDontExists
 
 test_dependencies = ["Share Type", "Shareholder"]
 
 
-class TestShareTransfer(unittest.TestCase):
+class TestShareTransfer(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.sql("delete from `tabShare Transfer`")
 		frappe.db.sql("delete from `tabShare Balance`")

--- a/erpnext/accounts/doctype/share_type/test_share_type.py
+++ b/erpnext/accounts/doctype/share_type/test_share_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestShareType(unittest.TestCase):
+
+class TestShareType(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/shareholder/test_shareholder.py
+++ b/erpnext/accounts/doctype/shareholder/test_shareholder.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestShareholder(unittest.TestCase):
+
+class TestShareholder(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/shipping_rule/test_shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/test_shipping_rule.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.shipping_rule.shipping_rule import (
 	FromGreaterThanToError,
@@ -14,7 +14,7 @@ from erpnext.accounts.doctype.shipping_rule.shipping_rule import (
 test_records = frappe.get_test_records("Shipping Rule")
 
 
-class TestShippingRule(unittest.TestCase):
+class TestShippingRule(IntegrationTestCase):
 	def test_from_greater_than_to(self):
 		shipping_rule = frappe.copy_doc(test_records[0])
 		shipping_rule.name = test_records[0].get("name")

--- a/erpnext/accounts/doctype/subscription_invoice/test_subscription_invoice.py
+++ b/erpnext/accounts/doctype/subscription_invoice/test_subscription_invoice.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSubscriptionInvoice(unittest.TestCase):
+
+class TestSubscriptionInvoice(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/subscription_plan/test_subscription_plan.py
+++ b/erpnext/accounts/doctype/subscription_plan/test_subscription_plan.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSubscriptionPlan(unittest.TestCase):
+
+class TestSubscriptionPlan(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/subscription_settings/test_subscription_settings.py
+++ b/erpnext/accounts/doctype/subscription_settings/test_subscription_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSubscriptionSettings(unittest.TestCase):
+
+class TestSubscriptionSettings(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/tax_category/test_tax_category.py
+++ b/erpnext/accounts/doctype/tax_category/test_tax_category.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestTaxCategory(unittest.TestCase):
+
+class TestTaxCategory(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule, get_tax_template
 from erpnext.crm.doctype.opportunity.opportunity import make_quotation
@@ -12,7 +12,7 @@ from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
 test_records = frappe.get_test_records("Tax Rule")
 
 
-class TestTaxRule(unittest.TestCase):
+class TestTaxRule(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		frappe.db.set_single_value("Shopping Cart Settings", "enabled", 0)

--- a/erpnext/accounts/report/account_balance/test_account_balance.py
+++ b/erpnext/accounts/report/account_balance/test_account_balance.py
@@ -1,13 +1,14 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import getdate
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.account_balance.account_balance import execute
 
 
-class TestAccountBalance(unittest.TestCase):
+class TestAccountBalance(IntegrationTestCase):
 	def test_account_balance(self):
 		frappe.db.sql("delete from `tabSales Invoice` where company='_Test Company 2'")
 		frappe.db.sql("delete from `tabGL Entry` where company='_Test Company 2'")

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import today
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
@@ -16,7 +15,7 @@ from erpnext.accounts.report.sales_payment_summary.sales_payment_summary import 
 test_dependencies = ["Sales Invoice"]
 
 
-class TestSalesPaymentSummary(unittest.TestCase):
+class TestSalesPaymentSummary(IntegrationTestCase):
 	@classmethod
 	def setUpClass(self):
 		create_records()

--- a/erpnext/accounts/test/test_reports.py
+++ b/erpnext/accounts/test/test_reports.py
@@ -1,5 +1,7 @@
 import unittest
 
+from frappe.tests import IntegrationTestCase
+
 from erpnext.tests.utils import ReportFilters, ReportName, execute_script_report
 
 DEFAULT_FILTERS = {
@@ -34,7 +36,7 @@ REPORT_FILTER_TEST_CASES: list[tuple[ReportName, ReportFilters]] = [
 OPTIONAL_FILTERS = {}
 
 
-class TestReports(unittest.TestCase):
+class TestReports(IntegrationTestCase):
 	def test_execute_all_accounts_reports(self):
 		"""Test that all script report in stock modules are executable with supported filters"""
 		for report, filter in REPORT_FILTER_TEST_CASES:

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -2,6 +2,7 @@ import unittest
 
 import frappe
 from frappe.test_runner import make_test_objects
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
@@ -16,7 +17,7 @@ from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_pu
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -42,7 +42,7 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
 
-class AssetSetup(unittest.TestCase):
+class AssetSetup(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		set_depreciation_settings_in_company()

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import cint, flt, getdate, now_datetime
 
 from erpnext.assets.doctype.asset.depreciation import post_depreciation_entries
@@ -21,7 +21,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 )
 
 
-class TestAssetCapitalization(unittest.TestCase):
+class TestAssetCapitalization(IntegrationTestCase):
 	def setUp(self):
 		set_depreciation_settings_in_company()
 		create_asset_data()

--- a/erpnext/assets/doctype/asset_category/test_asset_category.py
+++ b/erpnext/assets/doctype/asset_category/test_asset_category.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestAssetCategory(unittest.TestCase):
+class TestAssetCategory(IntegrationTestCase):
 	def test_mandatory_fields(self):
 		asset_category = frappe.new_doc("Asset Category")
 		asset_category.asset_category_name = "Computers"

--- a/erpnext/assets/doctype/asset_maintenance/test_asset_maintenance.py
+++ b/erpnext/assets/doctype/asset_maintenance/test_asset_maintenance.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, get_last_day, nowdate
 
 from erpnext.assets.doctype.asset_maintenance.asset_maintenance import calculate_next_due_date
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
 
-class TestAssetMaintenance(unittest.TestCase):
+class TestAssetMaintenance(IntegrationTestCase):
 	def setUp(self):
 		set_depreciation_settings_in_company()
 		self.pr = make_purchase_receipt(

--- a/erpnext/assets/doctype/asset_maintenance_log/test_asset_maintenance_log.py
+++ b/erpnext/assets/doctype/asset_maintenance_log/test_asset_maintenance_log.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestAssetMaintenanceLog(unittest.TestCase):
+
+class TestAssetMaintenanceLog(IntegrationTestCase):
 	pass

--- a/erpnext/assets/doctype/asset_maintenance_team/test_asset_maintenance_team.py
+++ b/erpnext/assets/doctype/asset_maintenance_team/test_asset_maintenance_team.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestAssetMaintenanceTeam(unittest.TestCase):
+
+class TestAssetMaintenanceTeam(IntegrationTestCase):
 	pass

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import now
 
 from erpnext.assets.doctype.asset.test_asset import create_asset_data
@@ -11,7 +11,7 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
 
-class TestAssetMovement(unittest.TestCase):
+class TestAssetMovement(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.set_value(
 			"Company", "_Test Company", "capital_work_in_progress_account", "CWIP Account - _TC"

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import flt, nowdate, nowtime, today
 
 from erpnext.assets.doctype.asset.asset import (
@@ -25,7 +25,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 )
 
 
-class TestAssetRepair(unittest.TestCase):
+class TestAssetRepair(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		set_depreciation_settings_in_company()

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, cstr, get_last_day, getdate, nowdate
 
 from erpnext.assets.doctype.asset.asset import get_asset_value_after_depreciation
@@ -16,7 +16,7 @@ from erpnext.assets.doctype.asset_repair.test_asset_repair import create_asset_r
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
 
-class TestAssetValueAdjustment(unittest.TestCase):
+class TestAssetValueAdjustment(IntegrationTestCase):
 	def setUp(self):
 		create_asset_data()
 		frappe.db.set_value(

--- a/erpnext/assets/doctype/location/test_location.py
+++ b/erpnext/assets/doctype/location/test_location.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import json
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Location")
 
 
-class TestLocation(unittest.TestCase):
+class TestLocation(IntegrationTestCase):
 	def runTest(self):
 		locations = ["Basil Farm", "Division 1", "Field 1", "Block 1"]
 		area = 0

--- a/erpnext/assets/doctype/maintenance_team_member/test_maintenance_team_member.py
+++ b/erpnext/assets/doctype/maintenance_team_member/test_maintenance_team_member.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestMaintenanceTeamMember(unittest.TestCase):
+
+class TestMaintenanceTeamMember(IntegrationTestCase):
 	pass

--- a/erpnext/buying/doctype/buying_settings/test_buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/test_buying_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestBuyingSettings(unittest.TestCase):
+
+class TestBuyingSettings(IntegrationTestCase):
 	pass

--- a/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/test_supplier_scorecard_period.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSupplierScorecardPeriod(unittest.TestCase):
+
+class TestSupplierScorecardPeriod(IntegrationTestCase):
 	pass

--- a/erpnext/buying/doctype/supplier_scorecard_standing/test_supplier_scorecard_standing.py
+++ b/erpnext/buying/doctype/supplier_scorecard_standing/test_supplier_scorecard_standing.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSupplierScorecardStanding(unittest.TestCase):
+
+class TestSupplierScorecardStanding(IntegrationTestCase):
 	pass

--- a/erpnext/controllers/tests/test_item_variant.py
+++ b/erpnext/controllers/tests/test_item_variant.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.controllers.item_variant import copy_attributes_to_variant, make_variant_item_code
 from erpnext.stock.doctype.item.test_item import set_item_variant_settings
@@ -10,7 +11,7 @@ from erpnext.stock.doctype.quality_inspection.test_quality_inspection import (
 )
 
 
-class TestItemVariant(unittest.TestCase):
+class TestItemVariant(IntegrationTestCase):
 	def test_tables_in_template_copied_to_variant(self):
 		fields = [{"field_name": "quality_inspection_template"}]
 		set_item_variant_settings(fields)

--- a/erpnext/controllers/tests/test_mapper.py
+++ b/erpnext/controllers/tests/test_mapper.py
@@ -5,10 +5,11 @@ import frappe
 import frappe.utils
 from frappe.model import mapper
 from frappe.tests.utils import make_test_records
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_months, nowdate
 
 
-class TestMapper(unittest.TestCase):
+class TestMapper(IntegrationTestCase):
 	def test_map_docs(self):
 		"""Test mapping of multiple source docs on a single target doc"""
 

--- a/erpnext/controllers/tests/test_qty_based_taxes.py
+++ b/erpnext/controllers/tests/test_qty_based_taxes.py
@@ -2,13 +2,14 @@ import unittest
 from uuid import uuid4 as _uuid4
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
 def uuid4():
 	return str(_uuid4())
 
 
-class TestTaxes(unittest.TestCase):
+class TestTaxes(IntegrationTestCase):
 	def setUp(self):
 		self.company = frappe.get_doc(
 			{

--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -2,6 +2,7 @@ import unittest
 from functools import partial
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.controllers import queries
 
@@ -10,7 +11,7 @@ def add_default_params(func, doctype):
 	return partial(func, doctype=doctype, txt="", searchfield="name", start=0, page_len=20, filters=None)
 
 
-class TestQueries(unittest.TestCase):
+class TestQueries(IntegrationTestCase):
 	# All tests are based on doctype/test_records.json
 
 	def assert_nested_in(self, item, container):

--- a/erpnext/controllers/tests/test_transaction_base.py
+++ b/erpnext/controllers/tests/test_transaction_base.py
@@ -1,9 +1,10 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(IntegrationTestCase):
 	def test_reset_default_field_value(self):
 		doc = frappe.get_doc(
 			{

--- a/erpnext/crm/doctype/appointment/test_appointment.py
+++ b/erpnext/crm/doctype/appointment/test_appointment.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import datetime
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 LEAD_EMAIL = "test_appointment_lead@example.com"
 
@@ -26,7 +26,7 @@ def create_test_appointment():
 	return test_appointment
 
 
-class TestAppointment(unittest.TestCase):
+class TestAppointment(IntegrationTestCase):
 	def setUpClass():
 		frappe.db.delete("Lead", {"email_id": LEAD_EMAIL})
 

--- a/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
+++ b/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestAppointmentBookingSettings(unittest.TestCase):
+
+class TestAppointmentBookingSettings(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/campaign/test_campaign.py
+++ b/erpnext/crm/doctype/campaign/test_campaign.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCampaign(unittest.TestCase):
+
+class TestCampaign(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/competitor/test_competitor.py
+++ b/erpnext/crm/doctype/competitor/test_competitor.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCompetitor(unittest.TestCase):
+
+class TestCompetitor(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/contract/test_contract.py
+++ b/erpnext/crm/doctype/contract/test_contract.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, nowdate
 
 
-class TestContract(unittest.TestCase):
+class TestContract(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.sql("delete from `tabContract`")
 		self.contract_doc = get_contract()

--- a/erpnext/crm/doctype/contract_fulfilment_checklist/test_contract_fulfilment_checklist.py
+++ b/erpnext/crm/doctype/contract_fulfilment_checklist/test_contract_fulfilment_checklist.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestContractFulfilmentChecklist(unittest.TestCase):
+
+class TestContractFulfilmentChecklist(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/contract_template/test_contract_template.py
+++ b/erpnext/crm/doctype/contract_template/test_contract_template.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestContractTemplate(unittest.TestCase):
+
+class TestContractTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/crm_settings/test_crm_settings.py
+++ b/erpnext/crm/doctype/crm_settings/test_crm_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCRMSettings(unittest.TestCase):
+
+class TestCRMSettings(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/email_campaign/test_email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/test_email_campaign.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestEmailCampaign(unittest.TestCase):
+
+class TestEmailCampaign(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/lead/test_lead.py
+++ b/erpnext/crm/doctype/lead/test_lead.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string, today
 
 from erpnext.crm.doctype.lead.lead import make_opportunity
@@ -13,7 +12,7 @@ from erpnext.crm.utils import get_linked_prospect
 test_records = frappe.get_test_records("Lead")
 
 
-class TestLead(unittest.TestCase):
+class TestLead(IntegrationTestCase):
 	def test_make_customer(self):
 		from erpnext.crm.doctype.lead.lead import make_customer
 

--- a/erpnext/crm/doctype/market_segment/test_market_segment.py
+++ b/erpnext/crm/doctype/market_segment/test_market_segment.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestMarketSegment(unittest.TestCase):
+
+class TestMarketSegment(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import now_datetime, random_string, today
 
 from erpnext.crm.doctype.lead.lead import make_customer
@@ -14,7 +14,7 @@ from erpnext.crm.utils import get_linked_communication_list
 test_records = frappe.get_test_records("Opportunity")
 
 
-class TestOpportunity(unittest.TestCase):
+class TestOpportunity(IntegrationTestCase):
 	def test_opportunity_status(self):
 		doc = make_opportunity(with_items=0)
 		quotation = make_quotation(doc.name)

--- a/erpnext/crm/doctype/opportunity_type/test_opportunity_type.py
+++ b/erpnext/crm/doctype/opportunity_type/test_opportunity_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestOpportunityType(unittest.TestCase):
+
+class TestOpportunityType(IntegrationTestCase):
 	pass

--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string
 
 from erpnext.crm.doctype.lead.lead import add_lead_to_prospect
 from erpnext.crm.doctype.lead.test_lead import make_lead
 
 
-class TestProspect(unittest.TestCase):
+class TestProspect(IntegrationTestCase):
 	def test_add_lead_to_prospect_and_address_linking(self):
 		lead_doc = make_lead()
 		address_doc = make_address(address_title=lead_doc.name)

--- a/erpnext/crm/doctype/sales_stage/test_sales_stage.py
+++ b/erpnext/crm/doctype/sales_stage/test_sales_stage.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSalesStage(unittest.TestCase):
+
+class TestSalesStage(IntegrationTestCase):
 	pass

--- a/erpnext/crm/report/opportunity_summary_by_sales_stage/test_opportunity_summary_by_sales_stage.py
+++ b/erpnext/crm/report/opportunity_summary_by_sales_stage/test_opportunity_summary_by_sales_stage.py
@@ -1,6 +1,7 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.crm.report.opportunity_summary_by_sales_stage.opportunity_summary_by_sales_stage import (
 	execute,
@@ -12,7 +13,7 @@ from erpnext.crm.report.sales_pipeline_analytics.test_sales_pipeline_analytics i
 )
 
 
-class TestOpportunitySummaryBySalesStage(unittest.TestCase):
+class TestOpportunitySummaryBySalesStage(IntegrationTestCase):
 	@classmethod
 	def setUpClass(self):
 		frappe.db.delete("Opportunity")

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import json
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils.response import json_handler
 
 from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings import (
@@ -16,7 +16,7 @@ from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings import (
 )
 
 
-class TestPlaidSettings(unittest.TestCase):
+class TestPlaidSettings(IntegrationTestCase):
 	def setUp(self):
 		pass
 

--- a/erpnext/erpnext_integrations/doctype/quickbooks_migrator/test_quickbooks_migrator.py
+++ b/erpnext/erpnext_integrations/doctype/quickbooks_migrator/test_quickbooks_migrator.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQuickBooksMigrator(unittest.TestCase):
+
+class TestQuickBooksMigrator(IntegrationTestCase):
 	pass

--- a/erpnext/erpnext_integrations/doctype/tally_migration/test_tally_migration.py
+++ b/erpnext/erpnext_integrations/doctype/tally_migration/test_tally_migration.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestTallyMigration(unittest.TestCase):
+
+class TestTallyMigration(IntegrationTestCase):
 	pass

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import format_date
 from frappe.utils.data import add_days, formatdate, today
 
@@ -17,7 +17,7 @@ from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_i
 # test_records = frappe.get_test_records('Maintenance Schedule')
 
 
-class TestMaintenanceSchedule(unittest.TestCase):
+class TestMaintenanceSchedule(IntegrationTestCase):
 	def test_events_should_be_created_and_deleted(self):
 		ms = make_maintenance_schedule()
 		ms.generate_schedule()

--- a/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils.data import today
 
 # test_records = frappe.get_test_records('Maintenance Visit')
 
 
-class TestMaintenanceVisit(unittest.TestCase):
+class TestMaintenanceVisit(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/manufacturing/doctype/downtime_entry/test_downtime_entry.py
+++ b/erpnext/manufacturing/doctype/downtime_entry/test_downtime_entry.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestDowntimeEntry(unittest.TestCase):
+
+class TestDowntimeEntry(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/manufacturing_settings/test_manufacturing_settings.py
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/test_manufacturing_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestManufacturingSettings(unittest.TestCase):
+
+class TestManufacturingSettings(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/material_request_plan_item/test_material_request_plan_item.py
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/test_material_request_plan_item.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestMaterialRequestPlanItem(unittest.TestCase):
+
+class TestMaterialRequestPlanItem(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/operation/test_operation.py
+++ b/erpnext/manufacturing/doctype/operation/test_operation.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Operation")
 
 
-class TestOperation(unittest.TestCase):
+class TestOperation(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/manufacturing/doctype/production_plan_material_request_warehouse/test_production_plan_material_request_warehouse.py
+++ b/erpnext/manufacturing/doctype/production_plan_material_request_warehouse/test_production_plan_material_request_warehouse.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestProductionPlanMaterialRequestWarehouse(unittest.TestCase):
+
+class TestProductionPlanMaterialRequestWarehouse(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/sub_operation/test_sub_operation.py
+++ b/erpnext/manufacturing/doctype/sub_operation/test_sub_operation.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSubOperation(unittest.TestCase):
+
+class TestSubOperation(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/report/test_reports.py
+++ b/erpnext/manufacturing/report/test_reports.py
@@ -1,6 +1,7 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.tests.utils import ReportFilters, ReportName, execute_script_report
 
@@ -50,7 +51,7 @@ OPTIONAL_FILTERS = {
 }
 
 
-class TestManufacturingReports(unittest.TestCase):
+class TestManufacturingReports(IntegrationTestCase):
 	def test_execute_all_manufacturing_reports(self):
 		"""Test that all script report in manufacturing modules are executable with supported filters"""
 		for report, filter in REPORT_FILTER_TEST_CASES:

--- a/erpnext/projects/doctype/activity_cost/test_activity_cost.py
+++ b/erpnext/projects/doctype/activity_cost/test_activity_cost.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.projects.doctype.activity_cost.activity_cost import DuplicationError
 
 
-class TestActivityCost(unittest.TestCase):
+class TestActivityCost(IntegrationTestCase):
 	def test_duplication(self):
 		frappe.db.sql("delete from `tabActivity Cost`")
 		activity_cost1 = frappe.new_doc("Activity Cost")

--- a/erpnext/projects/doctype/project_template/test_project_template.py
+++ b/erpnext/projects/doctype/project_template/test_project_template.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.projects.doctype.task.test_task import create_task
 
 
-class TestProjectTemplate(unittest.TestCase):
+class TestProjectTemplate(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/projects/doctype/project_type/test_project_type.py
+++ b/erpnext/projects/doctype/project_type/test_project_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestProjectType(unittest.TestCase):
+
+class TestProjectType(IntegrationTestCase):
 	pass

--- a/erpnext/projects/doctype/project_update/test_project_update.py
+++ b/erpnext/projects/doctype/project_update/test_project_update.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestProjectUpdate(unittest.TestCase):
+class TestProjectUpdate(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/projects/doctype/projects_settings/test_projects_settings.py
+++ b/erpnext/projects/doctype/projects_settings/test_projects_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestProjectsSettings(unittest.TestCase):
+
+class TestProjectsSettings(IntegrationTestCase):
 	pass

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -3,12 +3,13 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate, nowdate
 
 from erpnext.projects.doctype.task.task import CircularReferenceError
 
 
-class TestTask(unittest.TestCase):
+class TestTask(IntegrationTestCase):
 	def test_circular_reference(self):
 		task1 = create_task("_Test Task 1", add_days(nowdate(), -15), add_days(nowdate(), -10))
 		task2 = create_task("_Test Task 2", add_days(nowdate(), 11), add_days(nowdate(), 15), task1.name)

--- a/erpnext/projects/doctype/task_type/test_task_type.py
+++ b/erpnext/projects/doctype/task_type/test_task_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestTaskType(unittest.TestCase):
+
+class TestTaskType(IntegrationTestCase):
 	pass

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import datetime
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime, nowdate
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -12,7 +12,7 @@ from erpnext.projects.doctype.timesheet.timesheet import OverlapError, make_sale
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 
-class TestTimesheet(unittest.TestCase):
+class TestTimesheet(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.delete("Timesheet")
 

--- a/erpnext/projects/report/delayed_tasks_summary/test_delayed_tasks_summary.py
+++ b/erpnext/projects/report/delayed_tasks_summary/test_delayed_tasks_summary.py
@@ -1,13 +1,14 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, add_months, nowdate
 
 from erpnext.projects.doctype.task.test_task import create_task
 from erpnext.projects.report.delayed_tasks_summary.delayed_tasks_summary import execute
 
 
-class TestDelayedTasksSummary(unittest.TestCase):
+class TestDelayedTasksSummary(IntegrationTestCase):
 	@classmethod
 	def setUp(self):
 		task1 = create_task("_Test Task 98", add_days(nowdate(), -10), nowdate())

--- a/erpnext/quality_management/doctype/non_conformance/test_non_conformance.py
+++ b/erpnext/quality_management/doctype/non_conformance/test_non_conformance.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestNonConformance(unittest.TestCase):
+
+class TestNonConformance(IntegrationTestCase):
 	pass

--- a/erpnext/quality_management/doctype/quality_action/test_quality_action.py
+++ b/erpnext/quality_management/doctype/quality_action/test_quality_action.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2018, Frappe and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityAction(unittest.TestCase):
+
+class TestQualityAction(IntegrationTestCase):
 	# quality action has no code
 	pass

--- a/erpnext/quality_management/doctype/quality_feedback/test_quality_feedback.py
+++ b/erpnext/quality_management/doctype/quality_feedback/test_quality_feedback.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestQualityFeedback(unittest.TestCase):
+class TestQualityFeedback(IntegrationTestCase):
 	def test_quality_feedback(self):
 		template = frappe.get_doc(
 			dict(

--- a/erpnext/quality_management/doctype/quality_feedback_template/test_quality_feedback_template.py
+++ b/erpnext/quality_management/doctype/quality_feedback_template/test_quality_feedback_template.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityFeedbackTemplate(unittest.TestCase):
+
+class TestQualityFeedbackTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/quality_management/doctype/quality_goal/test_quality_goal.py
+++ b/erpnext/quality_management/doctype/quality_goal/test_quality_goal.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2018, Frappe and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestQualityGoal(unittest.TestCase):
+class TestQualityGoal(IntegrationTestCase):
 	def test_quality_goal(self):
 		# no code, just a basic sanity check
 		goal = get_quality_goal()

--- a/erpnext/quality_management/doctype/quality_meeting/test_quality_meeting.py
+++ b/erpnext/quality_management/doctype/quality_meeting/test_quality_meeting.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2018, Frappe and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityMeeting(unittest.TestCase):
+
+class TestQualityMeeting(IntegrationTestCase):
 	# nothing to test
 	pass

--- a/erpnext/quality_management/doctype/quality_meeting_agenda/test_quality_meeting_agenda.py
+++ b/erpnext/quality_management/doctype/quality_meeting_agenda/test_quality_meeting_agenda.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityMeetingAgenda(unittest.TestCase):
+
+class TestQualityMeetingAgenda(IntegrationTestCase):
 	pass

--- a/erpnext/quality_management/doctype/quality_review/test_quality_review.py
+++ b/erpnext/quality_management/doctype/quality_review/test_quality_review.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, Frappe and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from ..quality_goal.test_quality_goal import get_quality_goal
 from .quality_review import review
 
 
-class TestQualityReview(unittest.TestCase):
+class TestQualityReview(IntegrationTestCase):
 	def test_review_creation(self):
 		quality_goal = get_quality_goal()
 		review()

--- a/erpnext/regional/doctype/import_supplier_invoice/test_import_supplier_invoice.py
+++ b/erpnext/regional/doctype/import_supplier_invoice/test_import_supplier_invoice.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestImportSupplierInvoice(unittest.TestCase):
+
+class TestImportSupplierInvoice(IntegrationTestCase):
 	pass

--- a/erpnext/regional/doctype/lower_deduction_certificate/test_lower_deduction_certificate.py
+++ b/erpnext/regional/doctype/lower_deduction_certificate/test_lower_deduction_certificate.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestLowerDeductionCertificate(unittest.TestCase):
+
+class TestLowerDeductionCertificate(IntegrationTestCase):
 	pass

--- a/erpnext/regional/doctype/south_africa_vat_settings/test_south_africa_vat_settings.py
+++ b/erpnext/regional/doctype/south_africa_vat_settings/test_south_africa_vat_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSouthAfricaVATSettings(unittest.TestCase):
+
+class TestSouthAfricaVATSettings(IntegrationTestCase):
 	pass

--- a/erpnext/regional/doctype/uae_vat_settings/test_uae_vat_settings.py
+++ b/erpnext/regional/doctype/uae_vat_settings/test_uae_vat_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestUAEVATSettings(unittest.TestCase):
+
+class TestUAEVATSettings(IntegrationTestCase):
 	pass

--- a/erpnext/regional/united_states/test_united_states.py
+++ b/erpnext/regional/united_states/test_united_states.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.regional.report.irs_1099.irs_1099 import execute as execute_1099_report
 
 
-class TestUnitedStates(unittest.TestCase):
+class TestUnitedStates(IntegrationTestCase):
 	def test_irs_1099_custom_field(self):
 		if not frappe.db.exists("Supplier", "_US 1099 Test Supplier"):
 			doc = frappe.new_doc("Supplier")

--- a/erpnext/selling/doctype/installation_note/test_installation_note.py
+++ b/erpnext/selling/doctype/installation_note/test_installation_note.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Installation Note')
 
 
-class TestInstallationNote(unittest.TestCase):
+class TestInstallationNote(IntegrationTestCase):
 	pass

--- a/erpnext/selling/doctype/sales_partner_type/test_sales_partner_type.py
+++ b/erpnext/selling/doctype/sales_partner_type/test_sales_partner_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSalesPartnerType(unittest.TestCase):
+
+class TestSalesPartnerType(IntegrationTestCase):
 	pass

--- a/erpnext/selling/doctype/selling_settings/test_selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/test_selling_settings.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestSellingSettings(unittest.TestCase):
+class TestSellingSettings(IntegrationTestCase):
 	def test_defaults_populated(self):
 		# Setup default values are not populated on migrate, this test checks
 		# if setup was completed correctly

--- a/erpnext/setup/doctype/authorization_rule/test_authorization_rule.py
+++ b/erpnext/setup/doctype/authorization_rule/test_authorization_rule.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Authorization Rule')
 
 
-class TestAuthorizationRule(unittest.TestCase):
+class TestAuthorizationRule(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import json
 import unittest
 
 import frappe
 from frappe import _
+from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string
 
 from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import (
@@ -18,7 +18,7 @@ test_dependencies = ["Fiscal Year"]
 test_records = frappe.get_test_records("Company")
 
 
-class TestCompany(unittest.TestCase):
+class TestCompany(IntegrationTestCase):
 	def test_coa_based_on_existing_company(self):
 		company = frappe.new_doc("Company")
 		company.company_name = "COA from Existing Company"

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 from unittest import mock
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import cint, flt
 
 from erpnext.setup.utils import get_exchange_rate
@@ -80,7 +80,7 @@ def patched_requests_get(*args, **kwargs):
 
 
 @mock.patch("requests.get", side_effect=patched_requests_get)
-class TestCurrencyExchange(unittest.TestCase):
+class TestCurrencyExchange(IntegrationTestCase):
 	def clear_cache(self):
 		cache = frappe.cache()
 		for date in test_exchange_values.keys():

--- a/erpnext/setup/doctype/department/test_department.py
+++ b/erpnext/setup/doctype/department/test_department.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_ignore = ["Leave Block List"]
 
 
-class TestDepartment(unittest.TestCase):
+class TestDepartment(IntegrationTestCase):
 	def test_remove_department_data(self):
 		doc = create_department("Test Department")
 		frappe.delete_doc("Department", doc.name)

--- a/erpnext/setup/doctype/driver/test_driver.py
+++ b/erpnext/setup/doctype/driver/test_driver.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestDriver(unittest.TestCase):
+
+class TestDriver(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/email_digest/test_email_digest.py
+++ b/erpnext/setup/doctype/email_digest/test_email_digest.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Email Digest')
 
 
-class TestEmailDigest(unittest.TestCase):
+class TestEmailDigest(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/employee/test_employee.py
+++ b/erpnext/setup/doctype/employee/test_employee.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 
 import frappe
 import frappe.utils
+from frappe.tests import IntegrationTestCase
 
 import erpnext
 from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError
@@ -12,7 +12,7 @@ from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError
 test_records = frappe.get_test_records("Employee")
 
 
-class TestEmployee(unittest.TestCase):
+class TestEmployee(IntegrationTestCase):
 	def test_employee_status_left(self):
 		employee1 = make_employee("test_employee_1@company.com")
 		employee2 = make_employee("test_employee_2@company.com")

--- a/erpnext/setup/doctype/employee_group/test_employee_group.py
+++ b/erpnext/setup/doctype/employee_group/test_employee_group.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
 
-class TestEmployeeGroup(unittest.TestCase):
+class TestEmployeeGroup(IntegrationTestCase):
 	pass
 
 

--- a/erpnext/setup/doctype/global_defaults/test_global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/test_global_defaults.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestGlobalDefaults(unittest.TestCase):
+
+class TestGlobalDefaults(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/holiday_list/test_holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/test_holiday_list.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
 from contextlib import contextmanager
 from datetime import date, timedelta
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import getdate
 
 from erpnext.setup.doctype.holiday_list.holiday_list import local_country_name
 
 
-class TestHolidayList(unittest.TestCase):
+class TestHolidayList(IntegrationTestCase):
 	def test_holiday_list(self):
 		today_date = getdate()
 		test_holiday_dates = [today_date - timedelta(days=5), today_date - timedelta(days=4)]

--- a/erpnext/setup/doctype/item_group/test_item_group.py
+++ b/erpnext/setup/doctype/item_group/test_item_group.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils.nestedset import (
 	NestedSetChildExistsError,
 	NestedSetInvalidMergeError,
@@ -17,7 +16,7 @@ from frappe.utils.nestedset import (
 test_records = frappe.get_test_records("Item Group")
 
 
-class TestItem(unittest.TestCase):
+class TestItem(IntegrationTestCase):
 	def test_basic_tree(self, records=None):
 		min_lft = 1
 		max_rgt = frappe.db.sql("select max(rgt) from `tabItem Group`")[0][0]

--- a/erpnext/setup/doctype/party_type/test_party_type.py
+++ b/erpnext/setup/doctype/party_type/test_party_type.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Party Type')
 
 
-class TestPartyType(unittest.TestCase):
+class TestPartyType(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/uom_conversion_factor/test_uom_conversion_factor.py
+++ b/erpnext/setup/doctype/uom_conversion_factor/test_uom_conversion_factor.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestUOMConversionFactor(unittest.TestCase):
+
+class TestUOMConversionFactor(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/vehicle/test_vehicle.py
+++ b/erpnext/setup/doctype/vehicle/test_vehicle.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string
 
 # test_records = frappe.get_test_records('Vehicle')
 
 
-class TestVehicle(unittest.TestCase):
+class TestVehicle(IntegrationTestCase):
 	def test_make_vehicle(self):
 		vehicle = frappe.get_doc(
 			{

--- a/erpnext/stock/doctype/customs_tariff_number/test_customs_tariff_number.py
+++ b/erpnext/stock/doctype/customs_tariff_number/test_customs_tariff_number.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCustomsTariffNumber(unittest.TestCase):
+
+class TestCustomsTariffNumber(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/delivery_settings/test_delivery_settings.py
+++ b/erpnext/stock/doctype/delivery_settings/test_delivery_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestDeliverySettings(unittest.TestCase):
+
+class TestDeliverySettings(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
+++ b/erpnext/stock/doctype/item_manufacturer/test_item_manufacturer.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestItemManufacturer(unittest.TestCase):
+
+class TestItemManufacturer(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/item_variant_settings/test_item_variant_settings.py
+++ b/erpnext/stock/doctype/item_variant_settings/test_item_variant_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestItemVariantSettings(unittest.TestCase):
+
+class TestItemVariantSettings(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/manufacturer/test_manufacturer.py
+++ b/erpnext/stock/doctype/manufacturer/test_manufacturer.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
+
+from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Manufacturer')
 
 
-class TestManufacturer(unittest.TestCase):
+class TestManufacturer(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/quality_inspection_parameter/test_quality_inspection_parameter.py
+++ b/erpnext/stock/doctype/quality_inspection_parameter/test_quality_inspection_parameter.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityInspectionParameter(unittest.TestCase):
+
+class TestQualityInspectionParameter(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/quality_inspection_parameter_group/test_quality_inspection_parameter_group.py
+++ b/erpnext/stock/doctype/quality_inspection_parameter_group/test_quality_inspection_parameter_group.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityInspectionParameterGroup(unittest.TestCase):
+
+class TestQualityInspectionParameterGroup(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/quality_inspection_template/test_quality_inspection_template.py
+++ b/erpnext/stock/doctype/quality_inspection_template/test_quality_inspection_template.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestQualityInspectionTemplate(unittest.TestCase):
+
+class TestQualityInspectionTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/shipment_parcel_template/test_shipment_parcel_template.py
+++ b/erpnext/stock/doctype/shipment_parcel_template/test_shipment_parcel_template.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestShipmentParcelTemplate(unittest.TestCase):
+
+class TestShipmentParcelTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/stock_entry_type/test_stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/test_stock_entry_type.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestStockEntryType(unittest.TestCase):
+class TestStockEntryType(IntegrationTestCase):
 	def test_stock_entry_type_non_standard(self):
 		stock_entry_type = "Test Manufacturing"
 

--- a/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.stock.doctype.repost_item_valuation.repost_item_valuation import get_recipients
 
 
-class TestStockRepostingSettings(unittest.TestCase):
+class TestStockRepostingSettings(IntegrationTestCase):
 	def test_notify_reposting_error_to_role(self):
 		role = "Notify Reposting Role"
 

--- a/erpnext/stock/doctype/uom_category/test_uom_category.py
+++ b/erpnext/stock/doctype/uom_category/test_uom_category.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestUOMCategory(unittest.TestCase):
+
+class TestUOMCategory(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/variant_field/test_variant_field.py
+++ b/erpnext/stock/doctype/variant_field/test_variant_field.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestVariantField(unittest.TestCase):
+
+class TestVariantField(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/warehouse_type/test_warehouse_type.py
+++ b/erpnext/stock/doctype/warehouse_type/test_warehouse_type.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestWarehouseType(unittest.TestCase):
+
+class TestWarehouseType(IntegrationTestCase):
 	pass

--- a/erpnext/stock/report/test_reports.py
+++ b/erpnext/stock/report/test_reports.py
@@ -1,6 +1,7 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.tests.utils import ReportFilters, ReportName, execute_script_report
 
@@ -75,7 +76,7 @@ OPTIONAL_FILTERS = {
 }
 
 
-class TestReports(unittest.TestCase):
+class TestReports(IntegrationTestCase):
 	def test_execute_all_stock_reports(self):
 		"""Test that all script report in stock modules are executable with supported filters"""
 		for report, filter in REPORT_FILTER_TEST_CASES:

--- a/erpnext/stock/tests/test_valuation.py
+++ b/erpnext/stock/tests/test_valuation.py
@@ -15,7 +15,7 @@ value_gen = st.floats(min_value=1, max_value=1e6)
 stock_queue_generator = st.lists(st.tuples(qty_gen, value_gen), min_size=10)
 
 
-class TestFIFOValuation(unittest.TestCase):
+class TestFIFOValuation(IntegrationTestCase):
 	def setUp(self):
 		self.queue = FIFOValuation([])
 
@@ -195,7 +195,7 @@ class TestFIFOValuation(unittest.TestCase):
 			self.assertTotalValue(total_value)
 
 
-class TestLIFOValuation(unittest.TestCase):
+class TestLIFOValuation(IntegrationTestCase):
 	def setUp(self):
 		self.stack = LIFOValuation([])
 

--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
 from frappe import _
 from frappe.core.doctype.user_permission.test_user_permission import create_user
+from frappe.tests import IntegrationTestCase
 from frappe.utils import flt, get_datetime
 
 from erpnext.support.doctype.service_level_agreement.test_service_level_agreement import (
@@ -13,7 +13,7 @@ from erpnext.support.doctype.service_level_agreement.test_service_level_agreemen
 )
 
 
-class TestSetUp(unittest.TestCase):
+class TestSetUp(IntegrationTestCase):
 	def setUp(self):
 		frappe.db.sql("delete from `tabService Level Agreement`")
 		frappe.db.sql("delete from `tabService Level Priority`")

--- a/erpnext/support/doctype/issue_priority/test_issue_priority.py
+++ b/erpnext/support/doctype/issue_priority/test_issue_priority.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 
-class TestIssuePriority(unittest.TestCase):
+class TestIssuePriority(IntegrationTestCase):
 	def test_priorities(self):
 		make_priorities()
 		priorities = frappe.get_list("Issue Priority")

--- a/erpnext/support/doctype/issue_type/test_issue_type.py
+++ b/erpnext/support/doctype/issue_type/test_issue_type.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestIssueType(unittest.TestCase):
+
+class TestIssueType(IntegrationTestCase):
 	pass

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import datetime
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 from frappe.utils import flt
 
 from erpnext.support.doctype.issue_priority.test_issue_priority import make_priorities
@@ -13,7 +13,7 @@ from erpnext.support.doctype.service_level_agreement.service_level_agreement imp
 )
 
 
-class TestServiceLevelAgreement(unittest.TestCase):
+class TestServiceLevelAgreement(IntegrationTestCase):
 	def setUp(self):
 		self.create_company()
 		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)

--- a/erpnext/support/doctype/support_settings/test_support_settings.py
+++ b/erpnext/support/doctype/support_settings/test_support_settings.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestSupportSettings(unittest.TestCase):
+
+class TestSupportSettings(IntegrationTestCase):
 	pass

--- a/erpnext/support/doctype/warranty_claim/test_warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/test_warranty_claim.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 test_records = frappe.get_test_records("Warranty Claim")
 
 
-class TestWarrantyClaim(unittest.TestCase):
+class TestWarrantyClaim(IntegrationTestCase):
 	pass

--- a/erpnext/support/report/issue_analytics/test_issue_analytics.py
+++ b/erpnext/support/report/issue_analytics/test_issue_analytics.py
@@ -2,6 +2,7 @@ import unittest
 
 import frappe
 from frappe.desk.form.assign_to import add as add_assignment
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_months, getdate
 
 from erpnext.support.doctype.issue.test_issue import create_customer, make_issue
@@ -13,7 +14,7 @@ from erpnext.support.report.issue_analytics.issue_analytics import execute
 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
 
-class TestIssueAnalytics(unittest.TestCase):
+class TestIssueAnalytics(IntegrationTestCase):
 	@classmethod
 	def setUpClass(self):
 		frappe.db.sql("delete from `tabIssue` where company='_Test Company'")

--- a/erpnext/telephony/doctype/call_log/test_call_log.py
+++ b/erpnext/telephony/doctype/call_log/test_call_log.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestCallLog(unittest.TestCase):
+
+class TestCallLog(IntegrationTestCase):
 	pass

--- a/erpnext/telephony/doctype/incoming_call_settings/test_incoming_call_settings.py
+++ b/erpnext/telephony/doctype/incoming_call_settings/test_incoming_call_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestIncomingCallSettings(unittest.TestCase):
+
+class TestIncomingCallSettings(IntegrationTestCase):
 	pass

--- a/erpnext/telephony/doctype/telephony_call_type/test_telephony_call_type.py
+++ b/erpnext/telephony/doctype/telephony_call_type/test_telephony_call_type.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestTelephonyCallType(unittest.TestCase):
+
+class TestTelephonyCallType(IntegrationTestCase):
 	pass

--- a/erpnext/telephony/doctype/voice_call_settings/test_voice_call_settings.py
+++ b/erpnext/telephony/doctype/voice_call_settings/test_voice_call_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestVoiceCallSettings(unittest.TestCase):
+
+class TestVoiceCallSettings(IntegrationTestCase):
 	pass

--- a/erpnext/tests/test_init.py
+++ b/erpnext/tests/test_init.py
@@ -1,13 +1,14 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext import encode_company_abbr
 
 test_records = frappe.get_test_records("Company")
 
 
-class TestInit(unittest.TestCase):
+class TestInit(IntegrationTestCase):
 	def test_encode_company_abbr(self):
 		abbr = "NFECT"
 

--- a/erpnext/tests/test_notifications.py
+++ b/erpnext/tests/test_notifications.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
-
-
 import unittest
 
 import frappe
 from frappe.desk import notifications
+from frappe.tests import IntegrationTestCase
 
 
-class TestNotifications(unittest.TestCase):
+class TestNotifications(IntegrationTestCase):
 	def test_get_notifications_for_targets(self):
 		"""
 		Test notification config entries for targets as percentages

--- a/erpnext/tests/test_point_of_sale.py
+++ b/erpnext/tests/test_point_of_sale.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
 from erpnext.selling.page.point_of_sale.point_of_sale import get_items
@@ -11,7 +11,7 @@ from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 
 
-class TestPointOfSale(unittest.TestCase):
+class TestPointOfSale(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		frappe.db.savepoint("before_test_point_of_sale")

--- a/erpnext/tests/test_regional.py
+++ b/erpnext/tests/test_regional.py
@@ -1,6 +1,7 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 import erpnext
 
@@ -10,7 +11,7 @@ def test_method():
 	return "original"
 
 
-class TestInit(unittest.TestCase):
+class TestInit(IntegrationTestCase):
 	def test_regional_overrides(self):
 		frappe.flags.country = "Maldives"
 		self.assertEqual(test_method(), "original")

--- a/erpnext/tests/test_webform.py
+++ b/erpnext/tests/test_webform.py
@@ -1,12 +1,13 @@
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.buying.doctype.supplier.test_supplier import create_supplier
 
 
-class TestWebsite(unittest.TestCase):
+class TestWebsite(IntegrationTestCase):
 	def test_permission_for_custom_doctype(self):
 		create_user("Supplier 1", "supplier1@gmail.com")
 		create_user("Supplier 2", "supplier2@gmail.com")

--- a/erpnext/utilities/doctype/video/test_video.py
+++ b/erpnext/utilities/doctype/video/test_video.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestVideo(unittest.TestCase):
+
+class TestVideo(IntegrationTestCase):
 	pass

--- a/erpnext/utilities/doctype/video_settings/test_video_settings.py
+++ b/erpnext/utilities/doctype/video_settings/test_video_settings.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 # import frappe
 import unittest
 
+from frappe.tests import IntegrationTestCase
 
-class TestVideoSettings(unittest.TestCase):
+
+class TestVideoSettings(IntegrationTestCase):
 	pass


### PR DESCRIPTION
Infer probable test spec of unclear test cases (integration vs unit).

see: https://github.com/frappe/frappe/pull/27987
