### PR TITLE
Fix: Disable "Add Row" button in allocations table during UnReconcile process

### DIFF
--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -119,11 +119,18 @@ erpnext.accounts.unreconcile_payment = {
 							return r.message;
 						};
 
+						const allocationsTableField = unreconcile_dialog_fields.find(
+							(field) => field.fieldname === "allocations"
+						);
+
+						if (allocationsTableField) {
+							allocationsTableField.cannot_add_rows = true;
+						}
+
 						let d = new frappe.ui.Dialog({
 							title: "UnReconcile Allocations",
 							fields: unreconcile_dialog_fields,
 							size: "large",
-							cannot_add_rows: true,
 							primary_action_label: "UnReconcile",
 							primary_action(values) {
 								let selected_allocations = values.allocations.filter((x) => x.__checked);


### PR DESCRIPTION
### Problem:
In the UnReconcile Allocations dialog, the `cannot_add_rows` property was incorrectly applied to the dialog itself, which did not prevent users from adding rows to the allocations table.

### Solution:
The `cannot_add_rows` property has been moved and correctly applied to the allocations table field to disable the "Add Row" button, ensuring users cannot add new rows while reconciling
### Before:
![image](https://github.com/user-attachments/assets/c7147691-a21f-4929-9e5b-0ec67585e0c1)

### After:
![image](https://github.com/user-attachments/assets/6e19c536-90d2-4169-8abf-f6a97c37a9d8)