### PR TITLE
fix: bind this object explicitly on callback event function

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -65,7 +65,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		super.refresh();
 
 		if (doc.docstatus == 1 && !doc.is_return) {
-			this.frm.add_custom_button(__("Return"), this.make_sales_return, __("Create"));
+			this.frm.add_custom_button(__("Return"), this.make_sales_return.bind(this), __("Create"));
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 


### PR DESCRIPTION
Issue:
Unable to create return POS Invoice using return button. Getting `this` undefined error from client side.

![Screenshot from 2024-11-09 18-16-24](https://github.com/user-attachments/assets/825e90a7-a243-4fc6-aa0f-a12d4697199c)

Backport needed: v15