### PR TITLE
chore(tests): remove noop ad-hoc record creation

### DIFF
--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -4,7 +4,6 @@ import unittest
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.tests.utils import make_test_records
 from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.account.account import (
@@ -201,8 +200,6 @@ class TestAccount(IntegrationTestCase):
 		"""
 		In a parent->child company setup, child should inherit parent account currency if explicitly specified.
 		"""
-
-		make_test_records("Company")
 
 		frappe.local.flags.pop("ignore_root_company_validation", None)
 

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -3,7 +3,6 @@
 
 
 import frappe
-from frappe.tests.utils import make_test_records
 
 from erpnext.accounts.party import get_due_date
 from erpnext.controllers.website_list_for_contact import get_customers_suppliers
@@ -105,8 +104,6 @@ class TestSupplier(IntegrationTestCase):
 		self.assertEqual(due_date, "2017-01-22")
 
 	def test_supplier_disabled(self):
-		make_test_records("Item")
-
 		frappe.db.set_value("Supplier", "_Test Supplier", "disabled", 1)
 
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order

--- a/erpnext/controllers/tests/test_mapper.py
+++ b/erpnext/controllers/tests/test_mapper.py
@@ -5,15 +5,15 @@ import frappe
 import frappe.utils
 from frappe.model import mapper
 from frappe.tests import IntegrationTestCase
-from frappe.tests.utils import make_test_records
 from frappe.utils import add_months, nowdate
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["Item"]
 
 
 class TestMapper(IntegrationTestCase):
 	def test_map_docs(self):
 		"""Test mapping of multiple source docs on a single target doc"""
 
-		make_test_records("Item")
 		items = ["_Test Item", "_Test Item 2", "_Test FG Item"]
 
 		# Make source docs (quotations) and a target doc (sales order)

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import make_test_records
 from frappe.utils import random_string
 from frappe.utils.data import add_to_date, now, today
 
@@ -24,6 +23,8 @@ from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_ord
 from erpnext.manufacturing.doctype.work_order.work_order import WorkOrder
 from erpnext.manufacturing.doctype.workstation.test_workstation import make_workstation
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["UOM"]
 
 
 class UnitTestJobCard(UnitTestCase):
@@ -500,8 +501,6 @@ class TestJobCard(IntegrationTestCase):
 			{"operation": "Test Operation A1", "workstation": "Test Workstation A", "time_in_mins": 30},
 			{"operation": "Test Operation B1", "workstation": "Test Workstation A", "time_in_mins": 20},
 		]
-
-		make_test_records("UOM")
 
 		warehouse = create_warehouse("Test Warehouse 123 for Job Card")
 

--- a/erpnext/manufacturing/doctype/routing/test_routing.py
+++ b/erpnext/manufacturing/doctype/routing/test_routing.py
@@ -2,11 +2,12 @@
 # See license.txt
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import make_test_records
 
 from erpnext.manufacturing.doctype.job_card.job_card import OperationSequenceError
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.stock.doctype.item.test_item import make_item
+
+EXTRA_TEST_RECORD_DEPENDENCIES = ["UOM"]
 
 
 class UnitTestRouting(UnitTestCase):
@@ -32,8 +33,6 @@ class TestRouting(IntegrationTestCase):
 			{"operation": "Test Operation A", "workstation": "Test Workstation A", "time_in_mins": 30},
 			{"operation": "Test Operation B", "workstation": "Test Workstation A", "time_in_mins": 20},
 		]
-
-		make_test_records("UOM")
 
 		setup_operations(operations)
 		routing_doc = create_routing(routing_name="Testing Route", operations=operations)

--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -2,7 +2,6 @@
 # See license.txt
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import make_test_records
 
 from erpnext.manufacturing.doctype.operation.test_operation import make_operation
 from erpnext.manufacturing.doctype.routing.test_routing import create_routing, setup_bom

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -6,7 +6,6 @@ import json
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import make_test_records
 from frappe.utils import flt
 
 from erpnext.accounts.party import get_due_date
@@ -32,10 +31,6 @@ class UnitTestCustomer(UnitTestCase):
 
 
 class TestCustomer(IntegrationTestCase):
-	def setUp(self):
-		if not frappe.get_value("Item", "_Test Item"):
-			make_test_records("Item")
-
 	def tearDown(self):
 		set_credit_limit("_Test Customer", "_Test Company", 0)
 
@@ -205,8 +200,6 @@ class TestCustomer(IntegrationTestCase):
 		frappe.db.rollback()
 
 	def test_freezed_customer(self):
-		make_test_records("Item")
-
 		frappe.db.set_value("Customer", "_Test Customer", "is_frozen", 1)
 
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
@@ -230,8 +223,6 @@ class TestCustomer(IntegrationTestCase):
 		frappe.delete_doc("Customer", customer.name)
 
 	def test_disabled_customer(self):
-		make_test_records("Item")
-
 		frappe.db.set_value("Customer", "_Test Customer", "disabled", 1)
 
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order

--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -3,7 +3,6 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
-from frappe.tests.utils import make_test_records
 
 import erpnext
 from erpnext.accounts.doctype.account.test_account import create_account
@@ -22,11 +21,6 @@ class UnitTestWarehouse(UnitTestCase):
 
 
 class TestWarehouse(IntegrationTestCase):
-	def setUp(self):
-		super().setUp()
-		if not frappe.get_value("Item", "_Test Item"):
-			make_test_records("Item")
-
 	def test_parent_warehouse(self):
 		parent_warehouse = frappe.get_doc("Warehouse", "_Test Warehouse Group - _TC")
 		self.assertEqual(parent_warehouse.is_group, 1)

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -1,6 +1,5 @@
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.tests.utils import make_test_records
 
 from erpnext.stock.get_item_details import get_item_details
 
@@ -8,10 +7,6 @@ EXTRA_TEST_RECORD_DEPENDENCIES = ["Customer", "Supplier", "Item", "Price List", 
 
 
 class TestGetItemDetail(IntegrationTestCase):
-	def setUp(self):
-		make_test_records("Price List")
-		super().setUp()
-
 	def test_get_item_detail_purchase_order(self):
 		args = frappe._dict(
 			{


### PR DESCRIPTION
`make_test_records` is a no-op when not invoked with `force=True`, because these index doctypes
are already loaded by the test records dependency resolution.

Their presence might fake significance to the reader taking example on ERPNext tests.
