### PR TITLE
fix: calculate tds with net amount when invoice exceeds single threshold amount

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -514,7 +514,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 		payment_entry_filters.pop("apply_tax_withholding_amount", None)
 		payment_entry_filters.pop("tax_withholding_category", None)
 
-	supp_credit_amt = frappe.db.get_value("Purchase Invoice", invoice_filters, field) or 0.0
+	supp_inv_credit_amt = frappe.db.get_value("Purchase Invoice", invoice_filters, field) or 0.0
 
 	supp_jv_credit_amt = (
 		frappe.db.get_value(
@@ -538,7 +538,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 		group_by="payment_type",
 	)
 
-	supp_credit_amt += supp_jv_credit_amt
+	supp_credit_amt = supp_jv_credit_amt
 	supp_credit_amt += inv.tax_withholding_net_total
 
 	for type in payment_entry_amounts:
@@ -556,18 +556,18 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 		tax_withholding_net_total = inv.tax_withholding_net_total
 
 	if (threshold and tax_withholding_net_total >= threshold) or (
-		cumulative_threshold and supp_credit_amt >= cumulative_threshold
+		cumulative_threshold and (supp_credit_amt + supp_inv_credit_amt) >= cumulative_threshold
 	):
+		# Get net total again as TDS is calculated on net total
+		# Grand is used to just check for threshold breach
+		net_total = (
+			frappe.db.get_value("Purchase Invoice", invoice_filters, "sum(tax_withholding_net_total)") or 0.0
+		)
+		supp_credit_amt += net_total
+
 		if (cumulative_threshold and supp_credit_amt >= cumulative_threshold) and cint(
 			tax_details.tax_on_excess_amount
 		):
-			# Get net total again as TDS is calculated on net total
-			# Grand is used to just check for threshold breach
-			net_total = (
-				frappe.db.get_value("Purchase Invoice", invoice_filters, "sum(tax_withholding_net_total)")
-				or 0.0
-			)
-			net_total += inv.tax_withholding_net_total
 			supp_credit_amt = net_total - cumulative_threshold
 
 		if ldc and is_valid_certificate(ldc, inv.get("posting_date") or inv.get("transaction_date"), 0):


### PR DESCRIPTION
**Issue:**
When a purchase invoice exceeds the single threshold value but doesn't exceed the cumulative threshold, the TDS amount is calculated on the grand total instead of the net total when consider_party_ledger_amount is ticked on Tax Withholding Category
**ref:** [23540](https://support.frappe.io/helpdesk/tickets/23540)

**Before:**
[TDS Calculation Issue](https://github.com/user-attachments/assets/bca2f5f3-d6a1-4ee8-bd03-c3afeeaf3c7d)

**After:**
[TDS Calculation Fix](https://github.com/user-attachments/assets/5679224e-09f3-4af8-82e7-36f1a7ea53c8)

**Backport needed: v14 & v15**