### PR TITLE
fix: Increase quantity by `1 UOM` when adding an item from the selector in `POS`

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -556,9 +556,7 @@ erpnext.PointOfSale.Controller = class {
 			const item_row_exists = !$.isEmptyObject(item_row);
 
 			const from_selector = field === "qty" && value === "+1";
-			if (from_selector) {
-				value = flt(item_row.qty) + 1; // increase qty by 1 UOM
-			}
+			if (from_selector) value = flt(item_row.qty) + flt(value);
 
 			if (item_row_exists) {
 				if (field === "qty") value = flt(value);

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -556,7 +556,9 @@ erpnext.PointOfSale.Controller = class {
 			const item_row_exists = !$.isEmptyObject(item_row);
 
 			const from_selector = field === "qty" && value === "+1";
-			if (from_selector) value = flt(item_row.stock_qty) + flt(value);
+			if (from_selector) {
+				value = flt(item_row.qty) + 1; // increase qty by 1 UOM
+			}
 
 			if (item_row_exists) {
 				if (field === "qty") value = flt(value);

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -697,7 +697,7 @@ erpnext.PointOfSale.Controller = class {
 		const is_stock_item = resp[1];
 
 		frappe.dom.unfreeze();
-		const bold_uom = item_row.uom.bold();
+		const bold_uom = item_row.stock_uom.bold();
 		const bold_item_code = item_row.item_code.bold();
 		const bold_warehouse = warehouse.bold();
 		const bold_available_qty = available_qty.toString().bold();


### PR DESCRIPTION
## Issue: [Support Ticket - 25448](https://support.frappe.io/helpdesk/tickets/25448)

<details>

<summary> 
When Item's <strong>Selling UOM</strong> is different from <strong>Stock UOM</strong>, then Item is not incrementing properly. 
</summary> <br>

**Before:**
![Not-Proper-Increament-POS](https://github.com/user-attachments/assets/ff6c5056-943d-43ae-922e-03df1d6c3484)

**After:**
![Proper-Increment-POS](https://github.com/user-attachments/assets/b4959be6-4433-4d3a-a89b-78b708e79c50)

</details>

<details>

<summary> 
Available stock's error message showing available stock in <strong>UOM</strong> instead of  <strong>Stock UOM</strong>.
</summary><br>

**Before:**
![Not-Proper-Error-Msg-POS](https://github.com/user-attachments/assets/9844c98e-1016-49c3-8e4d-cdf10ecda56f)

**After:**
![Proper-Error-msg-POS](https://github.com/user-attachments/assets/a87c554a-124d-45db-b4b9-44fb80817ee2)

</details>

> [!IMPORTANT]
> Backport require for `V-15`
