### PR TITLE
test: step 2 refactor towards idempotency

### DIFF
--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -327,7 +327,7 @@ class TestAccount(IntegrationTestCase):
 
 
 def _make_test_records(verbose=None):
-	from frappe.test_runner import make_test_objects
+	from frappe.tests.utils import make_test_objects
 
 	accounts = [
 		# [account_name, parent_account, is_group]

--- a/erpnext/accounts/doctype/cost_center/test_cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/test_cost_center.py
@@ -5,14 +5,9 @@ import unittest
 import frappe
 from frappe.tests import IntegrationTestCase
 
-test_records = frappe.get_test_records("Cost Center")
-
 
 class TestCostCenter(IntegrationTestCase):
 	def test_cost_center_creation_against_child_node(self):
-		if not frappe.db.get_value("Cost Center", {"name": "_Test Cost Center 2 - _TC"}):
-			frappe.get_doc(test_records[1]).insert()
-
 		cost_center = frappe.get_doc(
 			{
 				"doctype": "Cost Center",

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -3,7 +3,6 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import change_settings
 from frappe.utils import flt, nowdate
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -25,22 +25,22 @@ class TestJournalEntry(IntegrationTestCase):
 		"Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1}
 	)
 	def test_journal_entry_with_against_jv(self):
-		jv_invoice = frappe.copy_doc(test_records[2])
-		base_jv = frappe.copy_doc(test_records[0])
+		jv_invoice = frappe.copy_doc(self.globalTestRecords["Journal Entry"][2])
+		base_jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][0])
 		self.jv_against_voucher_testcase(base_jv, jv_invoice)
 
 	def test_jv_against_sales_order(self):
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
 		sales_order = make_sales_order(do_not_save=True)
-		base_jv = frappe.copy_doc(test_records[0])
+		base_jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][0])
 		self.jv_against_voucher_testcase(base_jv, sales_order)
 
 	def test_jv_against_purchase_order(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 
 		purchase_order = create_purchase_order(do_not_save=True)
-		base_jv = frappe.copy_doc(test_records[1])
+		base_jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][1])
 		self.jv_against_voucher_testcase(base_jv, purchase_order)
 
 	def jv_against_voucher_testcase(self, base_jv, test_voucher):
@@ -589,6 +589,3 @@ def make_journal_entry(
 			jv.submit()
 
 	return jv
-
-
-test_records = frappe.get_test_records("Journal Entry")

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -25,7 +25,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.setup.doctype.employee.test_employee import make_employee
 
-EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Currency Exchange"]
 
 
 class UnitTestPaymentEntry(UnitTestCase):
@@ -619,12 +619,9 @@ class TestPaymentEntry(IntegrationTestCase):
 		self.assertEqual(flt(pe.references[0].exchange_gain_loss, 2), -94.74)
 
 	def test_payment_entry_retrieves_last_exchange_rate(self):
-		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import (
-			save_new_records,
-			test_records,
-		)
+		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import save_new_records
 
-		save_new_records(test_records)
+		save_new_records(self.globalTestRecords["Currency Exchange"])
 
 		pe = frappe.new_doc("Payment Entry")
 		pe.payment_type = "Pay"

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -23,6 +23,7 @@ from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 class TestPOSInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -24,6 +24,7 @@ class TestPOSInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -248,6 +248,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -289,6 +290,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -377,6 +379,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -431,6 +434,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -482,6 +486,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -512,6 +517,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(
+			self,
 			company="_Test Company",
 			target_warehouse="Stores - _TC",
 			cost_center="Main - _TC",
@@ -901,7 +907,7 @@ class TestPOSInvoice(IntegrationTestCase):
 
 		frappe.db.savepoint("before_test_delivered_serial_no_case")
 		try:
-			se = make_serialized_item()
+			se = make_serialized_item(self)
 			serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 
 			dn = create_delivery_note(item_code="_Test Serialized Item With Series", serial_no=[serial_no])

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -28,6 +28,11 @@ class UnitTestPosInvoiceMergeLog(UnitTestCase):
 
 
 class TestPOSInvoiceMergeLog(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+
 	def test_consolidated_invoice_creation(self):
 		frappe.db.sql("delete from `tabPOS Invoice`")
 

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -411,7 +411,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		frappe.db.sql("delete from `tabPOS Invoice`")
 
 		try:
-			se = make_serialized_item()
+			se = make_serialized_item(self)
 			serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 
 			init_user_and_profile()

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -4,7 +4,6 @@ import json
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import change_settings
 
 from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import make_sales_return

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -28,6 +28,7 @@ class TestPricingRule(IntegrationTestCase):
 	def setUp(self):
 		delete_existing_pricing_rules()
 		setup_pricing_rule_data()
+		self.enterClassContext(self.change_settings("Selling Settings", validate_selling_price=0))
 
 	def tearDown(self):
 		delete_existing_pricing_rules()

--- a/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
@@ -15,6 +15,11 @@ from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
 
 
 class TestProcessStatementOfAccounts(AccountsTestMixin, IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+
 	def setUp(self):
 		self.create_company()
 		self.create_customer()

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -115,7 +115,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 
 	def test_gl_entries_without_perpetual_inventory(self):
 		frappe.db.set_value("Company", "_Test Company", "round_off_account", "Round Off - _TC")
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		self.assertTrue(not cint(erpnext.is_perpetual_inventory_enabled(pi.company)))
 		pi.insert()
 		pi.submit()
@@ -156,7 +156,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		self.check_gle_for_pi(pi.name)
 
 	def test_terms_added_after_save(self):
-		pi = frappe.copy_doc(test_records[1])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][1])
 		pi.insert()
 		self.assertTrue(pi.payment_schedule)
 		self.assertEqual(pi.payment_schedule[0].due_date, pi.due_date)
@@ -383,13 +383,13 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		self.assertEqual(discrepancy_caused_by_exchange_rate_diff, amount)
 
 	def test_purchase_invoice_change_naming_series(self):
-		pi = frappe.copy_doc(test_records[1])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][1])
 		pi.insert()
 		pi.naming_series = "TEST-"
 
 		self.assertRaises(frappe.CannotChangeConstantError, pi.save)
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.insert()
 		pi.load_from_db()
 
@@ -429,7 +429,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 			self.assertEqual(expected_values[i][2], gle.credit)
 
 	def test_purchase_invoice_calculation(self):
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.insert()
 		pi.load_from_db()
 
