### PR TITLE
refactor: use `frappe._dict()` instead of `{}`

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -550,7 +550,7 @@ def get_item_tax_info(company, tax_category, item_codes, item_rates=None, item_t
 		if not item_code or item_code[1] in out or not item_tax_templates.get(item_code[1]):
 			continue
 
-		out[item_code[1]] = {}
+		out[item_code[1]] = frappe._dict()
 		item = frappe.get_cached_doc("Item", item_code[0])
 		ctx: ItemDetailsCtx = {
 			"company": company,

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -550,7 +550,7 @@ def get_item_tax_info(company, tax_category, item_codes, item_rates=None, item_t
 		if not item_code or item_code[1] in out or not item_tax_templates.get(item_code[1]):
 			continue
 
-		out[item_code[1]] = frappe._dict()
+		out[item_code[1]] = ItemDetails()
 		item = frappe.get_cached_doc("Item", item_code[0])
 		ctx: ItemDetailsCtx = {
 			"company": company,


### PR DESCRIPTION
A downstream function (`_get_item_tax_template`) expects this to be a frappe._dict and fails otherwise:

https://github.com/frappe/erpnext/blob/8d8070e8eb83aabc8db6d64a5554e89b480dcf46/erpnext/stock/get_item_details.py#L663

```
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 664, in _get_item_tax_template
    out.item_tax_template = ctx.get("item_tax_template")
    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'item_tax_template'
```