### PR TITLE
fix: add default height to POS item card selector

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -99,7 +99,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				return `<div class="item-qty-pill">
 							<span class="indicator-pill whitespace-nowrap ${indicator_color}">${qty_to_display}</span>
 						</div>
-						<div class="flex items-center justify-center h-32 border-b-grey text-6xl text-grey-100">
+						<div class="flex items-center justify-center border-b-grey text-6xl text-grey-100" style="height:8rem; min-height:8rem">
 							<img
 								onerror="cur_pos.item_selector.handle_broken_image(this)"
 								class="h-full item-img" src="${item_image}"


### PR DESCRIPTION
Issue:
Unable to view the item image in POS item card

Before:
![Screenshot from 2024-11-09 18-08-17](https://github.com/user-attachments/assets/453b025c-7919-4aa0-93e1-d84d7a097b33)

After:
![Screenshot from 2024-11-09 18-08-48](https://github.com/user-attachments/assets/94991391-a960-492f-8f7b-cd24730942d0)

Backport needed: v15