@@ -465,15 +465,11 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		"Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1}
 	)
 	def test_purchase_invoice_with_advance(self):
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.copy_doc(jv_test_records[1])
+		jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][1])
 		jv.insert()
 		jv.submit()
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.disable_rounded_total = 1
 		pi.allocate_advances_automatically = 0
 		pi.append(
@@ -522,15 +518,11 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		"Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1}
 	)
 	def test_invoice_with_advance_and_multi_payment_terms(self):
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.copy_doc(jv_test_records[1])
+		jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][1])
 		jv.insert()
 		jv.submit()
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.disable_rounded_total = 1
 		pi.allocate_advances_automatically = 0
 		pi.append(
@@ -945,16 +937,12 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		)
 
 	def test_outstanding_amount_after_advance_jv_cancelation(self):
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.copy_doc(jv_test_records[1])
+		jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][1])
 		jv.accounts[0].is_advance = "Yes"
 		jv.insert()
 		jv.submit()
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.append(
 			"advances",
 			{
@@ -1004,7 +992,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		pe.insert()
 		pe.submit()
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 		pi.is_pos = 0
 		pi.append(
 			"advances",
@@ -1040,7 +1028,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 			shipping_rule_type="Buying", shipping_rule_name="Shipping Rule - Purchase Invoice Test"
 		)
 
-		pi = frappe.copy_doc(test_records[0])
+		pi = frappe.copy_doc(self.globalTestRecords["Purchase Invoice"][0])
 
 		pi.shipping_rule = shipping_rule.name
 		pi.insert()
@@ -2662,6 +2650,3 @@ def toggle_provisional_accounting_setting(**args):
 	company.enable_provisional_accounting_for_non_stock_items = args.enable or 0
 	company.default_provisional_account = args.provisional_account
 	company.save()
-
-
-test_records = frappe.get_test_records("Purchase Invoice")

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -45,6 +45,7 @@ IGNORE_TEST_RECORD_DEPENDENCIES = ["Serial No"]
 class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 	@classmethod
 	def setUpClass(self):
+		super().setUpClass()
 		unlink_payment_on_cancel_of_invoice()
 		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -15,6 +15,11 @@ from erpnext.accounts.utils import get_fiscal_year
 
 
 class TestRepostAccountingLedger(AccountsTestMixin, IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+
 	def setUp(self):
 		self.create_company()
 		self.create_customer()

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -76,6 +76,7 @@ class TestSalesInvoice(IntegrationTestCase):
 
 	@classmethod
 	def setUpClass(self):
+		super().setUpClass()
 		unlink_payment_on_cancel_of_invoice()
 
 	@classmethod

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -75,8 +75,9 @@ class TestSalesInvoice(IntegrationTestCase):
 		return w
 
 	@classmethod
-	def setUpClass(self):
+	def setUpClass(cls):
 		super().setUpClass()
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		unlink_payment_on_cancel_of_invoice()
 
 	@classmethod

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -68,7 +68,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		frappe.db.rollback()
 
 	def make(self):
-		w = frappe.copy_doc(test_records[0])
+		w = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		w.is_pos = 0
 		w.insert()
 		w.submit()
@@ -93,7 +93,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(si.items[0].qty, 1)
 
 	def test_timestamp_change(self):
-		w = frappe.copy_doc(test_records[0])
+		w = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		w.docstatus = 0
 		w.insert()
 
@@ -110,27 +110,27 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertRaises(frappe.TimestampMismatchError, w2.save)
 
 	def test_sales_invoice_change_naming_series(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		si.insert()
 		si.naming_series = "TEST-"
 
 		self.assertRaises(frappe.CannotChangeConstantError, si.save)
 
-		si = frappe.copy_doc(test_records[1])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][1])
 		si.insert()
 		si.naming_series = "TEST-"
 
 		self.assertRaises(frappe.CannotChangeConstantError, si.save)
 
 	def test_add_terms_after_save(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		si.insert()
 
 		self.assertTrue(si.payment_schedule)
 		self.assertEqual(getdate(si.payment_schedule[0].due_date), getdate(si.due_date))
 
 	def test_sales_invoice_calculation_base_currency(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		si.insert()
 
 		expected_values = {
@@ -182,7 +182,7 @@ class TestSalesInvoice(IntegrationTestCase):
 	def test_payment_entry_unlink_against_invoice(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.is_pos = 0
 		si.insert()
 		si.submit()
@@ -248,7 +248,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertRaises(PaymentEntryUnlinkError, si1.cancel)
 
 	def test_sales_invoice_calculation_export_currency(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		si.currency = "USD"
 		si.conversion_rate = 50
 		si.get("items")[0].rate = 1
@@ -367,7 +367,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(si.grand_total, 4900.00)
 
 	def test_sales_invoice_discount_amount(self):
-		si = frappe.copy_doc(test_records[3])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])
 		si.discount_amount = 104.94
 		si.append(
 			"taxes",
@@ -449,7 +449,7 @@ class TestSalesInvoice(IntegrationTestCase):
 
 	def test_discount_amount_gl_entry(self):
 		frappe.db.set_value("Company", "_Test Company", "round_off_account", "Round Off - _TC")
-		si = frappe.copy_doc(test_records[3])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])
 		si.discount_amount = 104.94
 		si.append(
 			"taxes",
@@ -480,15 +480,15 @@ class TestSalesInvoice(IntegrationTestCase):
 			(d[0], d)
 			for d in [
 				[si.debit_to, 1500, 0.0],
-				[test_records[3]["items"][0]["income_account"], 0.0, 1163.45],
-				[test_records[3]["taxes"][0]["account_head"], 0.0, 130.31],
-				[test_records[3]["taxes"][1]["account_head"], 0.0, 2.61],
-				[test_records[3]["taxes"][2]["account_head"], 0.0, 1.30],
-				[test_records[3]["taxes"][3]["account_head"], 0.0, 25.95],
-				[test_records[3]["taxes"][4]["account_head"], 0.0, 145.43],
-				[test_records[3]["taxes"][5]["account_head"], 0.0, 116.34],
-				[test_records[3]["taxes"][6]["account_head"], 0.0, 100],
-				[test_records[3]["taxes"][7]["account_head"], 168.54, 0.0],
+				[self.globalTestRecords["Sales Invoice"][3]["items"][0]["income_account"], 0.0, 1163.45],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][0]["account_head"], 0.0, 130.31],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][1]["account_head"], 0.0, 2.61],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][2]["account_head"], 0.0, 1.30],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][3]["account_head"], 0.0, 25.95],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][4]["account_head"], 0.0, 145.43],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][5]["account_head"], 0.0, 116.34],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][6]["account_head"], 0.0, 100],
+				[self.globalTestRecords["Sales Invoice"][3]["taxes"][7]["account_head"], 168.54, 0.0],
 				["_Test Account Service Tax - _TC", 16.85, 0.0],
 				["Round Off - _TC", 0.01, 0.0],
 			]
@@ -638,7 +638,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(si.grand_total, 1116.0)
 
 	def test_inclusive_rate_validations(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		for i, tax in enumerate(si.get("taxes")):
 			tax.idx = i + 1
 
@@ -656,7 +656,7 @@ class TestSalesInvoice(IntegrationTestCase):
 
 	def test_sales_invoice_calculation_base_currency_with_tax_inclusive_price(self):
 		# prepare
-		si = frappe.copy_doc(test_records[3])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])
 		si.insert()
 
 		expected_values = {
@@ -730,7 +730,7 @@ class TestSalesInvoice(IntegrationTestCase):
 
 	def test_sales_invoice_calculation_export_currency_with_tax_inclusive_price(self):
 		# prepare
-		si = frappe.copy_doc(test_records[3])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])
 		si.currency = "USD"
 		si.conversion_rate = 50
 		si.get("items")[0].price_list_rate = 55.56
@@ -819,7 +819,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(w.outstanding_amount, w.base_rounded_total)
 
 	def test_rounded_total_with_cash_discount(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 
 		item = copy.deepcopy(si.get("items")[0])
 		item.update(
@@ -842,12 +842,7 @@ class TestSalesInvoice(IntegrationTestCase):
 
 	def test_payment(self):
 		w = self.make()
-
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.get_doc(frappe.copy_doc(jv_test_records[0]))
+		jv = frappe.get_doc(frappe.copy_doc(self.globalTestRecords["Journal Entry"][0]))
 		jv.get("accounts")[0].reference_type = w.doctype
 		jv.get("accounts")[0].reference_name = w.name
 		jv.insert()
@@ -886,7 +881,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		)
 
 		# make invoice
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.is_pos = 0
 		si.insert()
 		si.submit()
@@ -913,7 +908,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(si.outstanding_amount, 0)
 
 	def test_sales_invoice_gl_entry_without_perpetual_inventory(self):
-		si = frappe.copy_doc(test_records[1])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][1])
 		si.insert()
 		si.submit()
 
@@ -931,9 +926,9 @@ class TestSalesInvoice(IntegrationTestCase):
 			(d[0], d)
 			for d in [
 				[si.debit_to, 630.0, 0.0],
-				[test_records[1]["items"][0]["income_account"], 0.0, 500.0],
-				[test_records[1]["taxes"][0]["account_head"], 0.0, 80.0],
-				[test_records[1]["taxes"][1]["account_head"], 0.0, 50.0],
+				[self.globalTestRecords["Sales Invoice"][1]["items"][0]["income_account"], 0.0, 500.0],
+				[self.globalTestRecords["Sales Invoice"][1]["taxes"][0]["account_head"], 0.0, 80.0],
+				[self.globalTestRecords["Sales Invoice"][1]["taxes"][1]["account_head"], 0.0, 50.0],
 			]
 		)
 
@@ -1310,7 +1305,7 @@ class TestSalesInvoice(IntegrationTestCase):
 	def test_pos_si_without_payment(self):
 		make_pos_profile()
 
-		pos = copy.deepcopy(test_records[1])
+		pos = copy.deepcopy(dict(self.globalTestRecords["Sales Invoice"][1]))
 		pos["is_pos"] = 1
 		pos["update_stock"] = 1
 
@@ -1365,7 +1360,7 @@ class TestSalesInvoice(IntegrationTestCase):
 			(d[0], d)
 			for d in [
 				[si.debit_to, 100.0, 0.0],
-				[test_records[1]["items"][0]["income_account"], 0.0, 100.0],
+				[self.globalTestRecords["Sales Invoice"][1]["items"][0]["income_account"], 0.0, 100.0],
 			]
 		)
 		for _i, gle in enumerate(gl_entries):
