### PR TITLE
fix: remarks field in payment reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -323,6 +323,7 @@ class PaymentReconciliation(Document):
 								"posting_date": inv.posting_date,
 								"currency": inv.currency,
 								"cost_center": inv.cost_center,
+								"remarks": inv.remarks,
 							}
 						)
 					)

--- a/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.json
@@ -14,7 +14,7 @@
   "amount",
   "difference_amount",
   "sec_break1",
-  "remark",
+  "remarks",
   "currency",
   "exchange_rate",
   "cost_center"
@@ -75,12 +75,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "remark",
-   "fieldtype": "Small Text",
-   "label": "Remark",
-   "read_only": 1
-  },
-  {
    "fieldname": "currency",
    "fieldtype": "Link",
    "hidden": 1,
@@ -105,12 +99,18 @@
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks",
+   "read_only": 1
   }
  ],
  "is_virtual": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:10.980445",
+ "modified": "2024-10-29 16:24:43.021230",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Payment",

--- a/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.py
@@ -27,7 +27,7 @@ class PaymentReconciliationPayment(Document):
 		reference_name: DF.DynamicLink | None
 		reference_row: DF.Data | None
 		reference_type: DF.Link | None
-		remark: DF.SmallText | None
+		remarks: DF.SmallText | None
 	# end: auto-generated types
 
 	@staticmethod

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1997,6 +1997,7 @@ class QueryPaymentLedger:
 				ple.cost_center.as_("cost_center"),
 				Sum(ple.amount).as_("amount"),
 				Sum(ple.amount_in_account_currency).as_("amount_in_account_currency"),
+				ple.remarks,
 			)
 			.where(ple.delinked == 0)
 			.where(Criterion.all(filter_on_voucher_no))
@@ -2059,6 +2060,7 @@ class QueryPaymentLedger:
 				Table("vouchers").due_date,
 				Table("vouchers").currency,
 				Table("vouchers").cost_center.as_("cost_center"),
+				Table("vouchers").remarks,
 			)
 			.where(Criterion.all(filter_on_outstanding_amount))
 		)


### PR DESCRIPTION
The remarks in payments of Payment Reconciliation is not appearing because of the fieldname is `remark` and the code has `remarks`. 

![Screenshot 2024-10-29 at 11 14 13](https://github.com/user-attachments/assets/6404002d-5abc-433b-8ba9-9f16fb9cc525)
