### PR TITLE
fix: ignore free item when qty is zero

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1140,6 +1140,12 @@ class TestPricingRule(IntegrationTestCase):
 		self.assertEqual(so.items[1].item_code, "_Test Item")
 		self.assertEqual(so.items[1].qty, 3)
 
+		so = make_sales_order(item_code="_Test Item", qty=5, do_not_submit=1)
+		so.items[0].qty = 1
+		del so.items[-1]
+		so.save()
+		self.assertEqual(len(so.items), 1)
+
 	def test_apply_multiple_pricing_rules_for_discount_percentage_and_amount(self):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 2")

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -657,6 +657,9 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 			if pricing_rule.round_free_qty:
 				qty = math.floor(qty)
 
+	if not qty:
+		return
+
 	free_item_data_args = {
 		"item_code": free_item,
 		"qty": qty,


### PR DESCRIPTION
### Issue:

- Create a sales invoice and apply pricing rule for item group and 10 qty 1 free rule.
- After creating the sales invoice if I reduce the qty to less than 10 then the free qty is set to 0 and that free item cannot be removed.

![EB21E452-8FDC-4818-94C9-E025DFE9](https://github.com/user-attachments/assets/dccba16f-8e72-4cc8-bf17-d27f93a37dd7)


