### PR TITLE
fix: improve timesheet and project handling in sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1019,6 +1019,16 @@ frappe.ui.form.on("Sales Invoice", {
 							fieldtype: "Link",
 							options: "Project",
 							default: frm.doc.project,
+							get_query: function () {
+								if (!frm.doc.customer) {
+									return {};
+								}
+								return {
+									filters: {
+										customer: frm.doc.customer,
+									},
+								};
+							},
 						},
 					],
 					primary_action: function () {

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1028,6 +1028,7 @@ frappe.ui.form.on("Sales Invoice", {
 							to_time: data.to_time,
 							project: data.project,
 						});
+						frm.set_value("project", data.project);
 						d.hide();
 					},
 					primary_action_label: __("Get Timesheets"),

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -258,6 +258,7 @@
   },
   {
    "bold": 1,
+   "fetch_from": "project.customer",
    "fieldname": "customer",
    "fieldtype": "Link",
    "hide_days": 1,


### PR DESCRIPTION
This pull request fixes three bugs in Sales Invoice regarding timesheets and projects:
- When timesheets are fetched in a sales invoice and the correct project is not set in the sales invoice afterwards, the used timesheets are displayed as billed, even if not all hours in the timesheet have been charged
- In the “Fetch Timesheet” dialog, projects are displayed that do not belong to the customer defined in the sales invoice
- If a project is selected in the sales invoice before a customer is defined, any customer can be selected, even if it does not belong to the project

This pull request improves usability and minimizes errors.

fixing this bug: https://github.com/frappe/erpnext/issues/44167

Backport: Version-15