### PR TITLE
fix: basic rate not editable in Stock Entry Detail

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -830,6 +830,15 @@ frappe.ui.form.on("Stock Entry", {
 });
 
 frappe.ui.form.on("Stock Entry Detail", {
+	set_basic_rate_manually(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		frm.fields_dict.items.grid.update_docfield_property(
+			"basic_rate",
+			"read_only",
+			row?.set_basic_rate_manually ? 0 : 1
+		);
+	},
+
 	qty(frm, cdt, cdn) {
 		frm.events.set_basic_rate(frm, cdt, cdn);
 	},


### PR DESCRIPTION
**Issue**

Even if the "Set Basic Rate Manually" checkbox has enabled in the stock entry child table, the system is not allowing to edit the Basic Rate 

**After Fix**


https://github.com/user-attachments/assets/8ea14c96-7472-4aa2-86b2-044b91a4f997



