### PR TITLE
fix: `Disable Rounded Total` in Quotation DocType

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -65,6 +65,7 @@
   "grand_total",
   "rounding_adjustment",
   "rounded_total",
+  "disable_rounded_total",
   "in_words",
   "section_break_44",
   "apply_discount_on",
@@ -663,6 +664,7 @@
    "width": "200px"
   },
   {
+   "depends_on": "eval:!doc.disable_rounded_total",
    "fieldname": "base_rounding_adjustment",
    "fieldtype": "Currency",
    "label": "Rounding Adjustment (Company Currency)",
@@ -711,6 +713,7 @@
    "width": "200px"
   },
   {
+   "depends_on": "eval:!doc.disable_rounded_total",
    "fieldname": "rounding_adjustment",
    "fieldtype": "Currency",
    "label": "Rounding Adjustment",
@@ -1073,23 +1076,29 @@
   },
   {
    "fieldname": "utm_medium",
-   "print_hide": 1,
    "fieldtype": "Link",
    "label": "Medium",
-   "options": "UTM Medium"
+   "options": "UTM Medium",
+   "print_hide": 1
   },
   {
    "fieldname": "utm_content",
-   "print_hide": 1,
    "fieldtype": "Data",
-   "label": "Content"
+   "label": "Content",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_rounded_total",
+   "fieldtype": "Check",
+   "label": "Disable Rounded Total"
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-06-28 10:32:47.638342",
+ "modified": "2024-11-07 18:37:11.715189",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -60,6 +60,7 @@ class Quotation(SellingController):
 		customer_address: DF.Link | None
 		customer_group: DF.Link | None
 		customer_name: DF.Data | None
+		disable_rounded_total: DF.Check
 		discount_amount: DF.Currency
 		enq_det: DF.Text | None
 		grand_total: DF.Currency

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -738,6 +738,20 @@ class TestQuotation(IntegrationTestCase):
 		item_doc.taxes = []
 		item_doc.save()
 
+	def test_grand_total_and_rounded_total_values(self):
+		quotation = make_quotation(qty=6, rate=12.3, do_not_submit=1)
+
+		self.assertEqual(quotation.grand_total, 73.8)
+		self.assertEqual(quotation.rounding_adjustment, 0.2)
+		self.assertEqual(quotation.rounded_total, 74)
+
+		quotation.disable_rounded_total = 1
+		quotation.save()
+
+		self.assertEqual(quotation.grand_total, 73.8)
+		self.assertEqual(quotation.rounding_adjustment, 0)
+		self.assertEqual(quotation.rounded_total, 0)
+
 
 def enable_calculate_bundle_price(enable=1):
 	selling_settings = frappe.get_doc("Selling Settings")


### PR DESCRIPTION
Issue:

- `disable_rounded_total` field is provided in other buying and selling doctypes, but it is missing in `Quotation` DocType.

![Screenshot 2024-11-08 at 11 13 31 AM](https://github.com/user-attachments/assets/0578180f-4b9e-4537-96f0-3d78a9d9ee14)
