### PR TITLE
refactor: clarify test record module iface (treewide)

### DIFF
--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -14,7 +14,7 @@ from erpnext.accounts.doctype.account.account import (
 )
 from erpnext.stock import get_company_default_inventory_account, get_warehouse_account
 
-test_dependencies = ["Company"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Company"]
 
 
 class TestAccount(IntegrationTestCase):

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -8,7 +8,7 @@ from frappe.tests import IntegrationTestCase
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 
-test_dependencies = ["Cost Center", "Location", "Warehouse", "Department"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Cost Center", "Location", "Warehouse", "Department"]
 
 
 class TestAccountingDimension(IntegrationTestCase):

--- a/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
@@ -12,7 +12,7 @@ from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension imp
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.exceptions import InvalidAccountDimensionError, MandatoryAccountDimensionError
 
-test_dependencies = ["Location", "Cost Center", "Department"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Location", "Cost Center", "Department"]
 
 
 class TestAccountingDimensionFilter(unittest.TestCase):

--- a/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
@@ -12,7 +12,7 @@ from erpnext.accounts.doctype.accounting_period.accounting_period import (
 )
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 class TestAccountingPeriod(IntegrationTestCase):

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -18,7 +18,7 @@ from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.tests.utils import if_lending_app_installed
 
-test_dependencies = ["Item", "Cost Center"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Cost Center"]
 
 
 class UnitTestBankTransaction(UnitTestCase):

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -11,7 +11,7 @@ from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journ
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 
-test_dependencies = ["Monthly Distribution"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Monthly Distribution"]
 
 
 class TestBudget(IntegrationTestCase):

--- a/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
+++ b/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
@@ -7,7 +7,7 @@ from frappe.tests import IntegrationTestCase
 
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 def test_create_test_data():

--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -16,7 +16,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 	create_sales_invoice_against_cost_center,
 )
 
-test_dependencies = ["Company", "Cost Center"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Company", "Cost Center"]
 
 
 class UnitTestDunning(UnitTestCase):

--- a/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import now_datetime
 
-test_ignore = ["Company"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Company"]
 
 
 class TestFiscalYear(IntegrationTestCase):

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -12,7 +12,7 @@ from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_crea
 	get_temporary_opening_account,
 )
 
-test_dependencies = ["Customer", "Supplier", "Accounting Dimension"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Customer", "Supplier", "Accounting Dimension"]
 
 
 class UnitTestOpeningInvoiceCreationTool(UnitTestCase):

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -25,7 +25,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 class UnitTestPaymentEntry(UnitTestCase):

--- a/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
@@ -6,7 +6,7 @@ from frappe.tests import IntegrationTestCase
 
 # test_records = frappe.get_test_records('Payment Gateway Account')
 
-test_ignore = ["Payment Gateway"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Payment Gateway"]
 
 
 class TestPaymentGatewayAccount(IntegrationTestCase):

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -17,7 +17,7 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.stock.doctype.item.test_item import create_item
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 class UnitTestPaymentReconciliation(UnitTestCase):

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -16,7 +16,7 @@ from erpnext.buying.doctype.purchase_order.test_purchase_order import create_pur
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.setup.utils import get_exchange_rate
 
-test_dependencies = ["Currency Exchange", "Journal Entry", "Contact", "Address"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange", "Journal Entry", "Contact", "Address"]
 
 PAYMENT_URL = "https://example.com/payment"
 

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -380,5 +380,5 @@ def create_cost_center(cc_name):
 	return costcenter.name
 
 
-test_dependencies = ["Customer", "Cost Center"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Customer", "Cost Center"]
 test_records = frappe.get_test_records("Period Closing Voucher")

--- a/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
@@ -10,7 +10,7 @@ from erpnext.accounts.doctype.pos_profile.pos_profile import (
 )
 from erpnext.stock.get_item_details import get_pos_profile
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 class TestPOSProfile(IntegrationTestCase):

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1387,7 +1387,7 @@ class TestPricingRule(IntegrationTestCase):
 		pi.cancel()
 
 
-test_dependencies = ["UTM Campaign"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["UTM Campaign"]
 
 
 def make_pricing_rule(**args):

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -38,8 +38,8 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 from erpnext.stock.doctype.stock_entry.test_stock_entry import get_qty_after_transaction
 from erpnext.stock.tests.test_utils import StockTestMixin
 
-test_dependencies = ["Item", "Cost Center", "Payment Term", "Payment Terms Template"]
-test_ignore = ["Serial No"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Cost Center", "Payment Term", "Payment Terms Template"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Serial No"]
 
 
 class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4356,7 +4356,7 @@ def create_sales_invoice_against_cost_center(**args):
 	return si
 
 
-test_dependencies = ["Journal Entry", "Contact", "Address"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Journal Entry", "Contact", "Address"]
 test_records = frappe.get_test_records("Sales Invoice")
 
 

--- a/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
+++ b/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
@@ -7,7 +7,7 @@ from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.share_transfer.share_transfer import ShareDontExists
 
-test_dependencies = ["Share Type", "Shareholder"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Share Type", "Shareholder"]
 
 
 class TestShareTransfer(IntegrationTestCase):

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -18,7 +18,7 @@ from frappe.utils.data import (
 
 from erpnext.accounts.doctype.subscription.subscription import get_prorata_factor
 
-test_dependencies = ("UOM", "Item Group", "Item")
+EXTRA_TEST_RECORD_DEPENDENCIES = ("UOM", "Item Group", "Item")
 
 
 class UnitTestSubscription(UnitTestCase):

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -13,7 +13,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_ent
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
 
-test_dependencies = ["Supplier Group", "Customer Group"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Supplier Group", "Customer Group"]
 
 
 class UnitTestTaxWithholdingCategory(UnitTestCase):

--- a/erpnext/accounts/report/balance_sheet/test_balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/test_balance_sheet.py
@@ -10,7 +10,7 @@ from erpnext.accounts.report.balance_sheet.balance_sheet import execute
 COMPANY = "_Test Company 6"
 COMPANY_SHORT_NAME = "_TC6"
 
-test_dependencies = ["Company"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Company"]
 
 
 class TestBalanceSheet(IntegrationTestCase):

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -12,7 +12,7 @@ from erpnext.accounts.report.sales_payment_summary.sales_payment_summary import 
 	get_mode_of_payments,
 )
 
-test_dependencies = ["Sales Invoice"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Sales Invoice"]
 
 
 class TestSalesPaymentSummary(IntegrationTestCase):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1308,6 +1308,6 @@ def get_requested_qty(item_code="_Test Item", warehouse="_Test Warehouse - _TC")
 	return flt(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "indented_qty"))
 
 
-test_dependencies = ["BOM", "Item Price"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM", "Item Price"]
 
 test_records = frappe.get_test_records("Purchase Order")

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -9,7 +9,7 @@ from erpnext.accounts.party import get_due_date
 from erpnext.controllers.website_list_for_contact import get_customers_suppliers
 from erpnext.exceptions import PartyDisabled
 
-test_dependencies = ["Payment Term", "Payment Terms Template"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Payment Term", "Payment Terms Template"]
 test_records = frappe.get_test_records("Supplier")
 
 from frappe.tests import IntegrationTestCase, UnitTestCase

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -23,7 +23,7 @@ from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import
 )
 
 test_records = frappe.get_test_records("BOM")
-test_dependencies = ["Item", "Quality Inspection Template"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Quality Inspection Template"]
 
 
 class UnitTestBom(UnitTestCase):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -32,7 +32,7 @@ from erpnext.stock.doctype.stock_entry import test_stock_entry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.utils import get_bin
 
-test_dependencies = ["BOM"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM"]
 
 
 class UnitTestWorkOrder(UnitTestCase):

--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -12,7 +12,7 @@ from erpnext.manufacturing.doctype.workstation.workstation import (
 	check_if_within_operating_hours,
 )
 
-test_dependencies = ["Warehouse"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Warehouse"]
 test_records = frappe.get_test_records("Workstation")
 make_test_records("Workstation")
 

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -11,7 +11,7 @@ from erpnext.selling.doctype.sales_order.sales_order import make_project as make
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
 test_records = frappe.get_test_records("Project")
-test_ignore = ["Sales Order"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Sales Order"]
 
 
 class UnitTestProject(UnitTestCase):

--- a/erpnext/projects/doctype/project_update/test_project_update.py
+++ b/erpnext/projects/doctype/project_update/test_project_update.py
@@ -11,4 +11,4 @@ class TestProjectUpdate(IntegrationTestCase):
 
 
 test_records = frappe.get_test_records("Project Update")
-test_ignore = ["Sales Order"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Sales Order"]

--- a/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
+++ b/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
@@ -16,7 +16,7 @@ from erpnext.regional.report.uae_vat_201.uae_vat_201 import (
 )
 from erpnext.stock.doctype.warehouse.test_warehouse import get_warehouse_account
 
-test_dependencies = ["Territory", "Customer Group", "Supplier Group", "Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Territory", "Customer Group", "Supplier Group", "Item"]
 
 
 class TestUaeVat201(TestCase):

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -18,8 +18,8 @@ from erpnext.selling.doctype.customer.customer import (
 )
 from erpnext.tests.utils import create_test_contact_and_address
 
-test_ignore = ["Price List"]
-test_dependencies = ["Payment Term", "Payment Terms Template"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Price List"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Payment Term", "Payment Terms Template"]
 test_records = frappe.get_test_records("Customer")
 
 

--- a/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
@@ -6,7 +6,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 
 from erpnext.controllers.queries import item_query
 
-test_dependencies = ["Item", "Customer", "Supplier"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Customer", "Supplier"]
 
 
 def create_party_specific_item(**args):

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -7,7 +7,7 @@ from frappe.utils import add_days, add_months, flt, getdate, nowdate
 
 from erpnext.controllers.accounts_controller import InvalidQtyError
 
-test_dependencies = ["Product Bundle"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Product Bundle"]
 
 
 class UnitTestQuotation(UnitTestCase):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2349,7 +2349,7 @@ def get_reserved_qty(item_code="_Test Item", warehouse="_Test Warehouse - _TC"):
 	return flt(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "reserved_qty"))
 
 
-test_dependencies = ["Currency Exchange"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange"]
 
 
 def make_sales_order_workflow():

--- a/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
@@ -11,7 +11,13 @@ from erpnext.selling.report.payment_terms_status_for_sales_order.payment_terms_s
 )
 from erpnext.stock.doctype.item.test_item import create_item
 
-test_dependencies = ["Sales Order", "Item", "Sales Invoice", "Payment Terms Template", "Customer"]
+EXTRA_TEST_RECORD_DEPENDENCIES = [
+	"Sales Order",
+	"Item",
+	"Sales Invoice",
+	"Payment Terms Template",
+	"Customer",
+]
 
 
 class TestPaymentTermsStatusForSalesOrder(IntegrationTestCase):

--- a/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
@@ -7,7 +7,7 @@ from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_orde
 from erpnext.selling.report.sales_order_analysis.sales_order_analysis import execute
 from erpnext.stock.doctype.item.test_item import create_item
 
-test_dependencies = ["Sales Order", "Item", "Sales Invoice", "Delivery Note"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Sales Order", "Item", "Sales Invoice", "Delivery Note"]
 
 
 class TestSalesOrderAnalysis(IntegrationTestCase):

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -13,8 +13,14 @@ from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import
 )
 from erpnext.setup.doctype.company.company import get_default_company_address
 
-test_ignore = ["Account", "Cost Center", "Payment Terms Template", "Salary Component", "Warehouse"]
-test_dependencies = ["Fiscal Year"]
+IGNORE_TEST_RECORD_DEPENDENCIES = [
+	"Account",
+	"Cost Center",
+	"Payment Terms Template",
+	"Salary Component",
+	"Warehouse",
+]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Fiscal Year"]
 test_records = frappe.get_test_records("Company")
 
 

--- a/erpnext/setup/doctype/customer_group/test_customer_group.py
+++ b/erpnext/setup/doctype/customer_group/test_customer_group.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-test_ignore = ["Price List"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Price List"]
 
 
 import frappe

--- a/erpnext/setup/doctype/department/test_department.py
+++ b/erpnext/setup/doctype/department/test_department.py
@@ -5,7 +5,7 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_ignore = ["Leave Block List"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Leave Block List"]
 
 
 class TestDepartment(IntegrationTestCase):

--- a/erpnext/setup/doctype/sales_partner/test_sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/test_sales_partner.py
@@ -5,4 +5,4 @@ import frappe
 
 test_records = frappe.get_test_records("Sales Partner")
 
-test_ignore = ["Item Group"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/setup/doctype/sales_person/test_sales_person.py
+++ b/erpnext/setup/doctype/sales_person/test_sales_person.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-test_dependencies = ["Employee"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Employee"]
 
 import frappe
 
 test_records = frappe.get_test_records("Sales Person")
 
-test_ignore = ["Item Group"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/setup/doctype/territory/test_territory.py
+++ b/erpnext/setup/doctype/territory/test_territory.py
@@ -5,4 +5,4 @@ import frappe
 
 test_records = frappe.get_test_records("Territory")
 
-test_ignore = ["Item Group"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2148,4 +2148,4 @@ def create_delivery_note(**args):
 	return dn
 
 
-test_dependencies = ["Product Bundle"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Product Bundle"]

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -28,8 +28,8 @@ from erpnext.stock.doctype.item.item import (
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.get_item_details import get_item_details
 
-test_ignore = ["BOM"]
-test_dependencies = ["Warehouse", "Item Group", "Item Tax Template", "Brand", "Item Attribute"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["BOM"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Warehouse", "Item Group", "Item Tax Template", "Brand", "Item Attribute"]
 
 
 def make_item(item_code=None, properties=None, uoms=None, barcode=None):

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -890,5 +890,5 @@ def make_material_request(**args):
 	return mr
 
 
-test_dependencies = ["Currency Exchange", "BOM"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange", "BOM"]
 test_records = frappe.get_test_records("Material Request")

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -21,7 +21,7 @@ from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
 	EmptyStockReconciliationItemsError,
 )
 
-test_dependencies = ["Item", "Sales Invoice", "Stock Entry", "Batch"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Sales Invoice", "Stock Entry", "Batch"]
 
 
 class UnitTestPickList(UnitTestCase):

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -3954,5 +3954,5 @@ def make_purchase_receipt(**args):
 	return pr
 
 
-test_dependencies = ["BOM", "Item Price", "Location"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM", "Item Price", "Location"]
 test_records = frappe.get_test_records("Purchase Receipt")

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -21,7 +21,7 @@ from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
-test_dependencies = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 test_records = frappe.get_test_records("Serial No")
 
 

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1445,4 +1445,4 @@ def set_valuation_method(item_code, valuation_method):
 			)
 
 
-test_dependencies = ["Item", "Warehouse"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Warehouse"]

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -4,7 +4,7 @@ from frappe.tests.utils import make_test_records
 
 from erpnext.stock.get_item_details import get_item_details
 
-test_dependencies = ["Customer", "Supplier", "Item", "Price List", "Item Price"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Customer", "Supplier", "Item", "Price List", "Item Price"]
 
 
 class TestGetItemDetail(IntegrationTestCase):


### PR DESCRIPTION
This aims at reducing the deprecation warning pressure on a standard CLI-based ERPnext test run.

Following https://github.com/frappe/frappe/pull/28060
