### PR TITLE
fix: map item_ID instead of item_code while creating subcontracting order from PO

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -244,7 +244,7 @@ class SubcontractingOrder(SubcontractingController):
 				bom = (
 					frappe.db.get_value(
 						"Subcontracting BOM",
-						{"finished_good": item.item_code, "is_active": 1},
+						{"finished_good": item.name, "is_active": 1},
 						"finished_good_bom",
 					)
 					or item.default_bom
@@ -252,7 +252,7 @@ class SubcontractingOrder(SubcontractingController):
 
 				items.append(
 					{
-						"item_code": item.item_code,
+						"item_code": item.name,
 						"item_name": item.item_name,
 						"schedule_date": self.schedule_date,
 						"description": item.description,


### PR DESCRIPTION
## Error:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1778, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 37, in savedocs
    doc.submit()
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1048, in submit
    return self._submit()
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1031, in _submit
    return self.save()
           ^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 337, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 390, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1131, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 959, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 484, in on_submit
    self.auto_create_subcontracting_order()
  File "apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 638, in auto_create_subcontracting_order
    make_subcontracting_order(self.name, save=True, notify=True)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 871, in make_subcontracting_order
    target_doc.save()
  File "apps/frappe/frappe/model/document.py", line 337, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 359, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 291, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1091, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 959, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py", line 112, in validate
    super().validate()
  File "apps/erpnext/erpnext/controllers/subcontracting_controller.py", line 53, in validate
    self.validate_items()
  File "apps/erpnext/erpnext/controllers/subcontracting_controller.py", line 93, in validate_items
    is_stock_item, is_sub_contracted_item = frappe.get_value(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable NoneType object
```