### PR TITLE
test: fix item detail test module

### DIFF
--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -4,7 +4,6 @@ from frappe.tests.utils import make_test_records
 
 from erpnext.stock.get_item_details import get_item_details
 
-test_ignore = ["BOM"]
 test_dependencies = ["Customer", "Supplier", "Item", "Price List", "Item Price"]
 
 


### PR DESCRIPTION
```console
======================================================================
 ERROR  setUpClass (erpnext.stock.tests.test_get_item_details.TestGetItemDetail)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/tests/classes/integration_test_case.py", line 53, in setUpClass
    raise NotImplementedError(
    __class__ = <class 'frappe.tests.classes.integration_test_case.IntegrationTestCase'>
    cls = <class 'erpnext.stock.tests.test_get_item_details.TestGetItemDetail'>
    ignore = ['BOM']
    to_add = ['Customer', 'Supplier', 'Item', 'Price List', 'Item Price']
NotImplementedError: IGNORE_TEST_RECORD_DEPENDENCIES is only implement for test modules within a doctype folder <module 'erpnext.stock.tests.test_get_item_details' from '/home/runner/frappe-bench/apps/erpnext/erpnext/stock/tests/test_get_item_details.py'> None
```

cc @ruthra-kumar 