### PR TITLE
fix: update payment amount for partial pos return

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -845,13 +845,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		}
 
-		if(!this.frm.doc.is_return){
-			this.frm.doc.payments.find(payment => {
-				if (payment.default) {
-					payment.amount = total_amount_to_pay;
-				}
-			});
-		}
+		this.frm.doc.payments.find(payment => {
+			if (payment.default) {
+				payment.amount = total_amount_to_pay;
+			} else {
+				payment.amount = 0
+			}
+		});
 
 		this.frm.refresh_fields();
 	}


### PR DESCRIPTION
Issue:
When creating a POS partial return invoice, the payment table is not updating based on the qty and amount to pay.

Ref: [24091](https://support.frappe.io/helpdesk/tickets/24091)

Before:
[pos partial return issue.webm](https://github.com/user-attachments/assets/d0fd6061-1467-4f80-b6c6-ae80e40a4046)

After:
[pos partial return fixed.webm](https://github.com/user-attachments/assets/c30e8661-4dca-4845-97ff-2d66d05e2feb)

Backport Needed: v15
