### PR TITLE
fix: zero incoming rate for delivery note return

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -470,6 +470,16 @@ class SellingController(StockController):
 						raise_error_if_no_rate=False,
 					)
 
+				if (
+					not d.incoming_rate
+					and self.get("return_against")
+					and self.get("is_return")
+					and get_valuation_method(d.item_code) == "Moving Average"
+				):
+					d.incoming_rate = get_rate_for_return(
+						self.doctype, self.name, d.item_code, self.return_against, item_row=d
+					)
+
 				# For internal transfers use incoming rate as the valuation rate
 				if self.is_internal_transfer():
 					if self.doctype == "Delivery Note" or self.get("update_stock"):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1075,6 +1075,15 @@ class update_entries_after:
 						}
 					)
 
+					if not rate and sle.voucher_type in ["Delivery Note", "Sales Invoice"]:
+						rate = get_rate_for_return(
+							sle.voucher_type,
+							sle.voucher_no,
+							sle.item_code,
+							voucher_detail_no=sle.voucher_detail_no,
+							sle=sle,
+						)
+
 				else:
 					rate = get_rate_for_return(
 						sle.voucher_type,


### PR DESCRIPTION
Incoming rate set as zero for the delivery note return if the valuation method is Moving Average