### PR TITLE
fix: bind this object explicitly on pos create return event

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -65,7 +65,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		super.refresh();
 
 		if (doc.docstatus == 1 && !doc.is_return) {
-			this.frm.add_custom_button(__("Return"), this.make_sales_return, __("Create"));
+			this.frm.add_custom_button(__("Return"), this.make_sales_return.bind(this), __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -845,13 +845,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		}
 
-		if(!this.frm.doc.is_return){
-			this.frm.doc.payments.find(payment => {
-				if (payment.default) {
-					payment.amount = total_amount_to_pay;
-				}
-			});
-		}
+		this.frm.doc.payments.find(payment => {
+			if (payment.default) {
+				payment.amount = total_amount_to_pay;
+			} else {
+				payment.amount = 0
+			}
+		});
 
 		this.frm.refresh_fields();
 	}

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -99,7 +99,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				return `<div class="item-qty-pill">
 							<span class="indicator-pill whitespace-nowrap ${indicator_color}">${qty_to_display}</span>
 						</div>
-						<div class="flex items-center justify-center h-32 border-b-grey text-6xl text-grey-100">
+						<div class="flex items-center justify-center border-b-grey text-6xl text-grey-100" style="min-height:8rem; height:8rem">
 							<img
 								onerror="cur_pos.item_selector.handle_broken_image(this)"
 								class="h-full item-img" src="${item_image}"


### PR DESCRIPTION
Issue:
POS form create return button not worked, due to not binding `this` on callback function.

![Screenshot from 2024-11-09 18-16-24](https://github.com/user-attachments/assets/8accb75a-d05e-4a6a-b8fd-f268c3ebf034)

Backport needed: v15