### PR TITLE
fix: added parentheses for correct query formation for logical OR condition

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -353,9 +353,10 @@ class PeriodClosingVoucher(AccountsController):
 
 		if get_opening_entries:
 			query = query.where(
-				gl_entry.posting_date.between(self.get("year_start_date"), self.posting_date)
-				| gl_entry.is_opening
-				== "Yes"
+				(  # noqa: UP034
+					(gl_entry.posting_date.between(self.get("year_start_date"), self.posting_date))
+					| (gl_entry.is_opening == "Yes")
+				)
 			)
 		else:
 			query = query.where(


### PR DESCRIPTION
Issue:
Due to missing parenthesis, OR condition was executed outside the condition due to which cancelled opening GL Entries were included in the query.
Before:
```
SELECT 
  `account`, 
  `account_currency`, 
  SUM(`debit_in_account_currency`) `debit_in_account_currency`, 
  SUM(`credit_in_account_currency`) `credit_in_account_currency`, 
  SUM(`debit`) `debit`, 
  SUM(`credit`) `credit`, 
  `cost_center`, 
  `finance_book`, 
  `project`, 
  `account` 
FROM 
  `tabGL Entry` 
WHERE 
  `company` = 'Test' 
  AND `is_cancelled` = 0 
  AND `account` IN (...) 
  AND `posting_date` BETWEEN '2022-04-01' 
  AND '2023-03-31' 
  OR `is_opening` = 'Yes' 
  AND `voucher_type` <> 'Period Closing Voucher' 
GROUP BY 
  `cost_center`, 
  `finance_book`, 
  `project`, 
  `account`
```

After:
```
SELECT 
  `account`, 
  `account_currency`, 
  SUM(`debit_in_account_currency`) `debit_in_account_currency`, 
  SUM(`credit_in_account_currency`) `credit_in_account_currency`, 
  SUM(`debit`) `debit`, 
  SUM(`credit`) `credit`, 
  `cost_center`, 
  `finance_book`, 
  `project`, 
  `account` 
FROM 
  `tabGL Entry` 
WHERE 
  `company` = 'Test' 
  AND `is_cancelled` = 0 
  AND `account` IN ( ...) 
  AND (
    `posting_date` BETWEEN '2022-04-01' 
    AND '2023-03-31' 
    OR `is_opening` = 'Yes'
  ) 
  AND `voucher_type` <> 'Period Closing Voucher' 
GROUP BY 
  `cost_center`, 
  `finance_book`, 
  `project`, 
  `account`
```

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/23051