### PR TITLE
fix: add default parameter value as None on get_gl_entries

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1524,7 +1524,7 @@ class StockEntry(StockController):
 
 				sl_entries.append(sle)
 
-	def get_gl_entries(self, warehouse_account):
+	def get_gl_entries(self, warehouse_account=None):
 		gl_entries = super().get_gl_entries(warehouse_account)
 
 		if self.purpose in ("Repack", "Manufacture"):


### PR DESCRIPTION
Issue:
Unable to see preview of Stock Entry on Repost Accounting Ledger
Ref: [23100](https://support.frappe.io/helpdesk/tickets/23100)

Before:
[stock entry preview issue.webm](https://github.com/user-attachments/assets/15cf149e-55d7-456d-a50f-4f8108f40ff1)

After:
[stock entry preview issues fix.webm](https://github.com/user-attachments/assets/c6cb5dc2-5095-47dc-bd33-687ffd8a537b)

Backport needed: v14 & v15