### PR TITLE
refactor: query for expense_account moved to setup hook in purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -31,6 +31,13 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 				},
 			};
 		});
+
+		this.frm.set_query("expense_account", "items", function () {
+			return {
+				query: "erpnext.controllers.queries.get_expense_account",
+				filters: { company: doc.company },
+			};
+		});
 	}
 
 	onload() {
@@ -509,13 +516,6 @@ cur_frm.fields_dict["select_print_heading"].get_query = function (doc, cdt, cdn)
 		filters: [["Print Heading", "docstatus", "!=", 2]],
 	};
 };
-
-cur_frm.set_query("expense_account", "items", function (doc) {
-	return {
-		query: "erpnext.controllers.queries.get_expense_account",
-		filters: { company: doc.company },
-	};
-});
 
 cur_frm.set_query("wip_composite_asset", "items", function () {
 	return {


### PR DESCRIPTION
Probem: 
Previously accounts other than Profit and Loss Account based on account type were allowed in expense accounts.But after this PR https://github.com/frappe/erpnext/pull/35944, the user cannot select other accounts in the Purchase Invoice.

Issue:
The query was not setting in purchase invoice.js

backport version-15-hotfix
backport version-14-hotfix

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/24018
