### PR TITLE
 fix: submit POS Invoice only if the invoice amount is fully paid 

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -457,8 +457,7 @@ class POSInvoice(SalesInvoice):
 				frappe.throw(_("Row #{0} (Payment Table): Amount must be negative").format(entry.idx))
 
 		invoice_total = self.rounded_total or self.grand_total
-		total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
-
+		total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total")) + flt(self.loyalty_points, self.precision("grand_total"))
 		if self.docstatus != 0 and total_amount_in_payments and total_amount_in_payments < invoice_total:
 			if self.is_return:
 				frappe.throw(

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -20,6 +20,10 @@ from erpnext.controllers.queries import item_query as _item_query
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
 
+class PaymentValidationError(frappe.ValidationError):
+	pass
+
+
 class POSInvoice(SalesInvoice):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -452,11 +456,20 @@ class POSInvoice(SalesInvoice):
 			if self.is_return and entry.amount > 0:
 				frappe.throw(_("Row #{0} (Payment Table): Amount must be negative").format(entry.idx))
 
-		if self.is_return and self.docstatus != 0:
-			invoice_total = self.rounded_total or self.grand_total
-			total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
-			if total_amount_in_payments and total_amount_in_payments < invoice_total:
-				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
+		invoice_total = self.rounded_total or self.grand_total
+		total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
+
+		if self.docstatus != 0 and total_amount_in_payments and total_amount_in_payments < invoice_total:
+			if self.is_return:
+				frappe.throw(
+					_("Total payments amount can't be greater than {}").format(-invoice_total),
+					PaymentValidationError,
+				)
+			else:
+				frappe.throw(
+					_("Total payments amount can't be less than {}").format(invoice_total),
+					PaymentValidationError,
+				)
 
 	def validate_company_with_pos_company(self):
 		if self.company != frappe.db.get_value("POS Profile", self.pos_profile, "company"):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -457,7 +457,9 @@ class POSInvoice(SalesInvoice):
 				frappe.throw(_("Row #{0} (Payment Table): Amount must be negative").format(entry.idx))
 
 		invoice_total = self.rounded_total or self.grand_total
-		total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total")) + flt(self.loyalty_points, self.precision("grand_total"))
+		total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
+		if self.loyalty_amount:
+			total_amount_in_payments += flt(self.loyalty_amount, self.precision("grand_total"))
 		if self.docstatus != 0 and total_amount_in_payments and total_amount_in_payments < invoice_total:
 			if self.is_return:
 				frappe.throw(

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.tests import IntegrationTestCase
 
-from erpnext.accounts.doctype.pos_invoice.pos_invoice import make_sales_return
+from erpnext.accounts.doctype.pos_invoice.pos_invoice import PaymentValidationError, make_sales_return
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.stock.doctype.item.test_item import make_item
@@ -932,6 +932,13 @@ class TestPOSInvoice(IntegrationTestCase):
 		finally:
 			frappe.db.rollback(save_point="before_test_delivered_serial_no_case")
 			frappe.set_user("Administrator")
+
+	def test_validate_paid_amount(self):
+		inv = create_pos_invoice(qty=10, rate=5, do_not_save=True)
+		inv.payments = []
+		inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 45})
+		inv.insert()
+		self.assertRaises(PaymentValidationError, inv.submit)
 
 
 def create_pos_invoice(**args):

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -24,7 +24,7 @@ class TestPOSInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		# cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 
@@ -317,17 +317,17 @@ class TestPOSInvoice(IntegrationTestCase):
 		)
 
 		pos.append(
-			"payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 1000, "default": 1}
+			"payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2000, "default": 1}
 		)
 
 		pos.insert()
 		pos.submit()
 		pos.reload()
-
 		pos_return1 = make_sales_return(pos.name)
 
 		# partial return 1
 		pos_return1.get("items")[0].qty = -1
+		pos_return1.insert()
 		pos_return1.submit()
 		pos_return1.reload()
 

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -24,7 +24,7 @@ class TestPOSInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		# cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -77,7 +77,7 @@ class TestSalesInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		# cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		unlink_payment_on_cancel_of_invoice()
 
 	@classmethod
