### PR TITLE
feat: Add the chart of accounts for French NPOs

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/fr_plan_comptable_associatif_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/fr_plan_comptable_associatif_avec_code.json
@@ -1,0 +1,3374 @@
+{
+  "country_code": "fr",
+  "name": "France - Plan Comptable Associatif avec code (2018-06)",
+  "tree": {
+    "Comptes de Capitaux": {
+      "root_type": "Equity",
+      "Fonds propres et r\u00e9serves": {
+        "Capital": {
+          "Capital souscrit - non appel\u00e9": {
+            "account_number": "1011"
+          },
+          "Capital souscrit - appel\u00e9, non vers\u00e9": {
+            "account_number": "1012"
+          },
+          "Capital souscrit - appel\u00e9, vers\u00e9": {
+            "Capital non amorti": {
+              "account_number": "10131"
+            },
+            "Capital amorti": {
+              "account_number": "10132"
+            },
+            "account_number": "1013"
+          },
+          "Capital souscrit soumis \u00e0 des r\u00e9glementations particuli\u00e8res": {
+            "account_number": "1018"
+          },
+          "account_number": "101"
+        },
+        "Fonds propres sans droit de reprise": {
+          "Premi\u00e8re situation nette \u00e9tablie": {
+            "account_number": "1021"
+          },
+          "Fonds statutaires (\u00e0 subdiviser en fonction des statuts)": {
+            "account_number": "1022"
+          },
+          "Dotations non consomptibles": {
+            "Dotations non consomptibles initiales": {
+              "account_number": "10231"
+            },
+            "Dotations non consomptibles compl\u00e9mentaires": {
+              "account_number": "10232"
+            },
+            "account_number": "1023"
+          },
+          "Autres fonds propres sans droit de reprise": {
+            "account_number": "1024"
+          },
+          "account_number": "102"
+        },
+        "Primes li\u00e9es au capital social": {
+          "Primes d'\u00e9mission": {
+            "account_number": "1041"
+          },
+          "Primes de fusion": {
+            "account_number": "1042"
+          },
+          "Primes d'apport": {
+            "account_number": "1043"
+          },
+          "Primes de conversion d'obligations en actions": {
+            "account_number": "1044"
+          },
+          "Bons de souscription d'actions": {
+            "account_number": "1045"
+          },
+          "account_number": "104"
+        },
+        "Ecarts de r\u00e9\u00e9valuation": {
+          "Ecarts de r\u00e9\u00e9valuation sur des biens sans droit de reprise": {
+            "account_number": "1051"
+          },
+          "Ecarts de r\u00e9\u00e9valuation sur des biens avec droit de reprise": {
+            "account_number": "1052"
+          },
+          "R\u00e9serve de r\u00e9\u00e9valuation": {
+            "account_number": "1053"
+          },
+          "Ecarts de r\u00e9\u00e9valuation (autres op\u00e9rations l\u00e9gales)": {
+            "account_number": "1055"
+          },
+          "Autres \u00e9carts de r\u00e9\u00e9valuation en France": {
+            "account_number": "1057"
+          },
+          "Autres \u00e9carts de r\u00e9\u00e9valuation \u00e0 l'\u00e9tranger": {
+            "account_number": "1058"
+          },
+          "account_number": "105"
+        },
+        "R\u00e9serves": {
+          "R\u00e9serve l\u00e9gale": {
+            "R\u00e9serve l\u00e9gale proprement dite": {
+              "account_number": "10611"
+            },
+            "Plus-values nettes \u00e0 long terme": {
+              "account_number": "10612"
+            },
+            "account_number": "1061"
+          },
+          "R\u00e9serves indisponibles": {
+            "account_number": "1062"
+          },
+          "R\u00e9serves statutaires ou contractuelles": {
+            "account_number": "1063"
+          },
+          "R\u00e9serves r\u00e9glement\u00e9es": {
+            "Plus-values nettes \u00e0 long terme": {
+              "account_number": "10641"
+            },
+            "R\u00e9serves cons\u00e9cutives \u00e0 l'octroi de subventions d'investissement": {
+              "account_number": "10643"
+            },
+            "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+              "account_number": "10648"
+            },
+            "account_number": "1064"
+          },
+          "R\u00e9serves pour projet de l\u2019entit\u00e9": {
+            "R\u00e9serve de propre assureur": {
+              "account_number": "10681"
+            },
+            "R\u00e9serves diverses": {
+              "account_number": "10688"
+            },
+            "account_number": "1068"
+          },
+          "account_number": "106"
+        },
+        "Ecarts d'\u00e9quivalence": {
+          "account_number": "107"
+        },
+        "Dotations consomptibles": {
+          "Dotations consomptibles": {
+            "account_number": "1081"
+          },
+          "Dotations consomptibles inscrites au compte de r\u00e9sultat": {
+            "account_number": "1089"
+          },
+          "account_number": "108"
+        },
+        "Actionnaires: Capital souscrit - non appel\u00e9": {
+          "account_number": "109"
+        },
+        "Fonds propres avec droit de reprise": {
+          "Fonds statutaires (\u00e0 subdiviser en fonction des statuts)": {
+            "account_number": "1032"
+          },
+          "Autres fonds propres avec droit de reprise": {
+            "account_number": "1034"
+          },
+          "account_number": "103"
+        },
+        "account_number": "10"
+      },
+      "Report \u00e0 Nouveau": {
+        "Report \u00e0 nouveau (solde cr\u00e9diteur)": {
+          "account_number": "110"
+        },
+        "Report \u00e0 nouveau (solde d\u00e9biteur)": {
+          "account_number": "119"
+        },
+        "account_number": "11"
+      },
+      "R\u00e9sultat de l'Exercice": {
+        "R\u00e9sultat de l'exercice (b\u00e9n\u00e9fice)": {
+          "account_number": "120"
+        },
+        "R\u00e9sultat de l'exercice (perte)": {
+          "account_number": "129"
+        },
+        "account_number": "12"
+      },
+      "Subventions d'Investissement": {
+        "Subventions d'\u00e9quipement": {
+          "Etat": {
+            "account_number": "1311"
+          },
+          "R\u00e9gions": {
+            "account_number": "1312"
+          },
+          "D\u00e9partements": {
+            "account_number": "1313"
+          },
+          "Communes": {
+            "account_number": "1314"
+          },
+          "Collectivit\u00e9s publiques": {
+            "account_number": "1315"
+          },
+          "Entreprises publiques": {
+            "account_number": "1316"
+          },
+          "Entreprises et organismes priv\u00e9s": {
+            "account_number": "1317"
+          },
+          "Autres": {
+            "account_number": "1318"
+          },
+          "account_number": "131"
+        },
+        "Autres subventions d'investissement (m\u00eame ventilation que celle du compte 131)": {
+          "account_number": "138"
+        },
+        "Subventions d'investissement inscrites au compte de r\u00e9sultat": {
+          "Subventions d'\u00e9quipement": {
+            "Etat": {
+              "account_number": "13911"
+            },
+            "R\u00e9gions": {
+              "account_number": "13912"
+            },
+            "D\u00e9partements": {
+              "account_number": "13913"
+            },
+            "Communes": {
+              "account_number": "13914"
+            },
+            "Collectivit\u00e9s publiques": {
+              "account_number": "13915"
+            },
+            "Entreprises publiques": {
+              "account_number": "13916"
+            },
+            "Entreprises et organismes priv\u00e9s": {
+              "account_number": "13917"
+            },
+            "Autres": {
+              "account_number": "13918"
+            },
+            "account_number": "1391"
+          },
+          "Autres subventions d'investissement (m\u00eame ventilation que celle du compte 1391)": {
+            "account_number": "1398"
+          },
+          "account_number": "139"
+        },
+        "account_number": "13"
+      },
+      "Provisions R\u00e9glement\u00e9es": {
+        "Provisions r\u00e9glement\u00e9es relative aux immobilisations": {
+          "Provisions pour reconstitution des gisements miniers et p\u00e9troliers": {
+            "account_number": "1423"
+          },
+          "Provisions pour investissement (participation des salari\u00e9s)": {
+            "account_number": "1424"
+          },
+          "account_number": "142"
+        },
+        "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+          "Hausse des prix": {
+            "account_number": "1431"
+          },
+          "Fluctuation des cours": {
+            "account_number": "1432"
+          },
+          "account_number": "143"
+        },
+        "Provisions r\u00e9glement\u00e9es relatives aux autres \u00e9l\u00e9ments de l'actif": {
+          "account_number": "144"
+        },
+        "Amortissements d\u00e9rogatoires": {
+          "account_number": "145"
+        },
+        "Provision sp\u00e9ciale de r\u00e9\u00e9valuation": {
+          "account_number": "146"
+        },
+        "Plus-values r\u00e9investies": {
+          "account_number": "147"
+        },
+        "Autres provisions r\u00e9glement\u00e9es": {
+          "account_number": "148"
+        },
+        "account_number": "14"
+      },
+      "Provisions": {
+        "Provisions pour risques": {
+          "Provisions pour litiges": {
+            "account_number": "1511"
+          },
+          "Provisions pour garanties donn\u00e9es aux clients": {
+            "account_number": "1512"
+          },
+          "Provisions pour pertes sur march\u00e9s \u00e0 terme": {
+            "account_number": "1513"
+          },
+          "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+            "account_number": "1514"
+          },
+          "Provisions pour pertes de change": {
+            "account_number": "1515"
+          },
+          "Provisions pour pertes sur contrats": {
+            "account_number": "1516"
+          },
+          "Autres provisions pour risques": {
+            "account_number": "1518"
+          },
+          "account_number": "151"
+        },
+        "Provisions pour pensions et obligations similaires": {
+          "account_number": "153"
+        },
+        "Provisions pour restructurations": {
+          "account_number": "154"
+        },
+        "Provisions pour imp\u00f4ts": {
+          "account_number": "155"
+        },
+        "Provisions pour renouvellement des immobilisations (entreprises concessionnaires) ": {
+          "account_number": "156"
+        },
+        "Provisions pour charges \u00e0 r\u00e9partir sur plusieurs exercices": {
+          "Provisions pour gros entretien ou grandes r\u00e9visions": {
+            "account_number": "1572"
+          },
+          "account_number": "157"
+        },
+        "Autres provisions pour charges": {
+          "Provisions pour remises en \u00e9tat": {
+            "account_number": "1581"
+          },
+          "account_number": "158"
+        },
+        "Provisions pour charges sur legs ou donations": {
+          "account_number": "152"
+        },
+        "account_number": "15"
+      },
+      "Emprunts et dettes assimil\u00e9es": {
+        "Emprunts obligataires convertibles": {
+          "account_number": "161"
+        },
+        "Obligations repr\u00e9sentatives de passifs nets remis en fiducie": {
+          "account_number": "162"
+        },
+        "Autres emprunts obligataires": {
+          "Titres associatifs et assimil\u00e9s": {
+            "account_number": "1631"
+          },
+          "account_number": "163"
+        },
+        "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+          "account_number": "164"
+        },
+        "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+          "D\u00e9p\u00f4ts": {
+            "account_number": "1651"
+          },
+          "Cautionnements": {
+            "account_number": "1655"
+          },
+          "account_number": "165"
+        },
+        "Participation des salari\u00e9s aux r\u00e9sultats": {
+          "Comptes bloqu\u00e9s": {
+            "account_number": "1661"
+          },
+          "Fonds de participation": {
+            "account_number": "1662"
+          },
+          "account_number": "166"
+        },
+        "Emprunts et dettes assortis de conditions particuli\u00e8res": {
+          "Emissions de titres participatifs": {
+            "account_number": "1671"
+          },
+          "Avances conditionn\u00e9es de l'Etat": {
+            "account_number": "1674"
+          },
+          "Emprunts participatifs": {
+            "account_number": "1675"
+          },
+          "account_number": "167"
+        },
+        "Autres emprunts et dettes assimil\u00e9es": {
+          "Autres emprunts": {
+            "account_number": "1681"
+          },
+          "Rentes viag\u00e8res capitalis\u00e9es": {
+            "account_number": "1685"
+          },
+          "Autres dettes": {
+            "account_number": "1687"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "Int\u00e9r\u00eats courus sur emprunts obligataires convertibles": {
+              "account_number": "16881"
+            },
+            "Int\u00e9r\u00eats courus sur autres emprunts obligataires": {
+              "account_number": "16883"
+            },
+            "Int\u00e9r\u00eats courus sur emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+              "account_number": "16884"
+            },
+            "Int\u00e9r\u00eats courus sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+              "account_number": "16885"
+            },
+            "Int\u00e9r\u00eats courus sur participation des salari\u00e9s aux r\u00e9sultats": {
+              "account_number": "16886"
+            },
+            "Int\u00e9r\u00eats courus sur emprunts et dettes assortis de conditions particuli\u00e8res": {
+              "account_number": "16887"
+            },
+            "Int\u00e9r\u00eats courus sur autres emprunts et dettes assimil\u00e9es": {
+              "account_number": "16888"
+            },
+            "account_number": "1688"
+          },
+          "Primes de remboursement des obligations": {
+            "account_number": "169"
+          },
+          "account_number": "168"
+        },
+        "account_number": "16"
+      },
+      "Dettes Rattach\u00e9es \u00e0 des Participations": {
+        "Dettes rattach\u00e9es \u00e0 des participations (groupe)": {
+          "account_number": "171"
+        },
+        "Dettes rattach\u00e9es \u00e0 des participations (hors groupe)": {
+          "account_number": "174"
+        },
+        "Dettes rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+          "Principal": {
+            "account_number": "1781"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "account_number": "1788"
+          },
+          "account_number": "178"
+        },
+        "account_number": "17"
+      },
+      "Comptes de liaison des \u00e9tablisssements et soci\u00e9t\u00e9s en participation": {
+        "Comptes de liaison des \u00e9tablissements": {
+          "account_number": "181"
+        },
+        "Biens et prestations de services \u00e9chang\u00e9s entre \u00e9tablissements (charges)": {
+          "account_number": "186"
+        },
+        "Biens et prestations de services \u00e9chang\u00e9s entre \u00e9tablissements (produits)": {
+          "account_number": "187"
+        },
+        "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+          "account_number": "188"
+        },
+        "account_number": "18"
+      },
+      "Fonds d\u00e9di\u00e9s ou report\u00e9s": {
+        "Fonds report\u00e9s li\u00e9s aux legs ou donations": {
+          "Legs ou donations": {
+            "account_number": "1911"
+          },
+          "Donations temporaires d\u2019usufruit": {
+            "account_number": "1912"
+          },
+          "account_number": "191"
+        },
+        "Fonds d\u00e9di\u00e9s sur subventions d\u2019exploitation": {
+          "account_number": "194"
+        },
+        "Fonds d\u00e9di\u00e9s sur contributions financi\u00e8res d\u2019autres organismes": {
+          "account_number": "195"
+        },
+        "Fonds d\u00e9di\u00e9s sur ressources li\u00e9es \u00e0 la g\u00e9n\u00e9rosit\u00e9 du public": {
+          "account_number": "196"
+        },
+        "account_number": "19"
+      },
+      "account_number": "1"
+    },
+    "Comptes d'Immobilisations": {
+      "root_type": "Asset",
+      "Immobilisations incorporelles": {
+        "Frais \u00e9tablissement": {
+          "Frais de constitution": {
+            "account_number": "2011"
+          },
+          "Frais de premier \u00e9tablissement": {
+            "Frais de prospection": {
+              "account_number": "20121"
+            },
+            "Frais de publicit\u00e9": {
+              "account_number": "20122"
+            },
+            "account_number": "2012"
+          },
+          "Frais d'augmentation de capital et d'op\u00e9rations diverses (fusions, scissions, transformations)": {
+            "account_number": "2013"
+          },
+          "account_number": "201"
+        },
+        "Frais de recherche et de d\u00e9veloppement": {
+          "account_number": "203"
+        },
+        "Concessions et droits similaires, brevets, licences, marques, proc\u00e9d\u00e9s, logiciels, droits et valeurs similaires": {
+          "account_number": "205"
+        },
+        "Droit au bail": {
+          "account_number": "206"
+        },
+        "Fonds commercial": {
+          "account_number": "207"
+        },
+        "Autres immobilisations incorporelles": {
+          "Mali de fusion sur actifs incorporels": {
+            "account_number": "2081"
+          },
+          "account_number": "208"
+        },
+        "Donations temporaires d\u2019usufruit": {
+          "account_number": "204"
+        },
+        "account_number": "20"
+      },
+      "Immobilisations corporelles": {
+        "account_type": "Fixed Asset",
+        "Terrains": {
+          "account_type": "Fixed Asset",
+          "Terrains nus": {
+            "account_type": "Fixed Asset",
+            "account_number": "2111"
+          },
+          "Terrains am\u00e9nag\u00e9s": {
+            "account_type": "Fixed Asset",
+            "account_number": "2112"
+          },
+          "Sous-sols et sur-sols": {
+            "account_type": "Fixed Asset",
+            "account_number": "2113"
+          },
+          "Terrains de carri\u00e8res (tr\u00e9fonds)": {
+            "account_type": "Fixed Asset",
+            "account_number": "2114"
+          },
+          "Terrains b\u00e2tis": {
+            "account_type": "Fixed Asset",
+            "Ensembles immobiliers industriels (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21151"
+            },
+            "Ensembles immobiliers administratifs et commerciaux (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21155"
+            },
+            "Autres ensembles immobiliers": {
+              "account_type": "Fixed Asset",
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "211581"
+              },
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations non professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "211588"
+              },
+              "account_number": "21158"
+            },
+            "account_number": "2115"
+          },
+          "account_number": "211"
+        },
+        "Agencements et am\u00e9nagements de terrains (m\u00eame ventilation que celle du compte 211)": {
+          "account_type": "Fixed Asset",
+          "account_number": "212"
+        },
+        "Constructions": {
+          "account_type": "Fixed Asset",
+          "B\u00e2timents": {
+            "account_type": "Fixed Asset",
+            "Ensembles immobiliers industriels (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21311"
+            },
+            "Ensembles immobiliers administratifs et commerciaux (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21315"
+            },
+            "Autres ensembles immobiliers": {
+              "account_type": "Fixed Asset",
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "213181"
+              },
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations non professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "213188"
+              },
+              "account_number": "21318"
+            },
+            "account_number": "2131"
+          },
+          "Installations g\u00e9n\u00e9rales, agencements, am\u00e9nagements des constructions": {
+            "account_type": "Fixed Asset",
+            "Ensembles immobiliers industriels (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21351"
+            },
+            "Ensembles immobiliers administratifs et commerciaux (A, B)": {
+              "account_type": "Fixed Asset",
+              "account_number": "21355"
+            },
+            "Autres ensembles immobiliers": {
+              "account_type": "Fixed Asset",
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "213581"
+              },
+              "Autres ensembles immobiliers affect\u00e9s aux op\u00e9rations non professionnelles (A, B)": {
+                "account_type": "Fixed Asset",
+                "account_number": "213588"
+              },
+              "account_number": "21358"
+            },
+            "account_number": "2135"
+          },
+          "Ouvrages d'infrastructure": {
+            "account_type": "Fixed Asset",
+            "Voies de terre": {
+              "account_type": "Fixed Asset",
+              "account_number": "21381"
+            },
+            "Voies de fer": {
+              "account_type": "Fixed Asset",
+              "account_number": "21382"
+            },
+            "Voies d'eau": {
+              "account_type": "Fixed Asset",
+              "account_number": "21383"
+            },
+            "Barrages": {
+              "account_type": "Fixed Asset",
+              "account_number": "21384"
+            },
+            "Pistes d'a\u00e9rodromes": {
+              "account_type": "Fixed Asset",
+              "account_number": "21385"
+            },
+            "account_number": "2138"
+          },
+          "account_number": "213"
+        },
+        "Constructions sur sol d'autrui (m\u00eame ventilation que celle du compte 213)": {
+          "account_type": "Fixed Asset",
+          "account_number": "214"
+        },
+        "Installations techniques, mat\u00e9riel et outillage industriels": {
+          "account_type": "Fixed Asset",
+          "Installations complexes sp\u00e9cialis\u00e9es": {
+            "account_type": "Fixed Asset",
+            "Installations complexes sp\u00e9cialis\u00e9es - sur sol propre": {
+              "account_type": "Fixed Asset",
+              "account_number": "21511"
+            },
+            "Installations complexes sp\u00e9cialis\u00e9es - sur sol d'autrui": {
+              "account_type": "Fixed Asset",
+              "account_number": "21514"
+            },
+            "account_number": "2151"
+          },
+          "Installations \u00e0 caract\u00e8re sp\u00e9cifique": {
+            "account_type": "Fixed Asset",
+            "Installations \u00e0 caract\u00e8re sp\u00e9cifique - sur sol propre": {
+              "account_type": "Fixed Asset",
+              "account_number": "21531"
+            },
+            "Installations \u00e0 caract\u00e8re sp\u00e9cifique - sur sol d'autrui": {
+              "account_type": "Fixed Asset",
+              "account_number": "21534"
+            },
+            "account_number": "2153"
+          },
+          "Mat\u00e9riel industriel": {
+            "account_type": "Fixed Asset",
+            "account_number": "2154"
+          },
+          "Outillage industriel": {
+            "account_type": "Fixed Asset",
+            "account_number": "2155"
+          },
+          "Agencements et am\u00e9nagements du mat\u00e9riel et outillage industriel": {
+            "account_type": "Fixed Asset",
+            "account_number": "2157"
+          },
+          "account_number": "215"
+        },
+        "Autres immobilisations corporelles": {
+          "account_type": "Fixed Asset",
+          "Installations g\u00e9n\u00e9rales, agencements, am\u00e9nagements divers": {
+            "account_type": "Fixed Asset",
+            "account_number": "2181"
+          },
+          "Mat\u00e9riel de transport": {
+            "account_type": "Fixed Asset",
+            "account_number": "2182"
+          },
+          "Mat\u00e9riel de bureau et mat\u00e9riel informatique": {
+            "account_type": "Fixed Asset",
+            "account_number": "2183"
+          },
+          "Mobilier": {
+            "account_type": "Fixed Asset",
+            "account_number": "2184"
+          },
+          "Cheptel": {
+            "account_type": "Fixed Asset",
+            "account_number": "2185"
+          },
+          "Emballages r\u00e9cup\u00e9rables": {
+            "account_type": "Fixed Asset",
+            "account_number": "2186"
+          },
+          "Mali de fusion sur actifs corporels": {
+            "account_number": "2187"
+          },
+          "account_number": "218"
+        },
+        "account_number": "21"
+      },
+      "Immobilisations mises en concession": {
+        "account_number": "22"
+      },
+      "Immobilisations en cours": {
+        "Immobilisations corporelles en cours": {
+          "Terrains": {
+            "account_number": "2312"
+          },
+          "Constructions": {
+            "account_number": "2313"
+          },
+          "Installations techniques, mat\u00e9riel et outillage industriels": {
+            "account_number": "2315"
+          },
+          "Autres immobilisations corporelles": {
+            "account_number": "2318"
+          },
+          "account_number": "231"
+        },
+        "Immobilisations incorporelles en cours": {
+          "account_number": "232"
+        },
+        "Avances et acomptes vers\u00e9s sur commandes d'immobilisations incorporelles": {
+          "account_number": "237"
+        },
+        "Avances et acomptes vers\u00e9s sur commandes d'immobilisations corporelles": {
+          "Terrains": {
+            "account_number": "2382"
+          },
+          "Constructions": {
+            "account_number": "2383"
+          },
+          "Installations techniques, mat\u00e9riel et outillage industriels": {
+            "account_number": "2385"
+          },
+          "Autres immobilisations corporelles": {
+            "account_number": "2388"
+          },
+          "account_number": "238"
+        },
+        "account_number": "23"
+      },
+      "Parts dans des entreprises li\u00e9es et cr\u00e9ances sur des entreprises li\u00e9es": {
+        "is_group": 1,
+        "account_number": "25"
+      },
+      "Participations et cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+        "Titres de participation": {
+          "Actions": {
+            "account_number": "2611"
+          },
+          "Autres titres": {
+            "account_number": "2618"
+          },
+          "account_number": "261"
+        },
+        "Autres formes de participation": {
+          "Droit repr\u00e9sentatifs d'actifs nets remis en fiducie": {
+            "account_number": "2661"
+          },
+          "account_number": "266"
+        },
+        "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+          "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+            "account_number": "2671"
+          },
+          "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+            "account_number": "2674"
+          },
+          "Versements repr\u00e9sentatifs d'apports non capitalis\u00e9s (appel de fonds)": {
+            "account_number": "2675"
+          },
+          "Avances consolidables": {
+            "account_number": "2676"
+          },
+          "Autres cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+            "account_number": "2677"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "account_number": "2678"
+          },
+          "account_number": "267"
+        },
+        "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+          "Principal": {
+            "account_number": "2681"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "account_number": "2688"
+          },
+          "account_number": "268"
+        },
+        "Versements restant \u00e0 effectuer sur titres de participation non lib\u00e9r\u00e9s": {
+          "account_number": "269"
+        },
+        "account_number": "26"
+      },
+      "Autres immobilisations financi\u00e8res": {
+        "Titres immobilis\u00e9s autres que les titres immobilis\u00e9s de l'activit\u00e9 de portefeuille (droit de propri\u00e9t\u00e9)": {
+          "Actions": {
+            "account_number": "2711"
+          },
+          "Autres titres": {
+            "account_number": "2718"
+          },
+          "account_number": "271"
+        },
+        "Titres immobilis\u00e9s (droit de cr\u00e9ance)": {
+          "Obligations": {
+            "account_number": "2721"
+          },
+          "Bons": {
+            "account_number": "2722"
+          },
+          "account_number": "272"
+        },
+        "Titres immobilis\u00e9s de l'activit\u00e9 de portefeuille": {
+          "account_number": "273"
+        },
+        "Pr\u00eats": {
+          "Pr\u00eats participatifs": {
+            "account_number": "2741"
+          },
+          "Pr\u00eats aux partenaires": {
+            "account_number": "2742"
+          },
+          "Pr\u00eats au personnel": {
+            "account_number": "2743"
+          },
+          "Autres pr\u00eats": {
+            "account_number": "2748"
+          },
+          "account_number": "274"
+        },
+        "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+          "D\u00e9p\u00f4ts": {
+            "account_number": "2751"
+          },
+          "Cautionnements": {
+            "account_number": "2755"
+          },
+          "account_number": "275"
+        },
+        "Autres cr\u00e9ances immobilis\u00e9es": {
+          "Cr\u00e9ances diverses": {
+            "account_number": "2761"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "Int\u00e9r\u00eats courus sur titres immobilis\u00e9s (droit de cr\u00e9ance)": {
+              "account_number": "27682"
+            },
+            "Int\u00e9r\u00eats courus sur pr\u00eats": {
+              "account_number": "27684"
+            },
+            "Int\u00e9r\u00eats courus sur d\u00e9p\u00f4ts et cautionnements": {
+              "account_number": "27685"
+            },
+            "Int\u00e9r\u00eats courus sur cr\u00e9ances diverses": {
+              "account_number": "27688"
+            },
+            "account_number": "2768"
+          },
+          "account_number": "276"
+        },
+        "(Actions propres ou parts propres)": {
+          "Actions propres ou parts propres": {
+            "account_number": "2771"
+          },
+          "Actions propres ou parts propres en voie d'annulation": {
+            "account_number": "2772"
+          },
+          "account_number": "277"
+        },
+        "Mali de fusion sur actifs financiers": {
+          "account_number": "278"
+        },
+        "Versements restant \u00e0 effectuer sur titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+          "account_number": "279"
+        },
+        "account_number": "27"
+      },
+      "Amortissements des immobilisations": {
+        "account_type": "Accumulated Depreciation",
+        "Amortissements des immobilisations incorporelles": {
+          "account_type": "Accumulated Depreciation",
+          "Frais d'\u00e9tablissement (m\u00eame ventilation que celle du compte 212)": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2801"
+          },
+          "Frais de recherche et de d\u00e9veloppement": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2803"
+          },
+          "Concessions et droits similaires, brevets, licences, logiciels, droits et valeurs similaires": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2805"
+          },
+          "Fonds commercial": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2807"
+          },
+          "Autres immobilisations incorporelles": {
+            "account_type": "Accumulated Depreciation",
+            "Mali de fusion sur actifs incorporels": {
+              "account_type": "Accumulated Depreciation",
+              "account_number": "28081"
+            },
+            "account_number": "2808"
+          },
+          "Donations temporaires d\u2019usufruit": {
+            "account_number": "2804"
+          },
+          "account_number": "280"
+        },
+        "Amortissements des immobilisations corporelles": {
+          "account_type": "Accumulated Depreciation",
+          "Terrains de gisement": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2811"
+          },
+          "Agencements, am\u00e9nagements de terrains (m\u00eame ventilation que celle du compte 212)": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2812"
+          },
+          "Constructions (m\u00eame ventilation que celle du compte 213)": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2813"
+          },
+          "Constructions sur sol d'autrui (m\u00eame ventilation que celle du compte du 214)": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2814"
+          },
+          "Installations techniques, mat\u00e9riel et outillage industriels (m\u00eame ventilation que celle du compte 218)": {
+            "account_type": "Accumulated Depreciation",
+            "account_number": "2815"
+          },
+          "Autres immobilisations corporelles (m\u00eame ventilation que celle du compte 218)": {
+            "account_type": "Accumulated Depreciation",
+            "Mali de fusion sur actifs corporels": {
+              "account_type": "Accumulated Depreciation",
+              "account_number": "28187"
+            },
+            "account_number": "2818"
+          },
+          "account_number": "281"
+        },
+        "Amortissements des immobilisations mises en concession": {
+          "account_number": "282"
+        },
+        "account_number": "28"
+      },
+      "D\u00e9pr\u00e9ciations des immobilisations": {
+        "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+          "Marques,  proc\u00e9d\u00e9s, droits et valeurs similaires": {
+            "account_number": "2905"
+          },
+          "Droit au bail": {
+            "account_number": "2906"
+          },
+          "Fonds commercial": {
+            "account_number": "2907"
+          },
+          "Autres immobilisations incorporelles": {
+            "Mali de fusion sur actifs incorporels": {
+              "account_number": "29081"
+            },
+            "account_number": "2908"
+          },
+          "account_number": "290"
+        },
+        "D\u00e9pr\u00e9ciations des immobilisations corporelles (m\u00eame ventilation que celle du compte 21)": {
+          "Terrains (autres que terrains de gisement)": {
+            "Mali de fusion sur actifs corporels": {
+              "account_number": "29187"
+            },
+            "account_number": "2911"
+          },
+          "account_number": "291"
+        },
+        "D\u00e9pr\u00e9ciations des immobilisations mises en concession": {
+          "account_number": "292"
+        },
+        "D\u00e9pr\u00e9ciations des immobilisations en cours": {
+          "Immobilisations corporelles en cours": {
+            "account_number": "2931"
+          },
+          "Immobilisations incorporelles en cours": {
+            "account_number": "2932"
+          },
+          "account_number": "293"
+        },
+        "D\u00e9pr\u00e9ciations des participations et cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+          "Titres de participation": {
+            "account_number": "2961"
+          },
+          "Autres formes de participation": {
+            "account_number": "2966"
+          },
+          "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (m\u00eame ventilation que celle du compte 267)": {
+            "account_number": "2967"
+          },
+          "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation (m\u00eame ventilation que celle du compte 268)": {
+            "account_number": "2968"
+          },
+          "account_number": "296"
+        },
+        "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+          "Titres immobilis\u00e9s autres que les titres immobilis\u00e9s de l'activit\u00e9 de portefeuille - droit de propri\u00e9t\u00e9": {
+            "account_number": "2971"
+          },
+          "Titres immobilis\u00e9s - droit de cr\u00e9ance (m\u00eame ventilation que celle du compte 272)": {
+            "account_number": "2972"
+          },
+          " Titres immobilis\u00e9s de l'activit\u00e9 de portefuille": {
+            "account_number": "2973"
+          },
+          "Pr\u00eats (m\u00eame ventilation que celle du compte 274)": {
+            "account_number": "2974"
+          },
+          "D\u00e9p\u00f4ts et cautionnements vers\u00e9s (m\u00eame ventilation que celle du compte 275)": {
+            "account_number": "2975"
+          },
+          "Autres cr\u00e9ances immobilis\u00e9es (m\u00eame ventilation que celle du compte 276)": {
+            "Mali de fusion sur actifs financiers": {
+              "account_number": "29787"
+            },
+            "account_number": "2976"
+          },
+          "account_number": "297"
+        },
+        "D\u00e9pr\u00e9ciationsdes biens re\u00e7us par legs ou donations destin\u00e9s \u00e0 \u00eatre c\u00e9d\u00e9s": {
+          "account_number": "294"
+        },
+        "account_number": "29"
+      },
+      "Biens re\u00e7us par legs ou donations destin\u00e9s \u00e0 \u00eatre c\u00e9d\u00e9s": {
+        "account_number": "24"
+      },
+      "account_number": "2"
+    },
+    "Comptes de Stocks et En-Cours": {
+      "root_type": "Asset",
+      "Mati\u00e8res premi\u00e8res (et fournitures)": {
+        "Mati\u00e8res (ou groupe) A": {
+          "account_number": "311"
+        },
+        "Mati\u00e8res (ou groupe) B": {
+          "account_number": "312"
+        },
+        "Fournitures A, B, C, ...": {
+          "account_number": "317"
+        },
+        "account_number": "31"
+      },
+      "Autres approvisionnements": {
+        "Mat\u00e8res consommables": {
+          "Mati\u00e8res (ou groupe) C": {
+            "account_number": "3211"
+          },
+          "Mati\u00e8res (ou groupe) D": {
+            "account_number": "3212"
+          },
+          "account_number": "321"
+        },
+        "Fournitures consommables": {
+          "Combustibles": {
+            "account_number": "3221"
+          },
+          "Produits d'entretien": {
+            "account_number": "3222"
+          },
+          "Fournitures d'atelier et d'usine": {
+            "account_number": "3223"
+          },
+          "Fournitures de magasin": {
+            "account_number": "3224"
+          },
+          "Fournitures de bureau": {
+            "account_number": "3225"
+          },
+          "account_number": "322"
+        },
+        "Emballages": {
+          "Emballages perdus": {
+            "account_number": "3261"
+          },
+          "Emballages r\u00e9cup\u00e9rables non identifiables": {
+            "account_number": "3265"
+          },
+          "Emballages \u00e0 usage mixte": {
+            "account_number": "3267"
+          },
+          "account_number": "326"
+        },
+        "account_number": "32"
+      },
+      "En-cours de production de biens": {
+        "Produits en cours": {
+          "Produits en cours P1": {
+            "account_number": "3311"
+          },
+          "Produits en cours P2": {
+            "account_number": "3312"
+          },
+          "account_number": "331"
+        },
+        "Travaux en cours": {
+          "Travaux en cours T1": {
+            "account_number": "3351"
+          },
+          "Travaux en cours T2": {
+            "account_number": "3352"
+          },
+          "account_number": "335"
+        },
+        "account_number": "33"
+      },
+      "En-cours de production de services": {
+        "Etudes en cours": {
+          "Etudes en cours E1": {
+            "account_number": "3411"
+          },
+          "Etudes en cours E2": {
+            "account_number": "3412"
+          },
+          "account_number": "341"
+        },
+        "Prestations de services en cours": {
+          "Prestations de services S1": {
+            "account_number": "3451"
+          },
+          "Prestations de services S2": {
+            "account_number": "3452"
+          },
+          "account_number": "345"
+        },
+        "account_number": "34"
+      },
+      "Stocks de produits": {
+        "account_type": "Stock",
+        "Produits interm\u00e9diaires": {
+          "account_type": "Stock",
+          "Produits interm\u00e9diaires (ou groupe) A": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3511"
+          },
+          "Produits interm\u00e9diaires (ou groupe) B": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3512"
+          },
+          "account_number": "351"
+        },
+        "Produits finis": {
+          "account_type": "Stock",
+          "Produits finis (ou groupe) A": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3551"
+          },
+          "Produits finis (ou groupe) B": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3552"
+          },
+          "account_number": "355"
+        },
+        "Produits r\u00e9siduels (ou mati\u00e8res de r\u00e9cup\u00e9ration)": {
+          "account_type": "Stock",
+          "D\u00e9chets": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3581"
+          },
+          "Rebuts": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3585"
+          },
+          "Mati\u00e8res de r\u00e9cup\u00e9ration": {
+            "account_type": "Stock",
+            "is_group": 1,
+            "account_number": "3586"
+          },
+          "account_number": "358"
+        },
+        "account_number": "35"
+      },
+      "(Compte \u00e0 ouvrir, le cas \u00e9ch\u00e9ant, sous l'intitul\u00e9 \"stocks provenant d'immobilisations\")": {
+        "account_number": "36"
+      },
+      "Stocks de marchandises": {
+        "Marchandises (ou groupe) A": {
+          "account_number": "371"
+        },
+        "Marchandises (ou groupe) B": {
+          "account_number": "372"
+        },
+        "account_number": "37"
+      },
+      "Stocks en voie d'acheminement, mis en d\u00e9p\u00f4t ou donn\u00e9s en consignation (en cas d'inventaire permanent en comptabilit\u00e9 g\u00e9n\u00e9rale)": {
+        "account_type": "Stock",
+        "account_number": "38"
+      },
+      "D\u00e9pr\u00e9ciations des stocks et en-cours": {
+        "D\u00e9pr\u00e9ciations des mati\u00e8res premi\u00e8res (et fournitures)": {
+          "Mati\u00e8res (ou groupe) A": {
+            "account_number": "3911"
+          },
+          "Mati\u00e8res (ou groupe) B": {
+            "account_number": "3912"
+          },
+          "Fournitures A, B, C, ...": {
+            "account_number": "3917"
+          },
+          "account_number": "391"
+        },
+        "D\u00e9pr\u00e9ciations des autres approvisionnements": {
+          "Mati\u00e8res consommables (m\u00eame ventilation que celle du compte 321)": {
+            "account_number": "3921"
+          },
+          "Fournitures consommables (m\u00eame ventilation que celle du compte 322)": {
+            "account_number": "3922"
+          },
+          "Emballages (m\u00eame ventilation que celle du compte 326)": {
+            "account_number": "3926"
+          },
+          "account_number": "392"
+        },
+        "D\u00e9pr\u00e9ciations des en-cours de production de biens": {
+          "Etudes en cours (m\u00eame ventilation que celle du compte 341)": {
+            "account_number": "3931"
+          },
+          "Travaux en cours (m\u00eame ventilation que celle du compte 335)": {
+            "account_number": "3935"
+          },
+          "account_number": "393"
+        },
+        "D\u00e9pr\u00e9ciations des en-cours de production de services": {
+          "Etudes en cours (m\u00eame ventilation que celle du compte 341)": {
+            "account_number": "3941"
+          },
+          "Prestations de services en cours (m\u00eame ventilation que celle du compte 345)": {
+            "account_number": "3945"
+          },
+          "account_number": "394"
+        },
+        "D\u00e9pr\u00e9ciations des stocks de produits": {
+          "Produits interm\u00e9diaires (m\u00eame ventilation que celle du compte 351)": {
+            "account_number": "3951"
+          },
+          "Produits finis (m\u00eame ventilation que celle du compte 355)": {
+            "account_number": "3955"
+          },
+          "account_number": "395"
+        },
+        "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+          "Marchandise (ou groupe) A": {
+            "account_number": "3971"
+          },
+          "Marchandise (ou groupe) B": {
+            "account_number": "3972"
+          },
+          "account_number": "397"
+        },
+        "account_number": "39"
+      },
+      "account_number": "3"
+    },
+    "4-Comptes de Tiers (ACTIF)": {
+      "root_type": "Asset",
+      "40-Fournisseurs et Comptes Rattach\u00e9s (ACTIF)": {
+        "Fournisseurs d\u00e9biteurs": {
+          "Fournisseurs - Avances et acomptes vers\u00e9s sur commandes": {
+            "account_number": "4091"
+          },
+          "Fournisseurs - Cr\u00e9ances pour emballages et mat\u00e9riel \u00e0 rendre": {
+            "account_number": "4096"
+          },
+          "Fournisseurs - Autres avoirs": {
+            "Fournisseurs d'exploitation": {
+              "account_number": "40971"
+            },
+            "Fournisseurs d'immobilisation": {
+              "account_number": "40974"
+            },
+            "account_number": "4097"
+          },
+          "Rabais, remises, ristournes \u00e0 obtenir et autres avoirs non encore re\u00e7us": {
+            "account_number": "4098"
+          },
+          "account_number": "409"
+        }
+      },
+      "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+        "account_type": "Receivable",
+        "Clients et Comptes rattach\u00e9s": {
+          "account_type": "Receivable",
+          "account_number": "410"
+        },
+        "Clients": {
+          "account_type": "Receivable",
+          "Clients - Ventes de biens ou de prestations de services": {
+            "account_type": "Receivable",
+            "account_number": "4111"
+          },
+          "Clients - Retenues de garantie": {
+            "account_type": "Receivable",
+            "account_number": "4117"
+          },
+          "account_number": "411"
+        },
+        "Clients - Effets \u00e0 recevoir": {
+          "account_type": "Receivable",
+          "account_number": "413"
+        },
+        "Clients douteux ou litigieux": {
+          "account_type": "Receivable",
+          "account_number": "416"
+        },
+        "Clients - Produits non encore factur\u00e9s": {
+          "account_type": "Receivable",
+          "Clients - Factures \u00e0 \u00e9tablir": {
+            "account_type": "Receivable",
+            "account_number": "4181"
+          },
+          "Clients - Int\u00e9r\u00eats courus": {
+            "account_type": "Receivable",
+            "account_number": "4188"
+          },
+          "account_number": "418"
+        }
+      },
+      "42-Personnel et comptes rattach\u00e9s (ACTIF)": {
+        "Personnel - Avances et acomptes": {
+          "account_number": "425"
+        }
+      },
+      "43-S\u00e9curit\u00e9 sociale et autres organismes sociaux (ACTIF)": {
+        "S\u00e9curit\u00e9 sociale": {
+          "account_number": "431"
+        },
+        "Autres organismes sociaux": {
+          "account_number": "437"
+        },
+        "438-Organismes sociaux - Produits \u00e0 recevoir": {
+          "Produits \u00e0 recevoir": {
+            "account_number": "4387"
+          }
+        }
+      },
+      "44-Etat et autres collectivit\u00e9s publiques (ACTIF)": {
+        "Etat - Subventions \u00e0 recevoir": {
+          "Subventions d'investissement": {
+            "account_number": "4411"
+          },
+          "Subventions d'exploitation": {
+            "account_number": "4417"
+          },
+          "Subventions d'\u00e9quilibre": {
+            "account_number": "4418"
+          },
+          "Avances sur subventions": {
+            "account_number": "4419"
+          },
+          "account_number": "441"
+        },
+        "Op\u00e9rations particuli\u00e8res avec l'Etat, les collectivit\u00e9s publiques, les organismes internationaux": {
+          "Cr\u00e9ances sur l'Etat r\u00e9sultant de la suppression de la r\u00e8gle du d\u00e9calage d'un mois en mati\u00e8re de TVA": {
+            "account_number": "4431"
+          },
+          "Int\u00e9r\u00eats courus sur cr\u00e9ances figurant au compte 4431": {
+            "account_number": "4438"
+          },
+          "account_number": "443"
+        },
+        "Etat - Taxes sur le chiffre d'affaires (ACTIF)": {
+          "TVA due intracommunautaire": {
+            "account_number": "4452"
+          },
+          "Taxes sur le chiffre d'affaires d\u00e9ductibles": {
+            "TVA sur immobilisations": {
+              "account_number": "44562"
+            },
+            "TVA transf\u00e9r\u00e9e par d'autres entreprises": {
+              "account_number": "44563"
+            },
+            "TVA sur autres biens et services": {
+              "tax_rate": 20,
+              "account_number": "44566"
+            },
+            "Cr\u00e9dit de TVA \u00e0 reporter": {
+              "account_number": "44567"
+            },
+            "Taxes assimil\u00e9es \u00e0 la TVA": {
+              "account_number": "44568"
+            },
+            "account_number": "4456"
+          },
+          "4458-Taxes sur le chiffre d'affaires \u00e0 r\u00e9gulariser ou en attente (ACTIF)": {
+            "Acomptes - R\u00e9gime simplifi\u00e9 d'imposition": {
+              "account_number": "44581"
+            },
+            "Acomptes - R\u00e9gime du forfait": {
+              "account_number": "44582"
+            },
+            "Remboursement de taxes sur le chiffre d'affaires demand\u00e9": {
+              "account_number": "44583"
+            },
+            "Taxes sur le chiffre d'affaires sur factures non parvenues": {
+              "account_number": "44586"
+            }
+          }
+        },
+        "Etat - Charges \u00e0 payer et produits \u00e0 recevoir": {
+          "Charges fiscales sur cong\u00e9s \u00e0 payer": {
+            "account_number": "4482"
+          },
+          "Charges \u00e0 payer": {
+            "account_number": "4486"
+          },
+          "Produits \u00e0 recevoir": {
+            "account_number": "4487"
+          },
+          "account_number": "448"
+        }
+      },
+      "45-Groupe et associ\u00e9s (ACTIF)": {
+        "Associ\u00e9s - Op\u00e9rations sur le capital (ACTIF)": {
+          "456-Apporteurs - Capital appel\u00e9, non vers\u00e9": {
+            "Actionnaires - Capital souscrit et appel\u00e9, non vers\u00e9": {
+              "account_number": "45621"
+            },
+            "Associ\u00e9s - Capital appel\u00e9, non vers\u00e9": {
+              "account_number": "45625"
+            },
+            "account_number": "4562"
+          }
+        }
+      },
+      "46-D\u00e9biteurs divers et cr\u00e9diteurs divers (ACTIF)": {
+        "Cr\u00e9ances sur cessions d'immobilisations": {
+          "account_number": "462"
+        },
+        "Cr\u00e9ances sur cessions de valeurs mobili\u00e8res de placement": {
+          "account_number": "465"
+        },
+        "467-Autres comptes d\u00e9biteurs ou cr\u00e9diteurs (ACTIF)": {},
+        "468-Divers - Charges \u00e0 payer et produits \u00e0 recevoir (ACTIF)": {
+          "Produits \u00e0 recevoir": {
+            "account_number": "4687"
+          }
+        }
+      },
+      "47-Comptes transitoires ou d'attente (ACTIF)": {
+        "471-Comptes d'attente (ACTIF)": {
+          "account_type": "Temporary"
+        },
+        "Diff\u00e9rences de conversion (ACTIF)": {
+          "Diminution des cr\u00e9ances": {
+            "account_number": "4761"
+          },
+          "Augmentation des dettes": {
+            "account_number": "4762"
+          },
+          "Diff\u00e9rences compens\u00e9es par couverture de change": {
+            "account_number": "4768"
+          },
+          "account_number": "476"
+        },
+        "Autres comptes transitoires (ACTIF)": {
+          "Mali de fusion sur actif circulant": {
+            "account_number": "4781"
+          },
+          "478-Diff\u00e9rences d'\u00e9valuation sur instruments de tr\u00e9sorerie (ACTIF)": {
+            "account_number": "4786"
+          }
+        }
+      },
+      "48-Comptes de r\u00e9gularisation (ACTIF)": {
+        "Charges \u00e0 r\u00e9partir sur plusieurs exercices": {
+          "Frais d'\u00e9mission des emprunts": {
+            "account_number": "4816"
+          },
+          "account_number": "481"
+        },
+        "Charges constat\u00e9es d'avance": {
+          "account_number": "486"
+        },
+        "488-Comptes de r\u00e9partition p\u00e9riodique des charges et des produits (ACTIF)": {
+          "Charges": {
+            "account_number": "4886"
+          }
+        }
+      },
+      "49-D\u00e9pr\u00e9ciation des comptes de tiers (ACTIF)": {
+        "D\u00e9pr\u00e9ciations des comptes clients": {
+          "account_number": "491"
+        },
+        "D\u00e9pr\u00e9ciations des comptes du groupe et des associ\u00e9s": {
+          "Comptes du groupe": {
+            "account_number": "4951"
+          },
+          "Comptes courants des associ\u00e9s": {
+            "account_number": "4955"
+          },
+          "Op\u00e9rations faites en commun et en GIE": {
+            "account_number": "4958"
+          },
+          "account_number": "495"
+        },
+        "D\u00e9pr\u00e9ciations des comptes de d\u00e9biteurs divers": {
+          "Cr\u00e9ances sur cessions d'immobilisations": {
+            "account_number": "4962"
+          },
+          "Cr\u00e9ances sur cessions de valeurs mobili\u00e8res de placement": {
+            "account_number": "4965"
+          },
+          "Autres comptes d\u00e9biteurs": {
+            "account_number": "4967"
+          },
+          "account_number": "496"
+        }
+      }
+    },
+    "4-Comptes de Tiers (PASSIF)": {
+      "root_type": "Liability",
+      "40-Fournisseurs et Comptes Rattach\u00e9s (PASSIF)": {
+        "account_type": "Payable",
+        "Fournisseurs": {
+          "account_type": "Payable",
+          "Fournisseurs - Achats de biens ou de prestations de services": {
+            "account_type": "Payable",
+            "account_number": "4011"
+          },
+          "Fournisseurs - Retenues de garantie": {
+            "account_type": "Payable",
+            "account_number": "4017"
+          },
+          "account_number": "401"
+        },
+        "Fournisseurs - Effets \u00e0 payer": {
+          "account_type": "Payable",
+          "account_number": "403"
+        },
+        "Fournisseurs d'immobilisations": {
+          "account_type": "Payable",
+          "Fournisseurs - Achats d'immobilisations": {
+            "account_type": "Payable",
+            "account_number": "4041"
+          },
+          "Fournisseurs d'immobilisations - Retenues de garantie": {
+            "account_type": "Payable",
+            "account_number": "4047"
+          },
+          "account_number": "404"
+        },
+        "Fournisseurs d'immobilisations - Effets \u00e0 payer": {
+          "account_type": "Payable",
+          "account_number": "405"
+        },
+        "Fournisseurs - Factures non parvenues": {
+          "account_type": "Stock Received But Not Billed",
+          "Fournisseurs": {
+            "account_type": "Stock Received But Not Billed",
+            "account_number": "4081"
+          },
+          "Fournisseurs d'immobilisations": {
+            "account_type": "Stock Received But Not Billed",
+            "account_number": "4084"
+          },
+          "Fournisseurs - Int\u00e9r\u00eats courus": {
+            "account_type": "Stock Received But Not Billed",
+            "account_number": "4088"
+          },
+          "account_number": "408"
+        }
+      },
+      "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+        "Clients cr\u00e9diteurs": {
+          "Clients - Avances et acomptes re\u00e7us sur commandes": {
+            "account_type": "Income Account",
+            "account_number": "4191"
+          },
+          "Clients - Dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+            "account_number": "4196"
+          },
+          "Clients - Autres avoirs": {
+            "account_number": "4197"
+          },
+          "Rabais, remises, ristournes \u00e0 accorder et autres avoirs \u00e0 \u00e9tablir": {
+            "account_number": "4198"
+          },
+          "account_number": "419"
+        }
+      },
+      "42-Personnel et comptes rattach\u00e9s (PASSIF)": {
+        "Personnel - R\u00e9mun\u00e9rations dues": {
+          "account_number": "421"
+        },
+        "Comit\u00e9s d'entreprises, d'\u00e9tablissement...": {
+          "account_number": "422"
+        },
+        "Participation des salari\u00e9s aux r\u00e9sultats": {
+          "R\u00e9serve sp\u00e9ciale": {
+            "account_number": "4246"
+          },
+          "Comptes courants": {
+            "account_number": "4248"
+          },
+          "account_number": "424"
+        },
+        "Personnel - D\u00e9p\u00f4ts": {
+          "account_number": "426"
+        },
+        "Personnel - Oppositions": {
+          "account_number": "427"
+        },
+        "Personnel - Charges \u00e0 payer et produits \u00e0 recevoir": {
+          "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+            "account_number": "4282"
+          },
+          "Dettes provisionn\u00e9es pour participation des salari\u00e9s aux r\u00e9sultats": {
+            "account_number": "4284"
+          },
+          "Autres charges \u00e0 payer": {
+            "account_number": "4286"
+          },
+          "Produits \u00e0 recevoir": {
+            "account_number": "4287"
+          },
+          "account_number": "428"
+        }
+      },
+      "43-S\u00e9curit\u00e9 sociale et autres organismes sociaux (PASSIF)": {
+        "438-Organismes sociaux - Charges \u00e0 payer": {
+          "Charges sociales sur cong\u00e9s \u00e0 payer": {
+            "account_number": "4382"
+          },
+          "Autres charges \u00e0 payer": {
+            "account_number": "4386"
+          }
+        }
+      },
+      "44-Etat et autres collectivit\u00e9s publiques (PASSIF)": {
+        "Etat - Imp\u00f4ts et taxes recouvrables sur des tiers": {
+          "Obligataires": {
+            "account_number": "4424"
+          },
+          "Associ\u00e9s": {
+            "account_number": "4425"
+          },
+          "account_number": "442"
+        },
+        "Etat - Imp\u00f4ts sur les b\u00e9n\u00e9fices": {
+          "account_number": "444"
+        },
+        "Etat - Taxes sur le chiffre d'affaires (PASSIF)": {
+          "Taxes sur le chiffre d'affaires \u00e0 d\u00e9caisser": {
+            "TVA \u00e0 d\u00e9caisser": {
+              "account_number": "44551"
+            },
+            "Taxes assimil\u00e9es \u00e0 la TVA": {
+              "account_number": "44558"
+            },
+            "account_number": "4455"
+          },
+          "Taxes sur le chiffre d'affaires collect\u00e9es par l'entreprise": {
+            "TVA collect\u00e9e": {
+              "account_type": "Tax",
+              "is_group": 1,
+              "account_number": "44571"
+            },
+            "Taxes assimil\u00e9es \u00e0 la TVA": {
+              "account_number": "44578"
+            },
+            "account_number": "4457"
+          },
+          "4458-Taxes sur le chiffre d'affaires \u00e0 r\u00e9gulariser ou en attente (PASSIF)": {
+            "TVA r\u00e9cup\u00e9r\u00e9e  d'avance": {
+              "account_number": "44584"
+            },
+            "Taxes sur le chiffre d'affaires sur factures \u00e0 \u00e9tablir": {
+              "account_number": "44587"
+            }
+          }
+        },
+        "Obligations cautionn\u00e9es": {
+          "account_number": "446"
+        },
+        "Autres imp\u00f4ts, taxes et versements assimil\u00e9s": {
+          "account_number": "447"
+        },
+        "Quotas d'\u00e9mission \u00e0 acqu\u00e9rir": {
+          "account_number": "449"
+        }
+      },
+      "45-Groupe et associ\u00e9s (PASSIF)": {
+        "Groupe (PASSIF)": {
+          "account_number": "451"
+        },
+        "Partenaires - comptes courants": {
+          "Principal (PASSIF)": {
+            "account_number": "4551"
+          },
+          "Int\u00e9r\u00eats courus (PASSIF)": {
+            "account_number": "4558"
+          },
+          "account_number": "455"
+        },
+        "Associ\u00e9s - Op\u00e9rations sur le capital (PASSIF)": {
+          "456-Associ\u00e9s - Comptes d'apport en soci\u00e9t\u00e9": {
+            "Apports en nature": {
+              "account_number": "45611"
+            },
+            "Apports en num\u00e9raire": {
+              "account_number": "45615"
+            },
+            "account_number": "4561"
+          },
+          "Associ\u00e9s - Versements re\u00e7us sur augmentation de capital": {
+            "account_number": "4563"
+          },
+          "Associ\u00e9s - Versements anticip\u00e9s": {
+            "account_number": "4564"
+          },
+          "Actionnaires d\u00e9faillants": {
+            "account_number": "4566"
+          },
+          "Associ\u00e9s - Capital \u00e0 rembourser": {
+            "account_number": "4567"
+          }
+        },
+        "Associ\u00e9s - Dividendes \u00e0 payer": {
+          "account_number": "457"
+        },
+        "Associ\u00e9s - Op\u00e9rations faites en commun et en GIE": {
+          "Op\u00e9rations courantes": {
+            "account_number": "4581"
+          },
+          "Int\u00e9r\u00eats courus": {
+            "account_number": "4588"
+          },
+          "account_number": "458"
+        }
+      },
+      "46-D\u00e9biteurs divers et cr\u00e9diteurs divers (PASSIF)": {
+        "Dettes sur acquisitions de valeurs mobili\u00e8res de placement": {
+          "account_number": "464"
+        },
+        "467-Autres comptes d\u00e9biteurs ou cr\u00e9diteurs (PASSIF)": {},
+        "468-Divers - Charges \u00e0 payer et produits \u00e0 recevoir (PASSIF)": {
+          "Charges \u00e0 payer": {
+            "account_number": "4686"
+          }
+        }
+      },
+      "47-Comptes transitoires ou d'attente (PASSIF)": {
+        "471-Comptes d'attente (PASSIF)": {
+          "account_type": "Temporary"
+        },
+        "Diff\u00e9rences de conversion (PASSIF)": {
+          "Augmentation des cr\u00e9ances": {
+            "account_number": "4771"
+          },
+          "Diminution des dettes": {
+            "account_number": "4772"
+          },
+          "Diff\u00e9rences compens\u00e9es par couverture de change": {
+            "account_number": "4778"
+          },
+          "account_number": "477"
+        },
+        "478-Autres comptes transitoires (PASSIF)": {
+          "Diff\u00e9rences d'\u00e9valuation sur instruments de tr\u00e9sorerie (PASSIF)": {
+            "account_number": "4787"
+          }
+        }
+      },
+      "48-Comptes de r\u00e9gularisation (PASSIF)": {
+        "Produits constat\u00e9s d'avance": {
+          "account_number": "487"
+        },
+        "448-Comptes de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+          "Produits": {
+            "account_number": "4887"
+          }
+        }
+      },
+      "Clients, adh\u00e9rents, usagers et comptes rattach\u00e9s": {
+        "account_number": "41"
+      },
+      "Conf\u00e9d\u00e9ration, f\u00e9d\u00e9ration, union, entit\u00e9s affili\u00e9es": {
+        "account_number": "45"
+      },
+      "D\u00e9biteurs et cr\u00e9diteurs divers": {
+        "Cr\u00e9ances re\u00e7ues par legs ou donations": {
+          "account_number": "461"
+        },
+        "Dettes des legs ou donations": {
+          "account_number": "466"
+        },
+        "Divers \u2013 charges \u00e0 payer et produits \u00e0 recevoir": {
+          "Frais des b\u00e9n\u00e9voles": {
+            "account_number": "4681"
+          },
+          "account_number": "468"
+        },
+        "account_number": "46"
+      }
+    },
+    "Comptes Financiers": {
+      "root_type": "Asset",
+      "Valeurs mobili\u00e8res de placement": {
+        "Parts dans des entreprises li\u00e9es": {
+          "account_number": "501"
+        },
+        "Actions propres": {
+          "Actions destin\u00e9es \u00e0 \u00eatre attribu\u00e9es aux employ\u00e9s et affect\u00e9es \u00e0 des plans d\u00e9termin\u00e9s": {
+            "account_number": "5021"
+          },
+          "Actions disponibles pour \u00eatre attribu\u00e9es aux employ\u00e9s ou pour la r\u00e9gularisation des cours de bourse": {
+            "account_number": "5022"
+          },
+          "account_number": "502"
+        },
+        "Actions": {
+          "Titres cot\u00e9s": {
+            "account_number": "5031"
+          },
+          "Titres non cot\u00e9s": {
+            "account_number": "5035"
+          },
+          "account_number": "503"
+        },
+        "Autres titres conf\u00e9rant un droit de propri\u00e9t\u00e9": {
+          "account_number": "504"
+        },
+        "Obligations et bons \u00e9mis par la soci\u00e9t\u00e9 et rachet\u00e9s par elle": {
+          "account_number": "505"
+        },
+        "Obligations": {
+          "Titres cot\u00e9s": {
+            "account_number": "5061"
+          },
+          "Titres non cot\u00e9s": {
+            "account_number": "5065"
+          },
+          "account_number": "506"
+        },
+        "Bons du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+          "account_number": "507"
+        },
+        "Autres valeurs mobili\u00e8res de placement et autres cr\u00e9ances assimil\u00e9es": {
+          "Autres valeurs mobili\u00e8res": {
+            "account_number": "5081"
+          },
+          "Bons de souscription": {
+            "account_number": "5082"
+          },
+          "Int\u00e9r\u00eats courus sur obligations, bons et valeurs assimil\u00e9es": {
+            "account_number": "5088"
+          },
+          "account_number": "508"
+        },
+        "Versements restant \u00e0 effectuer sur valeurs mobili\u00e8res de placement non lib\u00e9r\u00e9es": {
+          "account_number": "509"
+        },
+        "account_number": "50"
+      },
+      "Banques, \u00e9tablissements financiers et assimil\u00e9s": {
+        "Valeurs \u00e0 l'encaissement": {
+          "Coupons \u00e9chus \u00e0 l'encaissement": {
+            "account_number": "5111"
+          },
+          "Ch\u00e8ques \u00e0 encaisser": {
+            "account_number": "5112"
+          },
+          "Effets \u00e0 l'encaissement": {
+            "account_number": "5113"
+          },
+          "Effets \u00e0 l'escompte": {
+            "account_number": "5114"
+          },
+          "account_number": "511"
+        },
+        "Banques": {
+          "account_type": "Bank",
+          "Comptes en monnaie nationale": {
+            "account_type": "Bank",
+            "account_number": "5121"
+          },
+          "Comptes en devises": {
+            "account_type": "Bank",
+            "account_number": "5124"
+          },
+          "account_number": "512"
+        },
+        "Ch\u00e8ques postaux": {
+          "account_number": "514"
+        },
+        "\"Caisses\" du Tr\u00e9sor et des \u00e9tablissements publics": {
+          "account_number": "515"
+        },
+        "Soci\u00e9t\u00e9s de bourse": {
+          "account_number": "516"
+        },
+        "Autres organismes financiers": {
+          "account_number": "517"
+        },
+        "Int\u00e9r\u00eats courus": {
+          "Int\u00e9r\u00eats courus \u00e0 payer": {
+            "account_number": "5181"
+          },
+          "Int\u00e9r\u00eats courus \u00e0 recevoir": {
+            "account_number": "5188"
+          },
+          "account_number": "518"
+        },
+        "Concours bancaires courants": {
+          "Cr\u00e9dit de mobilisation des cr\u00e9ances commerciales (CMCC)": {
+            "account_number": "5191"
+          },
+          "Mobilisation de cr\u00e9ances n\u00e9es \u00e0 l'\u00e9tranger": {
+            "account_number": "5193"
+          },
+          "Int\u00e9r\u00eats courus sur concours bancaires courants": {
+            "account_number": "5198"
+          },
+          "account_number": "519"
+        },
+        "account_number": "51"
+      },
+      "Instruments de tr\u00e9sorerie": {
+        "is_group": 1,
+        "account_number": "52"
+      },
+      "Caisse": {
+        "account_type": "Cash",
+        "Caisse si\u00e8ge social": {
+          "account_type": "Cash",
+          "Caisse en monnaie nationale": {
+            "account_type": "Cash",
+            "account_number": "5311"
+          },
+          "Caisse en devises": {
+            "account_type": "Cash",
+            "account_number": "5314"
+          },
+          "account_number": "531"
+        },
+        "Caisse succursale (ou usine) A": {
+          "account_type": "Cash",
+          "account_number": "532"
+        },
+        "Caisse succursale (ou usine) B": {
+          "account_type": "Cash",
+          "account_number": "533"
+        },
+        "account_number": "53"
+      },
+      "R\u00e9gies d'avance et accr\u00e9ditifs": {
+        "is_group": 1,
+        "account_number": "54"
+      },
+      "Virements internes": {
+        "is_group": 1,
+        "account_number": "58"
+      },
+      "D\u00e9pr\u00e9ciations des comptes financiers": {
+        "D\u00e9pr\u00e9ciations des valeurs mobili\u00e8res de placement": {
+          "Actions": {
+            "account_number": "5903"
+          },
+          "Autres titres conf\u00e9rant un droit de propri\u00e9t\u00e9": {
+            "account_number": "5904"
+          },
+          "Obligations": {
+            "account_number": "5906"
+          },
+          "Autres valeurs mobili\u00e8res de placement et cr\u00e9ances assimil\u00e9es": {
+            "account_number": "5908"
+          },
+          "account_number": "590"
+        },
+        "account_number": "59"
+      },
+      "account_number": "5"
+    },
+    "Comptes de Charges": {
+      "root_type": "Expense",
+      "Achats (sauf 603)": {
+        "Achats stock\u00e9s - Mati\u00e8res premi\u00e8res (et fournitures)": {
+          "account_type": "Cost of Goods Sold",
+          "Mati\u00e8res (ou groupe) A": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6011"
+          },
+          "Mati\u00e8res (ou groupe) B": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6012"
+          },
+          "Fournitures A, B, C...": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6017"
+          },
+          "account_number": "601"
+        },
+        "Achats stock\u00e9s - Autres approvisionnements": {
+          "account_type": "Cost of Goods Sold",
+          "Mati\u00e8res consommables": {
+            "account_type": "Cost of Goods Sold",
+            "Mati\u00e8res (ou groupe) C": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60211"
+            },
+            "Mati\u00e8res (ou groupe) D": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60212"
+            },
+            "account_number": "6021"
+          },
+          "Fournitures consommables": {
+            "account_type": "Cost of Goods Sold",
+            "Combustibles": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60221"
+            },
+            "Produits d'entretien": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60222"
+            },
+            "Fournitures d'atelier et d'usine": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60223"
+            },
+            "Fournitures de magasin": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60224"
+            },
+            "Fournitures de bureau": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60225"
+            },
+            "account_number": "6022"
+          },
+          "Emballages": {
+            "account_type": "Cost of Goods Sold",
+            "Emballages perdus": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60261"
+            },
+            "Emballages r\u00e9cup\u00e9rables non identifiables": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60265"
+            },
+            "Emballages \u00e0 usage mixte": {
+              "account_type": "Cost of Goods Sold",
+              "account_number": "60267"
+            },
+            "account_number": "6026"
+          },
+          "account_number": "602"
+        },
+        "Variations des stocks (approvisionnements et marchandises)": {
+          "account_type": "Stock Adjustment",
+          "Variation des stocks de mati\u00e8res premi\u00e8res (et fournitures)": {
+            "account_type": "Stock Adjustment",
+            "account_number": "6031"
+          },
+          "Variation des stocks des autres approvisionnements": {
+            "account_type": "Stock Adjustment",
+            "account_number": "6032"
+          },
+          "Variation des stocks de marchandises": {
+            "account_type": "Stock Adjustment",
+            "account_number": "6037"
+          },
+          "account_number": "603"
+        },
+        "Achats d'\u00e9tudes et prestations de service": {
+          "account_type": "Cost of Goods Sold",
+          "account_number": "604"
+        },
+        "Achats de mat\u00e9riel, \u00e9quipements et travaux": {
+          "account_type": "Cost of Goods Sold",
+          "account_number": "605"
+        },
+        "Achats non stock\u00e9s de mati\u00e8res et founitures": {
+          "account_type": "Cost of Goods Sold",
+          "Fournitures non stockables (eau, \u00e9nergie...)": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6061"
+          },
+          "Fournitures d'entretien et de petit \u00e9quipement": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6063"
+          },
+          "Fournitures administratives": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6064"
+          },
+          "Autres mati\u00e8res et fournitures": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6068"
+          },
+          "account_number": "606"
+        },
+        "Achats de marchandises": {
+          "account_type": "Cost of Goods Sold",
+          "Marchandises (ou groupe) A": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6071"
+          },
+          "Marchandises (ou groupe) B": {
+            "account_type": "Cost of Goods Sold",
+            "account_number": "6072"
+          },
+          "account_number": "607"
+        },
+        "(Compte r\u00e9serv\u00e9, le cas \u00e9ch\u00e9ant, \u00e0 la recapitulation des Frais accessoires incorpor\u00e9s aux achats)": {
+          "account_type": "Expenses Included In Valuation",
+          "account_number": "608"
+        },
+        "Rabais, remises et ristournes obtenus sur achats": {
+          "Rabais, remises et ristournes obtenus sur achats - de mati\u00e8res premi\u00e8res (et fournitures)": {
+            "account_number": "6091"
+          },
+          "Rabais, remises et ristournes obtenus sur achats - d'autres approvisionnements stock\u00e9s": {
+            "account_number": "6092"
+          },
+          "Rabais, remises et ristournes obtenus sur achats - d'\u00e9tudes et prestations de services": {
+            "account_number": "6094"
+          },
+          "Rabais, remises et ristournes obtenus sur achats - de mat\u00e9riel, \u00e9quipements et travaux": {
+            "account_number": "6095"
+          },
+          "Rabais, remises et ristournes obtenus sur achats - d'approvisionnements non stock\u00e9s": {
+            "account_number": "6096"
+          },
+          "Rabais, remises et ristournes obtenus sur achats - de marchandises": {
+            "account_number": "6097"
+          },
+          "Rabais, remises et ristournes non affect\u00e9s": {
+            "account_number": "6098"
+          },
+          "account_number": "609"
+        },
+        "account_number": "60"
+      },
+      "Services ext\u00e9rieurs": {
+        "Sous-traitance g\u00e9n\u00e9rale": {
+          "account_number": "611"
+        },
+        "Redevances de cr\u00e9dit-bail": {
+          "Cr\u00e9dit-bail mobilier": {
+            "account_number": "6122"
+          },
+          "Cr\u00e9dit-bail immobilier": {
+            "account_number": "6125"
+          },
+          "account_number": "612"
+        },
+        "Locations": {
+          "Locations immobili\u00e8res": {
+            "account_number": "6132"
+          },
+          "Locations mobili\u00e8res": {
+            "account_number": "6135"
+          },
+          "Malis sur emballages": {
+            "account_number": "6136"
+          },
+          "account_number": "613"
+        },
+        "Charges locatives et de copropri\u00e9t\u00e9": {
+          "account_number": "614"
+        },
+        "Entretiens et r\u00e9parations": {
+          "Entretiens et r\u00e9parations - sur biens immobiliers": {
+            "account_number": "6152"
+          },
+          "Entretiens et r\u00e9parations - sur biens mobiliers": {
+            "account_number": "6155"
+          },
+          "Maintenance": {
+            "account_number": "6156"
+          },
+          "account_number": "615"
+        },
+        "Primes d'assurance": {
+          "Multirisques": {
+            "account_number": "6161"
+          },
+          "Assurance obligatoire dommage construction": {
+            "account_number": "6162"
+          },
+          "Assurance-transport": {
+            "Assurance-transport - sur achats": {
+              "account_number": "61636"
+            },
+            "Assurance-transport - sur ventes": {
+              "account_number": "61637"
+            },
+            "Assurance-transport - sur autres biens": {
+              "account_number": "61638"
+            },
+            "account_number": "6163"
+          },
+          "Risques d'exploitation": {
+            "account_number": "6164"
+          },
+          "Insolvabilit\u00e9 clients": {
+            "account_number": "6165"
+          },
+          "account_number": "616"
+        },
+        "Etudes et recherches": {
+          "account_number": "617"
+        },
+        "Divers": {
+          "Documentation g\u00e9n\u00e9rale": {
+            "account_number": "6181"
+          },
+          "Documentation technique": {
+            "account_number": "6183"
+          },
+          "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+            "account_number": "6185"
+          },
+          "account_number": "618"
+        },
+        "Rabais, remises et ristournes obtenus sur services ext\u00e9rieurs": {
+          "account_number": "619"
+        },
+        "account_number": "61"
+      },
+      "Autres services ext\u00e9rieurs": {
+        "Personnel ext\u00e9rieur \u00e0 l'entreprise": {
+          "Personnel int\u00e9rimaire": {
+            "account_number": "6211"
+          },
+          "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l'entreprise": {
+            "account_number": "6214"
+          },
+          "account_number": "621"
+        },
+        "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et honoraires": {
+          "Commissions et courtages sur achats": {
+            "account_number": "6221"
+          },
+          "Commissions et courtages sur ventes": {
+            "account_number": "6222"
+          },
+          "R\u00e9mun\u00e9rations des transitaires": {
+            "account_number": "6224"
+          },
+          "R\u00e9mun\u00e9rations d'affacturage": {
+            "account_number": "6225"
+          },
+          "Honoraires": {
+            "Honoraires sur legs ou donations destin\u00e9s \u00e0 \u00eatre c\u00e9d\u00e9s": {
+              "account_number": "62264"
+            },
+            "account_number": "6226"
+          },
+          "Frais d'actes et de contentieux": {
+            "account_number": "6227"
+          },
+          "Divers": {
+            "account_number": "6228"
+          },
+          "account_number": "622"
+        },
+        "Publicit\u00e9, publications, relations publiques": {
+          "Annonces et insertions": {
+            "account_number": "6231"
+          },
+          "Echantillons": {
+            "account_number": "6232"
+          },
+          "Foires et expositions": {
+            "account_number": "6233"
+          },
+          "Cadeaux \u00e0 la client\u00e8le": {
+            "account_number": "6234"
+          },
+          "Primes": {
+            "account_number": "6235"
+          },
+          "Catalogues et imprim\u00e9s": {
+            "account_number": "6236"
+          },
+          "Publications": {
+            "account_number": "6237"
+          },
+          "Divers (pourboires, dons courants...)": {
+            "account_number": "6238"
+          },
+          "account_number": "623"
+        },
+        "Transports de biens et transports collectifs du personnel": {
+          "Transports sur achats": {
+            "account_number": "6241"
+          },
+          "Transports sur ventes": {
+            "account_type": "Chargeable",
+            "account_number": "6242"
+          },
+          "Transports entre \u00e9tablissements ou chantiers": {
+            "account_number": "6243"
+          },
+          "Transports administratifs": {
+            "account_number": "6244"
+          },
+          "Transports collectifs du personnel": {
+            "account_number": "6247"
+          },
+          "Divers": {
+            "account_number": "6248"
+          },
+          "account_number": "624"
+        },
+        "D\u00e9placements, missions et r\u00e9ceptions": {
+          "Voyages et d\u00e9placements": {
+            "account_number": "6251"
+          },
+          "Frais de d\u00e9m\u00e9nagement": {
+            "account_number": "6255"
+          },
+          "Missions": {
+            "account_number": "6256"
+          },
+          "R\u00e9ceptions": {
+            "account_number": "6257"
+          },
+          "account_number": "625"
+        },
+        "Frais postaux et de t\u00e9l\u00e9communications": {
+          "account_number": "626"
+        },
+        "Services bancaires et assimil\u00e9s": {
+          "Frais sur titres (achat, vente, garde)": {
+            "account_number": "6271"
+          },
+          "Commissions et frais sur \u00e9mission d'emprunts": {
+            "account_number": "6272"
+          },
+          "Frais sur effets": {
+            "account_number": "6275"
+          },
+          "Location de coffres": {
+            "account_number": "6276"
+          },
+          "Autres frais et commissions sur prestations de services": {
+            "account_number": "6278"
+          },
+          "account_number": "627"
+        },
+        "Divers": {
+          "Concours divers (cotisations...)": {
+            "account_number": "6281"
+          },
+          "Frais de recrutement de personnel": {
+            "account_number": "6284"
+          },
+          "account_number": "628"
+        },
+        "Rabais, remises et ristournes obtenus sur autres services ext\u00e9rieurs": {
+          "account_number": "629"
+        },
+        "account_number": "62"
+      },
+      "Imp\u00f4ts, taxes et versements assimil\u00e9s": {
+        "Imp\u00f4ts, taxes et versements assimil\u00e9s sur r\u00e9mun\u00e9rations (administrations des imp\u00f4ts)": {
+          "Taxes sur les salaires": {
+            "account_number": "6311"
+          },
+          "Taxe d'apprentissage": {
+            "account_number": "6312"
+          },
+          "Participation des employeurs \u00e0 la formation professionnelle continue": {
+            "account_number": "6313"
+          },
+          "Cotisation pour d\u00e9faut d'investissement obligatoire dans la construction": {
+            "account_number": "6314"
+          },
+          "Autres": {
+            "account_number": "6318"
+          },
+          "account_number": "631"
+        },
+        "Imp\u00f4ts, taxes et versements assimil\u00e9s sur r\u00e9mun\u00e9rations (autres organismes)": {
+          "Versement de transport": {
+            "account_number": "6331"
+          },
+          "Allocations logement": {
+            "account_number": "6332"
+          },
+          "Participation des employeurs \u00e0 la formation professionnelle continue": {
+            "account_number": "6333"
+          },
+          "Participation des employeurs \u00e0 l'effort de construction": {
+            "account_number": "6334"
+          },
+          "Versements lib\u00e9ratoires ouvrant droit \u00e0 l'\u00e9xon\u00e9ration de la taxe d'apprentissage": {
+            "account_number": "6335"
+          },
+          "Autres": {
+            "account_number": "6338"
+          },
+          "account_number": "633"
+        },
+        "Autres imp\u00f4ts, taxes et versements assimil\u00e9s (administrations des imp\u00f4ts)": {
+          "Imp\u00f4ts directs (sauf imp\u00f4ts sur les b\u00e9n\u00e9fices)": {
+            "Contribution \u00e9conomique territoriale": {
+              "account_number": "63511"
+            },
+            "Taxes fonci\u00e8res": {
+              "account_number": "63512"
+            },
+            "Autres imp\u00f4ts locaux": {
+              "account_number": "63513"
+            },
+            "Taxe sur les v\u00e9hicules des soci\u00e9t\u00e9s": {
+              "account_number": "63514"
+            },
+            "account_number": "6351"
+          },
+          "Taxes sur le chiffre d'affaires non r\u00e9cup\u00e9rables": {
+            "account_number": "6352"
+          },
+          "Imp\u00f4ts indirects": {
+            "account_number": "6353"
+          },
+          "Droits d'enregistrement et de timbre": {
+            "Droits de mutation": {
+              "account_number": "63541"
+            },
+            "account_number": "6354"
+          },
+          "Autres droits": {
+            "account_number": "6358"
+          },
+          "account_number": "635"
+        },
+        "Autres imp\u00f4ts, taxes et versements assimil\u00e9s (autres organismes)": {
+          "Contribution sociale de solidarit\u00e9 \u00e0 la charge des soci\u00e9t\u00e9s": {
+            "account_number": "6371"
+          },
+          "Taxes per\u00e7ues par les organismes publics internationaux": {
+            "account_number": "6372"
+          },
+          "Imp\u00f4ts et taxes exigibles \u00e0 l'\u00e9tranger": {
+            "account_number": "6374"
+          },
+          "Taxes diverses": {
+            "account_number": "6378"
+          },
+          "account_number": "637"
+        },
+        "account_number": "63"
+      },
+      "Charges de personnel": {
+        "R\u00e9mun\u00e9rations du personnel": {
+          "Salaires, appointements": {
+            "account_number": "6411"
+          },
+          "Cong\u00e9s pay\u00e9s": {
+            "account_number": "6412"
+          },
+          "Primes et gratifications": {
+            "account_number": "6413"
+          },
+          "Indemnit\u00e9s et avantages divers": {
+            "account_number": "6414"
+          },
+          "Suppl\u00e9ment familial": {
+            "account_number": "6415"
+          },
+          "account_number": "641"
+        },
+        "R\u00e9mun\u00e9ration du travail de l'exploitant": {
+          "account_number": "644"
+        },
+        "Charges de s\u00e9curit\u00e9 sociale et de pr\u00e9voyance": {
+          "Cotisations \u00e0 l'URSSAF": {
+            "account_number": "6451"
+          },
+          "Cotisations aux mutuelles": {
+            "account_number": "6452"
+          },
+          "Cotisations aux caisses de retraites": {
+            "account_number": "6453"
+          },
+          "Cotisations aux ASSEDIC": {
+            "account_number": "6454"
+          },
+          "account_number": "645"
+        },
+        "Cotisations sociales personnelles de l'exploitant": {
+          "account_number": "646"
+        },
+        "Autres charges sociales": {
+          "is_group": 1,
+          "account_number": "647"
+        },
+        "Autres charges de personnel": {
+          "account_number": "648"
+        },
+        "account_number": "64"
+      },
+      "Autres charges de gestion courante": {
+        "Redevances pour concessions, brevets, licences, marques, proc\u00e9d\u00e9s, logiciels, droits et valeurs similaires": {
+          "Redevances pour concessions, brevets, licences, marques, proc\u00e9d\u00e9s, logiciels": {
+            "account_number": "6511"
+          },
+          "Droits d'auteur et de reproduction": {
+            "account_number": "6516"
+          },
+          "Autres droits et valeurs similaires": {
+            "account_number": "6518"
+          },
+          "account_number": "651"
+        },
+        "Charges de la g\u00e9n\u00e9rosit\u00e9 du public": {
+          "Autres charges sur legs ou donations": {
+            "account_number": "6531"
+          },
+          "account_number": "653"
+        },
+        "Pertes sur cr\u00e9ances irr\u00e9couvrables": {
+          "Cr\u00e9ances de l'exercice": {
+            "account_number": "6541"
+          },
+          "Cr\u00e9ances des exercices ant\u00e9rieurs": {
+            "account_number": "6544"
+          },
+          "account_number": "654"
+        },
+        "Quotes-parts de r\u00e9sultat sur op\u00e9rations faites en commun": {
+          "Quote-part de b\u00e9n\u00e9fice transf\u00e9r\u00e9e (comptabilit\u00e9 du g\u00e9rant)": {
+            "account_number": "6551"
+          },
+          "Quote-part de perte support\u00e9e (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+            "account_number": "6555"
+          },
+          "account_number": "655"
+        },
+        "Pertes de change sur cr\u00e9ances et dettes commerciales": {
+          "account_number": "656"
+        },
+        "Charges diverses de gestion courante": {
+          "account_number": "658"
+        },
+        "Aides financi\u00e8res": {
+          "account_number": "657"
+        },
+        "account_number": "65"
+      },
+      "Charges financi\u00e8res": {
+        "Charges d'int\u00e9r\u00eats": {
+          "Int\u00e9r\u00eats des emprunts et dettes": {
+            "Int\u00e9r\u00eats des emprunts et dettes - des emprunts et dettes assimil\u00e9es": {
+              "account_number": "66116"
+            },
+            "Int\u00e9r\u00eats des emprunts et dettes - des dettes rattach\u00e9es \u00e0 des participations": {
+              "account_number": "66117"
+            },
+            "account_number": "6611"
+          },
+          "Charges de la fiducie, r\u00e9sultat de la p\u00e9riode": {
+            "account_number": "6612"
+          },
+          "Int\u00e9r\u00eats des comptes courants et des d\u00e9p\u00f4ts cr\u00e9diteurs": {
+            "account_number": "6615"
+          },
+          "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+            "account_number": "6616"
+          },
+          "Int\u00e9r\u00eats des obligations cautionn\u00e9es": {
+            "account_number": "6617"
+          },
+          "Int\u00e9r\u00eats des autres dettes": {
+            "Int\u00e9r\u00eats des autres dettes - des dettes commerciales": {
+              "account_number": "66181"
+            },
+            "Int\u00e9r\u00eats des autres dettes - des dettes diverses": {
+              "account_number": "66188"
+            },
+            "account_number": "6618"
+          },
+          "account_number": "661"
+        },
+        "Pertes sur cr\u00e9ances li\u00e9es \u00e0 des participations": {
+          "account_number": "664"
+        },
+        "Escomptes accord\u00e9s": {
+          "account_number": "665"
+        },
+        "Pertes de change financi\u00e8res": {
+          "account_type": "Round Off",
+          "account_number": "666"
+        },
+        "Charges nettes sur cessions de valeurs mobili\u00e8res de placement": {
+          "account_number": "667"
+        },
+        "Autres charges financi\u00e8res": {
+          "account_number": "668"
+        },
+        "account_number": "66"
+      },
+      "Charges exceptionnelles": {
+        "Charges exceptionnelles sur op\u00e9rations de gestion": {
+          "P\u00e9nalit\u00e9s sur march\u00e9s (et d\u00e9dits pay\u00e9s sur achats et ventes)": {
+            "account_number": "6711"
+          },
+          "P\u00e9nalit\u00e9s, amendes fiscales et p\u00e9nales": {
+            "account_number": "6712"
+          },
+          "Dons, lib\u00e9ralit\u00e9s": {
+            "account_number": "6713"
+          },
+          "Cr\u00e9ances devenues irr\u00e9couvrables dans l'exercice": {
+            "account_number": "6714"
+          },
+          "Subventions accord\u00e9es": {
+            "account_number": "6715"
+          },
+          "Rappel d'imp\u00f4ts (autres qu'imp\u00f4ts sur les b\u00e9n\u00e9fices)": {
+            "account_number": "6717"
+          },
+          "Autres charges exceptionnelles sur op\u00e9rations de gestion": {
+            "account_number": "6718"
+          },
+          "account_number": "671"
+        },
+        "(Compte \u00e0 la disposition des entit\u00e9s pour enregistrer, en cours d'exercice, les charges sur exercices ant\u00e9rieurs)": {
+          "account_number": "672"
+        },
+        "Op\u00e9rations de constitution ou liquidation des fiducies": {
+          "Op\u00e9rations li\u00e9es \u00e0 la constitution de la fiducie - transfert des \u00e9l\u00e9ments": {
+            "account_number": "6741"
+          },
+          "Op\u00e9rations li\u00e9es \u00e0 la liquidation de la fiducie": {
+            "account_number": "6742"
+          },
+          "account_number": "674"
+        },
+        "Valeurs comptables des \u00e9l\u00e9ments d\u2019actifs c\u00e9d\u00e9s": {
+          "Immobilisations incorporelles": {
+            "account_number": "6751"
+          },
+          "Immobilisations corporelles": {
+            "account_number": "6752"
+          },
+          "Immobilisations financi\u00e8res": {
+            "account_number": "6756"
+          },
+          "Autres \u00e9l\u00e9ments d'actif": {
+            "account_number": "6758"
+          },
+          "Immobilisations re\u00e7ues par legs ou donations": {
+            "account_number": "6754"
+          },
+          "account_number": "675"
+        },
+        "Autres charges exceptionnelles": {
+          "Mali provenant de clauses d'indexation": {
+            "account_number": "6781"
+          },
+          "Lots": {
+            "account_number": "6782"
+          },
+          "Malis provenant du rachat par l'entreprise d'actions et obligations \u00e9mises par elles-m\u00eame": {
+            "account_number": "6783"
+          },
+          "Charges exceptionnelles diverses": {
+            "account_number": "6788"
+          },
+          "account_number": "678"
+        },
+        "Apports ou affectations en num\u00e9raire": {
+          "account_number": "673"
+        },
+        "account_number": "67"
+      },
+      "Dotations aux amortissements, provisions et engagements": {
+        "account_type": "Depreciation",
+        "Dotations aux amortissements, d\u00e9pr\u00e9ciations et provisions - Charges d'exploitation": {
+          "account_type": "Depreciation",
+          "Dotations aux amortissements sur immobilisations incorporelles et corporelles": {
+            "account_type": "Depreciation",
+            "Immobilisations incorporelles": {
+              "account_type": "Depreciation",
+              "account_number": "68111"
+            },
+            "Immobilisations corporelles": {
+              "account_type": "Depreciation",
+              "account_number": "68112"
+            },
+            "account_number": "6811"
+          },
+          "Dotations aux amortissements des charges d'exploitation \u00e0 r\u00e9partir": {
+            "account_type": "Depreciation",
+            "account_number": "6812"
+          },
+          "Dotations aux provisions d'exploitation": {
+            "account_type": "Depreciation",
+            "account_number": "6815"
+          },
+          "Dotations pour d\u00e9pr\u00e9ciations des immobilisations incorporelles et corporelles": {
+            "account_type": "Depreciation",
+            "Immobilisations incorporelles": {
+              "account_type": "Depreciation",
+              "account_number": "68161"
+            },
+            "Immobilisations corporelles": {
+              "account_type": "Depreciation",
+              "account_number": "68162"
+            },
+            "Dotations pour d\u00e9pr\u00e9ciation d\u2019actifs re\u00e7us par legs ou donations destin\u00e9s \u00e0 \u00eatre c\u00e9d\u00e9s": {
+              "account_number": "68164"
+            },
+            "account_number": "6816"
+          },
+          "Dotations pour d\u00e9pr\u00e9ciations des actifs circulants": {
+            "account_type": "Depreciation",
+            "Stocks et en-cours": {
+              "account_type": "Depreciation",
+              "account_number": "68173"
+            },
+            "Cr\u00e9ances": {
+              "account_type": "Depreciation",
+              "account_number": "68174"
+            },
+            "account_number": "6817"
+          },
+          "account_number": "681"
+        },
+        "Dotations aux amortissements, d\u00e9pr\u00e9ciations et provisions - Charges financi\u00e8res": {
+          "account_type": "Depreciation",
+          "Dotations aux amortissements des primes de remboursement des obligations": {
+            "account_type": "Depreciation",
+            "account_number": "6861"
+          },
+          "Dotations aux provisions financi\u00e8res": {
+            "account_type": "Depreciation",
+            "account_number": "6865"
+          },
+          "Dotations aux d\u00e9pr\u00e9ciations des \u00e9l\u00e9ments financiers": {
+            "account_type": "Depreciation",
+            "Immobilisations financi\u00e8res": {
+              "account_type": "Depreciation",
+              "account_number": "68662"
+            },
+            "Valeurs mobili\u00e8res de placement": {
+              "account_type": "Depreciation",
+              "account_number": "68665"
+            },
+            "account_number": "6866"
+          },
+          "Autres dotations": {
+            "account_type": "Depreciation",
+            "account_number": "6868"
+          },
+          "account_number": "686"
+        },
+        "Dotations aux amortissements, d\u00e9pr\u00e9ciations et provisions - Charges exceptionnelles": {
+          "account_type": "Depreciation",
+          "Dotations aux amortissements exceptionnels des immobilisations": {
+            "account_type": "Depreciation",
+            "account_number": "6871"
+          },
+          "Dotations aux provisions r\u00e9glement\u00e9es (immobilisations)": {
+            "account_type": "Depreciation",
+            "Amortissements d\u00e9rogatoires": {
+              "account_type": "Depreciation",
+              "account_number": "68725"
+            },
+            "account_number": "6872"
+          },
+          "Dotations aux provisions r\u00e9glement\u00e9es (stocks)": {
+            "account_type": "Depreciation",
+            "account_number": "6873"
+          },
+          "Dotations aux autres provisions r\u00e9glement\u00e9es": {
+            "account_type": "Depreciation",
+            "account_number": "6874"
+          },
+          "Dotations aux provisions exceptionnelles": {
+            "account_type": "Depreciation",
+            "account_number": "6875"
+          },
+          "Dotations aux d\u00e9pr\u00e9ciations exceptionnelles": {
+            "account_type": "Depreciation",
+            "account_number": "6876"
+          },
+          "account_number": "687"
+        },
+        "Reports en fonds d\u00e9di\u00e9s": {
+          "Reports en fonds report\u00e9s": {
+            "account_number": "6891"
+          },
+          "Reports en fonds d\u00e9di\u00e9s sur subventions d\u2019exploitation": {
+            "account_number": "6894"
+          },
+          "Reports en fonds d\u00e9di\u00e9s sur contributions financi\u00e8res d\u2019autres organismes": {
+            "account_number": "6895"
+          },
+          "Reports en fonds d\u00e9di\u00e9s sur ressources li\u00e9es \u00e0 la g\u00e9n\u00e9rosit\u00e9 du public": {
+            "account_number": "6896"
+          },
+          "account_number": "689"
+        },
+        "account_number": "68"
+      },
+      "Participation des salari\u00e9s, imp\u00f4ts sur les b\u00e9n\u00e9fices et assimil\u00e9s": {
+        "Participation des salari\u00e9s aux r\u00e9sultats": {
+          "account_number": "691"
+        },
+        "Imp\u00f4ts sur les b\u00e9n\u00e9fices": {
+          "Imp\u00f4ts dus en France": {
+            "account_number": "6951"
+          },
+          "Contribution additionnelle \u00e0 l'imp\u00f4t sur les b\u00e9n\u00e9fices": {
+            "account_number": "6952"
+          },
+          "Imp\u00f4ts dus \u00e0 l'\u00e9tranger": {
+            "account_number": "6954"
+          },
+          "account_number": "695"
+        },
+        "Suppl\u00e9ments d'imp\u00f4ts sur les soci\u00e9t\u00e9s, li\u00e9s aux distributions": {
+          "account_number": "696"
+        },
+        "Int\u00e9gration fiscale": {
+          "Int\u00e9gration fiscale - Charges": {
+            "account_number": "6981"
+          },
+          "Int\u00e9gration fiscale - Produits": {
+            "account_number": "6989"
+          },
+          "account_number": "698"
+        },
+        "Produits - Report en arri\u00e8re des d\u00e9ficits": {
+          "account_number": "699"
+        },
+        "account_number": "69"
+      },
+      "account_number": "6"
+    },
+    "Comptes de Produits": {
+      "root_type": "Income",
+      "Ventes de produits fabriqu\u00e9s, prestations de services, marchandises": {
+        "Ventes de produits finis": {
+          "Produits finis (ou groupe) A": {
+            "account_number": "7011"
+          },
+          "Produits (ou groupe) B": {
+            "account_number": "7012"
+          },
+          "account_number": "701"
+        },
+        "Ventes de produits interm\u00e9diaires": {
+          "account_number": "702"
+        },
+        "Ventes de produits r\u00e9siduels": {
+          "account_number": "703"
+        },
+        "Travaux": {
+          "Travaux de cat\u00e9gorie (ou activit\u00e9) A": {
+            "account_number": "7041"
+          },
+          "Travaux de cat\u00e9gorie (ou activit\u00e9) B": {
+            "account_number": "7042"
+          },
+          "account_number": "704"
+        },
+        "Etudes": {
+          "account_number": "705"
+        },
+        "Ventes de prestations de services": {
+          "Parrainages": {
+            "account_number": "7063"
+          },
+          "account_number": "706"
+        },
+        "Ventes de marchandises": {
+          "Marchandises (ou groupe) A": {
+            "account_number": "7071"
+          },
+          "Marchandises (ou groupe) B": {
+            "account_number": "7072"
+          },
+          "Ventes de dons en nature": {
+            "account_number": "7073"
+          },
+          "account_number": "707"
+        },
+        "Produits des activit\u00e9s annexes": {
+          "Produits des services exploit\u00e9s dans l'int\u00e9r\u00eat du personnel": {
+            "account_number": "7081"
+          },
+          "Commissions et courtages": {
+            "account_number": "7082"
+          },
+          "Locations diverses": {
+            "account_number": "7083"
+          },
+          "Mise \u00e0 disposition de personnel factur\u00e9e": {
+            "account_number": "7084"
+          },
+          "Ports et frais accessoires factur\u00e9s": {
+            "account_number": "7085"
+          },
+          "Bonis sur reprises d'emballages consign\u00e9s": {
+            "account_number": "7086"
+          },
+          "Bonifications obtenues des clients et primes sur ventes": {
+            "account_number": "7087"
+          },
+          "Autres produits d'activit\u00e9s annexes (cessions d'approvisionnements...)": {
+            "account_number": "7088"
+          },
+          "account_number": "708"
+        },
+        "Rabais, remises et ristournes accord\u00e9s par l'entreprise": {
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur ventes de produits finis": {
+            "account_number": "7091"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur ventes de produits interm\u00e9diaires": {
+            "account_number": "7092"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur travaux": {
+            "account_number": "7094"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur \u00e9tudes": {
+            "account_number": "7095"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur prestations de services": {
+            "account_number": "7096"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur ventes de marchandises": {
+            "account_number": "7097"
+          },
+          "Rabais, remises et ristournes accord\u00e9s par l'entreprise - sur produits des activit\u00e9s annexes": {
+            "account_number": "7098"
+          },
+          "account_number": "709"
+        },
+        "account_number": "70"
+      },
+      "Production stock\u00e9e (ou d\u00e9stockage)": {
+        "Variation des stocks (en-cours de production, produits)": {
+          "Variation des en-cours de production de biens": {
+            "Produits en cours": {
+              "account_number": "71331"
+            },
+            "Travaux en cours": {
+              "account_number": "71335"
+            },
+            "account_number": "7133"
+          },
+          "Variation des en-cours de production de services": {
+            "Etudes en cours": {
+              "account_number": "71341"
+            },
+            "Prestations de services en cours": {
+              "account_number": "71345"
+            },
+            "account_number": "7134"
+          },
+          "Variation des stocks de produits": {
+            "Produits interm\u00e9diaires": {
+              "account_number": "71351"
+            },
+            "Produits finis": {
+              "account_number": "71355"
+            },
+            "Produits r\u00e9siduels": {
+              "account_number": "71358"
+            },
+            "account_number": "7135"
+          },
+          "account_number": "713"
+        },
+        "account_number": "71"
+      },
+      "Production immobilis\u00e9e": {
+        "Immobilisations incorporelles": {
+          "account_number": "721"
+        },
+        "Immobilisations corporelles": {
+          "account_number": "722"
+        },
+        "account_number": "72"
+      },
+      "Subventions d'exploitation": {
+        "is_group": 1,
+        "account_number": "74"
+      },
+      "Autres produits de gestion courante": {
+        "Redevances pour concessions, brevets, licences, marques, proc\u00e9d\u00e9s, logiciels, droits et valeurs similaires": {
+          "Redevances pour concessions, brevets, licences, marques, proc\u00e9d\u00e9s, logiciels": {
+            "account_number": "7511"
+          },
+          "Droits d'auteur et de reproduction": {
+            "account_number": "7516"
+          },
+          "Autres droits et valeurs similaires": {
+            "account_number": "7518"
+          },
+          "account_number": "751"
+        },
+        "Revenus des immeubles non affect\u00e9s aux activit\u00e9s professionnelles": {
+          "account_number": "752"
+        },
+        "Versements des fondateurs ou consommation de la dotation": {
+          "Versements des fondateurs": {
+            "account_number": "7531"
+          },
+          "Quotes-parts de dotation consomptible vir\u00e9e au compte de r\u00e9sultat": {
+            "account_number": "7532"
+          },
+          "account_number": "753"
+        },
+        "Ressources li\u00e9es \u00e0 la g\u00e9n\u00e9rosit\u00e9 du public": {
+          "Dons manuels": {
+            "Dons manuels": {
+              "account_number": "75411"
+            },
+            "Abandons de frais par les b\u00e9n\u00e9voles": {
+              "account_number": "75412"
+            },
+            "account_number": "7541"
+          },
+          "M\u00e9c\u00e9nats": {
+            "account_number": "7542"
+          },
+          "Legs, donations et assurances-vie": {
+            "Assurances-vie": {
+              "account_number": "75431"
+            },
+            "Legs ou donations": {
+              "account_number": "75432"
+            },
+            "Autres produits sur legs ou donations": {
+              "account_number": "75433"
+            },
+            "account_number": "7543"
+          },
+          "account_number": "754"
+        },
+        "Contributions financi\u00e8res": {
+          "Contributions financi\u00e8res d\u2019autres organismes": {
+            "account_number": "7551"
+          },
+          "Quote-part de b\u00e9n\u00e9fice attribu\u00e9 (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+            "account_number": "7555"
+          },
+          "Quotes-parts de g\u00e9n\u00e9rosit\u00e9 re\u00e7ues": {
+            "account_number": "7552"
+          },
+          "account_number": "755"
+        },
+        "Cotisations": {
+          "Cotisations sans contrepartie": {
+            "account_number": "7561"
+          },
+          "Cotisations avec contrepartie": {
+            "account_number": "7562"
+          },
+          "account_number": "756"
+        },
+        "Produits divers de gestion courante": {
+          "account_number": "758"
+        },
+        "Gains de change sur cr\u00e9ances et dettes d\u2019exploitation": {
+          "account_number": "757"
+        },
+        "account_number": "75"
+      },
+      "Produits financiers": {
+        "Produits de participations": {
+          "Revenus des titres de participation": {
+            "account_number": "7611"
+          },
+          "Produits de la fiducie, r\u00e9sultat de la p\u00e9riode": {
+            "account_number": "7612"
+          },
+          "Revenus sur autres formes de participation": {
+            "account_number": "7616"
+          },
+          "Revenus des cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+            "account_number": "7617"
+          },
+          "account_number": "761"
+        },
+        "Produits des autres immobilisations financi\u00e8res": {
+          "Revenus des titres immobilis\u00e9s": {
+            "account_number": "7621"
+          },
+          "Revenus des pr\u00eats": {
+            "account_number": "7626"
+          },
+          "Revenus des cr\u00e9ances immobilis\u00e9es": {
+            "account_number": "7627"
+          },
+          "account_number": "762"
+        },
+        "Revenus des autres cr\u00e9ances": {
+          "Revenus des cr\u00e9ances commerciales": {
+            "account_number": "7631"
+          },
+          "Revenus des cr\u00e9ances diverses": {
+            "account_number": "7638"
+          },
+          "account_number": "763"
+        },
+        "Revenus des valeurs mobili\u00e8res de placement": {
+          "account_number": "764"
+        },
+        "Escomptes obtenus": {
+          "account_number": "765"
+        },
+        "Gains de change financi\u00e8res": {
+          "account_type": "Round Off",
+          "account_number": "766"
+        },
+        "Produits nets sur cessions de valeurs mobili\u00e8res de placement": {
+          "account_number": "767"
+        },
+        "Autres produits financiers": {
+          "account_number": "768"
+        },
+        "account_number": "76"
+      },
+      "Produits exceptionnels": {
+        "Produits exceptionnels sur op\u00e9rations de gestion": {
+          "D\u00e9dits et p\u00e9nalit\u00e9s per\u00e7us sur achats et sur ventes": {
+            "account_number": "7711"
+          },
+          "Lib\u00e9ralit\u00e9s re\u00e7ues": {
+            "account_number": "7713"
+          },
+          "Rentr\u00e9es sur cr\u00e9ances amorties": {
+            "account_number": "7714"
+          },
+          "Subventions d'\u00e9quilibre": {
+            "account_number": "7715"
+          },
+          "D\u00e9gr\u00e8vements d'imp\u00f4ts autres qu'imp\u00f4ts sur les b\u00e9n\u00e9fices": {
+            "account_number": "7717"
+          },
+          "Autres produits exceptionnels sur op\u00e9rations de gestion": {
+            "account_number": "7718"
+          },
+          "account_number": "771"
+        },
+        "(Compte \u00e0 la disposition des entit\u00e9s pour enregistrer, en cours d'exercice, les Produits sur exercices ant\u00e9rieurs)": {
+          "account_number": "772"
+        },
+        "Op\u00e9rations de constitution ou liquidation des fiducies": {
+          "Op\u00e9rations li\u00e9es \u00e0 la constitution de la fiducie - transfert des \u00e9l\u00e9ments": {
+            "account_number": "7741"
+          },
+          "Op\u00e9rations li\u00e9es \u00e0 la liquidation de la fiducie": {
+            "account_number": "7742"
+          },
+          "account_number": "774"
+        },
+        "Produits des cessions d\u2019\u00e9l\u00e9ments d\u2019actifs": {
+          "Immobilisations incorporelles": {
+            "account_number": "7751"
+          },
+          "Immobilisations corporelles": {
+            "account_number": "7752"
+          },
+          "Immobilisations financi\u00e8res": {
+            "account_number": "7756"
+          },
+          "Autres \u00e9l\u00e9ments d'actif": {
+            "account_number": "7758"
+          },
+          "Immobilisations re\u00e7ues en legs ou donations destin\u00e9es \u00e0 \u00eatre c\u00e9d\u00e9es": {
+            "account_number": "7754"
+          },
+          "account_number": "775"
+        },
+        "Quote-part des subventions d'investissement vir\u00e9e au r\u00e9sultat de l'exercice": {
+          "account_number": "777"
+        },
+        "Autres produits exceptionnels": {
+          "Bonis provenant de clauses d'indexation": {
+            "account_number": "7781"
+          },
+          "Lots": {
+            "account_number": "7782"
+          },
+          "Bonis provenant du rachat par l'entreprise d'actions et d'obligations \u00e9mises par elle-m\u00eame": {
+            "account_number": "7783"
+          },
+          "Produits exceptionnels divers": {
+            "account_number": "7788"
+          },
+          "account_number": "778"
+        },
+        "account_number": "77"
+      },
+      "Reprises sur amortissements, d\u00e9pr\u00e9ciations et provisions": {
+        "Reprises sur amortissements des immobilisations d\u00e9pr\u00e9ciations et provisions (\u00e0 inscrire dans les produits d\u2019exploitation)": {
+          "Reprises sur amortissements des immobilisations incorporelles et corporelles": {
+            "Immobilisations incorporelles": {
+              "account_number": "78111"
+            },
+            "Immobilisations corporelles": {
+              "account_number": "78112"
+            },
+            "account_number": "7811"
+          },
+          "Reprises sur provisions d'exploitation": {
+            "account_number": "7815"
+          },
+          "Reprises sur d\u00e9pr\u00e9ciations des immobilisations incorporelles et corporelles": {
+            "Immobilisations incorporelles": {
+              "account_number": "78161"
+            },
+            "Immobilisations corporelles": {
+              "account_number": "78162"
+            },
+            "Reprises sur d\u00e9pr\u00e9ciations d\u2019actifs re\u00e7us par legs ou donations destin\u00e9s \u00e0 \u00eatre c\u00e9d\u00e9s": {
+              "account_number": "78164"
+            },
+            "account_number": "7816"
+          },
+          "Reprises sur d\u00e9pr\u00e9ciations des actifs circulants": {
+            "Stocks et en-cours": {
+              "account_number": "78173"
+            },
+            "Cr\u00e9ances": {
+              "account_number": "78174"
+            },
+            "account_number": "7817"
+          },
+          "account_number": "781"
+        },
+        "Reprises sur d\u00e9pr\u00e9ciations et provisions (\u00e0 inscrire dans les produits financiers)": {
+          "Reprises sur provisions financi\u00e8res": {
+            "account_number": "7865"
+          },
+          "Reprises sur d\u00e9pr\u00e9ciations des \u00e9l\u00e9ments financiers": {
+            "Immobilisations financi\u00e8res": {
+              "account_number": "78662"
+            },
+            "Valeurs mobili\u00e8res de placement": {
+              "account_number": "78665"
+            },
+            "account_number": "7866"
+          },
+          "account_number": "786"
+        },
+        "Reprises sur d\u00e9pr\u00e9ciations et provisions (\u00e0 inscrire dans les produits exceptionnels)": {
+          "Reprises sur provisions r\u00e9glement\u00e9es (immobilisations)": {
+            "Amortissements d\u00e9rogatoires": {
+              "account_number": "78725"
+            },
+            "Provision sp\u00e9ciale de r\u00e9\u00e9valuation": {
+              "account_number": "78726"
+            },
+            "Plus-values r\u00e9investies": {
+              "account_number": "78727"
+            },
+            "account_number": "7872"
+          },
+          "Reprises sur provisions r\u00e9glement\u00e9es (stocks)": {
+            "account_number": "7873"
+          },
+          "Reprises sur autres provisions r\u00e9glement\u00e9es": {
+            "account_number": "7874"
+          },
+          "Reprises sur provisions exceptionnelles": {
+            "account_number": "7875"
+          },
+          "Reprises sur d\u00e9pr\u00e9ciations exceptionnelles": {
+            "account_number": "7876"
+          },
+          "account_number": "787"
+        },
+        "Utilisations de fonds report\u00e9s et de fonds d\u00e9di\u00e9s": {
+          "Utilisations de fonds report\u00e9s": {
+            "account_number": "7891"
+          },
+          "Utilisations des fonds d\u00e9di\u00e9s sur subventions d\u2019exploitation": {
+            "account_number": "7894"
+          },
+          "Utilisations des fonds d\u00e9di\u00e9s sur contributions financi\u00e8res d\u2019autres organismes": {
+            "account_number": "7895"
+          },
+          "Utilisations des fonds d\u00e9di\u00e9s sur ressources li\u00e9es \u00e0 la g\u00e9n\u00e9rosit\u00e9 du public": {
+            "account_number": "7896"
+          },
+          "account_number": "789"
+        },
+        "account_number": "78"
+      },
+      "Transferts de charges": {
+        "Transferts de charges d'exploitation": {
+          "account_number": "791"
+        },
+        "Transferts de charges financi\u00e8res": {
+          "account_number": "796"
+        },
+        "Transferts de charges exceptionnelles": {
+          "account_number": "797"
+        },
+        "account_number": "79"
+      },
+      "Concours publics": {
+        "account_number": "73"
+      },
+      "account_number": "7"
+    },
+    "Comptes sp\u00e9ciaux": {
+      "root_type": "Income",
+      "Emplois des contributions volontaires en nature": {
+        "Secours en nature": {
+          "account_number": "860"
+        },
+        "Mises \u00e0 disposition gratuite de biens": {
+          "account_number": "861"
+        },
+        "Prestations": {
+          "account_number": "862"
+        },
+        "Personnel b\u00e9n\u00e9vole": {
+          "account_number": "864"
+        },
+        "account_number": "86"
+      },
+      "Contributions volontaires en nature": {
+        "Dons en nature": {
+          "account_number": "870"
+        },
+        "Prestations en nature": {
+          "account_number": "871"
+        },
+        "B\u00e9n\u00e9volat": {
+          "account_number": "875"
+        },
+        "account_number": "87"
+      },
+      "account_number": "8"
+    }
+  }
+}


### PR DESCRIPTION
The French chart of accounts for NPOs is a variation of the general chart. This adds the latest version of it: .2018-06.
Reference: https://www.associations.gouv.fr/le-nouveau-plan-comptable-depuis-le-1er-janvier-2020.html