### PR TITLE
refactor: pass typed arguments to get_item_details methods

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -41,3 +41,4 @@ a308792ee7fda18a681e9181f4fd00b36385bc23
 
 # noisy typing refactoring of get_item_details
 7b7211ac79c248a79ba8a999ff34e734d874c0ae
+d827ed21adc7b36047e247cbb0dc6388d048a7f9

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -533,7 +533,11 @@ class POSInvoice(SalesInvoice):
 
 	def set_pos_fields(self, for_validate=False):
 		"""Set retail related fields from POS Profiles"""
-		from erpnext.stock.get_item_details import get_pos_profile, get_pos_profile_item_details_
+		from erpnext.stock.get_item_details import (
+			ItemDetailsCtx,
+			get_pos_profile,
+			get_pos_profile_item_details_,
+		)
 
 		if not self.pos_profile:
 			pos_profile = get_pos_profile(self.company) or {}
@@ -603,7 +607,7 @@ class POSInvoice(SalesInvoice):
 			for item in self.get("items"):
 				if item.get("item_code"):
 					profile_details = get_pos_profile_item_details_(
-						frappe._dict(item.as_dict()), profile.get("company"), profile
+						ItemDetailsCtx(item.as_dict()), profile.get("company"), profile
 					)
 					for fname, val in profile_details.items():
 						if (not for_validate) or (for_validate and not item.get(fname)):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -766,7 +766,11 @@ class SalesInvoice(SellingController):
 				"Company", self.company, "default_cash_account"
 			)
 
-		from erpnext.stock.get_item_details import get_pos_profile, get_pos_profile_item_details_
+		from erpnext.stock.get_item_details import (
+			ItemDetailsCtx,
+			get_pos_profile,
+			get_pos_profile_item_details_,
+		)
 
 		if not self.pos_profile and not self.flags.ignore_pos_profile:
 			pos_profile = get_pos_profile(self.company) or {}
@@ -835,7 +839,7 @@ class SalesInvoice(SellingController):
 			for item in self.get("items"):
 				if item.get("item_code"):
 					profile_details = get_pos_profile_item_details_(
-						frappe._dict(item.as_dict()), pos, pos, update_data=True
+						ItemDetailsCtx(item.as_dict()), pos, pos, update_data=True
 					)
 					for fname, val in profile_details.items():
 						if (not for_validate) or (for_validate and not item.get(fname)):

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -14,7 +14,7 @@ from frappe.utils import nowdate, today, unique
 from pypika import Order
 
 import erpnext
-from erpnext.stock.get_item_details import _get_item_tax_template
+from erpnext.stock.get_item_details import ItemDetailsCtx, _get_item_tax_template
 
 
 # searches for active employees
@@ -813,14 +813,16 @@ def get_tax_template(doctype, txt, searchfield, start, page_len, filters):
 		valid_from = filters.get("valid_from")
 		valid_from = valid_from[1] if isinstance(valid_from, list) else valid_from
 
-		args = {
-			"item_code": filters.get("item_code"),
-			"posting_date": valid_from,
-			"tax_category": filters.get("tax_category"),
-			"company": company,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"item_code": filters.get("item_code"),
+				"posting_date": valid_from,
+				"tax_category": filters.get("tax_category"),
+				"company": company,
+			}
+		)
 
-		taxes = _get_item_tax_template(args, taxes, for_validate=True)
+		taxes = _get_item_tax_template(ctx, taxes, for_validate=True)
 		return [(d,) for d in set(taxes)]
 
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -16,7 +16,7 @@ from frappe.website.website_generator import WebsiteGenerator
 import erpnext
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.stock.doctype.item.item import get_item_details
-from erpnext.stock.get_item_details import get_conversion_factor, get_price_list_rate
+from erpnext.stock.get_item_details import ItemDetailsCtx, get_conversion_factor, get_price_list_rate
 
 form_grid_templates = {"items": "templates/form_grid/item_grid.html"}
 
@@ -1052,7 +1052,7 @@ def get_bom_item_rate(args, bom_doc):
 	elif bom_doc.rm_cost_as_per == "Price List":
 		if not bom_doc.buying_price_list:
 			frappe.throw(_("Please select Price List"))
