### PR TITLE
fix: lead create opp from connection not working

### DIFF
--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -7,9 +7,9 @@ cur_frm.email_field = "email_id";
 erpnext.LeadController = class LeadController extends frappe.ui.form.Controller {
 	setup() {
 		this.frm.make_methods = {
-			Customer: this.make_customer,
-			Quotation: this.make_quotation,
-			Opportunity: this.make_opportunity,
+			Customer: this.make_customer.bind(this),
+			Quotation: this.make_quotation.bind(this),
+			Opportunity: this.make_opportunity.bind(this),
 		};
 
 		// For avoiding integration issues.


### PR DESCRIPTION
Creating opportunity, quotation or prospect from connection tab doesn't work
<img width="480" alt="image" src="https://github.com/user-attachments/assets/81f260d5-d818-4bf4-afb4-2c39c64f1968">