@@ -1374,21 +1369,13 @@ class TestSalesInvoice(IntegrationTestCase):
 			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
 	def _insert_purchase_receipt(self):
-		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import (
-			test_records as pr_test_records,
-		)
-
-		pr = frappe.copy_doc(pr_test_records[0])
+		pr = frappe.copy_doc(self.globalTestRecords["Purchase Receipt"][0])
 		pr.naming_series = "_T-Purchase Receipt-"
 		pr.insert()
 		pr.submit()
 
 	def _insert_delivery_note(self):
-		from erpnext.stock.doctype.delivery_note.test_delivery_note import (
-			test_records as dn_test_records,
-		)
-
-		dn = frappe.copy_doc(dn_test_records[0])
+		dn = frappe.copy_doc(self.globalTestRecords["Delivery Note"][0])
 		dn.naming_series = "_T-Delivery Note-"
 		dn.insert()
 		dn.submit()
@@ -1398,15 +1385,11 @@ class TestSalesInvoice(IntegrationTestCase):
 		"Accounts Settings", {"unlink_payment_on_cancellation_of_invoice": 1}
 	)
 	def test_sales_invoice_with_advance(self):
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.copy_doc(jv_test_records[0])
+		jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][0])
 		jv.insert()
 		jv.submit()
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.allocate_advances_automatically = 0
 		si.append(
 			"advances",
@@ -1447,11 +1430,11 @@ class TestSalesInvoice(IntegrationTestCase):
 	def test_serialized(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
-		se = make_serialized_item()
+		se = make_serialized_item(self)
 		se.load_from_db()
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.update_stock = 1
 		si.get("items")[0].item_code = "_Test Serialized Item With Series"
 		si.get("items")[0].qty = 1
@@ -1499,7 +1482,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
-		se = make_serialized_item()
+		se = make_serialized_item(self)
 		se.load_from_db()
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 
@@ -1678,7 +1661,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(incoming_rate, 10.0)
 
 	def test_discount_on_net_total(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 		si.apply_discount_on = "Net Total"
 		si.discount_amount = 625
 		si.insert()
@@ -1917,16 +1900,12 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(si.get("items")[0].rate, flt((price_list_rate * 25) / 100 + price_list_rate))
 
 	def test_outstanding_amount_after_advance_jv_cancellation(self):
-		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (
-			test_records as jv_test_records,
-		)
-
-		jv = frappe.copy_doc(jv_test_records[0])
+		jv = frappe.copy_doc(self.globalTestRecords["Journal Entry"][0])
 		jv.accounts[0].is_advance = "Yes"
 		jv.insert()
 		jv.submit()
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.append(
 			"advances",
 			{
@@ -2000,7 +1979,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		sales_order.reload()
 		self.assertEqual(sales_order.advance_paid, 300)
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.items[0].sales_order = sales_order.name
 		si.items[0].so_detail = sales_order.get("items")[0].name
 		si.is_pos = 0
@@ -2053,7 +2032,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		item_price.price_list_rate = 100
 		item_price.insert()
 
-		si = frappe.copy_doc(test_records[1])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][1])
 		si.items[0].uom = "_Test UOM 1"
 		si.items[0].conversion_factor = None
 		si.items[0].price_list_rate = None
@@ -2354,7 +2333,7 @@ class TestSalesInvoice(IntegrationTestCase):
 			shipping_rule_type="Selling", shipping_rule_name="Shipping Rule - Sales Invoice Test"
 		)
 
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 
 		si.shipping_rule = shipping_rule.name
 		si.insert()
@@ -2698,7 +2677,7 @@ class TestSalesInvoice(IntegrationTestCase):
 			basic_rate=500,
 		)
 
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.customer = "_Test Internal Customer 3"
 		si.update_stock = 1
 		si.set_warehouse = "Finished Goods - _TC"
@@ -3315,7 +3294,7 @@ class TestSalesInvoice(IntegrationTestCase):
 			self.assertEqual(invoice.status, "Overdue and Discounted")
 
 	def test_sales_commission(self):
-		si = frappe.copy_doc(test_records[2])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 
 		frappe.db.set_value("Item", si.get("items")[0].item_code, "grant_commission", 1)
 		frappe.db.set_value("Item", si.get("items")[1].item_code, "grant_commission", 0)
@@ -4187,7 +4166,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		self.assertEqual(jv[0], si.grand_total)
 
 	def test_invoice_remarks(self):
-		si = frappe.copy_doc(test_records[0])
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
 		si.po_no = "Test PO"
 		si.po_date = nowdate()
 		si.save()
@@ -4357,7 +4336,6 @@ def create_sales_invoice_against_cost_center(**args):
 
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Journal Entry", "Contact", "Address"]
-test_records = frappe.get_test_records("Sales Invoice")
 
 
 def get_outstanding_amount(against_voucher_type, against_voucher, account, party, party_type):

--- a/erpnext/accounts/doctype/shipping_rule/test_shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/test_shipping_rule.py
@@ -11,19 +11,17 @@ from erpnext.accounts.doctype.shipping_rule.shipping_rule import (
 	OverlappingConditionError,
 )
 
-test_records = frappe.get_test_records("Shipping Rule")
-
 
 class TestShippingRule(IntegrationTestCase):
 	def test_from_greater_than_to(self):
-		shipping_rule = frappe.copy_doc(test_records[0])
-		shipping_rule.name = test_records[0].get("name")
+		shipping_rule = frappe.copy_doc(self.globalTestRecords["Shipping Rule"][0])
+		shipping_rule.name = self.globalTestRecords["Shipping Rule"][0].get("name")
 		shipping_rule.get("conditions")[0].from_value = 101
 		self.assertRaises(FromGreaterThanToError, shipping_rule.insert)
 
 	def test_many_zero_to_values(self):
-		shipping_rule = frappe.copy_doc(test_records[0])
-		shipping_rule.name = test_records[0].get("name")
+		shipping_rule = frappe.copy_doc(self.globalTestRecords["Shipping Rule"][0])
+		shipping_rule.name = self.globalTestRecords["Shipping Rule"][0].get("name")
 		shipping_rule.get("conditions")[0].to_value = 0
 		self.assertRaises(ManyBlankToValuesError, shipping_rule.insert)
 
@@ -35,8 +33,8 @@ class TestShippingRule(IntegrationTestCase):
 			((50, 150), (25, 175)),
 			((50, 150), (50, 150)),
 		]:
-			shipping_rule = frappe.copy_doc(test_records[0])
-			shipping_rule.name = test_records[0].get("name")
+			shipping_rule = frappe.copy_doc(self.globalTestRecords["Shipping Rule"][0])
+			shipping_rule.name = self.globalTestRecords["Shipping Rule"][0].get("name")
 			shipping_rule.get("conditions")[0].from_value = range_a[0]
 			shipping_rule.get("conditions")[0].to_value = range_a[1]
 			shipping_rule.get("conditions")[1].from_value = range_b[0]

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -28,6 +28,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 class TestAssetRepair(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		set_depreciation_settings_in_company()
 		create_asset_data()
 		create_item("_Test Stock Item")

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -90,7 +90,7 @@ class TestAssetRepair(IntegrationTestCase):
 	def test_serialized_item_consumption(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
-		stock_entry = make_serialized_item()
+		stock_entry = make_serialized_item(self)
 		bundle_id = stock_entry.get("items")[0].serial_and_batch_bundle
 		serial_nos = get_serial_nos_from_bundle(bundle_id)
 		serial_no = serial_nos[0]

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -19,7 +19,7 @@ class UnitTestSupplierQuotation(UnitTestCase):
 
 class TestPurchaseOrder(IntegrationTestCase):
 	def test_supplier_quotation_qty(self):
-		sq = frappe.copy_doc(test_records[0])
+		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])
 		sq.items[0].qty = 0
 		with self.assertRaises(InvalidQtyError):
 			sq.save()
@@ -32,7 +32,7 @@ class TestPurchaseOrder(IntegrationTestCase):
 	def test_make_purchase_order(self):
 		from erpnext.buying.doctype.supplier_quotation.supplier_quotation import make_purchase_order
 
-		sq = frappe.copy_doc(test_records[0]).insert()
+		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_purchase_order, sq.name)
 
@@ -50,6 +50,3 @@ class TestPurchaseOrder(IntegrationTestCase):
 				doc.set("schedule_date", "2013-04-12")
 
 		po.insert()
-
-
-test_records = frappe.get_test_records("Supplier Quotation")

