### PR TITLE
fix: populate payment schedule from payment terms

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2459,7 +2459,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	payment_terms_template() {
 		var me = this;
 		const doc = this.frm.doc;
-		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && doc.is_return == 0) {
+		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && !doc.is_return) {
 			var posting_date = doc.posting_date || doc.transaction_date;
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_terms",


### PR DESCRIPTION
Version: 15 and 14

fixes: https://github.com/frappe/erpnext/issues/44039

**Before:**
The code checked if `is_return` was exactly `0` with this condition:
```javascript
if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && doc.is_return == 0) {
```
This would only work if `is_return` was set to `0`. If `is_return` wasn't available or set to something else, the condition wouldn't trigger, and the payment schedule wouldn't populate.

**After:**
The code was changed to:
```javascript
if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && !doc.is_return) {
```
This condition checks if `is_return` is either not set or has a falsy value (like `0`, `null`, or `undefined`). So, even if `is_return` is missing in some doctypes, the payment schedule will still auto-populate. 

- This change was made because sometimes the `is_return` field is not available in certain documents. The new check ensures the payment schedule populates correctly even when `is_return` is not set.