### PR TITLE
fix: Drop Shipping address based on customer shopping address

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -956,9 +956,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
 			['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'].includes(this.frm.doctype)) {
-			erpnext.utils.get_shipping_address(this.frm, function() {
-				set_party_account(set_pricing);
-			});
+				let is_drop_ship = me.frm.doc.items.some(item => item.delivered_by_supplier);
+
+				if (!is_drop_ship) {
+					console.log('get_shipping_address');
+					erpnext.utils.get_shipping_address(this.frm, function() {
+						set_party_account(set_pricing);
+					});
+				}
 
 		} else {
 			set_party_account(set_pricing);

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1419,9 +1419,17 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		target.payment_schedule = []
 
 		if is_drop_ship_order(target):
-			target.customer = source.customer
-			target.customer_name = source.customer_name
-			target.shipping_address = source.shipping_address_name
+			if source.shipping_address_name:
+				target.shipping_address = source.shipping_address_name
+				target.shipping_address_display = source.shipping_address
+			else:
+				target.shipping_address = source.customer_address
+				target.shipping_address_display = source.address_display
+
+			target.customer_contact_person = source.contact_person
+			target.customer_contact_display = source.contact_display
+			target.customer_contact_mobile = source.contact_mobile
+			target.customer_contact_email = source.contact_email
 		else:
 			target.customer = target.customer_name = target.shipping_address = None
 


### PR DESCRIPTION
Version 15 & 14

fixes: https://github.com/frappe/erpnext/issues/44019 & https://github.com/frappe/erpnext/issues/37892

___

**Before:**

- For Drop shipping, if the purchase order is made with the default supplier, the flow works properly. However, when creating a purchase order without the default supplier, it redirects to the purchase page and sets the company address, but it should set the customer's shipping address instead of the company address.

[Before_DropShipping.webm](https://github.com/user-attachments/assets/bb53dc19-4465-400f-ba02-a3d67fd8d28a)

<br>


**After:**

- Set the value in the `set_missing_values` because some details were not being fetched. Also, fixed the condition in `transaction.js`. Previously, when redirecting from the sales order to the purchase order, the refresh event would trigger, removing the customer address and setting the company address. Now, I’ve added the `is_drop_ship` condition. If `is_drop_ship` is true, the refresh event won’t trigger, and the customer address will be kept.

[After_DropShipping.webm](https://github.com/user-attachments/assets/7c57ad7f-a658-41fd-aa6b-849ecbeeacc4)