--- a/erpnext/buying/report/requested_items_to_order_and_receive/test_requested_items_to_order_and_receive.py
+++ b/erpnext/buying/report/requested_items_to_order_and_receive/test_requested_items_to_order_and_receive.py
@@ -47,9 +47,7 @@ class TestRequestedItemsToOrderAndReceive(IntegrationTestCase):
 
 	def setup_material_request(self, order=False, receive=False, days=0):
 		po = None
-		test_records = frappe.get_test_records("Material Request")
-
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.transaction_date = add_days(today(), days)
 		mr.schedule_date = add_days(mr.transaction_date, 1)
 		for row in mr.items:

--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -11,8 +11,11 @@ def add_default_params(func, doctype):
 	return partial(func, doctype=doctype, txt="", searchfield="name", start=0, page_len=20, filters=None)
 
 
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Employee", "Lead", "Item", "BOM", "Project", "Account"]
+
+
 class TestQueries(IntegrationTestCase):
-	# All tests are based on doctype/test_records.json
+	# All tests are based on self.globalTestRecords[doctype]
 
 	def assert_nested_in(self, item, container):
 		self.assertIn(item, [vals for tuples in container for vals in tuples])

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -98,7 +98,7 @@ class TestMaintenanceSchedule(IntegrationTestCase):
 	def test_serial_no_filters(self):
 		# Without serial no. set in schedule -> returns None
 		item_code = "_Test Serial Item"
-		make_serial_item_with_serial(item_code)
+		make_serial_item_with_serial(self, item_code)
 		ms = make_maintenance_schedule(item_code=item_code)
 		ms.submit()
 
@@ -109,7 +109,7 @@ class TestMaintenanceSchedule(IntegrationTestCase):
 		self.assertEqual(serial_nos, None)
 
 		# With serial no. set in schedule -> returns serial nos.
-		make_serial_item_with_serial(item_code)
+		make_serial_item_with_serial(self, item_code)
 		ms = make_maintenance_schedule(item_code=item_code, serial_no="TEST001, TEST002")
 		ms.submit()
 
@@ -125,7 +125,7 @@ class TestMaintenanceSchedule(IntegrationTestCase):
 		# Checks whether serials are automatically updated when changing in items table.
 		# Also checks if other fields trigger generate schdeule if changed in items table.
 		item_code = "_Test Serial Item"
-		make_serial_item_with_serial(item_code)
+		make_serial_item_with_serial(self, item_code)
 		ms = make_maintenance_schedule(item_code=item_code, serial_no="TEST001, TEST002")
 		ms.save()
 
@@ -152,7 +152,7 @@ class TestMaintenanceSchedule(IntegrationTestCase):
 		frappe.db.rollback()
 
 
-def make_serial_item_with_serial(item_code):
+def make_serial_item_with_serial(self, item_code):
 	serial_item_doc = create_item(item_code, is_stock_item=1)
 	if not serial_item_doc.has_serial_no or not serial_item_doc.serial_no_series:
 		serial_item_doc.has_serial_no = 1
@@ -160,7 +160,7 @@ def make_serial_item_with_serial(item_code):
 		serial_item_doc.save(ignore_permissions=True)
 	active_serials = frappe.db.get_all("Serial No", {"status": "Active", "item_code": item_code})
 	if len(active_serials) < 2:
-		make_serialized_item(item_code=item_code)
+		make_serialized_item(self, item_code=item_code)
 
 
 def get_events(ms):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -22,7 +22,6 @@ from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import
 	create_stock_reconciliation,
 )
 
-test_records = frappe.get_test_records("BOM")
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Item", "Quality Inspection Template"]
 
 
@@ -43,8 +42,8 @@ class TestBOM(IntegrationTestCase):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=0
 		)
-		self.assertTrue(test_records[2]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(test_records[2]["items"][1]["item_code"] in items_dict)
+		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
+		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
 		self.assertEqual(len(items_dict.values()), 2)
 
 	@timeout
@@ -54,10 +53,10 @@ class TestBOM(IntegrationTestCase):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=1
 		)
-		self.assertTrue(test_records[2]["items"][0]["item_code"] in items_dict)
-		self.assertFalse(test_records[2]["items"][1]["item_code"] in items_dict)
-		self.assertTrue(test_records[0]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(test_records[0]["items"][1]["item_code"] in items_dict)
+		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
+		self.assertFalse(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
+		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][0]["item_code"] in items_dict)
+		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][1]["item_code"] in items_dict)
 		self.assertEqual(len(items_dict.values()), 3)
 
 	@timeout
@@ -115,7 +114,7 @@ class TestBOM(IntegrationTestCase):
 
 	@timeout
 	def test_bom_cost(self):
-		bom = frappe.copy_doc(test_records[2])
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2])
 		bom.insert()
 
 		raw_material_cost = 0.0
@@ -144,7 +143,7 @@ class TestBOM(IntegrationTestCase):
 
 	@timeout
 	def test_bom_cost_with_batch_size(self):
-		bom = frappe.copy_doc(test_records[2])
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2])
 		bom.docstatus = 0
 		op_cost = 0.0
 		for op_row in bom.operations:
@@ -174,7 +173,7 @@ class TestBOM(IntegrationTestCase):
 			item_price.price_list_rate = rate
 			item_price.insert()
 
-		bom = frappe.copy_doc(test_records[2])
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2])
 		bom.set_rate_of_sub_assembly_item_based_on_bom = 0
 		bom.rm_cost_as_per = "Price List"
 		bom.buying_price_list = "_Test Price List"
@@ -200,7 +199,7 @@ class TestBOM(IntegrationTestCase):
 
 	@timeout
 	def test_bom_cost_multi_uom_based_on_valuation_rate(self):
-		bom = frappe.copy_doc(test_records[2])
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2])
 		bom.set_rate_of_sub_assembly_item_based_on_bom = 0
 		bom.rm_cost_as_per = "Valuation Rate"
 		bom.items[0].uom = "_Test UOM 1"
@@ -220,7 +219,7 @@ class TestBOM(IntegrationTestCase):
 
 	@timeout
 	def test_bom_cost_with_fg_based_operating_cost(self):
-		bom = frappe.copy_doc(test_records[4])
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][4])
 		bom.insert()
 
 		raw_material_cost = 0.0
@@ -575,7 +574,7 @@ class TestBOM(IntegrationTestCase):
 
 	@timeout
 	def test_clear_inpection_quality(self):
