### PR TITLE
Refactor: Use IntegrationTestCase in test_accounting_dimension_filter.py

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -12,6 +12,8 @@ test_dependencies = ["Cost Center", "Location", "Warehouse", "Department"]
 
 
 class TestAccountingDimension(IntegrationTestCase):
+	SHOW_TRANSACTION_COMMIT_WARNINGS = True
+
 	def setUp(self):
 		create_dimension()
 

--- a/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
+from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
 	create_dimension,
@@ -15,7 +15,7 @@ from erpnext.exceptions import InvalidAccountDimensionError, MandatoryAccountDim
 test_dependencies = ["Location", "Cost Center", "Department"]
 
 
-class TestAccountingDimensionFilter(unittest.TestCase):
+class TestAccountingDimensionFilter(IntegrationTestCase):
 	def setUp(self):
 		create_dimension()
 		create_accounting_dimension_filter()

--- a/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
@@ -16,6 +16,8 @@ test_dependencies = ["Location", "Cost Center", "Department"]
 
 
 class TestAccountingDimensionFilter(IntegrationTestCase):
+	SHOW_TRANSACTION_COMMIT_WARNINGS = True
+
 	def setUp(self):
 		create_dimension()
 		create_accounting_dimension_filter()

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -155,7 +155,7 @@ class TestPaymentEntry(IntegrationTestCase):
 		supplier.save()
 
 	def test_payment_entry_for_blocked_supplier_payments_past_date(self):
-		# this test is meant to fail only if something fails in the try block
+		# this test is meant to fail only if nothing fails in the try block
 		with self.assertRaises(Exception):
 			try:
 				supplier = frappe.get_doc("Supplier", "_Test Supplier")

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -247,7 +247,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		supplier.save()
 
 	def test_purchase_invoice_for_blocked_supplier_payment_past_date(self):
-		# this test is meant to fail only if something fails in the try block
+		# this test is meant to fail only if nothing fails in the try block
 		with self.assertRaises(Exception):
 			try:
 				supplier = frappe.get_doc("Supplier", "_Test Supplier")


### PR DESCRIPTION
This PR attempts to use IntegrationTestCase in <code>test_accounting_dimension_filter.py</code> to test CI result (test 3 out of 181)