### PR TITLE
fix: error when saving POS merge log

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -438,7 +438,9 @@ def split_invoices(invoices):
 			if not item.serial_no and not item.serial_and_batch_bundle:
 				continue
 
-			return_against_is_added = any(d for d in _invoices if d.pos_invoice == pos_invoice.return_against)
+			return_against_is_added = any(
+				d for d in _invoices if d[0].pos_invoice == pos_invoice.return_against
+			)
 			if return_against_is_added:
 				break
 


### PR DESCRIPTION
### issue
```
builtins.AttributeError: 'list' object has no attribute 'pos_invoice'
```
### fix
check the first invoice in the list, instead of the list itself.