### PR TITLE
fix: item not set in the batch quick entry form

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -289,28 +289,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				}
 			]);
 		}
-
-		if(this.frm.fields_dict['items'].grid.get_field('serial_and_batch_bundle')) {
-			let sbb_field = this.frm.get_docfield('items', 'serial_and_batch_bundle');
-			if (sbb_field) {
-				sbb_field.get_route_options_for_new_doc = (row) => {
-					return {
-						'item_code': row.doc.item_code,
-					}
-				};
-			}
-		}
-
-		if(this.frm.fields_dict['items'].grid.get_field('batch_no')) {
-			let batch_no_field = this.frm.get_docfield('items', 'batch_no');
-			if (batch_no_field) {
-				batch_no_field.get_route_options_for_new_doc = function(row) {
-					return {
-						'item': row.doc.item_code
-					}
-				};
-			}
-		}
 	}
 
 	is_return() {
@@ -409,6 +387,35 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.setup_quality_inspection();
 		this.validate_has_items();
 		erpnext.utils.view_serial_batch_nos(this.frm);
+		this.set_route_options_for_new_doc();
+	}
+
+	set_route_options_for_new_doc() {
+		// While creating the batch from the link field, copy item from line item to batch form
+
+		if(this.frm.fields_dict['items'].grid.get_field('batch_no')) {
+			let batch_no_field = this.frm.get_docfield('items', 'batch_no');
+			if (batch_no_field) {
+				batch_no_field.get_route_options_for_new_doc = function(row) {
+					return {
+						'item': row.doc.item_code
+					}
+				};
+			}
+		}
+
+		// While creating the SABB from the link field, copy item, doctype from line item to SABB form
+		if(this.frm.fields_dict['items'].grid.get_field('serial_and_batch_bundle')) {
+			let sbb_field = this.frm.get_docfield('items', 'serial_and_batch_bundle');
+			if (sbb_field) {
+				sbb_field.get_route_options_for_new_doc = (row) => {
+					return {
+						"item_code": row.doc.item_code,
+						"voucher_type": this.frm.doc.doctype,
+					}
+				};
+			}
+		}
 	}
 
 	scan_barcode() {


### PR DESCRIPTION
**Issue**

Item not set in the Batch quick entry form from the purchase receipt


https://github.com/user-attachments/assets/14e6e25a-0e68-4a37-a890-a4c22d75e2aa



**After Fix**


https://github.com/user-attachments/assets/25bb3fd1-e1c7-43f5-baba-09c684613317

