### PR TITLE
test: step 1 refactor towards idempotency

### DIFF
--- a/erpnext/accounts/doctype/bank_account/test_bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/test_bank_account.py
@@ -6,8 +6,6 @@ import frappe
 from frappe import ValidationError
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Bank Account')
-
 
 class TestBankAccount(IntegrationTestCase):
 	def test_validate_iban(self):

--- a/erpnext/accounts/doctype/cheque_print_template/test_cheque_print_template.py
+++ b/erpnext/accounts/doctype/cheque_print_template/test_cheque_print_template.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Cheque Print Template')
-
 
 class TestChequePrintTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
+++ b/erpnext/accounts/doctype/mode_of_payment/test_mode_of_payment.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Mode of Payment')
-
 
 class TestModeofPayment(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
+++ b/erpnext/accounts/doctype/monthly_distribution/test_monthly_distribution.py
@@ -5,8 +5,6 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Monthly Distribution")
-
 
 class TestMonthlyDistribution(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Payment Gateway Account')
-
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Payment Gateway"]
 
 

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -381,4 +381,3 @@ def create_cost_center(cc_name):
 
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Customer", "Cost Center"]
-test_records = frappe.get_test_records("Period Closing Voucher")

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Purchase Taxes and Charges Template')
-
 
 class TestPurchaseTaxesandChargesTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.py
@@ -5,8 +5,6 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Sales Taxes and Charges Template")
-
 
 class TestSalesTaxesandChargesTemplate(IntegrationTestCase):
 	pass

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -9,8 +9,6 @@ from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule, get_t
 from erpnext.crm.doctype.opportunity.opportunity import make_quotation
 from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
 
-test_records = frappe.get_test_records("Tax Rule")
-
 
 class TestTaxRule(IntegrationTestCase):
 	@classmethod

--- a/erpnext/assets/doctype/location/test_location.py
+++ b/erpnext/assets/doctype/location/test_location.py
@@ -6,8 +6,6 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Location")
-
 
 class TestLocation(IntegrationTestCase):
 	def runTest(self):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1309,5 +1309,3 @@ def get_requested_qty(item_code="_Test Item", warehouse="_Test Warehouse - _TC")
 
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM", "Item Price"]
-
-test_records = frappe.get_test_records("Purchase Order")

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -10,7 +10,7 @@ from erpnext.controllers.website_list_for_contact import get_customers_suppliers
 from erpnext.exceptions import PartyDisabled
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Payment Term", "Payment Terms Template"]
-test_records = frappe.get_test_records("Supplier")
+
 
 from frappe.tests import IntegrationTestCase, UnitTestCase
 

--- a/erpnext/crm/doctype/lead/test_lead.py
+++ b/erpnext/crm/doctype/lead/test_lead.py
@@ -9,8 +9,6 @@ from frappe.utils import random_string, today
 from erpnext.crm.doctype.lead.lead import make_opportunity
 from erpnext.crm.utils import get_linked_prospect
 
-test_records = frappe.get_test_records("Lead")
-
 
 class TestLead(IntegrationTestCase):
 	def test_make_customer(self):

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -11,8 +11,6 @@ from erpnext.crm.doctype.lead.test_lead import make_lead
 from erpnext.crm.doctype.opportunity.opportunity import make_quotation
 from erpnext.crm.utils import get_linked_communication_list
 
-test_records = frappe.get_test_records("Opportunity")
-
 
 class TestOpportunity(IntegrationTestCase):
 	def test_opportunity_status(self):

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -14,8 +14,6 @@ from erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule impor
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
-# test_records = frappe.get_test_records('Maintenance Schedule')
-
 
 class TestMaintenanceSchedule(IntegrationTestCase):
 	def test_events_should_be_created_and_deleted(self):

--- a/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/test_maintenance_visit.py
@@ -6,8 +6,6 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils.data import today
 
-# test_records = frappe.get_test_records('Maintenance Visit')
-
 
 class TestMaintenanceVisit(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/operation/test_operation.py
+++ b/erpnext/manufacturing/doctype/operation/test_operation.py
@@ -5,8 +5,6 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Operation")
-
 
 class TestOperation(IntegrationTestCase):
 	pass

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2713,6 +2713,3 @@ def make_wo_order_test_record(**args):
 		if not args.do_not_submit:
 			wo_order.submit()
 	return wo_order
-
-
-test_records = frappe.get_test_records("Work Order")

--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -13,7 +13,7 @@ from erpnext.manufacturing.doctype.workstation.workstation import (
 )
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Warehouse"]
-test_records = frappe.get_test_records("Workstation")
+
 make_test_records("Workstation")
 
 

--- a/erpnext/projects/doctype/activity_type/test_activity_type.py
+++ b/erpnext/projects/doctype/activity_type/test_activity_type.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Activity Type")

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -10,7 +10,6 @@ from erpnext.projects.doctype.task.test_task import create_task
 from erpnext.selling.doctype.sales_order.sales_order import make_project as make_project_from_so
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
-test_records = frappe.get_test_records("Project")
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Sales Order"]
 
 

--- a/erpnext/projects/doctype/project_update/test_project_update.py
+++ b/erpnext/projects/doctype/project_update/test_project_update.py
@@ -10,5 +10,4 @@ class TestProjectUpdate(IntegrationTestCase):
 	pass
 
 
-test_records = frappe.get_test_records("Project Update")
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Sales Order"]

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -20,7 +20,6 @@ from erpnext.tests.utils import create_test_contact_and_address
 
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Price List"]
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Payment Term", "Payment Terms Template"]
-test_records = frappe.get_test_records("Customer")
 
 
 class UnitTestCustomer(UnitTestCase):

--- a/erpnext/selling/doctype/industry_type/test_industry_type.py
+++ b/erpnext/selling/doctype/industry_type/test_industry_type.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Industry Type")

--- a/erpnext/selling/doctype/installation_note/test_installation_note.py
+++ b/erpnext/selling/doctype/installation_note/test_installation_note.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Installation Note')
-
 
 class TestInstallationNote(IntegrationTestCase):
 	pass

--- a/erpnext/selling/doctype/product_bundle/test_product_bundle.py
+++ b/erpnext/selling/doctype/product_bundle/test_product_bundle.py
@@ -3,8 +3,6 @@
 
 import frappe
 
-test_records = frappe.get_test_records("Product Bundle")
-
 
 def make_product_bundle(parent, items, qty=None):
 	if frappe.db.exists("Product Bundle", parent):

--- a/erpnext/setup/doctype/authorization_rule/test_authorization_rule.py
+++ b/erpnext/setup/doctype/authorization_rule/test_authorization_rule.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Authorization Rule')
-
 
 class TestAuthorizationRule(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/branch/test_branch.py
+++ b/erpnext/setup/doctype/branch/test_branch.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Branch")

--- a/erpnext/setup/doctype/brand/test_brand.py
+++ b/erpnext/setup/doctype/brand/test_brand.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Brand")

--- a/erpnext/setup/doctype/customer_group/test_customer_group.py
+++ b/erpnext/setup/doctype/customer_group/test_customer_group.py
@@ -5,5 +5,3 @@ IGNORE_TEST_RECORD_DEPENDENCIES = ["Price List"]
 
 
 import frappe
-
-test_records = frappe.get_test_records("Customer Group")

--- a/erpnext/setup/doctype/department/test_department.py
+++ b/erpnext/setup/doctype/department/test_department.py
@@ -26,6 +26,3 @@ def create_department(department_name, parent_department=None):
 	).insert()
 
 	return doc
-
-
-test_records = frappe.get_test_records("Department")

--- a/erpnext/setup/doctype/designation/test_designation.py
+++ b/erpnext/setup/doctype/designation/test_designation.py
@@ -3,8 +3,6 @@
 
 import frappe
 
-# test_records = frappe.get_test_records('Designation')
-
 
 def create_designation(**args):
 	args = frappe._dict(args)

--- a/erpnext/setup/doctype/email_digest/test_email_digest.py
+++ b/erpnext/setup/doctype/email_digest/test_email_digest.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Email Digest')
-
 
 class TestEmailDigest(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/employee/test_employee.py
+++ b/erpnext/setup/doctype/employee/test_employee.py
@@ -9,8 +9,6 @@ from frappe.tests import IntegrationTestCase
 import erpnext
 from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError
 
-test_records = frappe.get_test_records("Employee")
-
 
 class TestEmployee(IntegrationTestCase):
 	def test_employee_status_left(self):

--- a/erpnext/setup/doctype/party_type/test_party_type.py
+++ b/erpnext/setup/doctype/party_type/test_party_type.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Party Type')
-
 
 class TestPartyType(IntegrationTestCase):
 	pass

--- a/erpnext/setup/doctype/print_heading/test_print_heading.py
+++ b/erpnext/setup/doctype/print_heading/test_print_heading.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Print Heading")

--- a/erpnext/setup/doctype/quotation_lost_reason/test_quotation_lost_reason.py
+++ b/erpnext/setup/doctype/quotation_lost_reason/test_quotation_lost_reason.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Quotation Lost Reason")

--- a/erpnext/setup/doctype/sales_partner/test_sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/test_sales_partner.py
@@ -3,6 +3,4 @@
 
 import frappe
 
-test_records = frappe.get_test_records("Sales Partner")
-
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/setup/doctype/sales_person/test_sales_person.py
+++ b/erpnext/setup/doctype/sales_person/test_sales_person.py
@@ -5,6 +5,4 @@ EXTRA_TEST_RECORD_DEPENDENCIES = ["Employee"]
 
 import frappe
 
-test_records = frappe.get_test_records("Sales Person")
-
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/setup/doctype/supplier_group/test_supplier_group.py
+++ b/erpnext/setup/doctype/supplier_group/test_supplier_group.py
@@ -2,5 +2,3 @@
 # See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Supplier Group")

--- a/erpnext/setup/doctype/terms_and_conditions/test_terms_and_conditions.py
+++ b/erpnext/setup/doctype/terms_and_conditions/test_terms_and_conditions.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("Terms and Conditions")

--- a/erpnext/setup/doctype/territory/test_territory.py
+++ b/erpnext/setup/doctype/territory/test_territory.py
@@ -3,6 +3,4 @@
 
 import frappe
 
-test_records = frappe.get_test_records("Territory")
-
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Group"]

--- a/erpnext/setup/doctype/uom/test_uom.py
+++ b/erpnext/setup/doctype/uom/test_uom.py
@@ -2,5 +2,3 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-
-test_records = frappe.get_test_records("UOM")

--- a/erpnext/setup/doctype/vehicle/test_vehicle.py
+++ b/erpnext/setup/doctype/vehicle/test_vehicle.py
@@ -6,8 +6,6 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import random_string
 
-# test_records = frappe.get_test_records('Vehicle')
-
 
 class TestVehicle(IntegrationTestCase):
 	def test_make_vehicle(self):

--- a/erpnext/stock/doctype/item_attribute/test_item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/test_item_attribute.py
@@ -3,9 +3,6 @@
 
 
 import frappe
-
-test_records = frappe.get_test_records("Item Attribute")
-
 from frappe.tests import IntegrationTestCase, UnitTestCase
 
 from erpnext.stock.doctype.item_attribute.item_attribute import ItemAttributeIncrementError

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -1165,6 +1165,3 @@ def distribute_landed_cost_on_items(lcv):
 	for item in lcv.get("items"):
 		item.applicable_charges = flt(item.get(based_on)) * flt(lcv.total_taxes_and_charges) / flt(total)
 		item.applicable_charges = flt(item.applicable_charges, lcv.precision("applicable_charges", item))
-
-
-test_records = frappe.get_test_records("Landed Cost Voucher")

--- a/erpnext/stock/doctype/manufacturer/test_manufacturer.py
+++ b/erpnext/stock/doctype/manufacturer/test_manufacturer.py
@@ -4,8 +4,6 @@ import unittest
 
 from frappe.tests import IntegrationTestCase
 
-# test_records = frappe.get_test_records('Manufacturer')
-
 
 class TestManufacturer(IntegrationTestCase):
 	pass

--- a/erpnext/stock/doctype/price_list/test_price_list.py
+++ b/erpnext/stock/doctype/price_list/test_price_list.py
@@ -5,5 +5,3 @@
 import frappe
 
 # test_ignore = ["Item"]
-
-test_records = frappe.get_test_records("Price List")

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -15,8 +15,6 @@ from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delive
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 
-# test_records = frappe.get_test_records('Quality Inspection')
-
 
 class UnitTestQualityInspection(UnitTestCase):
 	"""

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -22,7 +22,6 @@ from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_i
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
-test_records = frappe.get_test_records("Serial No")
 
 
 class UnitTestSerialNo(UnitTestCase):

--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -11,8 +11,6 @@ from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.doctype.warehouse.warehouse import convert_to_group_or_ledger, get_children
 
-test_records = frappe.get_test_records("Warehouse")
-
 
 class UnitTestWarehouse(UnitTestCase):
 	"""

--- a/erpnext/support/doctype/warranty_claim/test_warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/test_warranty_claim.py
@@ -5,8 +5,6 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Warranty Claim")
-
 
 class TestWarrantyClaim(IntegrationTestCase):
 	pass


### PR DESCRIPTION
- **chore: remove redundant declarations of test_records**
  Contrary to intuition, when `test_records` simply re-declare the current document, it is the default implementation of 
 any `IntegrationTestCase` via `frappe.tests.utils.generators.make_test_records`. At the very least it's a "wasteful" no-op, but more importantly its widespread use fake a nonexistent deviation from the default / convention.
 
Module attribute `test_records` or module function `_make_test_records` may be used when the default behaviour is not suitable. The default behaviour is loading the current doc and all its link-field transitory dependencies. Additional dependencies can be declared via module attribute `EXTRA_TEST_RECORD_DEPENDENCIES` while exemptions can be declared via `IGNORE_TEST_RECORD_DEPENDENCIES`.

Ref.: `frappe/tests/utils/generators.py`

`IGNORE_TEST_RECORD_DEPENDENCIES` does not mean that these records wouldn't be loaded by another test into `self.globalTestRecords`: **they could** (they are global, after all). It's just a cosmetic way to speed up **isolated** (!) execution by avoiding to pull in unneeded records.

This PR also reduces the deprecation warning pressure on the CLI.

cc @ruthra-kumar @rohitwaghchaure @s-aga-r @deepeshgarg007 