### PR TITLE
fix: net_amount calculation

### DIFF
--- a/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
@@ -13,6 +13,7 @@
   "col_break_1",
   "description",
   "included_in_paid_amount",
+  "set_by_item_tax_template",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
@@ -194,12 +195,22 @@
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "set_by_item_tax_template",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Set by Item Tax Template",
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-24 06:51:07.417348",
+ "modified": "2024-11-22 19:16:22.346267",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Advance Taxes and Charges",

--- a/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.py
@@ -34,6 +34,7 @@ class AdvanceTaxesandCharges(Document):
 		parenttype: DF.Data
 		rate: DF.Float
 		row_id: DF.Data | None
+		set_by_item_tax_template: DF.Check
 		tax_amount: DF.Currency
 		total: DF.Currency
 	# end: auto-generated types

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -157,16 +157,19 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 
 			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
 			item_wise_tax_detail = json.loads(consolidated_invoice.get("taxes")[0].item_wise_tax_detail)
-
-			tax_data = item_wise_tax_detail.get("_Test Item")
-			self.assertEqual(tax_data.get("tax_rate"), 9)
-			self.assertEqual(tax_data.get("tax_amount"), 9)
-			self.assertEqual(tax_data.get("net_amount"), 100)
-
-			tax_data = item_wise_tax_detail.get("_Test Item 2")
-			self.assertEqual(tax_data.get("tax_rate"), 5)
-			self.assertEqual(tax_data.get("tax_amount"), 5)
-			self.assertEqual(tax_data.get("net_amount"), 100)
+			expected_item_wise_tax_detail = {
+				"_Test Item": {
+					"tax_rate": 9,
+					"tax_amount": 9,
+					"net_amount": 100,
+				},
+				"_Test Item 2": {
+					"tax_rate": 5,
+					"tax_amount": 5,
+					"net_amount": 100,
+				},
+			}
+			self.assertEqual(item_wise_tax_detail, expected_item_wise_tax_detail)
 		finally:
 			frappe.set_user("Administrator")
 			frappe.db.sql("delete from `tabPOS Profile`")

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
@@ -17,6 +17,7 @@
   "account_head",
   "description",
   "is_tax_withholding_account",
+  "set_by_item_tax_template",
   "section_break_10",
   "rate",
   "accounting_dimensions_section",
@@ -254,12 +255,22 @@
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "set_by_item_tax_template",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Set by Item Tax Template",
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-24 06:47:25.129901",
+ "modified": "2024-11-22 19:17:02.377473",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges",

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.py
@@ -42,6 +42,7 @@ class PurchaseTaxesandCharges(Document):
 		parenttype: DF.Data
 		rate: DF.Float
 		row_id: DF.Data | None
+		set_by_item_tax_template: DF.Check
 		tax_amount: DF.Currency
 		tax_amount_after_discount_amount: DF.Currency
 		total: DF.Currency

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -13,6 +13,7 @@
   "description",
   "included_in_print_rate",
   "included_in_paid_amount",
+  "set_by_item_tax_template",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
@@ -232,13 +233,23 @@
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "set_by_item_tax_template",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Set by Item Tax Template",
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-24 06:49:32.034074",
+ "modified": "2024-11-22 19:17:31.898467",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges",

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.py
@@ -40,6 +40,7 @@ class SalesTaxesandCharges(Document):
 		parenttype: DF.Data
 		rate: DF.Float
 		row_id: DF.Data | None
+		set_by_item_tax_template: DF.Check
 		tax_amount: DF.Currency
 		tax_amount_after_discount_amount: DF.Currency
 		total: DF.Currency

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -961,6 +961,7 @@ class AccountsController(TransactionBase):
 							"account_head": account_head,
 							"rate": 0,
 							"description": account_head,
+							"set_by_item_tax_template": 1,
 						},
 					)
 
@@ -3176,10 +3177,11 @@ def set_child_tax_template_and_map(item, child_item, parent_doc):
 	)
 
 	child_item.item_tax_template = _get_item_tax_template(ctx, item.taxes)
-	if child_item.get("item_tax_template"):
-		child_item.item_tax_rate = get_item_tax_map(
-			parent_doc.get("company"), child_item.item_tax_template, as_json=True
-		)
+	child_item.item_tax_rate = get_item_tax_map(
+		doc=parent_doc,
+		tax_template=child_item.item_tax_template,
+		as_json=True,
+	)
 
 
 def add_taxes_from_tax_template(child_item, parent_doc, db_insert=True):
@@ -3202,6 +3204,7 @@ def add_taxes_from_tax_template(child_item, parent_doc, db_insert=True):
 						"charge_type": "On Net Total",
 						"account_head": tax_type,
 						"rate": tax_rate,
