### PR TITLE
Refactor: Use IntegrationTestCase for test_accounting_dimension.py

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -11,7 +11,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 test_dependencies = ["Cost Center", "Location", "Warehouse", "Department"]
 
 
-class TestAccountingDimension(unittest.TestCase):
+class TestAccountingDimension(IntegrationTestCase):
 	def setUp(self):
 		create_dimension()
 


### PR DESCRIPTION
This PR attempts to use IntegrationTestCase <code>test_accounting_dimension.py</code> to test CI result (test  out of )