### PR TITLE
fix: use get_datetime_as_string with correct time format

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -356,7 +356,7 @@ var calculate_end_time = function (frm, cdt, cdn) {
 	if (child.hours) {
 		d.add(child.hours, "hours");
 		frm._setting_hours = true;
-		frappe.model.set_value(cdt, cdn, "to_time", d.format(frappe.defaultDatetimeFormat)).then(() => {
+		frappe.model.set_value(cdt, cdn, "to_time", frappe.datetime.get_datetime_as_string(d)).then(() => {
 			frm._setting_hours = false;
 		});
 	}

--- a/erpnext/public/js/projects/timer.js
+++ b/erpnext/public/js/projects/timer.js
@@ -89,7 +89,7 @@ erpnext.timesheet.control_timer = function (frm, dialog, row, timestamp = 0) {
 			let d = moment(row.from_time);
 			if (row.expected_hours) {
 				d.add(row.expected_hours, "hours");
-				row.to_time = d.format(frappe.defaultDatetimeFormat);
+				row.to_time = frappe.datetime.get_datetime_as_string(d);
 			}
 			frm.refresh_field("time_logs");
 			frm.save();
@@ -117,8 +117,7 @@ erpnext.timesheet.control_timer = function (frm, dialog, row, timestamp = 0) {
 		grid_row.doc.project = args.project;
 		grid_row.doc.task = args.task;
 		grid_row.doc.expected_hours = args.expected_hours;
-		grid_row.doc.hours = currentIncrement / 3600;
-		grid_row.doc.to_time = frappe.datetime.now_datetime();
+		grid_row.doc.to_time = frappe.datetime.get_datetime_as_string();
 		grid_row.refresh();
 		frm.dirty();
 		frm.save();


### PR DESCRIPTION
Timesheet and Timer use a mixture of d.format(frappe.defaultDatetimeFormat) and frappe.datetime.get_datetime_as_string().
Both until now do not respect the time format set in sysdefaults.
This can cause rounding errors when client side scripts calculate based upon unsubmitted values.
When sysdefaults TimeFormat is selected to be "HH:mm" and in a Timesheet a to_time or from_time with seconds is submitted, the hours field is calculated with seconds included. After submission the seconds are stripped from to_time or from_time, creating a missmatch of hours calculated and to_time - from_time.

This patch depends on [fix: get_datetime_as_string should respect time_format](https://github.com/frappe/frappe/pull/28333) in frappe and solves the rounding/missmatch problem, as well as cleans up the scripts to only use get_datetime_as_string.