### PR TITLE
fix: recalculate outstanding after save on checkout for POS Invoice

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -350,6 +350,11 @@ erpnext.PointOfSale.Payment = class {
 	}
 
 	checkout() {
+		const frm = this.events.get_frm();
+		frm.cscript.calculate_outstanding_amount();
+		frm.refresh_field("outstanding_amount");
+		frm.refresh_field("paid_amount");
+		frm.refresh_field("base_paid_amount");
 		this.events.toggle_other_sections(true);
 		this.toggle_component(true);
 


### PR DESCRIPTION
Issue: Default payment amount after checkout is incorrect due to changes in grand_total on save.

Step to Replicate:
-  Create an item with a selling rate of 5000.
-   Create a Pricing Rule with a discount of 1000 on a minimum order value of 10000.
- Open POS and add 3 items to the cart. The Grand total is showing 14160 but the Cash/Paid Amount is showing 17700. However, it should show 14160

![image](https://github.com/user-attachments/assets/cbe901cb-d902-421f-8538-11862f71fee9)



Solution:
Resetting payments table after saving on checkout.


backport version-15-hotfix

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/24344


