### PR TITLE
fix: update payment schedule table

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2459,7 +2459,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	payment_terms_template() {
 		var me = this;
 		const doc = this.frm.doc;
-		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && doc.is_return == 0) {
+		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && doc.is_return != 1) {
 			var posting_date = doc.posting_date || doc.transaction_date;
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_terms",


### PR DESCRIPTION
**Issue:**
When doctype doesn't have the `is_return` field payment schedule table is not updating while selecting the Payment Term Template

**ref:** [24911](https://support.frappe.io/helpdesk/tickets/24911)

**Before:**
[Payment Term Template Issue](https://github.com/user-attachments/assets/1c83fb02-d00d-4d53-b70f-4de18658ee11) 

**After:**
[Payment Term Template Fix](https://github.com/user-attachments/assets/eedd2716-78ab-4905-90e6-e95e8bae7eb1)


**Backport Needed:**  v15
