### PR TITLE
fix: get period estimate till service end date

### DIFF
--- a/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
+++ b/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
@@ -122,21 +122,24 @@ class Deferred_Item:
 		"""
 		simulate future posting by creating dummy gl entries. starts from the last posting date.
 		"""
-		if self.service_start_date != self.service_end_date:
-			if add_days(self.last_entry_date, 1) < self.period_list[-1].to_date:
-				self.estimate_for_period_list = get_period_list(
-					self.filters.from_fiscal_year,
-					self.filters.to_fiscal_year,
-					add_days(self.last_entry_date, 1),
-					self.period_list[-1].to_date,
-					"Date Range",
-					"Monthly",
-					company=self.filters.company,
-				)
-				for period in self.estimate_for_period_list:
-					amount = self.calculate_amount(period.from_date, period.to_date)
-					gle = self.make_dummy_gle(period.key, period.to_date, amount)
-					self.gle_entries.append(gle)
+		if (
+			self.service_start_date != self.service_end_date
+			and add_days(self.last_entry_date, 1) < self.service_end_date
+		):
+			self.estimate_for_period_list = get_period_list(
+				self.filters.from_fiscal_year,
+				self.filters.to_fiscal_year,
+				add_days(self.last_entry_date, 1),
+				self.service_end_date,
+				"Date Range",
+				"Monthly",
+				company=self.filters.company,
+			)
+
+			for period in self.estimate_for_period_list:
+				amount = self.calculate_amount(period.from_date, period.to_date)
+				gle = self.make_dummy_gle(period.key, period.to_date, amount)
+				self.gle_entries.append(gle)
 
 	def calculate_item_revenue_expense_for_period(self):
 		"""


### PR DESCRIPTION
**Issue:**
The Deferred Revenue and Expense report, shows the upcoming expenses till the end of the fiscal year, irrespective of the service end date in the purchase invoice
**ref:** [22991](https://support.frappe.io/helpdesk/tickets/22991)

**Fix:** 
Calculated the future period estimate till the service end date from the purchase invoice

**Before:**
![Purchase Invoice](https://github.com/user-attachments/assets/f68351c2-9b62-4abd-9f7d-cb1103b6bb88)

![Report Issue](https://github.com/user-attachments/assets/f945779e-df76-435c-bb1a-85e2dee8ad24)

**After:**
![Report Fix](https://github.com/user-attachments/assets/80401286-5cf2-416b-96f9-85098126ebdf)

**Backport needed: v14 & v15**
