### PR TITLE
fix: refetch items from BOM if 'Use Multi-Level BOM' has changed usin…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -176,10 +176,19 @@ class WorkOrder(Document):
 		self.validate_operation_time()
 		self.status = self.get_status()
 		self.validate_workstation_type()
+		self.reset_use_multi_level_bom()
 
 		validate_uom_is_integer(self, "stock_uom", ["qty", "produced_qty"])
 
 		self.set_required_items(reset_only_qty=len(self.get("required_items")))
+
+	def reset_use_multi_level_bom(self):
+		if self.is_new():
+			return
+
+		before_save_obj = self.get_doc_before_save()
+		if before_save_obj.use_multi_level_bom != self.use_multi_level_bom:
+			self.get_items_and_operations_from_bom()
 
 	def validate_workstation_type(self):
 		for row in self.operations:


### PR DESCRIPTION
On disable of Use Multi-Level BOM in the work order, system fetches the sub assembly items from the BOM and change the requires items table in the work order. This works fine when user manually change it from the work order form but doesn't works when it change through API