### PR TITLE
fix: handle NoneType error when updating ordered_qty in SO for remove…

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -629,9 +629,11 @@ class PurchaseOrder(BuyingController):
 		if not self.is_against_so():
 			return
 		for item in removed_items:
-			prev_ordered_qty = frappe.get_cached_value(
-				"Sales Order Item", item.get("sales_order_item"), "ordered_qty"
+			prev_ordered_qty = (
+				frappe.get_cached_value("Sales Order Item", item.get("sales_order_item"), "ordered_qty")
+				or 0.0
 			)
+
 			frappe.db.set_value(
 				"Sales Order Item", item.get("sales_order_item"), "ordered_qty", prev_ordered_qty - item.qty
 			)


### PR DESCRIPTION
Added fallback to prevent `NoneType` error by setting `prev_ordered_qty` to 0 if it is None.