### PR TITLE
fix: sort by ascending to get the first period closing voucher

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -417,7 +417,7 @@ class PeriodClosingVoucher(AccountsController):
 			"Period Closing Voucher",
 			{"company": self.company, "docstatus": 1},
 			"name",
-			order_by="period_end_date",
+			order_by="period_end_date asc",
 		)
 
 		if not first_pcv or first_pcv == self.name:

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -314,7 +314,7 @@ erpnext.patches.v15_0.update_asset_value_for_manual_depr_entries
 erpnext.patches.v15_0.update_gpa_and_ndb_for_assdeprsch
 erpnext.patches.v14_0.create_accounting_dimensions_for_closing_balance
 erpnext.patches.v14_0.set_period_start_end_date_in_pcv
-erpnext.patches.v14_0.update_closing_balances #29-10-2024
+erpnext.patches.v14_0.update_closing_balances #08-11-2024
 execute:frappe.db.set_single_value("Accounts Settings", "merge_similar_account_heads", 0)
 erpnext.patches.v14_0.update_reference_type_in_journal_entry_accounts
 erpnext.patches.v14_0.update_subscription_details


### PR DESCRIPTION
Issue:
Since the period closing voucher is sorted with descending ```is_first_period_closing_voucher``` function validated with the last created voucher instead of the first. while executing the patch ```erpnext.patches.v14_0.update_closing_balances``` account closing balance was not posted for opening vouchers.

Fix:
Sorted the Period Closing Voucher in ascending

ref: [24822](https://support.frappe.io/helpdesk/tickets/24822)

Backport needed for v15