### PR TITLE
fix: validation for corrective job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -689,7 +689,12 @@ class JobCard(Document):
 		self.set_transferred_qty()
 
 	def validate_transfer_qty(self):
-		if not self.finished_good and self.items and self.transferred_qty < self.for_quantity:
+		if (
+			not self.finished_good
+			and not self.is_corrective_job_card
+			and self.items
+			and self.transferred_qty < self.for_quantity
+		):
 			frappe.throw(
 				_(
 					"Materials needs to be transferred to the work in progress warehouse for the job card {0}"


### PR DESCRIPTION
**Issue**

While completing the corrective job card, system throwing the below error

<img width="883" alt="Screenshot 2024-10-08 at 12 10 02 PM" src="https://github.com/user-attachments/assets/b85d8fb9-36a3-465e-8350-66eee1a1d60d">