@@ -3904,7 +3904,11 @@ class TestSalesInvoice(IntegrationTestCase):
 		)
 		dn1.save().submit()
 		make_stock_entry(
-			target="_Test Warehouse - _TC", item_code="_Test Item", company="_Test Company", qty=5, basic_rate=100
+			target="_Test Warehouse - _TC",
+			item_code="_Test Item",
+			company="_Test Company",
+			qty=5,
+			basic_rate=100,
 		)
 		dn2 = create_delivery_note(do_not_submit=1)
 		dn2.items[0].qty = 5

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -77,7 +77,7 @@ class TestSalesInvoice(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		# cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
 		unlink_payment_on_cancel_of_invoice()
 
 	@classmethod
@@ -1021,12 +1021,40 @@ class TestSalesInvoice(IntegrationTestCase):
 		pos.submit()
 
 		pos_return = make_sales_return(pos.name)
-
 		pos_return.insert()
 		pos_return.submit()
 
 		self.assertEqual(pos_return.get("payments")[0].amount, -500)
 		self.assertEqual(pos_return.get("payments")[1].amount, -500)
+
+	def test_partial_pos_returns_with_repayment(self):
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
+
+		pos_profile = make_pos_profile()
+
+		pos_profile.payments = []
+		pos_profile.append("payments", {"default": 1, "mode_of_payment": "Cash"})
+
+		pos_profile.save()
+
+		pos = create_sales_invoice(qty=10, do_not_save=True)
+
+		pos.is_pos = 1
+		pos.pos_profile = pos_profile.name
+
+		pos.append(
+			"payments", {"mode_of_payment": "Bank Draft", "account": "_Test Bank - _TC", "amount": 500}
+		)
+		pos.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 500})
+		pos.insert()
+		pos.submit()
+
+		pos_return = make_sales_return(pos.name)
+		pos_return.items[0].qty = -5
+		pos_return.insert()
+		pos_return.submit()
+
+		self.assertEqual(pos_return.get("payments")[0].amount, -500)
 
 	def test_pos_change_amount(self):
 		make_pos_profile(
@@ -3875,7 +3903,9 @@ class TestSalesInvoice(IntegrationTestCase):
 			},
 		)
 		dn1.save().submit()
-
+		make_stock_entry(
+			target="_Test Warehouse - _TC", item_code="_Test Item", company="_Test Company", qty=5, basic_rate=100
+		)
 		dn2 = create_delivery_note(do_not_submit=1)
 		dn2.items[0].qty = 5
 		dn2.items[0].rate = 100

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -60,7 +60,7 @@ class calculate_taxes_and_totals:
 
 		self.calculate_shipping_charges()
 
-		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
+		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice","POS Invoice"]:
 			self.calculate_total_advance()
 
 		if self.doc.meta.get_field("other_charges_calculation"):
@@ -768,7 +768,6 @@ class calculate_taxes_and_totals:
 						self.doc.party_account_currency, invoice_total
 					)
 				)
-
 			if self.doc.docstatus.is_draft():
 				if self.doc.get("write_off_outstanding_amount_automatically"):
 					self.doc.write_off_amount = 0
@@ -805,7 +804,7 @@ class calculate_taxes_and_totals:
 		self.doc.round_floats_in(self.doc, ["grand_total", "total_advance", "write_off_amount"])
 		self._set_in_company_currency(self.doc, ["write_off_amount"])
 
-		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
+		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice","POS Invoice"]:
 			grand_total = self.doc.rounded_total or self.doc.grand_total
 			base_grand_total = self.doc.base_rounded_total or self.doc.base_grand_total
 
@@ -857,7 +856,7 @@ class calculate_taxes_and_totals:
 					self.doc.write_off_outstanding_amount_automatically = 1
 
 			if (
-				self.doc.doctype == "Sales Invoice"
+				self.doc.doctype in ["Sales Invoice","POS Invoice"]
 				and self.doc.get("is_pos")
 				and self.doc.get("is_return")
 				and not self.doc.get("is_consolidated")
@@ -969,27 +968,32 @@ class calculate_taxes_and_totals:
 				if self.doc.party_account_currency == self.doc.currency
 				else payment.base_amount
 			)
+		if total_paid_amount < total_amount_to_pay:
+			pending_amount = total_amount_to_pay
+		elif total_paid_amount > total_amount_to_pay:
+			pending_amount = total_amount_to_pay - total_paid_amount
+		else:
+			return
+			
 
-		pending_amount = total_amount_to_pay - total_paid_amount
+		default_mode_of_payment = frappe.db.get_value(
+			"POS Payment Method",
+			{"parent": self.doc.pos_profile, "default": 1},
+			["mode_of_payment"],
+			as_dict=1,
+		)
 
-		if pending_amount > 0:
-			default_mode_of_payment = frappe.db.get_value(
-				"POS Payment Method",
-				{"parent": self.doc.pos_profile, "default": 1},
-				["mode_of_payment"],
-				as_dict=1,
+		if default_mode_of_payment:
+			self.doc.payments = []
+			self.doc.append(
+				"payments",
+				{
+					"mode_of_payment": default_mode_of_payment.mode_of_payment,
+					"amount": pending_amount,
+					"default": 1,
+				},
 			)
-
-			if default_mode_of_payment:
-				self.doc.payments = []
-				self.doc.append(
-					"payments",
-					{
-						"mode_of_payment": default_mode_of_payment.mode_of_payment,
-						"amount": pending_amount,
-						"default": 1,
-					},
-				)
+		
 
 
 def get_itemised_tax_breakup_html(doc):


### PR DESCRIPTION
Issue:
POS Invoice can be submitted with partial payments.

Ref:[20857](https://support.frappe.io/helpdesk/tickets/20857)

Before:
https://github.com/user-attachments/assets/36a56dd2-be75-4c9b-b93c-cd78aa59136d

After:
https://github.com/user-attachments/assets/64c0d0da-6d4a-4b49-9293-1b27c2882a3b

backport needed for v15