### PR TITLE
test: remove no-op flags in preparation of cleaning upstream

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -62,9 +62,6 @@ class TaxRule(Document):
 		use_for_shopping_cart: DF.Check
 	# end: auto-generated types
 
-	def __setup__(self):
-		self.flags.ignore_these_exceptions_in_test = [ConflictingTaxRule]
-
 	def validate(self):
 		self.validate_tax_template()
 		self.validate_from_to_dates("from_date", "to_date")

--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -37,9 +37,6 @@ class ItemAttribute(Document):
 		to_range: DF.Float
 	# end: auto-generated types
 
-	def __setup__(self):
-		self.flags.ignore_these_exceptions_in_test = [InvalidItemAttributeValueError]
-
 	def validate(self):
 		frappe.flags.attribute_values = None
 		self.validate_numeric()


### PR DESCRIPTION
Upstream tolerating test record creation errors leaves the entire test record manager in an inconsistent state.

These here are not actively doing anything, so we can remove them and then remove that offending feature upstream.

Inside `frappe` gh org, these were the only uses suggesting it was used as a "dirty fix" in the past: https://github.com/search?q=org%3Afrappe+ignore_these_exceptions_in_test&type=code

Removal of these tolerations is necessary to eliminate and prevent the re-execution error:

```
:: Fiscal Year _Test Fiscal Year 2024 not found ::

Context:
 File '/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/__init__.py', line 613

 608: 				exc = raise_exception(msg)
 609: 			else:
 610: 				exc = ValidationError(msg)
 611: 			if out.__frappe_exc_id:
 612: 				exc.__frappe_exc_id = out.__frappe_exc_id
 613> 			raise exc
 614:
 615: 	if flags.mute_messages:
 616: 		_raise_exception()
 617: 		return
 618:

Do you want to see the full traceback? [y/N]: ^CAborted!
```

Cause we can only keep track of records, if they are in a defined state and comply with the spec. If creation errors are silently ignored, then test records don't comply with the spec and we can't properly manage state.
