### PR TITLE
fix: check for the existence of a doctype before querying.

### DIFF
--- a/erpnext/patches/v15_0/migrate_to_utm_analytics.py
+++ b/erpnext/patches/v15_0/migrate_to_utm_analytics.py
@@ -10,6 +10,8 @@ def execute():
 	Remove Lead Source doctype and use UTM Source Instead
 	Ensure that for each Campaign, a UTM Campaign is also set
 	"""
+	if not frappe.db.exists("DocType", "Lead Source") or not frappe.db.exists("DocType", "UTM Source"):
+		return
 
 	ls = frappe.qb.DocType("Lead Source")
 	ms = frappe.qb.DocType("UTM Source")


### PR DESCRIPTION
The current implementation doesn't check if the `DocType` exists before running the query on `lead_sources`, which leads to errors if the `DocType` does not exist.
``Fix``:
Added a conditional check to verify the existence of the DocType before executing the query.
