### PR TITLE
fix: apply "cannot_add_rows" directly to table field for more efficient solution

### DIFF
--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -100,6 +100,7 @@ erpnext.accounts.unreconcile_payment = {
 					fieldtype: "Table",
 					read_only: 1,
 					fields: child_table_fields,
+					cannot_add_rows: true,
 				},
 			];
 
@@ -118,14 +119,6 @@ erpnext.accounts.unreconcile_payment = {
 						unreconcile_dialog_fields[0].get_data = function () {
 							return r.message;
 						};
-
-						const allocationsTableField = unreconcile_dialog_fields.find(
-							(field) => field.fieldname === "allocations"
-						);
-
-						if (allocationsTableField) {
-							allocationsTableField.cannot_add_rows = true;
-						}
 
 						let d = new frappe.ui.Dialog({
 							title: "UnReconcile Allocations",


### PR DESCRIPTION
### Problem:
The initial fix in PR #44148 to disable the "Add Row" button was not the most efficient approach.

### Solution:
This update applies the `cannot_add_rows` property directly to the allocations table field, offering a cleaner and more efficient solution. It works the same as expected as in PR #44148 but with a more efficient code structure.
