### PR TITLE
fix: add parenttype clause to invoice tax query in sales_register report

### DIFF
--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -526,7 +526,8 @@ def get_invoice_tax_map(invoice_list, invoice_income_map, income_accounts, inclu
 	tax_details = frappe.db.sql(
 		"""select parent, account_head,
 		sum(base_tax_amount_after_discount_amount) as tax_amount
-		from `tabSales Taxes and Charges` where parent in (%s) group by parent, account_head"""
+		from `tabSales Taxes and Charges` where parent in (%s) and parenttype = 'Sales Invoice'
+		group by parent, account_head"""
 		% ", ".join(["%s"] * len(invoice_list)),
 		tuple(inv.name for inv in invoice_list),
 		as_dict=1,


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

The `Sales Register` report's tax calculation query was only grouping by `parent` on `tabSales Taxes and Charges`. This can cause the `Sales Taxes and Charges` of another document (ex: Quotation) having the same name (where doc names are manually set or proforma invoice) to be calculated into the sales tax. Adding the `parenttype = 'Sales Invoice'` condition avoids such issues in this PR.

closes #43811

backport version-15
backport version-14