### PR TITLE
fix: do not make new depreciation for fully depreciated asset

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1354,14 +1354,15 @@ class SalesInvoice(SellingController):
 
 					else:
 						if asset.calculate_depreciation:
-							notes = _(
-								"This schedule was created when Asset {0} was sold through Sales Invoice {1}."
-							).format(
-								get_link_to_form(asset.doctype, asset.name),
-								get_link_to_form(self.doctype, self.get("name")),
-							)
-							depreciate_asset(asset, self.posting_date, notes)
-							asset.reload()
+							if not asset.status == "Fully Depreciated":
+								notes = _(
+									"This schedule was created when Asset {0} was sold through Sales Invoice {1}."
+								).format(
+									get_link_to_form(asset.doctype, asset.name),
+									get_link_to_form(self.doctype, self.get("name")),
+								)
+								depreciate_asset(asset, self.posting_date, notes)
+								asset.reload()
 
 						fixed_asset_gl_entries = get_gl_entries_on_asset_disposal(
 							asset,


### PR DESCRIPTION
This PR fixes an issue where depreciation for fully depreciated assets is incorrectly reposted when the asset is sold. Upon submitting the sales invoice, the system duplicated depreciation entries.

<img width="825" alt="Screenshot 2024-10-18 at 4 54 56 PM" src="https://github.com/user-attachments/assets/fbd20bc5-a2b5-4741-a7dd-df0d28e2a893">

`no-docs`