### PR TITLE
fix: update payment amount on pos partial return

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -65,7 +65,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		super.refresh();
 
 		if (doc.docstatus == 1 && !doc.is_return) {
-			this.frm.add_custom_button(__("Return"), this.make_sales_return, __("Create"));
+			this.frm.add_custom_button(__("Return"), this.make_sales_return.bind(this), __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -65,7 +65,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		super.refresh();
 
 		if (doc.docstatus == 1 && !doc.is_return) {
-			this.frm.add_custom_button(__("Return"), this.make_sales_return.bind(this), __("Create"));
+			this.frm.add_custom_button(__("Return"), this.make_sales_return, __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -65,7 +65,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		super.refresh();
 
 		if (doc.docstatus == 1 && !doc.is_return) {
-			this.frm.add_custom_button(__("Return"), this.make_sales_return, __("Create"));
+			this.frm.add_custom_button(__("Return"), this.make_sales_returnbind(this), __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -845,13 +845,14 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		}
 
-		if(!this.frm.doc.is_return){
-			this.frm.doc.payments.find(payment => {
-				if (payment.default) {
-					payment.amount = total_amount_to_pay;
-				}
-			});
-		}
+		this.frm.doc.payments.find(payment => {
+			if (payment.default) {
+				payment.amount = total_amount_to_pay;
+			}
+			else {
+				payment.amount = 0
+			}
+		});
 
 		this.frm.refresh_fields();
 	}

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -99,7 +99,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				return `<div class="item-qty-pill">
 							<span class="indicator-pill whitespace-nowrap ${indicator_color}">${qty_to_display}</span>
 						</div>
-						<div class="flex items-center justify-center h-32 border-b-grey text-6xl text-grey-100">
+						<div class="flex items-center justify-center border-b-grey text-6xl text-grey-100" style="height:8rem; min-height:8rem">
 							<img
 								onerror="cur_pos.item_selector.handle_broken_image(this)"
 								class="h-full item-img" src="${item_image}"


### PR DESCRIPTION
Issue:
When creating a POS partial return invoice, the payment table is not updating based on the qty and amount to pay.

ref:[24091](https://support.frappe.io/helpdesk/tickets/24091)

Before:
[Screencast from 09-11-24 06:13:13 PM IST.webm](https://github.com/user-attachments/assets/1dcbed34-7760-44f1-8029-d14d3a717183)

After:
[Screencast from 09-11-24 06:14:05 PM IST.webm](https://github.com/user-attachments/assets/53ccad58-2086-452f-a559-c7ee030cca44)

While working on the above issue, solved following issues and mentioned commits below.

Issue 1:  feaa8e88571771e56295229900c4d6b53df14345
Not able to create a POS return using `create` button.

![Screenshot from 2024-11-09 18-16-24](https://github.com/user-attachments/assets/2554a193-36d8-4cc1-95dd-3d35fd1d2a91)

Issue 2: b363d5be34e8f8446e19e4644628af62982289b5
POS item card height doesn't applied.

Before:
![Screenshot from 2024-11-09 18-08-17](https://github.com/user-attachments/assets/ee64d5f1-9c61-46d9-a38a-af67fe18a71c)

After:
![Screenshot from 2024-11-09 18-08-48](https://github.com/user-attachments/assets/21780b42-4b6e-45e1-b51b-0e671c81e624)

Backport Needed: v15


