### PR TITLE
fix: set price_list_currency only if it exists

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1914,8 +1914,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			callback: function(r) {
 				if (!r.exc) {
 					frappe.run_serially([
-						() => me.frm.set_value("price_list_currency", r.message.parent.price_list_currency),
-						() => me.frm.set_value("plc_conversion_rate", r.message.parent.plc_conversion_rate),
+						() => {
+							if (r.message.parent.price_list_currency)
+								me.frm.set_value("price_list_currency", r.message.parent.price_list_currency);
+						},
+						() => {
+							if (r.message.parent.plc_conversion_rate)
+								me.frm.set_value("plc_conversion_rate", r.message.parent.plc_conversion_rate);
+						},
 						() => {
 							if(args.items.length) {
 								me._set_values_for_item_list(r.message.children);


### PR DESCRIPTION
Issue:
After a Request For Quotation record is saved, if we try to change quantity field value it shows field price_list_currency not found.

ref: [25739](https://support.frappe.io/helpdesk/tickets/25739)

Before:

[Screencast from 21-11-24 07:15:10 PM IST.webm](https://github.com/user-attachments/assets/1e39606a-0359-4015-a44c-215c64cdc1ef)

After:

[Screencast from 21-11-24 07:20:25 PM IST.webm](https://github.com/user-attachments/assets/a1258d42-9ede-46f7-a24f-4359c6c6ed87)

Back port needed for v15.
