### PR TITLE
fix: use field precision in Sales and Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -93,7 +93,10 @@ frappe.ui.form.on("Purchase Order", {
 	get_materials_from_supplier: function (frm) {
 		let po_details = [];
 
-		if (frm.doc.supplied_items && (flt(frm.doc.per_received, 2) == 100 || frm.doc.status === "Closed")) {
+		if (
+			frm.doc.supplied_items &&
+			(flt(frm.doc.per_received, precision("per_received")) == 100 || frm.doc.status === "Closed")
+		) {
 			frm.doc.supplied_items.forEach((d) => {
 				if (d.total_supplied_qty && d.total_supplied_qty != d.consumed_qty) {
 					po_details.push(d.name);
@@ -329,8 +332,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			if (!["Closed", "Delivered"].includes(doc.status)) {
 				if (
 					this.frm.doc.status !== "Closed" &&
-					flt(this.frm.doc.per_received, 2) < 100 &&
-					flt(this.frm.doc.per_billed, 2) < 100
+					flt(this.frm.doc.per_received, precision("per_received")) < 100 &&
+					flt(this.frm.doc.per_billed, precision("per_billed")) < 100
 				) {
 					if (!this.frm.doc.__onload || this.frm.doc.__onload.can_update_items) {
 						this.frm.add_custom_button(__("Update Items"), () => {
@@ -344,7 +347,10 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 					}
 				}
 				if (this.frm.has_perm("submit")) {
-					if (flt(doc.per_billed, 2) < 100 || flt(doc.per_received, 2) < 100) {
+					if (
+						flt(doc.per_billed, precision("per_billed")) < 100 ||
+						flt(doc.per_received, precision("per_received")) < 100
+					) {
 						if (doc.status != "On Hold") {
 							this.frm.add_custom_button(
 								__("Hold"),
@@ -382,7 +388,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			}
 			if (doc.status != "Closed") {
 				if (doc.status != "On Hold") {
-					if (flt(doc.per_received) < 100 && allow_receipt) {
+					if (flt(doc.per_received, precision("per_received")) < 100 && allow_receipt) {
 						this.frm.add_custom_button(
 							__("Purchase Receipt"),
 							() => {
@@ -413,7 +419,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						}
 					}
 					// Please do not add precision in the below flt function
-					if (flt(doc.per_billed) < 100)
+					if (flt(doc.per_billed, precision("per_billed")) < 100)
 						this.frm.add_custom_button(
 							__("Purchase Invoice"),
 							() => {
@@ -422,7 +428,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 							__("Create")
 						);
 
-					if (flt(doc.per_billed, 2) < 100 && doc.status != "Delivered") {
+					if (flt(doc.per_billed, precision("per_billed")) < 100 && doc.status != "Delivered") {
 						this.frm.add_custom_button(
 							__("Payment"),
 							() => this.make_payment_entry(),
@@ -430,7 +436,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						);
 					}
 
-					if (flt(doc.per_billed, 2) < 100) {
+					if (flt(doc.per_billed, precision("per_billed")) < 100) {
 						this.frm.add_custom_button(
 							__("Payment Request"),
 							function () {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -57,8 +57,8 @@ frappe.ui.form.on("Sales Order", {
 		if (frm.doc.docstatus === 1) {
 			if (
 				frm.doc.status !== "Closed" &&
-				flt(frm.doc.per_delivered, 2) < 100 &&
-				flt(frm.doc.per_billed, 2) < 100 &&
+				flt(frm.doc.per_delivered, precision("per_delivered")) < 100 &&
+				flt(frm.doc.per_billed, precision("per_billed")) < 100 &&
 				frm.has_perm("write")
 			) {
 				frm.add_custom_button(__("Update Items"), () => {
@@ -75,7 +75,7 @@ frappe.ui.form.on("Sales Order", {
 				if (
 					frm.doc.__onload &&
 					frm.doc.__onload.has_unreserved_stock &&
-					flt(frm.doc.per_picked) === 0
+					flt(frm.doc.per_picked, precision("per_picked")) === 0
 				) {
 					frm.add_custom_button(
 						__("Reserve"),
@@ -604,7 +604,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						__("Status")
 					);
 
-					if (flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed, 2) < 100) {
+					if (
+						flt(doc.per_delivered, precision("per_delivered")) < 100 ||
+						flt(doc.per_billed, precision("per_billed")) < 100
+					) {
 						// close
 						this.frm.add_custom_button(__("Close"), () => this.close_sales_order(), __("Status"));
 					}
@@ -627,7 +630,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						) && !this.frm.doc.skip_delivery_note;
 
 					if (this.frm.has_perm("submit")) {
-						if (flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed, 2) < 100) {
+						if (
+							flt(doc.per_delivered, precision("per_delivered")) < 100 ||
+							flt(doc.per_billed, precision("per_billed")) < 100
+						) {
 							// hold
 							this.frm.add_custom_button(
 								__("Hold"),
@@ -645,8 +651,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					if (
 						(!doc.__onload || !doc.__onload.has_reserved_stock) &&
-						flt(doc.per_picked, 2) < 100 &&
-						flt(doc.per_delivered, 2) < 100 &&
+						flt(doc.per_picked, precision("per_picked")) < 100 &&
+						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
 						frappe.model.can_create("Pick List")
 					) {
 						this.frm.add_custom_button(
@@ -664,7 +670,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					// delivery note
 					if (
-						flt(doc.per_delivered, 2) < 100 &&
+						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
 						(order_is_a_sale || order_is_a_custom_sale) &&
 						allow_delivery
 					) {
@@ -686,7 +692,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// sales invoice
-					if (flt(doc.per_billed, 2) < 100 && frappe.model.can_create("Sales Invoice")) {
+					if (
+						flt(doc.per_billed, precision("per_billed")) < 100 &&
+						frappe.model.can_create("Sales Invoice")
+					) {
 						this.frm.add_custom_button(
 							__("Sales Invoice"),
 							() => me.make_sales_invoice(),
@@ -698,7 +707,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					if (
 						(!doc.order_type ||
 							((order_is_a_sale || order_is_a_custom_sale) &&
-								flt(doc.per_delivered, 2) < 100)) &&
+								flt(doc.per_delivered, precision("per_delivered")) < 100)) &&
 						frappe.model.can_create("Material Request")
 					) {
 						this.frm.add_custom_button(
@@ -723,7 +732,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// maintenance
-					if (flt(doc.per_delivered, 2) < 100 && (order_is_maintenance || order_is_a_custom_sale)) {
+					if (
+						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
+						(order_is_maintenance || order_is_a_custom_sale)
+					) {
 						if (frappe.model.can_create("Maintenance Visit")) {
 							this.frm.add_custom_button(
 								__("Maintenance Visit"),
@@ -741,7 +753,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// project
-					if (flt(doc.per_delivered, 2) < 100 && frappe.model.can_create("Project")) {
+					if (
+						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
+						frappe.model.can_create("Project")
+					) {
 						this.frm.add_custom_button(__("Project"), () => this.make_project(), __("Create"));
 					}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0244f65c-d5c5-4ce5-a583-423969868e5f)
Issue: https://support.frappe.io/helpdesk/tickets/21161
Option to Close the Sales Order is not visble even when **% Delivered** or **% Amount Billed** are less than 100.

Fix: 
Use field precision for fields: 
- % Delivered
- % Amount Billed
- % Picked