### PR TITLE
ci: validate fix

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -116,8 +116,8 @@ jobs:
         env:
           DB: mariadb
           TYPE: server
-          FRAPPE_USER: ${{ github.event.inputs.user }}
-          FRAPPE_BRANCH: ${{ github.event.inputs.branch }}
+          FRAPPE_USER: blaggacao
+          FRAPPE_BRANCH: testing/erpnext-temp-incompat
 
       - name: Run Tests
         run: 'cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app erpnext --total-builds ${{ strategy.job-total }} --build-number ${{ matrix.container }}'


### PR DESCRIPTION
Alternative to https://github.com/frappe/erpnext/pull/43517

cc @rohitwaghchaure This should be the definitive temporary work around, as it seems the other one was not quite enough. :pray:

I'm confident, because this was the only functional change introduced to `parallel_test_runner` code path