### PR TITLE
refactor: validate_return_against_account

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -395,12 +395,17 @@ class AccountsController(TransactionBase):
 	def validate_return_against_account(self):
 		if self.doctype in ["Sales Invoice", "Purchase Invoice"] and self.is_return and self.return_against:
 			cr_dr_account_field = "debit_to" if self.doctype == "Sales Invoice" else "credit_to"
-			cr_dr_account_label = "Debit To" if self.doctype == "Sales Invoice" else "Credit To"
+			cr_dr_account_label = self.meta.get_label(cr_dr_account_field)
 			cr_dr_account = self.get(cr_dr_account_field)
-			if frappe.get_value(self.doctype, self.return_against, cr_dr_account_field) != cr_dr_account:
+			original_account = frappe.get_value(self.doctype, self.return_against, cr_dr_account_field)
+			if original_account != cr_dr_account:
 				frappe.throw(
-					_("'{0}' account: '{1}' should match the Return Against Invoice").format(
-						frappe.bold(cr_dr_account_label), frappe.bold(cr_dr_account)
+					_(
+						"Please set {0} to {1}, the same account that was used in the original invoice {2}."
+					).format(
+						frappe.bold(_(cr_dr_account_label, context=self.doctype)),
+						frappe.bold(cr_dr_account),
+						frappe.bold(self.return_against),
 					)
 				)
 


### PR DESCRIPTION
Show a better error message:

- Tell the user what to do
- Fetch the field label from `self.meta` and translate it
- Remove excessive quoting (bold is enough highlighting)

Before:

![Bildschirmfoto 2024-10-22 um 13 14 17](https://github.com/user-attachments/assets/8ec0132e-a113-4a31-b2ad-3086b25f2559)

After:

![Bildschirmfoto 2024-10-22 um 13 13 55](https://github.com/user-attachments/assets/c48b44b9-8e2a-4913-906c-ffa236bd4ff5)

(don't worry about the incorrectly configured naming series in my original invoice)