### PR TITLE
fix: remove unnecessary auth from plaid connector

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
@@ -69,23 +69,7 @@ class PlaidConnector:
 		else:
 			return response["link_token"]
 
-	def auth(self):
-		try:
-			self.client.Auth.get(self.access_token)
-		except ItemError as e:
-			if e.code == "ITEM_LOGIN_REQUIRED":
-				pass
-		except APIError as e:
-			if e.code == "PLANNED_MAINTENANCE":
-				pass
-		except requests.Timeout:
-			pass
-		except Exception as e:
-			frappe.log_error("Plaid: Authentication error")
-			frappe.throw(_(str(e)), title=_("Authentication Failed"))
-
 	def get_transactions(self, start_date, end_date, account_id=None):
-		self.auth()
 		kwargs = dict(access_token=self.access_token, start_date=start_date, end_date=end_date)
 		if account_id:
 			kwargs.update(dict(account_ids=[account_id]))


### PR DESCRIPTION
The plaid connector is using the plaid [Auth](https://plaid.com/docs/api/products/auth) endpoint with the intent to authenticate the connection. However, this API endpoint is actually intended for setting up electronic fund transfers using ACH, etc. Accessing it requires additional user consent, which the plaid connector is not requesting, so the API returns a [ADDITIONAL_CONSENT_REQUIRED](https://plaid.com/docs/errors/invalid-input/#additional_consent_required) error. 

This PR removes the unnecessary Auth call. After removing this, I was able to link and retrieve transactions from a bank in the US. Before, I was getting the same error as in #43699.

