### PR TITLE
refactor: remove 'format:' based naming

### DIFF
--- a/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
+++ b/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
@@ -1,7 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
- "autoname": "format:UNREC-{#####}",
  "creation": "2023-08-22 10:26:34.421423",
  "default_view": "List",
  "doctype": "DocType",
@@ -58,11 +56,10 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:57.073165",
+ "modified": "2024-10-10 12:03:50.022444",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Unreconcile Payment",
- "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
Issue:
While unreconciling the payment entry, getting a duplicate name
ref: [23390](https://support.frappe.io/helpdesk/tickets/23390)