### PR TITLE
fix: party_balance based on company in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2588,7 +2588,9 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 	account_balance = get_balance_on(party_account, date, cost_center=cost_center)
 	_party_name = "title" if party_type == "Shareholder" else party_type.lower() + "_name"
 	party_name = frappe.db.get_value(party_type, party, _party_name)
-	party_balance = get_balance_on(party_type=party_type, party=party, cost_center=cost_center)
+	party_balance = get_balance_on(
+		party_type=party_type, party=party, company=company, cost_center=cost_center
+	)
 	if party_type in ["Customer", "Supplier"]:
 		party_bank_account = get_party_bank_account(party_type, party)
 		bank_account = get_default_company_bank_account(company, party_type, party)


### PR DESCRIPTION
In Payment Entry, Party Balance is not as per company.

Steps to replicate:
- Create two companies
- Create a supplier and make invoices for both companies.
- Now create a Payment Entry and check the party balance field.

![image](https://github.com/user-attachments/assets/1cbf0d1e-e03b-4c8b-b6ea-e0497905ee41)
 
backport version-15
backport version-14


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/23720
