### PR TITLE
fix: added precision validation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -119,6 +119,7 @@ class Asset(AccountsController):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_precision()
 		self.validate_asset_values()
 		self.validate_asset_and_reference()
 		self.validate_item()
@@ -307,6 +308,15 @@ class Asset(AccountsController):
 					title=_("Missing Finance Book"),
 				)
 
+	def validate_precision(self):
+		float_precision = cint(frappe.db.get_default("float_precision")) or 2
+		if self.gross_purchase_amount:
+			self.gross_purchase_amount = flt(self.gross_purchase_amount, float_precision)
+		if self.opening_accumulated_depreciation:
+			self.opening_accumulated_depreciation = flt(
+				self.opening_accumulated_depreciation, float_precision
+			)
+
 	def validate_asset_values(self):
 		if not self.asset_category:
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
@@ -472,6 +482,9 @@ class Asset(AccountsController):
 
 	def validate_expected_value_after_useful_life(self):
 		for row in self.get("finance_books"):
+			row.expected_value_after_useful_life = flt(
+				row.expected_value_after_useful_life, self.precision("gross_purchase_amount")
+			)
 			depr_schedule = get_depr_schedule(self.name, "Draft", row.finance_book)
 
 			if not depr_schedule:


### PR DESCRIPTION
Problem:
This fix addresses an issue where row.expected_value_after_useful_life was triggering a condition due to minor decimal differences, even when the values should logically be considered equal. Since row.expected_value_after_useful_life is not adjusted for precision.

Solution:
To resolve this, we will apply consistent precision to row.expected_value_after_useful_life and asset_value_after_full_schedule before performing the comparison.