-		bom = frappe.copy_doc(test_records[2], ignore_no_copy=True)
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2], ignore_no_copy=True)
 		bom.docstatus = 0
 		bom.is_default = 0
 		bom.quality_inspection_template = "_Test Quality Inspection Template"

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -6,8 +6,7 @@ from collections import deque
 from functools import partial
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import timeout
+from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
 from frappe.utils import cstr, flt
 
 from erpnext.controllers.tests.test_subcontracting_controller import (

--- a/erpnext/manufacturing/doctype/bom_update_log/test_bom_update_log.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/test_bom_update_log.py
@@ -13,8 +13,6 @@ from erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool import (
 	enqueue_update_cost,
 )
 
-test_records = frappe.get_test_records("BOM")
-
 
 class UnitTestBomUpdateLog(UnitTestCase):
 	"""
@@ -25,11 +23,14 @@ class UnitTestBomUpdateLog(UnitTestCase):
 	pass
 
 
+EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM"]
+
+
 class TestBOMUpdateLog(IntegrationTestCase):
 	"Test BOM Update Tool Operations via BOM Update Log."
 
 	def setUp(self):
-		bom_doc = frappe.copy_doc(test_records[0])
+		bom_doc = frappe.copy_doc(self.globalTestRecords["BOM"][0])
 		bom_doc.items[1].item_code = "_Test Item"
 		bom_doc.insert()
 

--- a/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
+++ b/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
@@ -12,8 +12,6 @@ from erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool import enqueu
 from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 from erpnext.stock.doctype.item.test_item import create_item
 
-test_records = frappe.get_test_records("BOM")
-
 
 class UnitTestBomUpdateTool(UnitTestCase):
 	"""
@@ -22,6 +20,9 @@ class UnitTestBomUpdateTool(UnitTestCase):
 	"""
 
 	pass
+
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM"]
 
 
 class TestBOMUpdateTool(IntegrationTestCase):
@@ -34,7 +35,7 @@ class TestBOMUpdateTool(IntegrationTestCase):
 	def test_replace_bom(self):
 		current_bom = "BOM-_Test Item Home Desktop Manufactured-001"
 
-		bom_doc = frappe.copy_doc(test_records[0])
+		bom_doc = frappe.copy_doc(self.globalTestRecords["BOM"][0])
 		bom_doc.items[1].item_code = "_Test Item"
 		bom_doc.insert()
 

--- a/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
+++ b/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
@@ -2,8 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import timeout
+from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
 
 from erpnext.manufacturing.doctype.bom_update_log.test_bom_update_log import (
 	update_cost_in_all_boms_in_test,

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -37,10 +37,18 @@ class UnitTestJobCard(UnitTestCase):
 
 class TestJobCard(IntegrationTestCase):
 	def setUp(self):
-		make_bom_for_jc_tests()
+		self.make_bom_for_jc_tests()
 		self.transfer_material_against: Literal["Work Order", "Job Card"] = "Work Order"
 		self.source_warehouse = None
 		self._work_order = None
+
+	def make_bom_for_jc_tests(self):
+		bom = frappe.copy_doc(self.globalTestRecords["BOM"][2])
+		bom.set_rate_of_sub_assembly_item_based_on_bom = 0
+		bom.rm_cost_as_per = "Valuation Rate"
+		bom.items[0].uom = "_Test UOM 1"
+		bom.items[0].conversion_factor = 5
+		bom.insert()
 
 	@property
 	def work_order(self) -> WorkOrder:
@@ -669,13 +677,3 @@ def make_wo_with_transfer_against_jc():
 	work_order.submit()
 
 	return work_order
-
-
-def make_bom_for_jc_tests():
-	test_records = frappe.get_test_records("BOM")
-	bom = frappe.copy_doc(test_records[2])
-	bom.set_rate_of_sub_assembly_item_based_on_bom = 0
-	bom.rm_cost_as_per = "Valuation Rate"
-	bom.items[0].uom = "_Test UOM 1"
-	bom.items[0].conversion_factor = 5
-	bom.insert()

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3,8 +3,7 @@
 
 
 import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import timeout
+from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
 from frappe.utils import add_days, add_months, add_to_date, cint, flt, now, today
 
 from erpnext.manufacturing.doctype.job_card.job_card import JobCardCancelError

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -41,7 +41,7 @@ class TestQuotation(IntegrationTestCase):
 	def test_make_sales_order_terms_copied(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.insert()
@@ -90,7 +90,7 @@ class TestQuotation(IntegrationTestCase):
 		maintain_rate = frappe.db.get_single_value("Selling Settings", "maintain_same_sales_rate")
 		frappe.db.set_single_value("Selling Settings", "maintain_same_sales_rate", 1)
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.insert()
@@ -105,7 +105,7 @@ class TestQuotation(IntegrationTestCase):
 	def test_make_sales_order_with_different_currency(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.insert()
@@ -125,7 +125,7 @@ class TestQuotation(IntegrationTestCase):
 	def test_make_sales_order(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.insert()
@@ -149,7 +149,7 @@ class TestQuotation(IntegrationTestCase):
 	def test_make_sales_order_with_terms(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.update({"payment_terms_template": "_Test Payment Term Template"})
@@ -189,7 +189,7 @@ class TestQuotation(IntegrationTestCase):
 		)
 
 	def test_valid_till_before_transaction_date(self):
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.valid_till = add_days(quotation.transaction_date, -1)
 		self.assertRaises(frappe.ValidationError, quotation.validate)
 
@@ -198,7 +198,7 @@ class TestQuotation(IntegrationTestCase):
 
 		frappe.db.set_single_value("Selling Settings", "allow_sales_order_creation_for_expired_quotation", 0)
 
-		quotation = frappe.copy_doc(test_records[0])
+		quotation = frappe.copy_doc(self.globalTestRecords["Quotation"][0])
 		quotation.valid_till = add_days(nowdate(), -1)
 		quotation.insert()
 		quotation.submit()
@@ -218,11 +218,13 @@ class TestQuotation(IntegrationTestCase):
 
 		rate_with_margin = flt((1500 * 18.75) / 100 + 1500)
 
-		test_records[0]["items"][0]["price_list_rate"] = 1500
-		test_records[0]["items"][0]["margin_type"] = "Percentage"
-		test_records[0]["items"][0]["margin_rate_or_amount"] = 18.75
+		test_record = dict(self.globalTestRecords["Quotation"][0])
 
-		quotation = frappe.copy_doc(test_records[0])
+		test_record["items"][0]["price_list_rate"] = 1500
+		test_record["items"][0]["margin_type"] = "Percentage"
+		test_record["items"][0]["margin_rate_or_amount"] = 18.75
+
+		quotation = frappe.copy_doc(test_record)
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
 		quotation.insert()
@@ -735,9 +737,6 @@ class TestQuotation(IntegrationTestCase):
 
 		item_doc.taxes = []
 		item_doc.save()
-
-
-test_records = frappe.get_test_records("Quotation")
 
 
 def enable_calculate_bundle_price(enable=1):

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -21,7 +21,6 @@ IGNORE_TEST_RECORD_DEPENDENCIES = [
 	"Warehouse",
 ]
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Fiscal Year"]
-test_records = frappe.get_test_records("Company")
 
 
 class TestCompany(IntegrationTestCase):
@@ -116,7 +115,7 @@ class TestCompany(IntegrationTestCase):
 		max_rgt = frappe.db.sql("select max(rgt) from `tabCompany`")[0][0]
 
 		if not records:
-			records = test_records[2:]
+			records = self.globalTestRecords["Company"][2:]
 
 		for company in records:
 			lft, rgt, parent_company = frappe.db.get_value(

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -9,8 +9,6 @@ from frappe.utils import cint, flt
 
 from erpnext.setup.utils import get_exchange_rate
 
-test_records = frappe.get_test_records("Currency Exchange")
-
 
 def save_new_records(test_records):
 	for record in test_records:
@@ -92,7 +90,7 @@ class TestCurrencyExchange(IntegrationTestCase):
 		self.clear_cache()
 
 	def test_exchange_rate(self, mock_get):
-		save_new_records(test_records)
+		save_new_records(self.globalTestRecords["Currency Exchange"])
 
 		frappe.db.set_single_value("Accounts Settings", "allow_stale", 1)
 
@@ -117,7 +115,7 @@ class TestCurrencyExchange(IntegrationTestCase):
 		self.assertEqual(flt(exchange_rate, 3), 65.1)
 
 	def test_exchange_rate_via_exchangerate_host(self, mock_get):
-		save_new_records(test_records)
+		save_new_records(self.globalTestRecords["Currency Exchange"])
 
 		# Update Currency Exchange Rate
 		settings = frappe.get_single("Currency Exchange Settings")

--- a/erpnext/setup/doctype/item_group/test_item_group.py
+++ b/erpnext/setup/doctype/item_group/test_item_group.py
@@ -13,8 +13,6 @@ from frappe.utils.nestedset import (
 	rebuild_tree,
 )
 
-test_records = frappe.get_test_records("Item Group")
-
 
 class TestItem(IntegrationTestCase):
 	def test_basic_tree(self, records=None):
@@ -22,7 +20,7 @@ class TestItem(IntegrationTestCase):
 		max_rgt = frappe.db.sql("select max(rgt) from `tabItem Group`")[0][0]
 
 		if not records:
-			records = test_records[2:]
+			records = self.globalTestRecords["Item Group"][2:]
 
 		for item_group in records:
 			lft, rgt, parent_item_group = frappe.db.get_value(
@@ -165,7 +163,7 @@ class TestItem(IntegrationTestCase):
 		)
 
 		frappe.delete_doc("Item Group", "_Test Item Group B - 3")
-		records_to_test = test_records[2:]
+		records_to_test = self.globalTestRecords["Item Group"][2:]
 		del records_to_test[4]
 		self.test_basic_tree(records=records_to_test)
 
@@ -175,7 +173,7 @@ class TestItem(IntegrationTestCase):
 			self.assertEqual(new_rgt, item_group.rgt - 2)
 
 		# insert it back
-		frappe.copy_doc(test_records[6]).insert()
+		frappe.copy_doc(self.globalTestRecords["Item Group"][6]).insert()
 
 		self.test_basic_tree()
 
@@ -185,12 +183,12 @@ class TestItem(IntegrationTestCase):
 
 	def test_merge_groups(self):
 		frappe.rename_doc("Item Group", "_Test Item Group B", "_Test Item Group C", merge=True)
-		records_to_test = test_records[2:]
+		records_to_test = self.globalTestRecords["Item Group"][2:]
 		del records_to_test[1]
 		self.test_basic_tree(records=records_to_test)
 
 		# insert Group B back
-		frappe.copy_doc(test_records[3]).insert()
+		frappe.copy_doc(self.globalTestRecords["Item Group"][3]).insert()
 		self.test_basic_tree()
 
 		# move its children back
@@ -206,12 +204,12 @@ class TestItem(IntegrationTestCase):
 
 	def test_merge_leaves(self):
 		frappe.rename_doc("Item Group", "_Test Item Group B - 2", "_Test Item Group B - 1", merge=True)
-		records_to_test = test_records[2:]
+		records_to_test = self.globalTestRecords["Item Group"][2:]
 		del records_to_test[3]
 		self.test_basic_tree(records=records_to_test)
 
 		# insert Group B - 2back
-		frappe.copy_doc(test_records[5]).insert()
+		frappe.copy_doc(self.globalTestRecords["Item Group"][5]).insert()
 		self.test_basic_tree()
 
 	def test_merge_leaf_into_group(self):

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -756,7 +756,7 @@ class TestDeliveryNote(IntegrationTestCase):
 		self.assertEqual(flt(bin_details.ordered_qty), flt(packed_item.ordered_qty))
 
 	def test_return_for_serialized_items(self):
-		se = make_serialized_item()
+		se = make_serialized_item(self)
 
 		serial_no = [get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]]
 

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -89,16 +89,16 @@ class TestItem(IntegrationTestCase):
 		frappe.flags.attribute_values = None
 
 	def get_item(self, idx):
-		item_code = test_records[idx].get("item_code")
+		item_code = self.globalTestRecords["Item"][idx].get("item_code")
 		if not frappe.db.exists("Item", item_code):
-			item = frappe.copy_doc(test_records[idx])
+			item = frappe.copy_doc(self.globalTestRecords["Item"][idx])
 			item.insert()
 		else:
 			item = frappe.get_doc("Item", item_code)
 		return item
 
 	def test_get_item_details(self):
-		# delete modified item price record and make as per test_records
+		# delete modified item price record and make as per self.globalTestRecords["Item"]
 		frappe.db.sql("""delete from `tabItem Price`""")
 		frappe.db.sql("""delete from `tabBin`""")
 
@@ -693,7 +693,7 @@ class TestItem(IntegrationTestCase):
 		self.assertEqual(received_attrs, {"Extra Small", "Extra Large"})
 
 	def test_check_stock_uom_with_bin(self):
-		# this item has opening stock and stock_uom set in test_records.
+		# this item has opening stock and stock_uom set in self.globalTestRecords["Item"].
 		item = frappe.get_doc("Item", "_Test Item")
 		item.stock_uom = "Gram"
 		self.assertRaises(frappe.ValidationError, item.save)
@@ -934,9 +934,6 @@ def make_item_variant():
 		variant.item_code = "_Test Variant Item-S"
 		variant.item_name = "_Test Variant Item-S"
 		variant.save()
-
-
-test_records = frappe.get_test_records("Item")
 
 
 def create_item(

--- a/erpnext/stock/doctype/item_price/test_item_price.py
+++ b/erpnext/stock/doctype/item_price/test_item_price.py
@@ -48,7 +48,7 @@ class TestItemPrice(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, doc.save)
 
 	def test_duplicate_item(self):
-		doc = frappe.copy_doc(test_records[0])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][0])
 		self.assertRaises(ItemPriceDuplicateItem, doc.save)
 
 	def test_addition_of_new_fields(self):
@@ -63,13 +63,13 @@ class TestItemPrice(IntegrationTestCase):
 			"valid_upto",
 			"note",
 		]
-		doc_fields = frappe.copy_doc(test_records[1]).__dict__.keys()
+		doc_fields = frappe.copy_doc(self.globalTestRecords["Item Price"][1]).__dict__.keys()
 
 		for test_field in test_fields_existance:
 			self.assertTrue(test_field in doc_fields)
 
 	def test_dates_validation_error(self):
-		doc = frappe.copy_doc(test_records[1])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])
 		# Enter invalid dates valid_from  >= valid_upto
 		doc.valid_from = "2017-04-20"
 		doc.valid_upto = "2017-04-17"
@@ -78,7 +78,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_price_in_a_qty(self):
 		# Check correct price at this quantity
-		doc = frappe.copy_doc(test_records[2])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 
 		args = {
 			"price_list": doc.price_list,
@@ -93,7 +93,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_price_with_no_qty(self):
 		# Check correct price when no quantity
-		doc = frappe.copy_doc(test_records[2])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 		args = {
 			"price_list": doc.price_list,
 			"customer": doc.customer,
@@ -106,7 +106,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_prices_at_date(self):
 		# Check correct price at first date
-		doc = frappe.copy_doc(test_records[2])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 
 		args = {
 			"price_list": doc.price_list,
@@ -121,7 +121,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_prices_at_invalid_date(self):
 		# Check correct price at invalid date
-		doc = frappe.copy_doc(test_records[3])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][3])
 
 		args = {
 			"price_list": doc.price_list,
@@ -135,7 +135,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_prices_outside_of_date(self):
 		# Check correct price when outside of the date
-		doc = frappe.copy_doc(test_records[4])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][4])
 
 		args = {
 			"price_list": doc.price_list,
@@ -150,7 +150,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_lowest_price_when_no_date_provided(self):
 		# Check lowest price when no date provided
-		doc = frappe.copy_doc(test_records[1])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])
 
 		args = {
 			"price_list": doc.price_list,
@@ -162,14 +162,14 @@ class TestItemPrice(IntegrationTestCase):
 		self.assertEqual(price, 10)
 
 	def test_invalid_item(self):
-		doc = frappe.copy_doc(test_records[1])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])
 		# Enter invalid item code
 		doc.item_code = "This is not an item code"
 		# Valid item codes must already exist
 		self.assertRaises(frappe.ValidationError, doc.save)
 
 	def test_invalid_price_list(self):
-		doc = frappe.copy_doc(test_records[1])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])
 		# Check for invalid price list
 		doc.price_list = "This is not a price list"
 		# Valid price list must already exist
@@ -177,7 +177,7 @@ class TestItemPrice(IntegrationTestCase):
 
 	def test_empty_duplicate_validation(self):
 		# Check if none/empty values are not compared during insert validation
-		doc = frappe.copy_doc(test_records[2])
+		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 		doc.customer = None
 		doc.price_list_rate = 21
 		doc.insert()
@@ -193,6 +193,3 @@ class TestItemPrice(IntegrationTestCase):
 		frappe.db.rollback()
 
 		self.assertEqual(price, 21)
-
-
-test_records = frappe.get_test_records("Item Price")

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -30,6 +30,9 @@ class UnitTestLandedCostVoucher(UnitTestCase):
 	pass
 
 
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange"]
+
+
 class TestLandedCostVoucher(IntegrationTestCase):
 	def test_landed_cost_voucher(self):
 		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
@@ -508,12 +511,9 @@ class TestLandedCostVoucher(IntegrationTestCase):
 		self.assertEqual(pr.items[1].landed_cost_voucher_amount, 100)
 
 	def test_multi_currency_lcv(self):
-		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import (
-			save_new_records,
-			test_records,
-		)
+		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import save_new_records
 
-		save_new_records(test_records)
+		save_new_records(self.globalTestRecords["Currency Exchange"])
 
 		## Create USD Shipping charges_account
 		usd_shipping = create_account(

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -31,7 +31,7 @@ class UnitTestMaterialRequest(UnitTestCase):
 
 class TestMaterialRequest(IntegrationTestCase):
 	def test_material_request_qty(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.items[0].qty = 0
 		with self.assertRaises(InvalidQtyError):
 			mr.insert()
@@ -42,7 +42,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(mr.items[0].qty, 1)
 
 	def test_make_purchase_order(self):
-		mr = frappe.copy_doc(test_records[0]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_purchase_order, mr.name)
 
@@ -54,7 +54,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(len(po.get("items")), len(mr.get("items")))
 
 	def test_make_supplier_quotation(self):
-		mr = frappe.copy_doc(test_records[0]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_supplier_quotation, mr.name)
 
@@ -66,7 +66,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(len(sq.get("items")), len(mr.get("items")))
 
 	def test_make_stock_entry(self):
-		mr = frappe.copy_doc(test_records[0]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_stock_entry, mr.name)
 
@@ -81,7 +81,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(len(se.get("items")), len(mr.get("items")))
 
 	def test_in_transit_make_stock_entry(self):
-		mr = frappe.copy_doc(test_records[0]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_stock_entry, mr.name)
 
@@ -142,7 +142,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		se.submit()
 
 	def test_cannot_stop_cancelled_material_request(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 
@@ -151,7 +151,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, mr.update_status, "Stopped")
 
 	def test_mr_changes_from_stopped_to_pending_after_reopen(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		self.assertEqual("Pending", mr.status)
@@ -163,7 +163,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual("Pending", mr.status)
 
 	def test_cannot_submit_cancelled_mr(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		mr.load_from_db()
@@ -171,14 +171,14 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, mr.submit)
 
 	def test_mr_changes_from_pending_to_cancelled_after_cancel(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		mr.cancel()
 		self.assertEqual("Cancelled", mr.status)
 
 	def test_cannot_change_cancelled_mr(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		mr.load_from_db()
@@ -192,21 +192,21 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertRaises(frappe.InvalidStatusError, mr.update_status, "Pending")
 
 	def test_cannot_submit_deleted_material_request(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.delete()
 
 		self.assertRaises(frappe.ValidationError, mr.submit)
 
 	def test_cannot_delete_submitted_mr(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 
 		self.assertRaises(frappe.ValidationError, mr.delete)
 
 	def test_stopped_mr_changes_to_pending_after_reopen(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		mr.load_from_db()
@@ -216,7 +216,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(mr.status, "Pending")
 
 	def test_pending_mr_changes_to_stopped_after_stop(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 		mr.load_from_db()
@@ -225,7 +225,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(mr.status, "Stopped")
 
 	def test_cannot_stop_unsubmitted_mr(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		self.assertRaises(frappe.InvalidStatusError, mr.update_status, "Stopped")
 
@@ -238,7 +238,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		)
 
 		# submit material request of type Purchase
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.insert()
 		mr.submit()
 
@@ -310,7 +310,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		)
 
 		# submit material request of type Purchase
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Material Transfer"
 		mr.insert()
 		mr.submit()
@@ -472,7 +472,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		)
 
 		# submit material request of type Purchase
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Material Transfer"
 		mr.insert()
 		mr.submit()
@@ -547,7 +547,7 @@ class TestMaterialRequest(IntegrationTestCase):
 
 	def test_incorrect_mapping_of_stock_entry(self):
 		# submit material request of type Transfer
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Material Transfer"
 		mr.insert()
 		mr.submit()
@@ -584,7 +584,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertRaises(frappe.MappingMismatchError, se.insert)
 
 		# submit material request of type Transfer
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Material Issue"
 		mr.insert()
 		mr.submit()
@@ -595,7 +595,7 @@ class TestMaterialRequest(IntegrationTestCase):
 	def test_warehouse_company_validation(self):
 		from erpnext.stock.utils import InvalidWarehouseCompany
 
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.company = "_Test Company 1"
 		self.assertRaises(InvalidWarehouseCompany, mr.insert)
 
@@ -605,7 +605,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		)
 
 	def test_make_stock_entry_for_material_issue(self):
-		mr = frappe.copy_doc(test_records[0]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0]).insert()
 
 		self.assertRaises(frappe.ValidationError, make_stock_entry, mr.name)
 
@@ -629,7 +629,7 @@ class TestMaterialRequest(IntegrationTestCase):
 
 		existing_requested_qty = _get_requested_qty()
 
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Material Issue"
 		mr.submit()
 		frappe.db.value_cache = {}
@@ -657,7 +657,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(_get_requested_qty(), existing_requested_qty)
 
 	def test_material_request_type_manufacture(self):
-		mr = frappe.copy_doc(test_records[1]).insert()
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][1]).insert()
 		mr = frappe.get_doc("Material Request", mr.name)
 		mr.submit()
 		completed_qty = mr.items[0].ordered_qty
@@ -729,7 +729,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(requested_qty, existing_requested_qty)
 
 	def test_multi_uom_for_purchase(self):
-		mr = frappe.copy_doc(test_records[0])
+		mr = frappe.copy_doc(self.globalTestRecords["Material Request"][0])
 		mr.material_request_type = "Purchase"
 		item = mr.items[0]
 		mr.schedule_date = today()
@@ -891,4 +891,3 @@ def make_material_request(**args):
 
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange", "BOM"]
-test_records = frappe.get_test_records("Material Request")

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -790,7 +790,7 @@ class TestPickList(IntegrationTestCase):
 		self.assertEqual(so.per_delivered, 100)
 
 	def test_picklist_with_partial_bundles(self):
-		# from test_records.json
+		# from self.globalTestRecords
 		warehouse = "_Test Warehouse - _TC"
 
 		quantities = [5, 2]

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -374,7 +374,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertFalse(frappe.db.get_value("Serial No", pr_row_1_serial_no, "warehouse"))
 
 	def test_rejected_warehouse_filter(self):
-		pr = frappe.copy_doc(test_records[0])
+		pr = frappe.copy_doc(self.globalTestRecords["Purchase Receipt"][0])
 		pr.get("items")[0].item_code = "_Test Serialized Item With Series"
 		pr.get("items")[0].qty = 3
 		pr.get("items")[0].rejected_qty = 2
@@ -383,7 +383,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, pr.save)
 
 	def test_rejected_serial_no(self):
-		pr = frappe.copy_doc(test_records[0])
+		pr = frappe.copy_doc(self.globalTestRecords["Purchase Receipt"][0])
 		pr.get("items")[0].item_code = "_Test Serialized Item With Series"
 		pr.get("items")[0].qty = 3
 		pr.get("items")[0].rejected_qty = 2
@@ -3955,4 +3955,3 @@ def make_purchase_receipt(**args):
 
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["BOM", "Item Price", "Location"]
-test_records = frappe.get_test_records("Purchase Receipt")

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -55,7 +55,7 @@ class TestSerialNo(IntegrationTestCase):
 		self.assertTrue(SerialNoCannotCannotChangeError, sr.save)
 
 	def test_inter_company_transfer(self):
-		se = make_serialized_item(target_warehouse="_Test Warehouse - _TC")
+		se = make_serialized_item(self, target_warehouse="_Test Warehouse - _TC")
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)
 
 		create_delivery_note(item_code="_Test Serialized Item With Series", qty=1, serial_no=[serial_nos[0]])
@@ -85,7 +85,7 @@ class TestSerialNo(IntegrationTestCase):
 		Then Receive into and Deliver from second company.
 		Try to cancel intermediate receipts/deliveries to test if it is blocked.
 		"""
-		se = make_serialized_item(target_warehouse="_Test Warehouse - _TC")
+		se = make_serialized_item(self, target_warehouse="_Test Warehouse - _TC")
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)
 
 		sn_doc = frappe.get_doc("Serial No", serial_nos[0])
