### PR TITLE
fix: add field conversion_factor when include_uom is settled

### DIFF
--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -297,6 +297,7 @@ def get_item_map(item_code, include_uom):
 
 	if include_uom:
 		ucd = frappe.qb.DocType("UOM Conversion Detail")
+		query = query.select(ucd.conversion_factor)
 		query = query.left_join(ucd).on((ucd.parent == item.name) & (ucd.uom == include_uom))
 
 	items = query.run(as_dict=True)


### PR DESCRIPTION
When we set a unit on filter Include UOM to get a comparison with stock UOM, the conversion factor is not loading

To simulate the case, choose a item with multiples unit and conversion factor settled, on filter Include UOM different of stock uom, the report will add a new column based on your choosed unit, applying the conversion factor.

On refactory the code to use query builder, this field was removed.