### PR TITLE
refactor: allow unreconcile on bank and cash entry type journals

### DIFF
--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -4,7 +4,8 @@ erpnext.accounts.unreconcile_payment = {
 	add_unreconcile_btn(frm) {
 		if (frm.doc.docstatus == 1) {
 			if (
-				(frm.doc.doctype == "Journal Entry" && frm.doc.voucher_type != "Journal Entry") ||
+				(frm.doc.doctype == "Journal Entry" &&
+					!["Journal Entry", "Bank Entry", "Cash Entry"].includes(frm.doc.voucher_type)) ||
 				!["Purchase Invoice", "Sales Invoice", "Journal Entry", "Payment Entry"].includes(
 					frm.doc.doctype
 				)


### PR DESCRIPTION
Extend `UnReconcile` action on Journals of type `Bank Entry` and `Cash Entry`.