### PR TITLE
fix: set debit in transaction currency in GL Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1243,6 +1243,12 @@ class PaymentEntry(AccountsController):
 		if self.payment_type in ("Receive", "Pay") and not self.get("party_account_field"):
 			self.setup_party_account_field()
 
+		company_currency = erpnext.get_company_currency(self.company)
+		if self.paid_from_account_currency != company_currency:
+			self.currency = self.paid_from_account_currency
+		elif self.paid_to_account_currency != company_currency:
+			self.currency = self.paid_to_account_currency
+
 		gl_entries = []
 		self.add_party_gl_entries(gl_entries)
 		self.add_bank_gl_entries(gl_entries)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1347,13 +1347,22 @@ class PaymentEntry(AccountsController):
 			base_unallocated_amount = self.unallocated_amount * exchange_rate
 
 			gle = party_gl_dict.copy()
-			gle.update(
-				{
-					dr_or_cr + "_in_account_currency": self.unallocated_amount,
-					dr_or_cr: base_unallocated_amount,
-				}
-			)
 
+			gle.update(
+				self.get_gl_dict(
+					{
+						"account": self.party_account,
+						"party_type": self.party_type,
+						"party": self.party,
+						"against": against_account,
+						"account_currency": self.party_account_currency,
+						"cost_center": self.cost_center,
+						dr_or_cr + "_in_account_currency": self.unallocated_amount,
+						dr_or_cr: base_unallocated_amount,
+					},
+					item=self,
+				)
+			)
 			if self.book_advance_payments_in_separate_party_account:
 				gle.update(
 					{

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1001,8 +1001,8 @@ class TestPaymentEntry(IntegrationTestCase):
 			.run()
 		)
 		expected_gl_entries = (
-			(paid_from, 0.0, 8440.0, 0.0, 100.0, 0.0, 8440.0),
-			("_Test Payable USD - _TC", 8440.0, 0.0, 100.0, 0.0, 8440.0, 0.0),
+			(paid_from, 0.0, 8440.0, 0.0, 100.0, 0.0, 100.0),
+			("_Test Payable USD - _TC", 8440.0, 0.0, 100.0, 0.0, 100.0, 0.0),
 		)
 		self.assertEqual(gl_entries, expected_gl_entries)
 

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -968,7 +968,7 @@ class TestPaymentEntry(IntegrationTestCase):
 		save_new_records(self.globalTestRecords["Currency Exchange"])
 		paid_from = create_account(
 			parent_account="Current Liabilities - _TC",
-			account_name="Cash USD",
+			account_name="_Test Cash USD",
 			company="_Test Company",
 			account_type="Cash",
 			account_currency="USD",
@@ -1001,10 +1001,9 @@ class TestPaymentEntry(IntegrationTestCase):
 			.run()
 		)
 		expected_gl_entries = (
-			("_Test Payable USD - _TC", 8440.0, 0, 100.0, 0.0, 8440.0, 0.0),
-			(paid_from, 0, 8440.0, 0, 100.0, 0, 8440.0),
+			(paid_from, 0.0, 8440.0, 0.0, 100.0, 0.0, 8440.0),
+			("_Test Payable USD - _TC", 8440.0, 0.0, 100.0, 0.0, 8440.0, 0.0),
 		)
-
 		self.assertEqual(gl_entries, expected_gl_entries)
 
 	def test_multi_currency_payment_entry_with_taxes(self):

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -962,6 +962,51 @@ class TestPaymentEntry(IntegrationTestCase):
 		self.assertEqual(flt(expected_party_balance), party_balance)
 		self.assertEqual(flt(expected_party_account_balance, 2), flt(party_account_balance, 2))
 
+	def test_gl_of_multi_currency_payment_transaction(self):
+		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import save_new_records
+
+		save_new_records(self.globalTestRecords["Currency Exchange"])
+		paid_from = create_account(
+			parent_account="Current Liabilities - _TC",
+			account_name="Cash USD",
+			company="_Test Company",
+			account_type="Cash",
+			account_currency="USD",
+		)
+		payment_entry = create_payment_entry(
+			party="_Test Supplier USD",
+			paid_from=paid_from,
+			paid_to="_Test Payable USD - _TC",
+			paid_amount=100,
+			save=True,
+		)
+		payment_entry.source_exchange_rate = 84.4
+		payment_entry.target_exchange_rate = 84.4
+		payment_entry.save()
+		payment_entry = payment_entry.submit()
+		gle = qb.DocType("GL Entry")
+		gl_entries = (
+			qb.from_(gle)
+			.select(
+				gle.account,
+				gle.debit,
+				gle.credit,
+				gle.debit_in_account_currency,
+				gle.credit_in_account_currency,
+				gle.debit_in_transaction_currency,
+				gle.credit_in_transaction_currency,
+			)
+			.orderby(gle.account)
+			.where(gle.voucher_no == payment_entry.name)
+			.run()
+		)
+		expected_gl_entries = (
+			("_Test Payable USD - _TC", 8440.0, 0, 100.0, 0.0, 8440.0, 0.0),
+			(paid_from, 0, 8440.0, 0, 100.0, 0, 8440.0),
+		)
+
+		self.assertEqual(gl_entries, expected_gl_entries)
+
 	def test_multi_currency_payment_entry_with_taxes(self):
 		payment_entry = create_payment_entry(
 			party="_Test Supplier USD", paid_to="_Test Payable USD - _TC", save=True


### PR DESCRIPTION
**Issue:**   When a multi-currency payment transaction is made, the debit value in the transaction currency is not being updated in the GL Entry posted against that payment.

**ref:** [25193](https://support.frappe.io/helpdesk/tickets/25193)

**Before:**
![gl_entry_before_fix](https://github.com/user-attachments/assets/5a61dcb6-895e-4fe7-b070-fce9b7097a3e)

**After:**
![gl_entry_after_fix](https://github.com/user-attachments/assets/b1575a5e-e547-415f-b268-01bfee3ba45d)


Backport needed: v15