### PR TITLE
fix: include current invoice amount when tax_on_excess_amount is checked

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -568,7 +568,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 		if (cumulative_threshold and supp_credit_amt >= cumulative_threshold) and cint(
 			tax_details.tax_on_excess_amount
 		):
-			supp_credit_amt = net_total - cumulative_threshold
+			supp_credit_amt = net_total + tax_withholding_net_total - cumulative_threshold
 
 		if ldc and is_valid_certificate(ldc, inv.get("posting_date") or inv.get("transaction_date"), 0):
 			tds_amount = get_lower_deduction_amount(

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -177,6 +177,45 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		for d in reversed(invoices):
 			d.cancel()
 
+	def test_cumulative_threshold_with_tax_on_excess_amount(self):
+		invoices = []
+		frappe.db.set_value("Supplier", "Test TDS Supplier3", "tax_withholding_category", "New TDS Category")
+
+		# Invoice with tax and without exceeding single and cumulative thresholds
+		for _ in range(2):
+			pi = create_purchase_invoice(supplier="Test TDS Supplier3", rate=10000, do_not_save=True)
+			pi.apply_tds = 1
+			pi.append(
+				"taxes",
+				{
+					"category": "Total",
+					"charge_type": "Actual",
+					"account_head": "_Test Account VAT - _TC",
+					"cost_center": "Main - _TC",
+					"tax_amount": 500,
+					"description": "Test",
+					"add_deduct_tax": "Add",
+				},
+			)
+			pi.save()
+			pi.submit()
+			invoices.append(pi)
+
+		# Third Invoice exceeds single threshold and not exceeding cumulative threshold
+		pi1 = create_purchase_invoice(supplier="Test TDS Supplier3", rate=20000)
+		pi1.apply_tds = 1
+		pi1.save()
+		pi1.submit()
+		invoices.append(pi1)
+
+		# Cumulative threshold is 10,000
+		# Threshold calculation should be only on the third invoice
+		self.assertTrue(len(pi1.taxes) > 0)
+		self.assertEqual(pi1.taxes[0].tax_amount, 1000)
+
+		for d in reversed(invoices):
+			d.cancel()
+
 	def test_cumulative_threshold_tcs(self):
 		frappe.db.set_value(
 			"Customer", "Test TCS Customer", "tax_withholding_category", "Cumulative Threshold TCS"


### PR DESCRIPTION
**Issue:**
TDS is not calculated when tax_on_excess_amount is ticked in the Tax Withholding Category

**ref:** [25643](https://support.frappe.io/helpdesk/tickets/25643)

**Before:**
https://github.com/user-attachments/assets/0c090c2f-9daf-48c4-b796-91216e8737ad

**After:**
https://github.com/user-attachments/assets/d8d30bda-4bc9-44e7-9554-51a279210552

**Backport needed:** v14 & v15
