### PR TITLE
fix: filter with item group only if it is mentioned in pos profile

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -96,6 +96,8 @@ def search_by_term(search_term, warehouse, price_list):
 def filter_result_items(result, pos_profile):
 	if result and result.get("items"):
 		pos_item_groups = frappe.db.get_all("POS Item Group", {"parent": pos_profile}, pluck="item_group")
+		if not pos_item_groups:
+			return
 		result["items"] = [item for item in result.get("items") if item.get("item_group") in pos_item_groups]
 
 


### PR DESCRIPTION
**Issue:**
The barcode filter is not working when the item group is not mentioned in the POS Profile
**ref:** [25847](https://support.frappe.io/helpdesk/tickets/25847)

**Before:**
![image](https://github.com/user-attachments/assets/05c03f8d-298d-4d6a-a020-e6686981cbf8)


**After:**
![image](https://github.com/user-attachments/assets/42481e42-d74e-4976-b535-e37ef21da745)


Backport Needed: v15