### PR TITLE
fix: Handle None value for item description in customer portal invoice view

### DIFF
--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -173,7 +173,7 @@
 		<div class="col-xs-8 col-sm-10">
 			{{ d.item_code }}
 			<div class="text-muted small item-description">
-				{{ html2text(d.description) | truncate(140) }}
+				{{ html2text(d.description or  "") | truncate(140) }}
 			</div>
 			<span class="text-muted mt-2 d-l-n order-qty">
 				{{ _("Qty ") }}({{ d.get_formatted("qty") }})


### PR DESCRIPTION
If the description was not set in an item it throws an error in the customer portal invoice view.

Steps to replicate:
- Create an invoice without a description.
- View that invoice in customer portal.

Before:
![image](https://github.com/user-attachments/assets/39610bb6-8907-4347-a7e2-86cd9ea0a8bc)


After:
![image](https://github.com/user-attachments/assets/90a2d27f-1c94-4831-b5a6-ea7b2f1f83a2)

backport-version-15

<details>
  <summary>Traceback</summary>
    ```log
    Traceback (most recent call last):
      File "apps/frappe/frappe/website/serve.py", line 20, in get_response
        response = renderer_instance.render()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/website/page_renderers/template_page.py", line 84, in render
        html = self.get_html()
               ^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/website/utils.py", line 523, in cache_html_decorator
        html = func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/website/page_renderers/template_page.py", line 101, in get_html
        html = self.render_template()
               ^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/website/page_renderers/template_page.py", line 236, in render_template
        html = frappe.render_template(self.source, self.context, safe_render=safe_render)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/utils/jinja.py", line 97, in render_template
        return get_jenv().from_string(template).render(context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
        self.environment.handle_exception()
      File "env/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
        raise rewrite_traceback_stack(source=source)
      File "<template>", line 179, in top-level template code
      File "apps/frappe/frappe/templates/web.html", line 1, in top-level template code
        {% extends base_template_path %}
        ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/templates/base.html", line 77, in top-level template code
        {% block content %}
      File "apps/frappe/frappe/templates/web.html", line 63, in block 'content'
        {{ main_content() }}
      File "env/lib/python3.11/site-packages/jinja2/sandbox.py", line 393, in call
        return __context.call(__obj, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/jinja2/runtime.py", line 777, in _invoke
        rv = self._func(*arguments)
             ^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/templates/web.html", line 15, in template
        {% block page_container %}
        ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/templates/web.html", line 30, in block 'page_container'
        {%- block page_content -%}{%- endblock -%}
        ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "<template>", line 110, in block 'page_content'
      File "env/lib/python3.11/site-packages/jinja2/sandbox.py", line 393, in call
        return __context.call(__obj, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/jinja2/runtime.py", line 777, in _invoke
        rv = self._func(*arguments)
             ^^^^^^^^^^^^^^^^^^^^^^
      File "<template>", line 176, in template
      File "env/lib/python3.11/site-packages/jinja2/sandbox.py", line 393, in call
        return __context.call(__obj, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "apps/frappe/frappe/core/utils.py", line 91, in html2text
        return md(html, heading_style="ATX", strip=strip, wrap=wrap)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/markdownify/__init__.py", line 395, in markdownify
        return MarkdownConverter(**options).convert(html)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/markdownify/__init__.py", line 96, in convert
        soup = BeautifulSoup(html, 'html.parser')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "env/lib/python3.11/site-packages/bs4/__init__.py", line 315, in __init__
        elif len(markup) <= 256 and (
             ^^^^^^^^^^^
    TypeError: object of type 'NoneType' has no len()
    
    ```
</details>