### PR TITLE
fix: Subcontracting Receipt has no reference field for Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
@@ -32,7 +32,7 @@ def get_data():
 			},
 			{
 				"label": _("Sub-contracting"),
-				"items": ["Subcontracting Order", "Subcontracting Receipt", "Stock Entry"],
+				"items": ["Subcontracting Order", "Stock Entry"],
 			},
 			{"label": _("Internal"), "items": ["Sales Order"]},
 		],


### PR DESCRIPTION
Issue from PR: https://github.com/frappe/erpnext/commit/4f8a8a5e9901e3a3b8f24d195f1354e833648e3e

<img width="1297" alt="Screenshot 2024-11-07 at 4 42 43 PM" src="https://github.com/user-attachments/assets/2d317e1f-40fd-403d-8311-40289ea74c37">