-		bom_args = frappe._dict(
+		ctx = ItemDetailsCtx(
 			{
 				"doctype": "BOM",
 				"price_list": bom_doc.buying_price_list,
@@ -1070,7 +1070,7 @@ def get_bom_item_rate(args, bom_doc):
 			}
 		)
 		item_doc = frappe.get_cached_doc("Item", args.get("item_code"))
-		price_list_data = get_price_list_rate(bom_args, item_doc)
+		price_list_data = get_price_list_rate(ctx, item_doc)
 		rate = price_list_data.price_list_rate
 
 	return flt(rate)

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -54,7 +54,7 @@ class TestQuotation(IntegrationTestCase):
 	def test_gross_profit(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-		from erpnext.stock.get_item_details import insert_item_price
+		from erpnext.stock.get_item_details import ItemDetailsCtx, insert_item_price
 
 		item_doc = make_item("_Test Item for Gross Profit", {"is_stock_item": 1})
 		item_code = item_doc.name
@@ -63,7 +63,7 @@ class TestQuotation(IntegrationTestCase):
 		selling_price_list = frappe.get_all("Price List", filters={"selling": 1}, limit=1)[0].name
 		frappe.db.set_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing", 1)
 		insert_item_price(
-			frappe._dict(
+			ItemDetailsCtx(
 				{
 					"item_code": item_code,
 					"price_list": selling_price_list,

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -35,7 +35,12 @@ from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry impor
 	get_sre_reserved_qty_details_for_voucher,
 	has_reserved_stock,
 )
-from erpnext.stock.get_item_details import get_bin_details, get_default_bom, get_price_list_rate
+from erpnext.stock.get_item_details import (
+	ItemDetailsCtx,
+	get_bin_details,
+	get_default_bom,
+	get_price_list_rate,
+)
 from erpnext.stock.stock_balance import get_reserved_qty, update_bin_qty
 
 form_grid_templates = {"items": "templates/form_grid/item_grid.html"}
@@ -849,8 +854,8 @@ def make_material_request(source_name, target_doc=None):
 			target.item_code, target.warehouse, source_parent.company, True
 		).get("actual_qty", 0)
 
-		args = target.as_dict().copy()
-		args.update(
+		ctx = ItemDetailsCtx(target.as_dict().copy())
+		ctx.update(
 			{
 				"company": source_parent.get("company"),
 				"price_list": frappe.db.get_single_value("Buying Settings", "buying_price_list"),
@@ -860,7 +865,7 @@ def make_material_request(source_name, target_doc=None):
 		)
 
 		target.rate = flt(
-			get_price_list_rate(args, item_doc=frappe.get_cached_doc("Item", target.item_code)).get(
+			get_price_list_rate(ctx, item_doc=frappe.get_cached_doc("Item", target.item_code)).get(
 				"price_list_rate"
 			)
 		)

--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -20,7 +20,7 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 	get_batch_from_bundle,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.get_item_details import get_item_details
+from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_details
 from erpnext.stock.serial_batch_bundle import SerialBatchCreation
 
 
@@ -436,7 +436,7 @@ class TestBatch(IntegrationTestCase):
 		company = "_Test Company with perpetual inventory"
 		currency = frappe.get_cached_value("Company", company, "default_currency")
 
-		args = frappe._dict(
+		ctx = ItemDetailsCtx(
 			{
 				"item_code": "_Test Batch Price Item",
 				"company": company,
@@ -452,18 +452,18 @@ class TestBatch(IntegrationTestCase):
 		)
 
 		# test price for batch1
-		args.update({"batch_no": batch1})
-		details = get_item_details(args)
+		ctx.update({"batch_no": batch1})
+		details = get_item_details(ctx)
 		self.assertEqual(details.get("price_list_rate"), 200)
 
 		# test price for batch2
-		args.update({"batch_no": batch2})
-		details = get_item_details(args)
+		ctx.update({"batch_no": batch2})
+		details = get_item_details(ctx)
 		self.assertEqual(details.get("price_list_rate"), 300)
 
 		# test price for batch3
-		args.update({"batch_no": batch3})
-		details = get_item_details(args)
+		ctx.update({"batch_no": batch3})
+		details = get_item_details(ctx)
 		self.assertEqual(details.get("price_list_rate"), 400)
 
 	def test_basic_batch_wise_valuation(self, batch_qty=100):

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -26,7 +26,7 @@ from erpnext.stock.doctype.item.item import (
 	validate_is_stock_item,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.get_item_details import get_item_details
+from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_details
 
 IGNORE_TEST_RECORD_DEPENDENCIES = ["BOM"]
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Warehouse", "Item Group", "Item Tax Template", "Brand", "Item Attribute"]
@@ -145,21 +145,23 @@ class TestItem(IntegrationTestCase):
 		currency = frappe.get_cached_value("Company", company, "default_currency")
 
 		details = get_item_details(
-			{
-				"item_code": "_Test Item",
-				"company": company,
-				"price_list": "_Test Price List",
-				"currency": currency,
-				"doctype": "Sales Order",
-				"conversion_rate": 1,
-				"price_list_currency": currency,
-				"plc_conversion_rate": 1,
-				"order_type": "Sales",
-				"customer": "_Test Customer",
-				"conversion_factor": 1,
-				"price_list_uom_dependant": 1,
-				"ignore_pricing_rule": 1,
-			}
+			ItemDetailsCtx(
+				{
+					"item_code": "_Test Item",
+					"company": company,
+					"price_list": "_Test Price List",
+					"currency": currency,
+					"doctype": "Sales Order",
+					"conversion_rate": 1,
+					"price_list_currency": currency,
+					"plc_conversion_rate": 1,
+					"order_type": "Sales",
+					"customer": "_Test Customer",
+					"conversion_factor": 1,
+					"price_list_uom_dependant": 1,
+					"ignore_pricing_rule": 1,
+				}
+			)
 		)
 
 		for key, value in to_check.items():
@@ -172,23 +174,27 @@ class TestItem(IntegrationTestCase):
 		create_fixed_asset_item()
 
 		details = get_item_details(
-			{
-				"item_code": "Macbook Pro",
-				"company": "_Test Company",
-				"currency": "INR",
-				"doctype": "Purchase Receipt",
-			}
+			ItemDetailsCtx(
+				{
+					"item_code": "Macbook Pro",
+					"company": "_Test Company",
+					"currency": "INR",
+					"doctype": "Purchase Receipt",
+				}
+			)
 		)
 		self.assertEqual(details.get("expense_account"), "_Test Fixed Asset - _TC")
 
 		frappe.db.set_value("Asset Category", "Computers", "enable_cwip_accounting", "1")
 		details = get_item_details(
-			{
-				"item_code": "Macbook Pro",
-				"company": "_Test Company",
-				"currency": "INR",
-				"doctype": "Purchase Receipt",
-			}
+			ItemDetailsCtx(
+				{
+					"item_code": "Macbook Pro",
+					"company": "_Test Company",
+					"currency": "INR",
+					"doctype": "Purchase Receipt",
+				}
+			)
 		)
 		self.assertEqual(details.get("expense_account"), "CWIP Account - _TC")
 
@@ -271,22 +277,24 @@ class TestItem(IntegrationTestCase):
 
 		for data in expected_item_tax_template:
 			details = get_item_details(
-				{
-					"item_code": data["item_code"],
-					"tax_category": data["tax_category"],
-					"company": "_Test Company",
-					"price_list": "_Test Price List",
-					"currency": "_Test Currency",
-					"doctype": "Sales Order",
-					"conversion_rate": 1,
-					"price_list_currency": "_Test Currency",
-					"plc_conversion_rate": 1,
-					"order_type": "Sales",
-					"customer": "_Test Customer",
-					"conversion_factor": 1,
-					"price_list_uom_dependant": 1,
-					"ignore_pricing_rule": 1,
-				}
+				ItemDetailsCtx(
+					{
+						"item_code": data["item_code"],
+						"tax_category": data["tax_category"],
+						"company": "_Test Company",
+						"price_list": "_Test Price List",
+						"currency": "_Test Currency",
+						"doctype": "Sales Order",
+						"conversion_rate": 1,
+						"price_list_currency": "_Test Currency",
+						"plc_conversion_rate": 1,
+						"order_type": "Sales",
+						"customer": "_Test Customer",
+						"conversion_factor": 1,
+						"price_list_uom_dependant": 1,
+						"ignore_pricing_rule": 1,
+					}
+				)
 			)
 
 			self.assertEqual(details.item_tax_template, data["item_tax_template"])
@@ -320,17 +328,19 @@ class TestItem(IntegrationTestCase):
 			"cost_center": "_Test Cost Center 2 - _TC",  # from item group
 		}
 		sales_item_details = get_item_details(
-			{
-				"item_code": "Test Item With Defaults",
-				"company": "_Test Company",
-				"price_list": "_Test Price List",
-				"currency": "_Test Currency",
-				"doctype": "Sales Invoice",
-				"conversion_rate": 1,
-				"price_list_currency": "_Test Currency",
-				"plc_conversion_rate": 1,
-				"customer": "_Test Customer",
-			}
+			ItemDetailsCtx(
+				{
+					"item_code": "Test Item With Defaults",
+					"company": "_Test Company",
+					"price_list": "_Test Price List",
+					"currency": "_Test Currency",
+					"doctype": "Sales Invoice",
+					"conversion_rate": 1,
+					"price_list_currency": "_Test Currency",
+					"plc_conversion_rate": 1,
+					"customer": "_Test Customer",
+				}
+			)
 		)
 		for key, value in sales_item_check.items():
 			self.assertEqual(value, sales_item_details.get(key))
@@ -343,17 +353,19 @@ class TestItem(IntegrationTestCase):
 			"cost_center": "_Test Write Off Cost Center - _TC",  # from item
 		}
 		purchase_item_details = get_item_details(
-			{
-				"item_code": "Test Item With Defaults",
-				"company": "_Test Company",
-				"price_list": "_Test Price List",
-				"currency": "_Test Currency",
-				"doctype": "Purchase Invoice",
-				"conversion_rate": 1,
-				"price_list_currency": "_Test Currency",
-				"plc_conversion_rate": 1,
-				"supplier": "_Test Supplier",
-			}
+			ItemDetailsCtx(
+				{
+					"item_code": "Test Item With Defaults",
+					"company": "_Test Company",
+					"price_list": "_Test Price List",
+					"currency": "_Test Currency",
+					"doctype": "Purchase Invoice",
+					"conversion_rate": 1,
+					"price_list_currency": "_Test Currency",
+					"plc_conversion_rate": 1,
+					"supplier": "_Test Supplier",
+				}
+			)
 		)
 		for key, value in purchase_item_check.items():
 			self.assertEqual(value, purchase_item_details.get(key))

--- a/erpnext/stock/doctype/item_price/test_item_price.py
+++ b/erpnext/stock/doctype/item_price/test_item_price.py
@@ -7,7 +7,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.tests.utils import make_test_records_for_doctype
 
 from erpnext.stock.doctype.item_price.item_price import ItemPriceDuplicateItem
-from erpnext.stock.get_item_details import get_price_list_rate_for
+from erpnext.stock.get_item_details import ItemDetailsCtx, get_price_list_rate_for
 
 
 class UnitTestItemPrice(UnitTestCase):
@@ -80,85 +80,97 @@ class TestItemPrice(IntegrationTestCase):
 		# Check correct price at this quantity
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 
-		args = {
-			"price_list": doc.price_list,
-			"customer": doc.customer,
-			"uom": "_Test UOM",
-			"transaction_date": "2017-04-18",
-			"qty": 10,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"customer": doc.customer,
+				"uom": "_Test UOM",
+				"transaction_date": "2017-04-18",
+				"qty": 10,
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, 20.0)
 
 	def test_price_with_no_qty(self):
 		# Check correct price when no quantity
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
-		args = {
-			"price_list": doc.price_list,
-			"customer": doc.customer,
-			"uom": "_Test UOM",
-			"transaction_date": "2017-04-18",
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"customer": doc.customer,
+				"uom": "_Test UOM",
+				"transaction_date": "2017-04-18",
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, None)
 
 	def test_prices_at_date(self):
 		# Check correct price at first date
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][2])
 
-		args = {
-			"price_list": doc.price_list,
-			"customer": "_Test Customer",
-			"uom": "_Test UOM",
-			"transaction_date": "2017-04-18",
-			"qty": 7,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"customer": "_Test Customer",
+				"uom": "_Test UOM",
+				"transaction_date": "2017-04-18",
+				"qty": 7,
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, 20)
 
 	def test_prices_at_invalid_date(self):
 		# Check correct price at invalid date
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][3])
 
-		args = {
-			"price_list": doc.price_list,
-			"qty": 7,
-			"uom": "_Test UOM",
-			"transaction_date": "01-15-2019",
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"qty": 7,
+				"uom": "_Test UOM",
+				"transaction_date": "01-15-2019",
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, None)
 
 	def test_prices_outside_of_date(self):
 		# Check correct price when outside of the date
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][4])
 
-		args = {
-			"price_list": doc.price_list,
-			"customer": "_Test Customer",
-			"uom": "_Test UOM",
-			"transaction_date": "2017-04-25",
-			"qty": 7,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"customer": "_Test Customer",
+				"uom": "_Test UOM",
+				"transaction_date": "2017-04-25",
+				"qty": 7,
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, None)
 
 	def test_lowest_price_when_no_date_provided(self):
 		# Check lowest price when no date provided
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])
 
