### PR TITLE
fix: Get submitted documents in validate_for_closed_fiscal_year

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -45,7 +45,7 @@ class RepostAccountingLedger(Document):
 			latest_pcv = (
 				frappe.db.get_all(
 					"Period Closing Voucher",
-					filters={"company": self.company},
+					filters={"company": self.company, "docstatus": 1},
 					order_by="period_end_date desc",
 					pluck="period_end_date",
 					limit=1,


### PR DESCRIPTION
Issue:

While updating a submitted "Purchase invoice" that is between the fiscal year of a cancelled "Period Closing Voucher" it was throwing the following popup:

![image](https://github.com/user-attachments/assets/008c894c-b9af-4a4e-ade3-aa1f70eb756b)

![image](https://github.com/user-attachments/assets/0673bcdc-7297-4a46-a88c-6795be31f60e)


Backport needed: Version 15