### PR TITLE
fix: check if pricing rule matches with coupon code

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -456,9 +456,7 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 					return item_details
 
 				coupon_code = frappe.db.get_value(
-					doctype="Coupon Code",
-					filters={"pricing_rule": pricing_rule.name},
-					fieldname="name"
+					doctype="Coupon Code", filters={"pricing_rule": pricing_rule.name}, fieldname="name"
 				)
 				if args.coupon_code != coupon_code:
 					continue

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -451,6 +451,18 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 					get_pricing_rule_items(pricing_rule, other_items=fetch_other_item) or []
 				)
 
+			if pricing_rule.coupon_code_based == 1:
+				if not args.coupon_code:
+					return item_details
+
+				coupon_code = frappe.db.get_value(
+					doctype="Coupon Code",
+					filters={"pricing_rule": pricing_rule.name},
+					fieldname="name"
+				)
+				if args.coupon_code != coupon_code:
+					continue
+
 			if pricing_rule.get("suggestion"):
 				continue
 
@@ -475,9 +487,6 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 					item_details["apply_rule_on_other_items"] = json.dumps(
 						pricing_rule.apply_rule_on_other_items
 					)
-
-			if pricing_rule.coupon_code_based == 1 and args.coupon_code is None:
-				return item_details
 
 			if not pricing_rule.validate_applied_rule:
 				if pricing_rule.price_or_product_discount == "Price":


### PR DESCRIPTION
### Summary
There are two coupon codes, each with distinct pricing rules:

1. Karneval2024: Discounts a specific item (20%, Item Code 003).
2. Winter2024: Discounts items from a specific item group (50%, Item Group "Accessoire").

In a sales order, two items are added. The first item belongs to the item group eligible for a discount from Winter2024, while the second item is the specific item eligible for a discount through Karneval2024.

When I apply Karneval2024 in the sales order to discount only the specific item, Winter2024 pricing rule is also incorrectly applied, as it matches the second item (because it is in the item group).

### Changes
Update the check in `get_pricing_rule_for_item` and check whether the current pricing rule matches the specified voucher code.

### Backports
version-14
version-15

### Issue
closes #40013

### Images
Winter2024 Coupon Code and Pricing Rule:
![image](https://github.com/user-attachments/assets/a217cc1b-9a46-4fec-bb21-35f9364808cb)
![image](https://github.com/user-attachments/assets/255a9f87-426c-4366-a4fc-d580e8436308)

Karneval2024 Coupon Code and Pricing Rule:
![image](https://github.com/user-attachments/assets/46e34e2e-ca56-49e3-9991-e556b881dba8)
![image](https://github.com/user-attachments/assets/3ab17b37-30b6-454b-9ee0-28ffc9e9e3f9)

Added Karneval2024 Coupon Code to Sales Order, both Items discounted:
![image](https://github.com/user-attachments/assets/3f6e5ca3-6f2b-40a8-91aa-e4775661bf5b)
![image](https://github.com/user-attachments/assets/d37fd9ba-3684-451b-93b3-89af97007e3e)
