### PR TITLE
fix: Initially Closing Amount Should be Equal to Expected Amount

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -147,7 +147,7 @@ frappe.ui.form.on("POS Closing Entry", {
 						frm.doc.grand_total += flt(doc.grand_total);
 						frm.doc.net_total += flt(doc.net_total);
 						frm.doc.total_quantity += flt(doc.total_qty);
-						refresh_payments(doc, frm);
+						refresh_payments(doc, frm, false);
 						refresh_taxes(doc, frm);
 						refresh_fields(frm);
 						set_html_data(frm);
@@ -172,7 +172,7 @@ function set_form_data(data, frm) {
 		frm.doc.grand_total += flt(d.grand_total);
 		frm.doc.net_total += flt(d.net_total);
 		frm.doc.total_quantity += flt(d.total_qty);
-		refresh_payments(d, frm);
+		refresh_payments(d, frm, true);
 		refresh_taxes(d, frm);
 	});
 }
@@ -186,7 +186,7 @@ function add_to_pos_transaction(d, frm) {
 	});
 }
 
-function refresh_payments(d, frm) {
+function refresh_payments(d, frm, is_new) {
 	d.payments.forEach((p) => {
 		const payment = frm.doc.payment_reconciliation.find(
 			(pay) => pay.mode_of_payment === p.mode_of_payment
@@ -196,9 +196,7 @@ function refresh_payments(d, frm) {
 		}
 		if (payment) {
 			payment.expected_amount += flt(p.amount);
-			if (payment.closing_amount === 0) {
-				payment.closing_amount = payment.expected_amount;
-			}
+			if (is_new) payment.closing_amount = payment.expected_amount;
 			payment.difference = payment.closing_amount - payment.expected_amount;
 		} else {
 			frm.add_child("payment_reconciliation", {


### PR DESCRIPTION
### Initial ERPNext Implementation:
- The `closing amount` is set to expected amount initially. But when user changes its value, then also in `before save` it is set again to `expected value`.

### After [this](https://github.com/frappe/erpnext/pull/43358) PR:
- The closing amount is only updated when closing amount is zero. So initially closing amount is set same as first invoice value.

### Current Fix:
- Initially the closing amount should be set same as expected amount , and should not be overridden when user changes the value.
