### PR TITLE
feat(Sales Invoice): allow linking to project without adding timesheets

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1092,13 +1092,16 @@ class SalesInvoice(SellingController):
 					timesheet.billing_amount = ts_doc.total_billable_amount
 
 	def update_timesheet_billing_for_project(self):
-		if not self.timesheets and self.project:
-			self.add_timesheet_data()
-		else:
+		if self.timesheets:
 			self.calculate_billing_amount_for_timesheet()
 
-	@frappe.whitelist()
+	@frappe.whitelist(methods=["PUT"])
 	def add_timesheet_data(self):
+		if not self.timesheets and self.project:
+			self._add_timesheet_data()
+			self.save()
+
+	def _add_timesheet_data(self):
 		self.set("timesheets", [])
 		if self.project:
 			for data in get_projectwise_timesheet_data(self.project):

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -62,6 +62,7 @@ class TestTimesheet(IntegrationTestCase):
 		)
 		sales_invoice = create_sales_invoice(do_not_save=True)
 		sales_invoice.project = project
+		sales_invoice._add_timesheet_data()
 		sales_invoice.submit()
 
 		ts = frappe.get_doc("Timesheet", timesheet.name)


### PR DESCRIPTION
We used to always add unbilled Timesheets to a **Sales Invoice** if _Project_ is set.  This PR changes that.

From a UI perspective, this feature doesn't make sense. If the user explicitly empties the timesheets table, we shouldn't automatically add them back. This makes it impossible to create a **Sales Invoice** that is linked to the project (e.g. travel expenses) but shouldn't include any timesheets.

When creating a **Sales Invoice** via API, this can be useful. We only have to specify the project and billable timesheets are fetched automatically. This use case is covered by providing a whitelisted method: `PUT /api/v2/document/Sales%20Invoice/SINV-0001/method/add_timesheet_data`

https://github.com/frappe/erpnext/wiki/Migration-Guide-To-ERPNext-Version-16#timesheet-billing-via-api