### PR TITLE
fix: added string for translation in bank reconciliation statement

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.js
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.js
@@ -47,7 +47,7 @@ frappe.query_reports["Bank Reconciliation Statement"] = {
 		},
 	],
 	formatter: function (value, row, column, data, default_formatter, filter) {
-		if (column.fieldname == "payment_entry" && value == "Cheques and Deposits incorrectly cleared") {
+		if (column.fieldname == "payment_entry" && value == __("Cheques and Deposits incorrectly cleared")) {
 			column.link_onclick =
 				"frappe.query_reports['Bank Reconciliation Statement'].open_utility_report()";
 		}


### PR DESCRIPTION
The string was translated in the backend but not in the frontend, which caused the condition to be false and the route to not be set.
![image](https://github.com/user-attachments/assets/2344ae27-58bc-4210-b85b-952ef59cdbe8)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/23331

