### PR TITLE
fix: Used `Fiscal Dates` instead of year's `Start` and `End` dates

### DIFF
--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -94,8 +94,8 @@ frappe.ui.form.on("Account", {
 				function () {
 					frappe.route_options = {
 						account: frm.doc.name,
-						from_date: frappe.sys_defaults.year_start_date,
-						to_date: frappe.sys_defaults.year_end_date,
+						from_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
+						to_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 						company: frm.doc.company,
 					};
 					frappe.set_route("query-report", "General Ledger");

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -279,8 +279,8 @@ frappe.treeview_settings["Account"] = {
 			click: function (node, btn) {
 				frappe.route_options = {
 					account: node.label,
-					from_date: frappe.sys_defaults.year_start_date,
-					to_date: frappe.sys_defaults.year_end_date,
+					from_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
+					to_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 					company:
 						frappe.treeview_settings["Account"].treeview.page.fields_dict.company.get_value(),
 				};

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
@@ -8,7 +8,7 @@ frappe.query_reports["Batch Item Expiry Status"] = {
 			label: __("From Date"),
 			fieldtype: "Date",
 			width: "80",
-			default: frappe.sys_defaults.year_start_date,
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 			reqd: 1,
 		},
 		{

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
@@ -16,7 +16,7 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 			label: __("From Date"),
 			fieldtype: "Date",
 			width: "80",
-			default: frappe.sys_defaults.year_start_date,
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 			reqd: 1,
 		},
 		{

--- a/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.js
+++ b/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.js
@@ -7,7 +7,7 @@ frappe.query_reports["Itemwise Recommended Reorder Level"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: frappe.sys_defaults.year_start_date,
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 		},
 		{
 			fieldname: "to_date",


### PR DESCRIPTION
## Issue: [Support Ticket - 25933 ](https://support.frappe.io/helpdesk/tickets/25933)

## Related PRs

- Main changes to `Version-15` (At moment it was `develop`)
   - https://github.com/frappe/erpnext/pull/36360

- Manually backport to `Version-14` for reports only
   - https://github.com/frappe/erpnext/pull/41170
   
 - Missed Report
   - https://github.com/frappe/erpnext/pull/42960