### PR TITLE
fix: added validation for UOM must be whole number

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3551,6 +3551,9 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 	parent.update_billing_percentage()
 	parent.set_status()
 
+	parent.validate_uom_is_integer("uom", "qty")
+	parent.validate_uom_is_integer("stock_uom", "stock_qty")
+
 	# Cancel and Recreate Stock Reservation Entries.
 	if parent_doctype == "Sales Order":
 		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (


### PR DESCRIPTION
Steps to replicate the issue

- Create the PO and select the UOM having "Must be Whole Number" enabled (Example Nos)
- Set the quantity as 1 and submit it
- After that click on "Update Items" and change the quantity from 1 to 1.2 and update it
- System allows the non integer value which should not be

**After fix**

Added validation
<img width="677" alt="Screenshot 2024-10-17 at 12 34 08 PM" src="https://github.com/user-attachments/assets/4d096fab-9097-4998-8dfa-c5e949984c5a">

