### PR TITLE
fix: run gl_entries and closing voucher processes in same function

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -60,7 +60,7 @@ class PeriodClosingVoucher(AccountsController):
 		)
 		if gle_count > 5000:
 			frappe.enqueue(
-				make_reverse_gl_entries,
+				process_cancellation,
 				voucher_type="Period Closing Voucher",
 				voucher_no=self.name,
 				queue="long",
@@ -71,9 +71,7 @@ class PeriodClosingVoucher(AccountsController):
 				alert=True,
 			)
 		else:
-			make_reverse_gl_entries(voucher_type="Period Closing Voucher", voucher_no=self.name)
-
-		self.delete_closing_entries()
+			process_cancellation(voucher_type="Period Closing Voucher", voucher_no=self.name)
 
 	def validate_future_closing_vouchers(self):
 		if frappe.db.exists(
@@ -85,12 +83,6 @@ class PeriodClosingVoucher(AccountsController):
 					"You can not cancel this Period Closing Voucher, please cancel the future Period Closing Vouchers first"
 				)
 			)
-
-	def delete_closing_entries(self):
-		closing_balance = frappe.qb.DocType("Account Closing Balance")
-		frappe.qb.from_(closing_balance).delete().where(
-			closing_balance.period_closing_voucher == self.name
-		).run()
 
 	def validate_account_head(self):
 		closing_account_type = frappe.get_cached_value("Account", self.closing_account_head, "root_type")
@@ -166,14 +158,7 @@ class PeriodClosingVoucher(AccountsController):
 		closing_entries = self.get_grouped_gl_entries(get_opening_entries=get_opening_entries)
 		if len(gl_entries + closing_entries) > 3000:
 			frappe.enqueue(
-				process_gl_entries,
-				gl_entries=gl_entries,
-				voucher_name=self.name,
-				timeout=3000,
-			)
-
-			frappe.enqueue(
-				process_closing_entries,
+				process_gl_and_closing_entries,
 				gl_entries=gl_entries,
 				closing_entries=closing_entries,
 				voucher_name=self.name,
@@ -187,8 +172,9 @@ class PeriodClosingVoucher(AccountsController):
 				alert=True,
 			)
 		else:
-			process_gl_entries(gl_entries, self.name)
-			process_closing_entries(gl_entries, closing_entries, self.name, self.company, self.posting_date)
+			process_gl_and_closing_entries(
+				gl_entries, closing_entries, self.name, self.company, self.posting_date
+			)
 
 	def get_grouped_gl_entries(self, get_opening_entries=False):
 		closing_entries = []
@@ -373,12 +359,16 @@ class PeriodClosingVoucher(AccountsController):
 		return query.run(as_dict=1)
 
 
-def process_gl_entries(gl_entries, voucher_name):
+def process_gl_and_closing_entries(gl_entries, closing_entries, voucher_name, company, closing_date):
+	from erpnext.accounts.doctype.account_closing_balance.account_closing_balance import (
+		make_closing_entries,
+	)
 	from erpnext.accounts.general_ledger import make_gl_entries
 
 	try:
 		if gl_entries:
 			make_gl_entries(gl_entries, merge_entries=False)
+		make_closing_entries(gl_entries + closing_entries, voucher_name, company, closing_date)
 		frappe.db.set_value("Period Closing Voucher", voucher_name, "gle_processing_status", "Completed")
 	except Exception as e:
 		frappe.db.rollback()
@@ -386,25 +376,21 @@ def process_gl_entries(gl_entries, voucher_name):
 		frappe.db.set_value("Period Closing Voucher", voucher_name, "gle_processing_status", "Failed")
 
 
-def process_closing_entries(gl_entries, closing_entries, voucher_name, company, closing_date):
-	from erpnext.accounts.doctype.account_closing_balance.account_closing_balance import (
-		make_closing_entries,
-	)
-
-	try:
-		make_closing_entries(gl_entries + closing_entries, voucher_name, company, closing_date)
-	except Exception as e:
-		frappe.db.rollback()
-		frappe.log_error(e)
-
-
-def make_reverse_gl_entries(voucher_type, voucher_no):
+def process_cancellation(voucher_type, voucher_no):
 	from erpnext.accounts.general_ledger import make_reverse_gl_entries
 
 	try:
 		make_reverse_gl_entries(voucher_type=voucher_type, voucher_no=voucher_no)
+		delete_closing_entries(voucher_no)
 		frappe.db.set_value("Period Closing Voucher", voucher_no, "gle_processing_status", "Completed")
 	except Exception as e:
 		frappe.db.rollback()
 		frappe.log_error(e)
 		frappe.db.set_value("Period Closing Voucher", voucher_no, "gle_processing_status", "Failed")
+
+
+def delete_closing_entries(voucher_no):
+	closing_balance = frappe.qb.DocType("Account Closing Balance")
+	frappe.qb.from_(closing_balance).delete().where(
+		closing_balance.period_closing_voucher == voucher_no
+	).run()


### PR DESCRIPTION
continued:https://github.com/frappe/erpnext/pull/42737
Issue;

GL Entry and Account Closing Balance processes are executed individually, so in enqueue if one fails other function is still executed.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/19986


backport version-15-hotfix
backport version-14-hotfix
