### PR TITLE
fix: Project name instead of ID in chart

### DIFF
--- a/erpnext/projects/report/project_summary/project_summary.py
+++ b/erpnext/projects/report/project_summary/project_summary.py
@@ -15,6 +15,7 @@ def execute(filters=None):
 		filters=filters,
 		fields=[
 			"name",
+			"project_name",
 			"status",
 			"percent_complete",
 			"expected_start_date",
@@ -46,6 +47,11 @@ def get_columns():
 			"label": _("Project"),
 			"fieldtype": "Link",
 			"options": "Project",
+			"width": 200,
+		},
+		{
+			"fieldname": "project_name",
+			"label": _("Project Name"),
 			"width": 200,
 		},
 		{
@@ -82,7 +88,7 @@ def get_chart_data(data):
 	overdue = []
 
 	for project in data:
-		labels.append(project.name)
+		labels.append(project.project_name)
 		total.append(project.total_tasks)
 		completed.append(project.completed_tasks)
 		overdue.append(project.overdue_tasks)


### PR DESCRIPTION
The "Open Projects" chart in the main projects workspace currently shows the document name as a x-axis label. This is not helpful for the user as this is just the project number "PROJ-0001", "PROJ-0002" etc. 
Instead this label should be the correct, human readable label from the Project DocType "project_name".

This fix solves the issue and shows the correct label in the graph. The old field "name" is kept in the report for backwards compatibility. 
