### PR TITLE
fix: work order finish button not showing

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -210,6 +210,48 @@ frappe.ui.form.on("Job Card", {
 		}
 	},
 
+	complete_job_card(frm) {
+		let fields = [
+			{
+				fieldtype: "Float",
+				label: __("Completed Quantity"),
+				fieldname: "qty",
+				reqd: 1,
+				default: frm.doc.for_quantity - frm.doc.manufactured_qty,
+			},
+			{
+				fieldtype: "Datetime",
+				label: __("End Time"),
+				fieldname: "end_time",
+				default: frappe.datetime.now_datetime(),
+			},
+		];
+
+		frappe.prompt(
+			fields,
+			(data) => {
+				if (data.qty <= 0) {
+					frappe.throw(__("Quantity should be greater than 0"));
+				}
+
+				frm.call({
+					method: "complete_job_card",
+					doc: frm.doc,
+					args: {
+						qty: data.qty,
+						end_time: data.end_time,
+					},
+					callback: function (r) {
+						frm.reload_doc();
+					},
+				});
+			},
+			__("Enter Value"),
+			__("Update"),
+			__("Set Finished Good Quantity")
+		);
+	},
+
 	make_subcontracting_po(frm) {
 		if (frm.doc.docstatus === 1 && frm.doc.for_quantity > frm.doc.manufactured_qty) {
 			frm.add_custom_button(__("Make Subcontracting PO"), () => {

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -991,22 +991,16 @@ class JobCard(Document):
 
 		qty = 0.0
 		if doc.transfer_material_against == "Job Card" and not doc.skip_transfer:
-			completed = True
+			min_qty = []
 			for d in doc.operations:
-				if d.status != "Completed":
-					completed = False
+				if d.completed_qty:
+					min_qty.append(d.completed_qty)
+				else:
+					min_qty = []
 					break
 
-			if completed:
-				job_cards = frappe.get_all(
-					"Job Card",
-					filters={"work_order": self.work_order, "docstatus": ("!=", 2)},
-					fields="sum(transferred_qty) as qty",
-					group_by="operation_id",
-				)
-
-				if job_cards:
-					qty = min(d.qty for d in job_cards)
+			if min_qty:
+				qty = min(min_qty)
 
 			doc.db_set("material_transferred_for_manufacturing", qty)
 


### PR DESCRIPTION
**Issue**

- Make Work Order with Single operation and qty to manufacture as 4
- Set "Transfer Material Against" as "Job Card"
- In the job card, change the qty from 4 to 2 and complete the job card
- In the work order, Finish button not showing.

