### PR TITLE
fix: disable conversion to user tz for sales order calender

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1247,7 +1247,10 @@ def get_events(start, end, filters=None):
 		""",
 		{"start": start, "end": end},
 		as_dict=True,
-		update={"allDay": 0},
+		update={
+			"allDay": 0,
+			"convertToUserTz": 0,
+		},
 	)
 	return data
 

--- a/erpnext/selling/doctype/sales_order/sales_order_calendar.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_calendar.js
@@ -8,6 +8,7 @@ frappe.views.calendar["Sales Order"] = {
 		id: "name",
 		title: "customer_name",
 		allDay: "allDay",
+		convertToUserTz: "convertToUserTz",
 	},
 	gantt: true,
 	filters: [


### PR DESCRIPTION
There is inconsistencies between the Form View and Calendar View for date .because Form View shows the date as per the system timezone but the calendar view converts it to the user timezone.

Steps to Replicate:
- Change the User Timezone to something with more than 12 hours difference.
- Check the Sales Order Calender.

![image](https://github.com/user-attachments/assets/7da9f28e-83a2-4268-8d7e-3bcbb41eb435)
![image](https://github.com/user-attachments/assets/0d2644db-4805-4f9f-8054-93239ba4f7cf)

Before:
![image](https://github.com/user-attachments/assets/d8edd087-d089-481d-9bc3-5a28052364f3)



After:
![image](https://github.com/user-attachments/assets/5dd3ed89-5561-4c1e-9166-f173d025c92c)


Frappe Support Issue:https://support.frappe.io/helpdesk/tickets/25422
Fraape PR for reference: https://github.com/frappe/frappe/pull/20051

backport version-15 
backport version-14



