### PR TITLE
fix: accounting dimension fieldname

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -58,7 +58,7 @@ frappe.ui.form.on("Accounting Dimension", {
 	},
 
 	label: function (frm) {
-		frm.set_value("fieldname", frappe.model.scrub(frm.doc.label));
+		frm.set_value("fieldname", frm.doc.label.replace(/ /g, "_").replace(/-/g, "_").toLowerCase());
 	},
 
 	document_type: function (frm) {

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -7,6 +7,7 @@ import json
 import frappe
 from frappe import _, scrub
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+from frappe.database.schema import validate_column_name
 from frappe.model import core_doctypes_list
 from frappe.model.document import Document
 from frappe.utils import cstr
@@ -60,6 +61,7 @@ class AccountingDimension(Document):
 		if not self.is_new():
 			self.validate_document_type_change()
 
+		validate_column_name(self.fieldname)
 		self.validate_dimension_defaults()
 
 	def validate_document_type_change(self):


### PR DESCRIPTION
Problem:
If the Doctype name contains "-" in its name incorrect field name was set in the Account Dimension doc due to which field was not created.

Issue:
There is inconsistency in scrub in JS and Python.
In Python, it scrubs whitespace and "-" dash but in js it only scrubs whitespace.

Fixing it in frappe will be a breaking change so fixing it here.

Also added validation for fieldname.

Steps to replicate:
- Create an Accounting Dimension with doctype having "-" in its field.


backport version-15 hotfix

Before:
![image](https://github.com/user-attachments/assets/57f723e6-eaee-4bcc-b2d7-2b52336dd4c0)

<details>
    <summary> Traceback</summary>
```log
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 220, in execute_job
    retval = method(**kwargs)
      site = 'precihole.localhost'
      method = <function make_dimension_in_accounting_doctypes at 0x7fdf637de700>
      event = None
      job_name = 'erpnext.accounts.doctype.accounting_dimension.accounting_dimension.make_dimension_in_accounting_doctypes'
      kwargs = {'doc': <AccountingDimension: GSTR-1 Beta>}
      user = 'Administrator'
      is_async = True
      retry = 0
      retval = None
      method_name = 'erpnext.accounts.doctype.accounting_dimension.accounting_dimension.make_dimension_in_accounting_doctypes'
      before_job_task = 'frappe.monitor.start'
  File "apps/erpnext/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py", line 136, in make_dimension_in_accounting_doctypes
    create_custom_field(doctype, df, ignore_validate=True)
      doc = <AccountingDimension: GSTR-1 Beta>
      doclist = ['GL Entry', 'Payment Ledger Entry', 'Sales Invoice', 'Purchase Invoice', 'Payment Entry', 'Asset', 'Stock Entry', 'Budget', 'Delivery Note', 'Sales Invoice Item', 'Purchase Invoice Item', 'Purchase Order Item', 'Sales Order Item', 'Journal Entry Account', 'Material Request Item', 'Delivery Note Item', 'Purchase Receipt Item', 'Stock Entry Detail', 'Payment Entry Deduction', 'Sales Taxes and Charges', 'Purchase Taxes and Charges', 'Shipping Rule', 'Landed Cost Item', 'Asset Value Adjustment', 'Asset Repair', 'Asset Capitalization', 'Loyalty Program', 'Stock Reconciliation', 'POS Profile', 'Opening Invoice Creation Tool', 'Opening Invoice Creation Tool Item', 'Subscription', 'Subscription Plan', 'POS Invoice', 'POS Invoice Item', 'Purchase Order', 'Purchase Receipt', 'Sales Order', 'Subcontracting Order', 'Subcontracting Order Item', 'Subcontracting Receipt', 'Subcontracting Receipt Item', 'Account Closing Balance', 'Supplier Quotation', 'Supplier Quotation Item', 'Payment Reconciliatio...
      doc_count = 2
      count = 0
      repostable_doctypes = ['Expense Claim', 'Journal Entry', 'Payment Entry', 'Purchase Invoice', 'Sales Invoice']
      doctype = 'GL Entry'
      insert_after_field = 'accounting_dimensions_section'
      df = {'fieldname': 'gstr-1_beta', 'label': 'GSTR-1 Beta', 'fieldtype': 'Link', 'options': 'GSTR-1 Beta', 'insert_after': 'accounting_dimensions_section', 'owner': 'Administrator', 'allow_on_submit': 0}
      meta = <Meta: GL Entry>
      fieldnames = ['posting_date', 'transaction_date', 'account', 'party_type', 'party', 'cost_center', 'debit', 'credit', 'account_currency', 'debit_in_account_currency', 'credit_in_account_currency', 'against', 'against_voucher_type', 'against_voucher', 'voucher_type', 'voucher_subtype', 'voucher_no', 'voucher_detail_no', 'project', 'remarks', 'is_opening', 'is_advance', 'fiscal_year', 'company', 'company_gstin', 'finance_book', 'to_rename', 'due_date', 'is_cancelled', 'transaction_currency', 'debit_in_transaction_currency', 'credit_in_transaction_currency', 'transaction_exchange_rate']
  File "apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 293, in create_custom_field
    custom_field.insert()
      doctype = 'GL Entry'
      df = {'fieldname': 'gstr-1_beta', 'label': 'GSTR-1 Beta', 'fieldtype': 'Link', 'options': 'GSTR-1 Beta', 'insert_after': 'accounting_dimensions_section', 'owner': 'Administrator', 'allow_on_submit': 0}
      ignore_validate = True
      is_system_generated = True
      custom_field = <CustomField: GL Entry-gstr-1_beta>
  File "apps/frappe/frappe/model/document.py", line 315, in insert
    self.run_post_save_methods()
      self = <CustomField: GL Entry-gstr-1_beta>
      ignore_permissions = None
      ignore_links = None
      ignore_if_duplicate = False
      ignore_mandatory = None
      set_name = None
      set_child_names = True
  File "apps/frappe/frappe/model/document.py", line 1128, in run_post_save_methods
    self.run_method("on_update")
      self = <CustomField: GL Entry-gstr-1_beta>
  File "apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
      self = <CustomField: GL Entry-gstr-1_beta>
      method = 'on_update'
      args = ()
      kwargs = {}
      fn = <function Document.run_method.<locals>.fn at 0x7fdf62a1f7e0>
  File "apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
      self = <CustomField: GL Entry-gstr-1_beta>
      args = ()
      kwargs = {}
      hooks = [<function clear_doctype_notifications at 0x7fdf61df5580>, <function process_workflow_actions at 0x7fdf61df7600>, <function attach_files_to_document at 0x7fdf654cd1c0>, <function apply at 0x7fdf61c222a0>, <function update_due_date at 0x7fdf61c22340>, <function apply_permissions_for_non_standard_user_type at 0x7fdf61c23a60>]
      method = 'on_update'
      doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_w...
      handler = 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type'
      composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x7fdf61df4b80>
      compose = <function Document.hook.<locals>.compose at 0x7fdf62a1ff60>
      f = <function Document.run_method.<locals>.fn at 0x7fdf62a1f7e0>
  File "apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
      self = <CustomField: GL Entry-gstr-1_beta>
      method = 'on_update'
      args = ()
      kwargs = {}
      add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7fdf62a1f740>
      fn = <function Document.run_method.<locals>.fn at 0x7fdf62a1f7e0>
      hooks = (<function clear_doctype_notifications at 0x7fdf61df5580>, <function process_workflow_actions at 0x7fdf61df7600>, <function attach_files_to_document at 0x7fdf654cd1c0>, <function apply at 0x7fdf61c222a0>, <function update_due_date at 0x7fdf61c22340>, <function apply_permissions_for_non_standard_user_type at 0x7fdf61c23a60>)
  File "apps/frappe/frappe/model/document.py", line 959, in fn
    return method_object(*args, **kwargs)
      self = <CustomField: GL Entry-gstr-1_beta>
      args = ()
      kwargs = {}
      method_object = <bound method CustomField.on_update of <CustomField: GL Entry-gstr-1_beta>>
      method = 'on_update'
  File "apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 212, in on_update
    frappe.db.updatedb(self.dt)
      self = <CustomField: GL Entry-gstr-1_beta>
  File "apps/frappe/frappe/database/mariadb/database.py", line 443, in updatedb
    db_table.sync()
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7fdf62dfd6d0>
      doctype = 'GL Entry'
      meta = None
      res = ((0,),)
      db_table = <frappe.database.mariadb.schema.MariaDBTable object at 0x7fdf61c39b50>
  File "apps/frappe/frappe/database/schema.py", line 44, in sync
    self.alter()
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7fdf61c39b50>
  File "apps/frappe/frappe/database/mariadb/schema.py", line 67, in alter
    col.build_for_alter_table(self.current_columns.get(col.fieldname.lower()))
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7fdf61c39b50>
      col = <frappe.database.schema.DbColumn object at 0x7fdf6169fd10>
  File "apps/frappe/frappe/database/schema.py", line 220, in build_for_alter_table
    self.fieldname = validate_column_name(self.fieldname)
      self = <frappe.database.schema.DbColumn object at 0x7fdf6169fd10>
      current_def = None
      column_type = 'varchar(140)'
  File "apps/frappe/frappe/database/schema.py", line 305, in validate_column_name
    frappe.throw(
      n = 'gstr-1_beta'
      special_characters = '"-"'
  File "apps/frappe/frappe/__init__.py", line 645, in throw
    msgprint(
      msg = 'Fieldname <strong>gstr-1_beta</strong> cannot have special characters like "-"'
      exc = <class 'frappe.database.database.Database.InvalidColumnName'>
      title = None
      is_minimizable = False
      wide = False
      as_list = False
      primary_action = None
  File "apps/frappe/frappe/__init__.py", line 610, in msgprint
    _raise_exception()
      msg = 'Fieldname gstr-1_beta cannot have special characters like "-"'
      title = None
      raise_exception = <class 'frappe.database.database.Database.InvalidColumnName'>
      as_table = False
      as_list = False
      indicator = 'red'
      alert = False
      primary_action = None
      is_minimizable = False
      wide = False
      realtime = False
      sys = <module 'sys' (built-in)>
      _raise_exception = <function msgprint.<locals>._raise_exception at 0x7fdf6167e980>
      inspect = <module 'inspect' from '/usr/lib/python3.11/inspect.py'>
      out = {'message': 'Fieldname <strong>gstr-1_beta</strong> cannot have special characters like "-"', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'bbddab1fbe3f344a6a7ce4460f207a1f253e5c1f9547672167b40ec0'}
  File "apps/frappe/frappe/__init__.py", line 561, in _raise_exception
    raise exc
      exc = InvalidColumnName('Fieldname gstr-1_beta cannot have special characters like "-"')
      inspect = <module 'inspect' from '/usr/lib/python3.11/inspect.py'>
      msg = 'Fieldname gstr-1_beta cannot have special characters like "-"'
      out = {'message': 'Fieldname <strong>gstr-1_beta</strong> cannot have special characters like "-"', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'bbddab1fbe3f344a6a7ce4460f207a1f253e5c1f9547672167b40ec0'}
      raise_exception = <class 'frappe.database.database.Database.InvalidColumnName'>
frappe.database.database.InvalidColumnName: Fieldname gstr-1_beta cannot have special characters like "-"
```

 </details>


After:
![image](https://github.com/user-attachments/assets/f125b1b3-3c73-460a-aeac-05a87e2cbccd)

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/24135




 