### PR TITLE
fix: use period closing voucher object to call get_account_closing_ba…

### DIFF
--- a/erpnext/patches/v14_0/update_closing_balances.py
+++ b/erpnext/patches/v14_0/update_closing_balances.py
@@ -24,8 +24,9 @@ def execute():
 		for pcv in get_period_closing_vouchers(company):
 			company_wise_order.setdefault(pcv.company, [])
 			if pcv.period_end_date not in company_wise_order[pcv.company]:
-				pcv.pl_accounts_reverse_gle = get_pcv_gl_entries(pcv, gle_fields)
-				closing_entries = pcv.get_account_closing_balances()
+				pcv_doc = frappe.get_doc("Period Closing Voucher", pcv.name)
+				pcv_doc.pl_accounts_reverse_gle = get_pcv_gl_entries(pcv, gle_fields)
+				closing_entries = pcv_doc.get_account_closing_balances()
 				if closing_entries:
 					make_closing_entries(closing_entries, pcv.name, pcv.company, pcv.period_end_date)
 


### PR DESCRIPTION
Issue:
Patch update_closing_balances failing while migrating the site
ref: [24399](https://support.frappe.io/helpdesk/tickets/24399)

![image](https://github.com/user-attachments/assets/992c7d94-ef45-4588-82fb-3d94d1402b66)

Backport needed: v15