-		args = {
-			"price_list": doc.price_list,
-			"uom": "_Test UOM",
-			"qty": 7,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"uom": "_Test UOM",
+				"qty": 7,
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		self.assertEqual(price, 10)
 
 	def test_invalid_item(self):
@@ -182,14 +194,16 @@ class TestItemPrice(IntegrationTestCase):
 		doc.price_list_rate = 21
 		doc.insert()
 
-		args = {
-			"price_list": doc.price_list,
-			"uom": "_Test UOM",
-			"transaction_date": "2017-04-18",
-			"qty": 7,
-		}
+		ctx = ItemDetailsCtx(
+			{
+				"price_list": doc.price_list,
+				"uom": "_Test UOM",
+				"transaction_date": "2017-04-18",
+				"qty": 7,
+			}
+		)
 
-		price = get_price_list_rate_for(args, doc.item_code)
+		price = get_price_list_rate_for(ctx, doc.item_code)
 		frappe.db.rollback()
 
 		self.assertEqual(price, 21)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1618,7 +1618,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertTrue(return_pi.docstatus == 1)
 
 	def test_disable_last_purchase_rate(self):
-		from erpnext.stock.get_item_details import get_item_details
+		from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_details
 
 		item = make_item(
 			"_Test Disable Last Purchase Rate",
@@ -1633,8 +1633,8 @@ class TestPurchaseReceipt(IntegrationTestCase):
 			item_code=item.name,
 		)
 
-		args = pr.items[0].as_dict()
-		args.update(
+		ctx = ItemDetailsCtx(pr.items[0].as_dict())
+		ctx.update(
 			{
 				"supplier": pr.supplier,
 				"doctype": pr.doctype,
@@ -1646,7 +1646,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 			}
 		)
 
-		res = get_item_details(args)
+		res = get_item_details(ctx)
 		self.assertEqual(res.get("last_purchase_rate"), 0)
 
 		frappe.db.set_single_value("Buying Settings", "disable_last_purchase_rate", 0)
@@ -1657,7 +1657,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 			item_code=item.name,
 		)
 
-		res = get_item_details(args)
+		res = get_item_details(ctx)
 		self.assertEqual(res.get("last_purchase_rate"), 100)
 
 	def test_validate_received_qty_for_internal_pr(self):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -40,6 +40,7 @@ from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
 	OpeningEntryAccountError,
 )
 from erpnext.stock.get_item_details import (
+	ItemDetailsCtx,
 	get_barcode_data,
 	get_bin_details,
 	get_conversion_factor,
@@ -1636,7 +1637,7 @@ class StockEntry(StockController):
 				pro_doc.set_actual_dates()
 
 	@frappe.whitelist()
-	def get_item_details(self, args=None, for_update=False):
+	def get_item_details(self, args: ItemDetailsCtx = None, for_update=False):
 		item = frappe.db.sql(
 			"""select i.name, i.stock_uom, i.description, i.image, i.item_name, i.item_group,
 				i.has_batch_no, i.sample_quantity, i.has_serial_no, i.allow_alternative_item,


### PR DESCRIPTION
This is a clarification in order to be able to investigate https://github.com/frappe/erpnext/issues/44219

This works by being able to reliably `grep` for `ItemDetailCtx` or use similar intellisense features.