### PR TITLE
fix: Global Defaults Configuration "Disable Rounded Total" is ignored…

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -142,6 +142,8 @@ class POSInvoiceMergeLog(Document):
 		sales_invoice.set_posting_time = 1
 		sales_invoice.posting_date = getdate(self.posting_date)
 		sales_invoice.posting_time = get_time(self.posting_time)
+		sales_invoice.disable_rounded_total = frappe.db.get_single_value("Global Defaults", "disable_rounded_total")
+		
 		sales_invoice.save()
 		sales_invoice.submit()
 


### PR DESCRIPTION
When creating a Sales Invoice from a POS Invoice Merge Log, the option "Disable Rounded Total" is ignored. This commit fixes it.

![image](https://github.com/user-attachments/assets/e9eafd79-8ad9-4748-a314-197dca703385)

