### PR TITLE
fix: update gross profit for returned invoices

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -526,11 +526,16 @@ class GrossProfitGenerator:
 				if returned_item_row.qty != 0:
 					if row.qty >= abs(returned_item_row.qty):
 						row.qty += returned_item_row.qty
+						row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
 						returned_item_row.qty = 0
+						returned_item_row.base_amount = 0
+
 					else:
 						row.qty = 0
+						row.base_amount = 0
 						returned_item_row.qty += row.qty
-				row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
+						returned_item_row.base_amount += row.base_amount
+
 			row.buying_amount = flt(flt(row.qty) * flt(row.buying_rate), self.currency_precision)
 
 	def get_average_rate_based_on_group_by(self):

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -440,6 +440,7 @@ class GrossProfitGenerator:
 
 		if grouped_by_invoice:
 			buying_amount = 0
+			base_amount = 0
 
 		for row in reversed(self.si_list):
 			if self.filters.get("group_by") == "Monthly":
@@ -480,12 +481,11 @@ class GrossProfitGenerator:
 			else:
 				row.buying_amount = flt(self.get_buying_amount(row, row.item_code), self.currency_precision)
 
-			if grouped_by_invoice:
-				if row.indent == 1.0:
-					buying_amount += row.buying_amount
-				elif row.indent == 0.0:
-					row.buying_amount = buying_amount
-					buying_amount = 0
+			if grouped_by_invoice and row.indent == 0.0:
+				row.buying_amount = buying_amount
+				row.base_amount = base_amount
+				buying_amount = 0
+				base_amount = 0
 
 			# get buying rate
 			if flt(row.qty):
@@ -495,11 +495,19 @@ class GrossProfitGenerator:
 				if self.is_not_invoice_row(row):
 					row.buying_rate, row.base_rate = 0.0, 0.0
 
+			if self.is_not_invoice_row(row):
+				self.update_return_invoices(row)
+
+			if grouped_by_invoice and row.indent == 1.0:
+				buying_amount += row.buying_amount
+				base_amount += row.base_amount
+
 			# calculate gross profit
 			row.gross_profit = flt(row.base_amount - row.buying_amount, self.currency_precision)
 			if row.base_amount:
 				row.gross_profit_percent = flt(
-					(row.gross_profit / row.base_amount) * 100.0, self.currency_precision
+					(row.gross_profit / row.base_amount) * 100.0,
+					self.currency_precision,
 				)
 			else:
 				row.gross_profit_percent = 0.0
@@ -510,33 +518,24 @@ class GrossProfitGenerator:
 		if self.grouped:
 			self.get_average_rate_based_on_group_by()
 
+	def update_return_invoices(self, row):
+		if row.parent in self.returned_invoices and row.item_code in self.returned_invoices[row.parent]:
+			returned_item_rows = self.returned_invoices[row.parent][row.item_code]
+			for returned_item_row in returned_item_rows:
+				# returned_items 'qty' should be stateful
+				if returned_item_row.qty != 0:
+					if row.qty >= abs(returned_item_row.qty):
+						row.qty += returned_item_row.qty
+						returned_item_row.qty = 0
+					else:
+						row.qty = 0
+						returned_item_row.qty += row.qty
+				row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
+			row.buying_amount = flt(flt(row.qty) * flt(row.buying_rate), self.currency_precision)
+
 	def get_average_rate_based_on_group_by(self):
 		for key in list(self.grouped):
-			if self.filters.get("group_by") == "Invoice":
-				for row in self.grouped[key]:
-					if row.indent == 1.0:
-						if (
-							row.parent in self.returned_invoices
-							and row.item_code in self.returned_invoices[row.parent]
-						):
-							returned_item_rows = self.returned_invoices[row.parent][row.item_code]
-							for returned_item_row in returned_item_rows:
-								# returned_items 'qty' should be stateful
-								if returned_item_row.qty != 0:
-									if row.qty >= abs(returned_item_row.qty):
-										row.qty += returned_item_row.qty
-										returned_item_row.qty = 0
-									else:
-										row.qty = 0
-										returned_item_row.qty += row.qty
-								row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
-							row.buying_amount = flt(
-								flt(row.qty) * flt(row.buying_rate), self.currency_precision
-							)
-						if flt(row.qty) or row.base_amount:
-							row = self.set_average_rate(row)
-							self.grouped_data.append(row)
-			elif self.filters.get("group_by") == "Payment Term":
+			if self.filters.get("group_by") == "Payment Term":
 				for i, row in enumerate(self.grouped[key]):
 					invoice_portion = 0
 
@@ -556,7 +555,7 @@ class GrossProfitGenerator:
 
 				new_row = self.set_average_rate(new_row)
 				self.grouped_data.append(new_row)
-			else:
+			elif self.filters.get("group_by") != "Invoice":
 				for i, row in enumerate(self.grouped[key]):
 					if i == 0:
 						new_row = row

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -421,12 +421,12 @@ class TestGrossProfit(IntegrationTestCase):
 			"item_name": self.item,
 			"warehouse": "Stores - _GP",
 			"qty": 0.0,
-			"avg._selling_rate": 0.0,
+			"avg._selling_rate": 100,
 			"valuation_rate": 0.0,
-			"selling_amount": -100.0,
+			"selling_amount": 0.0,
 			"buying_amount": 0.0,
-			"gross_profit": -100.0,
-			"gross_profit_%": 100.0,
+			"gross_profit": 0.0,
+			"gross_profit_%": 0.0,
 		}
 		gp_entry = [x for x in data if x.parent_invoice == sinv.name]
 		# Both items of Invoice should have '0' qty


### PR DESCRIPTION
Issue:

- If Group by is set as  "Invoice", the returned invoice quantity is updated but gross profit is not recalculated.

Before:
![image](https://github.com/user-attachments/assets/a8942933-399e-4224-a6aa-f79bb790a25a)


After:
![image](https://github.com/user-attachments/assets/89d2af6d-4ea2-4bb1-9e81-01fd68b94de2)


- If Group by is set as "Item", returned invoices are not deducted from the item.

Before:
![image](https://github.com/user-attachments/assets/d142c82d-3be0-4db7-a251-51af5f7509f1)


After:
![image](https://github.com/user-attachments/assets/becc9176-de28-4519-9b8d-747ef412ffef)


Steps To Replicate:
- Create a invoice
- Create a Sales Return against it.

Frappe Support Issue:
- https://support.frappe.io/app/hd-ticket/21142
- https://support.frappe.io/app/hd-ticket/23827

backport version-15
backport version-14
