### PR TITLE
refactor: make stem utility for normalizing ctx args from dict json-str or Document

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -1,7 +1,9 @@
 import functools
 import inspect
+from typing import TypeVar
 
 import frappe
+from frappe.model.document import Document
 from frappe.utils.user import is_website_user
 
 __version__ = "16.0.0-dev"
@@ -160,3 +162,34 @@ def check_app_permission():
 		return False
 
 	return True
+
+
+T = TypeVar("T")
+
+
+def normalize_ctx_input(T: type) -> callable:
+	"""
+	Normalizes the first argument (ctx) of the decorated function by:
+	- Converting Document objects to dictionaries
+	- Parsing JSON strings
+	- Casting the result to the specified type T
+	"""
+
+	def decorator(func: callable):
+		# conserve annotations for frappe.utils.typing_validations
+		@functools.wraps(func, assigned=(a for a in functools.WRAPPER_ASSIGNMENTS if a != "__annotations__"))
+		def wrapper(ctx: T | Document | dict | str, *args, **kwargs):
+			if isinstance(ctx, Document):
+				ctx = T(**ctx.as_dict())
+			elif isinstance(ctx, dict):
+				ctx = T(**ctx)
+			else:
+				ctx = T(**frappe.parse_json(ctx))
+
+			return func(ctx, *args, **kwargs)
+
+		# set annotations from function
+		wrapper.__annotations__.update({k: v for k, v in func.__annotations__.items() if k != "ctx"})
+		return wrapper
+
+	return decorator


### PR DESCRIPTION
This PR creates a stem utility that can be used in refactoring like #44226 in order
to normalize a `ctx` parameter into the given type from these types:

 - Json String, e.g. coming from the frontend
 - dict coming from a pre-processed json payload or from a _dict or dict
 - Document instance passed as is

This can be used to cast the input into a local type to improve maintainability of the code.

It also ensures that a document instance is copied (via as_dict) to avoid mutations.

cc @ruthra-kumar
