### PR TITLE
fix: add missing fields to field_no_map array

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1364,6 +1364,8 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 						"discount_percentage",
 						"discount_amount",
 						"pricing_rules",
+						"margin_type",
+						"margin_rate_or_amount",
 					],
 					"postprocess": update_item,
 					"condition": lambda doc: doc.ordered_qty < doc.stock_qty


### PR DESCRIPTION
In the `make_purchase_order_for_default_supplier` method in the `Sales Order.py` file, the `field_no_map` array lists fields that should not be copied to the Purchase Order. Currently, these two fields are missing from the array ( `margin_type` and `margin_rate_or_amount` ), leading to unintended field copies. Adding them to the `field_no_map` array resolves this issue.



closes #43865 

backport version-15
backport version-14