### PR TITLE
fix: set_payment_schedule base payment amount calculation error

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2220,7 +2220,7 @@ class AccountsController(TransactionBase):
 					d.outstanding = d.payment_amount
 				elif not d.invoice_portion:
 					d.base_payment_amount = flt(
-						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")
+						flt(d.payment_amount) * self.get("conversion_rate"), d.precision("base_payment_amount")
 					)
 		else:
 			self.fetch_payment_terms_from_order(po_or_so, doctype)


### PR DESCRIPTION
NoneType * Float error in set_payment_schedule function

![image](https://github.com/user-attachments/assets/8a9fead3-953a-4b82-9406-60cfa21c8561)


@deepeshgarg007 @rohitwaghchaure please check