### PR TITLE
fix: list view and form status not same for purchase order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -382,7 +382,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			}
 			if (doc.status != "Closed") {
 				if (doc.status != "On Hold") {
-					if (flt(doc.per_received, 2) < 100 && allow_receipt) {
+					if (flt(doc.per_received) < 100 && allow_receipt) {
 						this.frm.add_custom_button(
 							__("Purchase Receipt"),
 							() => {
@@ -412,7 +412,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 							}
 						}
 					}
-					if (flt(doc.per_billed, 2) < 100)
+					// Please do not add precision in the below flt function
+					if (flt(doc.per_billed) < 100)
 						this.frm.add_custom_button(
 							__("Purchase Invoice"),
 							() => {

--- a/erpnext/buying/doctype/purchase_order/purchase_order_list.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_list.js
@@ -11,6 +11,7 @@ frappe.listview_settings["Purchase Order"] = {
 		"advance_payment_status",
 	],
 	get_indicator: function (doc) {
+		// Please do not add precision in the flt function
 		if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
 		} else if (doc.status === "On Hold") {
@@ -19,8 +20,8 @@ frappe.listview_settings["Purchase Order"] = {
 			return [__("Delivered"), "green", "status,=,Closed"];
 		} else if (doc.advance_payment_status == "Initiated") {
 			return [__("To Pay"), "gray", "advance_payment_status,=,Initiated"];
-		} else if (flt(doc.per_received, 2) < 100 && doc.status !== "Closed") {
-			if (flt(doc.per_billed, 2) < 100) {
+		} else if (flt(doc.per_received) < 100 && doc.status !== "Closed") {
+			if (flt(doc.per_billed) < 100) {
 				return [
 					__("To Receive and Bill"),
 					"orange",
@@ -29,17 +30,9 @@ frappe.listview_settings["Purchase Order"] = {
 			} else {
 				return [__("To Receive"), "orange", "per_received,<,100|per_billed,=,100|status,!=,Closed"];
 			}
-		} else if (
-			flt(doc.per_received, 2) >= 100 &&
-			flt(doc.per_billed, 2) < 100 &&
-			doc.status !== "Closed"
-		) {
+		} else if (flt(doc.per_received) >= 100 && flt(doc.per_billed) < 100 && doc.status !== "Closed") {
 			return [__("To Bill"), "orange", "per_received,=,100|per_billed,<,100|status,!=,Closed"];
-		} else if (
-			flt(doc.per_received, 2) >= 100 &&
-			flt(doc.per_billed, 2) == 100 &&
-			doc.status !== "Closed"
-		) {
+		} else if (flt(doc.per_received) >= 100 && flt(doc.per_billed) == 100 && doc.status !== "Closed") {
 			return [__("Completed"), "green", "per_received,=,100|per_billed,=,100|status,!=,Closed"];
 		}
 	},


### PR DESCRIPTION
The listview status is completed but the form status is To Bill which should be same. The default precision 2 causing the issue. To replicate the issue, follow the below steps

- Create the PO with the rate as 1,57,327.00
- Create the PI against the above PO and change the rate as  **1,57,323.00**
- Create the PR with rate as 1,57,327.00
- After that check the status of the above PO, the listview status and form status is not same.

<img width="1053" alt="Screenshot 2024-10-16 at 1 27 41 PM" src="https://github.com/user-attachments/assets/50948d33-81ec-46da-9bd3-1479f9bdf9da">



**After Fix**

<img width="1377" alt="Screenshot 2024-10-16 at 1 38 22 PM" src="https://github.com/user-attachments/assets/79a5b0e8-9171-460a-b66e-ff4d892d2376">
