### PR TITLE
perf: avoid reposting of entries created after stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1275,6 +1275,60 @@ class TestStockReconciliation(IntegrationTestCase, StockTestMixin):
 		qty = get_batch_qty(batch_id, warehouse, batch_item_code)
 		self.assertEqual(qty, 110)
 
+	def test_skip_reposting_for_entries_after_stock_reco(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		item_code = create_item("Test Item For Skip Reposting After Stock Reco", is_stock_item=1).name
+
+		warehouse = "_Test Warehouse - _TC"
+
+		make_stock_entry(
+			posting_date="2024-11-01",
+			posting_time="11:00",
+			item_code=item_code,
+			target=warehouse,
+			qty=10,
+			basic_rate=100,
+		)
+
+		create_stock_reconciliation(
+			posting_date="2024-11-02",
+			posting_time="11:00",
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=20,
+			rate=100,
+		)
+
+		se = make_stock_entry(
+			posting_date="2024-11-03",
+			posting_time="11:00",
+			item_code=item_code,
+			source=warehouse,
+			qty=15,
+		)
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry", {"voucher_no": se.name, "is_cancelled": 0}, "stock_value_difference"
+		)
+
+		self.assertEqual(stock_value_difference, 1500.00 * -1)
+
+		make_stock_entry(
+			posting_date="2024-10-29",
+			posting_time="11:00",
+			item_code=item_code,
+			target=warehouse,
+			qty=10,
+			basic_rate=100,
+		)
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry", {"voucher_no": se.name, "is_cancelled": 0}, "stock_value_difference"
+		)
+
+		self.assertEqual(stock_value_difference, 1500.00 * -1)
+
 
 def create_batch_item_with_batch(item_name, batch_id):
 	batch_item_doc = create_item(item_name, is_stock_item=1)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -624,8 +624,20 @@ class update_entries_after:
 				if sle.dependant_sle_voucher_detail_no:
 					entries_to_fix = self.get_dependent_entries_to_fix(entries_to_fix, sle)
 
+				if self.has_stock_reco_with_serial_batch(sle):
+					break
+
 		if self.exceptions:
 			self.raise_exceptions()
+
+	def has_stock_reco_with_serial_batch(self, sle):
+		if (
+			sle.vocher_type == "Stock Reconciliation"
+			and frappe.db.get_value(sle.voucher_type, sle.voucher_no, "set_posting_time") == 1
+		):
+			return not (sle.batch_no or sle.serial_no or sle.serial_and_batch_bundle)
+
+		return False
 
 	def process_sle_against_current_timestamp(self):
 		sl_entries = self.get_sle_against_current_voucher()


### PR DESCRIPTION
No need to do reposting of entries which has been created after the stock reconciliation for the non serialized or non batched items 