### PR TITLE
fix: delete invalid pricing rule on change of applicable_for values

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
@@ -90,6 +90,31 @@ class TestPromotionalScheme(IntegrationTestCase):
 		price_rules = frappe.get_all("Pricing Rule", filters={"promotional_scheme": ps.name})
 		self.assertEqual(price_rules, [])
 
+	def test_change_applicable_for_values_in_promotional_scheme(self):
+		ps = make_promotional_scheme(applicable_for="Customer", customer="_Test Customer")
+		ps.append("customer", {"customer": "_Test Customer 2"})
+		ps.save()
+
+		price_rules = frappe.get_all(
+			"Pricing Rule", filters={"promotional_scheme": ps.name, "applicable_for": "Customer"}
+		)
+		self.assertTrue(len(price_rules), 2)
+
+		ps.set("customer", [])
+		ps.append("customer", {"customer": "_Test Customer 2"})
+		ps.save()
+
+		price_rules = frappe.get_all(
+			"Pricing Rule",
+			filters={
+				"promotional_scheme": ps.name,
+				"applicable_for": "Customer",
+				"customer": "_Test Customer",
+			},
+		)
+		self.assertEqual(price_rules, [])
+		frappe.delete_doc("Promotional Scheme", ps.name)
+
 	def test_min_max_amount_configuration(self):
 		ps = make_promotional_scheme()
 		ps.price_discount_slabs[0].min_amount = 10


### PR DESCRIPTION
Issue:
On change of applicable_for_values Pricing Rules are not deleted.

Steps to replicate:
- Create a Promotional Scheme for two Customers. (two pricing rules will be created)
- Remove any customer from the promotional scheme.
The pricing rule still exists for both of the customers.

![image](https://github.com/user-attachments/assets/2cbcb121-a1cb-49f3-aa37-92e084b79ebc)


Closes: https://github.com/frappe/erpnext/issues/43456
Frappe Support: https://support.frappe.io/app/hd-ticket/22927

backport version-15-hotfix
backport version-14-hotfix
