### PR TITLE
fix: Add Company Filter

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -45,6 +45,7 @@ frappe.ui.form.on("Project", {
 		frm.set_query("sales_order", function () {
 			var filters = {
 				project: ["in", frm.doc.__islocal ? [""] : [frm.doc.name, ""]],
+				company: frm.doc.company,
 			};
 
 			if (frm.doc.customer) {

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -29,6 +29,7 @@ erpnext.sales_common = {
 						query: "erpnext.controllers.queries.get_project_name",
 						filters: {
 							customer: doc.customer,
+							company: doc.company,
 						},
 					};
 				});


### PR DESCRIPTION
- In Project dt "Sales Order" field
- In Sales Order dt Project field

* In the Project doctype, I can see and select sales orders from different companies, which should not be the case. Similarly, in the Sales Order doctype, when I select a specific company, I should only see projects associated with that company. However, the dropdown displays all projects, including those associated with other companies. This issue is also present on the demo site.

![image](https://github.com/user-attachments/assets/81e69f48-aecc-4690-91f5-43da10a5710b)