@@ -145,7 +145,7 @@ class TestSerialNo(IntegrationTestCase):
 		If Receipt is cancelled, it should be Inactive in the same company.
 		"""
 		# Receipt in **first** company
-		se = make_serialized_item(target_warehouse="_Test Warehouse - _TC")
+		se = make_serialized_item(self, target_warehouse="_Test Warehouse - _TC")
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)
 		sn_doc = frappe.get_doc("Serial No", serial_nos[0])
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -389,7 +389,7 @@ class TestStockEntry(IntegrationTestCase):
 		"Test `is_finished_item` for one item repacked into two items."
 		make_stock_entry(item_code="_Test Item", target="_Test Warehouse - _TC", qty=100, basic_rate=100)
 
-		repack = frappe.copy_doc(test_records[3])
+		repack = frappe.copy_doc(self.globalTestRecords["Stock Entry"][3])
 		repack.posting_date = nowdate()
 		repack.posting_time = nowtime()
 
@@ -434,7 +434,7 @@ class TestStockEntry(IntegrationTestCase):
 			item_code="_Test Item Home Desktop 100", target="_Test Warehouse - _TC", qty=50, basic_rate=100
 		)
 
-		repack = frappe.copy_doc(test_records[3])
+		repack = frappe.copy_doc(self.globalTestRecords["Stock Entry"][3])
 		repack.posting_date = nowdate()
 		repack.posting_time = nowtime()
 		repack.set_stock_entry_type()
@@ -571,7 +571,7 @@ class TestStockEntry(IntegrationTestCase):
 			self.assertEqual(expected_gl_entries[i][2], gle[2])
 
 	def test_serial_no_not_reqd(self):
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.get("items")[0].serial_no = "ABCD"
 
 		bundle_id = make_serial_batch_bundle(
@@ -593,7 +593,7 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, bundle_id.make_serial_and_batch_bundle)
 
 	def test_serial_no_reqd(self):
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.get("items")[0].item_code = "_Test Serialized Item"
 		se.get("items")[0].qty = 2
 		se.get("items")[0].transfer_qty = 2
@@ -616,7 +616,7 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, bundle_id.make_serial_and_batch_bundle)
 
 	def test_serial_no_qty_less(self):
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.get("items")[0].item_code = "_Test Serialized Item"
 		se.get("items")[0].qty = 2
 		se.get("items")[0].serial_no = "ABCD"
@@ -649,7 +649,7 @@ class TestStockEntry(IntegrationTestCase):
 				doc.item_code = "_Test Serialized Item"
 				doc.insert(ignore_permissions=True)
 
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.get("items")[0].item_code = "_Test Serialized Item"
 		se.get("items")[0].qty = 2
 		se.get("items")[0].transfer_qty = 2
@@ -681,7 +681,7 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertFalse(frappe.db.get_value("Serial No", "ABCD1", "warehouse"))
 
 	def test_serial_by_series(self):
-		se = make_serialized_item()
+		se = make_serialized_item(self)
 
 		serial_nos = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)
 
@@ -691,11 +691,11 @@ class TestStockEntry(IntegrationTestCase):
 		return se, serial_nos
 
 	def test_serial_move(self):
-		se = make_serialized_item()
+		se = make_serialized_item(self)
 		serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 		frappe.flags.use_serial_and_batch_fields = True
 
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.purpose = "Material Transfer"
 		se.get("items")[0].item_code = "_Test Serialized Item With Series"
 		se.get("items")[0].qty = 1
@@ -765,7 +765,7 @@ class TestStockEntry(IntegrationTestCase):
 
 		from erpnext.stock.utils import InvalidWarehouseCompany
 
-		st1 = frappe.copy_doc(test_records[0])
+		st1 = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		st1.get("items")[0].t_warehouse = "_Test Warehouse 2 - _TC1"
 		st1.set_stock_entry_type()
 		st1.insert()
@@ -784,7 +784,7 @@ class TestStockEntry(IntegrationTestCase):
 			"Sales User", "Sales Manager", "Stock User", "Stock Manager"
 		)
 
-		st1 = frappe.copy_doc(test_records[0])
+		st1 = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		st1.company = "_Test Company 1"
 
 		frappe.set_user("test@example.com")
@@ -794,7 +794,7 @@ class TestStockEntry(IntegrationTestCase):
 		test_user.add_roles("System Manager")
 
 		frappe.set_user("test2@example.com")
-		st1 = frappe.copy_doc(test_records[0])
+		st1 = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		st1.company = "_Test Company 1"
 		st1.get("items")[0].t_warehouse = "_Test Warehouse 2 - _TC1"
 		st1.get("items")[0].expense_account = "Stock Adjustment - _TC1"
@@ -814,14 +814,14 @@ class TestStockEntry(IntegrationTestCase):
 
 		# test freeze_stocks_upto
 		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto", add_days(nowdate(), 5))
-		se = frappe.copy_doc(test_records[0]).insert()
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0]).insert()
 		self.assertRaises(StockFreezeError, se.submit)
 
 		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto", "")
 
 		# test freeze_stocks_upto_days
 		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto_days", -1)
-		se = frappe.copy_doc(test_records[0])
+		se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 		se.set_posting_time = 1
 		se.posting_date = nowdate()
 		se.set_stock_entry_type()
@@ -989,7 +989,7 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, ste.submit)
 
 	def test_same_serial_nos_in_repack_or_manufacture_entries(self):
-		s1 = make_serialized_item(target_warehouse="_Test Warehouse - _TC")
+		s1 = make_serialized_item(self, target_warehouse="_Test Warehouse - _TC")
 		serial_nos = get_serial_nos_from_bundle(s1.get("items")[0].serial_and_batch_bundle)
 
 		s2 = make_stock_entry(
@@ -1048,7 +1048,7 @@ class TestStockEntry(IntegrationTestCase):
 		if not frappe.db.exists("Item", item_code):
 			create_item(item_code)
 
-		repack = frappe.copy_doc(test_records[3])
+		repack = frappe.copy_doc(self.globalTestRecords["Stock Entry"][3])
 		repack.inspection_required = 1
 		for d in repack.items:
 			if not d.s_warehouse and d.t_warehouse:
@@ -1182,7 +1182,7 @@ class TestStockEntry(IntegrationTestCase):
 
 	def test_conversion_factor_change(self):
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
-		repack_entry = frappe.copy_doc(test_records[3])
+		repack_entry = frappe.copy_doc(self.globalTestRecords["Stock Entry"][3])
 		repack_entry.posting_date = nowdate()
 		repack_entry.posting_time = nowtime()
 		repack_entry.set_stock_entry_type()
@@ -1867,9 +1867,9 @@ class TestStockEntry(IntegrationTestCase):
 			self.assertEqual(sle.stock_value, 100 * i)
 
 
-def make_serialized_item(**args):
+def make_serialized_item(self, **args):
 	args = frappe._dict(args)
-	se = frappe.copy_doc(test_records[0])
+	se = frappe.copy_doc(self.globalTestRecords["Stock Entry"][0])
 
 	if args.company:
 		se.company = args.company
@@ -1959,9 +1959,6 @@ def get_multiple_items():
 			"uom": "_Test UOM",
 		},
 	]
-
-
-test_records = frappe.get_test_records("Stock Entry")
 
 
 def initialize_records_for_future_negative_sle_test(

--- a/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
+++ b/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
@@ -12,7 +12,7 @@ from erpnext.maintenance.doctype.maintenance_schedule.test_maintenance_schedule 
 
 class TestStockLedgerReeport(IntegrationTestCase):
 	def setUp(self) -> None:
-		make_serial_item_with_serial("_Test Stock Report Serial Item")
+		make_serial_item_with_serial(self, "_Test Stock Report Serial Item")
 		self.filters = frappe._dict(
 			company="_Test Company",
 			from_date=today(),

--- a/erpnext/tests/test_init.py
+++ b/erpnext/tests/test_init.py
@@ -5,7 +5,7 @@ from frappe.tests import IntegrationTestCase
 
 from erpnext import encode_company_abbr
 
-test_records = frappe.get_test_records("Company")
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Company"]
 
 
 class TestInit(IntegrationTestCase):


### PR DESCRIPTION
- **refactor: use cls.globalTestRecords instead of declaring test_records**
  As with https://github.com/frappe/erpnext/pull/43610 `test_records` may be considered an anti-pattern if it doesn't deviate from the default behaviour. Instead, we ensure proper dependency declaration, and use `self.globalTestRecords` (actually: `cls.globalTestRecords`)

cc @ruthra-kumar @rohitwaghchaure @s-aga-r @deepeshgarg007

If we can get this to green, then this is a significant step, because it means that we have achived (or maybe only _ensured_, cause it already was the case) a baseline for a certain locality and isolation of tests: items inside `cls.globalTestRecords` are MappingProxys and therefore can't be written to. They represent the records at their time of insertion into the database. On a rerun on the CLI with the same database, they are reconstructed from `sites/test_site/.test_log.jsonl` instead of from an actual insert and represent the records at the time of their original insert on prior test runs.

This PR also significantly reduces the deprecation warning pressure on CLI.

---

**Intermediate Step Required**
- https://github.com/frappe/frappe/pull/28083

> `AttributeError: 'mappingproxy' object has no attribute 'as_dict'`

This is wonderful! It shows that the mapping proxies are working as intended. On the framework side, we want to modify at least `frappe.copy_doc` to work with MappingProxy, as of its widespread use in tests.

---
**`enterClassContext` / `enterContext` technique**

All [`frappe.tests.classes.context_managers`](https://github.com/frappe/frappe/blob/develop/frappe/tests/classes/context_managers.py) can be used in `setUp` or `setUpClass` with `enterContext` or `enterClassContext`. This is a relatively new unittest feature which takes a context manager and ensures the context is upheld during the entire scope of the test class / test case respecitvely.

An example of its use: https://github.com/frappe/erpnext/pull/43612/commits/c17de26e4453ec9e42c51967a245f85482931325

---
**Further Intemediate Steps Required**

- https://github.com/frappe/frappe/pull/28102
- https://github.com/frappe/frappe/pull/28094

These mainly fixed the Test Record loading for correctness. The most significant change was to load actual json records into `cls.globalTestRecords` instead of `doc.as_dict()` post db-insertion. This matches more closely the expectations that test designers had when they previously declared `test_records = ...`.
