### PR TITLE
fix: updated label "Is short year" to "Is Short/Long year" for both short and long fiscal years

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.json
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.json
@@ -72,10 +72,10 @@
   },
   {
    "default": "0",
-   "description": "Less than 12 months.",
+   "description": "More/Less than 12 months.",
    "fieldname": "is_short_year",
    "fieldtype": "Check",
-   "label": "Is Short Year",
+   "label": "Is Short/Long Year",
    "set_only_once": 1
   }
  ],


### PR DESCRIPTION
Is short/long year.

FY can be short or long here in Nepal.

FY starts in July every year, but date can be 15/16/17 which varies every year.
Also FY end date can be different.

For ex. any of this is possible:
1. Start : 07-16 End: 07-15
2. Start : 07-16 End: 07-16 -> probably long year
3. Start : 07-16 End: 07-14
4. Start : 07-15 End: 07-16 -> long year

Same goes for other dates. 

The `Is short year` check mark seems to work good for long years as well. So, decided to update the text label to avoid confusion.