+						"set_by_item_tax_template": 1,
 					}
 				)
 				if parent_doc.doctype == "Purchase Order":

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -501,9 +501,7 @@ class calculate_taxes_and_totals:
 				)
 
 		elif tax.charge_type == "On Net Total":
-			if not item_tax_map:
-				current_net_amount = item.net_amount
-			elif tax.account_head in item_tax_map:
+			if tax.account_head in item_tax_map:
 				current_net_amount = item.net_amount
 			current_tax_amount = (tax_rate / 100.0) * item.net_amount
 		elif tax.charge_type == "On Previous Row Amount":

--- a/erpnext/controllers/tests/test_item_wise_tax_details.py
+++ b/erpnext/controllers/tests/test_item_wise_tax_details.py
@@ -79,7 +79,7 @@ class TestTaxesAndTotals(FrappeTestCase):
 				"rate": 50,
 			},
 		)
-
+		self.doc.set_missing_item_details()
 		calculate_taxes_and_totals(self.doc)
 
 		expected_values = {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -336,6 +336,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					child.charge_type = "On Net Total";
 					child.account_head = tax;
 					child.rate = 0;
+					child.set_by_item_tax_template = true;
 				}
 			});
 		}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -751,6 +751,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					child.charge_type = "On Net Total";
 					child.account_head = tax;
 					child.rate = 0;
+					child.set_by_item_tax_template = true;
 				}
 			});
 		}
@@ -2076,7 +2077,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_item_tax_info",
 				args: {
-					company: me.frm.doc.company,
+					doc: me.frm.doc,
 					tax_category: cstr(me.frm.doc.tax_category),
 					item_codes: item_codes,
 					item_rates: item_rates,
@@ -2107,7 +2108,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_item_tax_map",
 				args: {
-					company: me.frm.doc.company,
+					doc: me.frm.doc,
 					item_tax_template: item.item_tax_template,
 					as_json: true
 				},


### PR DESCRIPTION
depends on: 
- https://github.com/frappe/frappe/pull/28525
- https://github.com/frappe/frappe/pull/28526

This PR ensures that `item_tax_rate` is populated from the doc-wide template, if available and if no item wise tax has been set.

This is necessary to match net_amounts to account heads in taxes and totals.

fixes: #44219

---
**Before NOK**
```
❯ tail -f erpnext.controllers.taxes_and_totals.log
2024-11-20 00:10:43,131 DEBUG erpnext.controllers.taxes_and_totals Sales Invoice (FUP00006) ...
2024-11-20 00:10:43,132 DEBUG erpnext.controllers.taxes_and_totals  Item 0: ALMBOT1050
2024-11-20 00:10:43,132 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 50420.17             tax_amount: 9579.83              - IVA @ 19
2024-11-20 00:10:43,132 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 50420.17             tax_amount: 0.0                  - 240805 - IVA Descontable
2024-11-20 00:10:43,132 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 50420.17             tax_amount: 26.82                - Gastos de personal (fijo)
2024-11-20 00:10:43,132 DEBUG erpnext.controllers.taxes_and_totals  Item 1: ARAN500 - {'240801 - IVA Generado - P': 0.0, '240805 - IVA Descontable - P': 0.0}
2024-11-20 00:10:43,133 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 0.0                  - IVA @ 19
2024-11-20 00:10:43,133 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 0.0                  - 240805 - IVA Descontable
2024-11-20 00:10:43,134 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 53.18                - Gastos de personal (fijo)
```

**Now OK** 
_compare `net_amount` of `ALMBOT1050` for `240805 - IVA Descontable` and also note the new item rate ` {'240801 - IVA Generado - P': 19.0}` addition_
```
❯ tail -f erpnext.controllers.taxes_and_totals.log
2024-11-20 02:48:38,133 DEBUG erpnext.controllers.taxes_and_totals Sales Invoice (FUP00006) ...
2024-11-20 02:48:38,135 DEBUG erpnext.controllers.taxes_and_totals  Item 0: ALMBOT1050 - {'240801 - IVA Generado - P': 19.0}
2024-11-20 02:48:38,135 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 50420.17             tax_amount: 9579.83              - IVA @ 19
2024-11-20 02:48:38,136 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 0.0                  tax_amount: 0.0                  - 240805 - IVA Descontable
2024-11-20 02:48:38,136 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 50420.17             tax_amount: 26.82                - Gastos de personal (fijo)
2024-11-20 02:48:38,136 DEBUG erpnext.controllers.taxes_and_totals  Item 1: ARAN500 - {'240801 - IVA Generado - P': 0.0, '240805 - IVA Descontable - P': 0.0}
2024-11-20 02:48:38,137 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 0.0                  - IVA @ 19
2024-11-20 02:48:38,137 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 0.0                  - 240805 - IVA Descontable
2024-11-20 02:48:38,138 DEBUG erpnext.controllers.taxes_and_totals   net_amount: 100000.0             tax_amount: 53.18                - Gastos de personal (fijo)
```
