### PR TITLE
fix: use correct variable in error message

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -395,15 +395,13 @@ class AccountsController(TransactionBase):
 	def validate_return_against_account(self):
 		if self.doctype in ["Sales Invoice", "Purchase Invoice"] and self.is_return and self.return_against:
 			cr_dr_account_field = "debit_to" if self.doctype == "Sales Invoice" else "credit_to"
-			cr_dr_account_label = self.meta.get_label(cr_dr_account_field)
-			cr_dr_account = self.get(cr_dr_account_field)
 			original_account = frappe.get_value(self.doctype, self.return_against, cr_dr_account_field)
-			if original_account != cr_dr_account:
+			if original_account != self.get(cr_dr_account_field):
 				frappe.throw(
 					_(
 						"Please set {0} to {1}, the same account that was used in the original invoice {2}."
 					).format(
-						frappe.bold(_(cr_dr_account_label, context=self.doctype)),
+						frappe.bold(_(self.meta.get_label(cr_dr_account_field), context=self.doctype)),
 						frappe.bold(original_account),
 						frappe.bold(self.return_against),
 					)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -404,7 +404,7 @@ class AccountsController(TransactionBase):
 						"Please set {0} to {1}, the same account that was used in the original invoice {2}."
 					).format(
 						frappe.bold(_(cr_dr_account_label, context=self.doctype)),
-						frappe.bold(cr_dr_account),
+						frappe.bold(original_account),
 						frappe.bold(self.return_against),
 					)
 				)


### PR DESCRIPTION
- Use correct variable in error message (resolves typo introduced in https://github.com/frappe/erpnext/pull/43778)
- Removed excessive variables that were only used one time