### PR TITLE
fix: coupon code validation logic

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -726,11 +726,9 @@ def get_pricing_rule_items(pr_doc, other_items=False) -> list:
 def validate_coupon_code(coupon_name):
 	coupon = frappe.get_doc("Coupon Code", coupon_name)
 
-	if coupon.valid_from:
-		if coupon.valid_from > getdate(today()):
-			frappe.throw(_("Sorry, this coupon code's validity has not started"))
-	elif coupon.valid_upto:
-		if coupon.valid_upto < getdate(today()):
+	if coupon.valid_from and coupon.valid_from > getdate(today()):
+		frappe.throw(_("Sorry, this coupon code's validity has not started"))
+	elif coupon.valid_upto and coupon.valid_upto < getdate(today()):
 			frappe.throw(_("Sorry, this coupon code's validity has expired"))
 	elif coupon.used >= coupon.maximum_use:
 		frappe.throw(_("Sorry, this coupon code is no longer valid"))

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -729,7 +729,7 @@ def validate_coupon_code(coupon_name):
 	if coupon.valid_from and coupon.valid_from > getdate(today()):
 		frappe.throw(_("Sorry, this coupon code's validity has not started"))
 	elif coupon.valid_upto and coupon.valid_upto < getdate(today()):
-			frappe.throw(_("Sorry, this coupon code's validity has expired"))
+		frappe.throw(_("Sorry, this coupon code's validity has expired"))
 	elif coupon.used >= coupon.maximum_use:
 		frappe.throw(_("Sorry, this coupon code is no longer valid"))
 


### PR DESCRIPTION
Ensure errors are thrown if the coupon validity hasn't started, has expired, or if the maximum usage has been exceeded.

Previously, the condition was always satisfied with if coupon.valid_from:, which prevented the elif condition from being reached.