### PR TITLE
fix: post account closing balance against pcv closing account

### DIFF
--- a/erpnext/patches/v14_0/update_closing_balances.py
+++ b/erpnext/patches/v14_0/update_closing_balances.py
@@ -27,8 +27,7 @@ def execute():
 				pcv_doc = frappe.get_doc("Period Closing Voucher", pcv.name)
 				pcv_doc.pl_accounts_reverse_gle = get_pcv_gl_entries(pcv, gle_fields)
 				closing_entries = pcv_doc.get_account_closing_balances()
-				if closing_entries:
-					make_closing_entries(closing_entries, pcv.name, pcv.company, pcv.period_end_date)
+				make_closing_entries(closing_entries, pcv.name, pcv.company, pcv.period_end_date)
 
 				company_wise_order[pcv.company].append(pcv.period_end_date)
 				i += 1


### PR DESCRIPTION
- Post account closing balance against pcv closing account with "is_period_closing_voucher_entry" checked.
- Create closing balances even if there are no gle records within a period, to copy closing balances for the previous period.