### PR TITLE
fix: production plan bom error

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -277,7 +277,7 @@ frappe.ui.form.on("Production Plan", {
 		frm.clear_table("prod_plan_references");
 
 		frappe.call({
-			method: "get_items",
+			method: "combine_so_items",
 			freeze: true,
 			doc: frm.doc,
 			callback: function () {


### PR DESCRIPTION
Steps to replicate error

- Create an Item A
- Create a BOM against item A
- Create the Sales Order and add Item A two times in the sales order
- Create a new BOM against item A
- Create a production plan against the above Sales Order
- Fetch materials
- Change the BOM for items
- Click on "Consolidate Sales Order Items", you will get the below error

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/8ea9eecc-9666-4ba1-8323-ab67dd9f727d">
