### PR TITLE
fix: create repost payment ledger entries from the report for differerences

### DIFF
--- a/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js
+++ b/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js
@@ -49,4 +49,32 @@ function get_filters() {
 
 frappe.query_reports["General and Payment Ledger Comparison"] = {
 	filters: get_filters(),
+
+	get_datatable_options(options) {
+		return Object.assign(options, {
+			checkboxColumn: true,
+		});
+	},
+
+	onload(report) {
+		report.page.add_inner_button(__("Create Reposting Entries"), function () {
+			let message = `Are you sure you want to create Reposting Entries?`;
+			let indexes = frappe.query_report.datatable.rowmanager.getCheckedRows();
+			let selected_rows = indexes.map((i) => frappe.query_report.data[i]);
+
+			if (!selected_rows.length) {
+				frappe.throw(__("Please select rows to create Reposting Entries"));
+			}
+
+			frappe.confirm(__(message), () => {
+				frappe.call({
+					method: "erpnext.accounts.report.general_and_payment_ledger_comparison.general_and_payment_ledger_comparison.create_repost_payment_ledger_entry",
+					args: {
+						rows: selected_rows,
+						company: frappe.query_report.get_filter_values().company,
+					},
+				});
+			});
+		});
+	},
 };

--- a/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js
+++ b/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js
@@ -57,13 +57,13 @@ frappe.query_reports["General and Payment Ledger Comparison"] = {
 	},
 
 	onload(report) {
-		report.page.add_inner_button(__("Create Reposting Entries"), function () {
-			let message = `Are you sure you want to create Reposting Entries?`;
+		report.page.add_inner_button(__("Repost"), function () {
+			let message = `Are you sure you want to Repost Payment Ledger Entry for the selected differences?`;
 			let indexes = frappe.query_report.datatable.rowmanager.getCheckedRows();
 			let selected_rows = indexes.map((i) => frappe.query_report.data[i]);
 
 			if (!selected_rows.length) {
-				frappe.throw(__("Please select rows to create Reposting Entries"));
+				frappe.throw(__("Please select rows to create repost entries"));
 			}
 
 			frappe.confirm(__(message), () => {

--- a/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
+++ b/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _, qb
 from frappe.query_builder import Criterion
 from frappe.query_builder.functions import Sum
+from frappe.utils import getdate
 
 
 class General_Payment_Ledger_Comparison:
@@ -272,3 +273,19 @@ def execute(filters=None):
 	columns, data = rpt.run()
 
 	return columns, data
+
+
+@frappe.whitelist()
+def create_repost_payment_ledger_entry(rows, company):
+	if isinstance(rows, str):
+		rows = frappe.parse_json(rows)
+
+	entry = frappe.new_doc("Repost Payment Ledger", company=company, posting_date=getdate(), add_manually=1)
+
+	for row in rows:
+		entry.append(
+			"repost_vouchers", {"voucher_type": row.get("voucher_type"), "voucher_no": row.get("voucher_no")}
+		)
+
+	entry.save()
+	entry.submit()


### PR DESCRIPTION
### Issue

- Repost entries created for all vouchers could be less performant and unnecessary
- End user may be less confident / unaware of how to use the repost feature

### Fix

Create repost entries from Report General and Payment Ledger Comparison only for the entries with differences

### Video


https://github.com/user-attachments/assets/a7aacff6-132d-472d-91f1-2016cfa3fb12


