### PR TITLE
fix: apply posting date sorting to invoices in Payment Reconciliation similar to payments

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -370,11 +370,11 @@ class PaymentReconciliation(Document):
 
 		if self.invoice_limit:
 			non_reconciled_invoices = non_reconciled_invoices[: self.invoice_limit]
-			
+
 		non_reconciled_invoices = sorted(
 			non_reconciled_invoices, key=lambda k: k["posting_date"] or getdate(nowdate())
 		)
-		
+
 		self.add_invoice_entries(non_reconciled_invoices)
 
 	def add_invoice_entries(self, non_reconciled_invoices):

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -370,7 +370,11 @@ class PaymentReconciliation(Document):
 
 		if self.invoice_limit:
 			non_reconciled_invoices = non_reconciled_invoices[: self.invoice_limit]
-
+			
+		non_reconciled_invoices = sorted(
+			non_reconciled_invoices, key=lambda k: k["posting_date"] or getdate(nowdate())
+		)
+		
 		self.add_invoice_entries(non_reconciled_invoices)
 
 	def add_invoice_entries(self, non_reconciled_invoices):


### PR DESCRIPTION
### Summary
In the Payment Reconciliation tool, payment entries are ordered by their posting date, but the invoice entries were not. 
This update adds sorting for invoice entries by their posting date in the `get_invoice_entries` function. The sorting of invoices is now aligned with the sorting applied to payments, ensuring consistency and improving the reconciliation process.

### Changes
 Updated `get_invoice_entries` function to sort `non_reconciled_invoices` by `posting_date`, similar to the sorting applied in `get_nonreconciled_payment_entries` to sort payments.

### Screenshots
#### Before Sorting
![image](https://github.com/user-attachments/assets/ff40bad6-f2a1-4941-9abd-67be9a486fad)
#### After Sorting
![image](https://github.com/user-attachments/assets/98f00fb5-0588-479a-9886-3bcf588e8975)