### PR TITLE
fix: set debit transaction currency in gl entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1318,11 +1318,19 @@ class PaymentEntry(AccountsController):
 				dr_or_cr = "debit" if dr_or_cr == "credit" else "credit"
 
 			gle.update(
-				{
-					dr_or_cr: allocated_amount_in_company_currency,
-					dr_or_cr + "_in_account_currency": d.allocated_amount,
-					"cost_center": cost_center,
-				}
+				self.get_gl_dict(
+					{
+						"account": self.party_account,
+						"party_type": self.party_type,
+						"party": self.party,
+						"against": against_account,
+						"account_currency": self.party_account_currency,
+						"cost_center": cost_center,
+						dr_or_cr + "_in_account_currency": d.allocated_amount,
+						dr_or_cr: allocated_amount_in_company_currency,
+					},
+					item=self,
+				)
 			)
 
 			if self.book_advance_payments_in_separate_party_account:


### PR DESCRIPTION
**Issue:**
Payment Entry gl entry doesn't have debit transaction currency when there is payment is made against an invoice
**ref:** [25193](https://support.frappe.io/helpdesk/tickets/25193)

**Before:**
![Screenshot 2024-11-26_00-00-04](https://github.com/user-attachments/assets/9c09a241-e560-46e8-a4d5-fbb7d2c30a01)

**After:**
![Screenshot 2024-11-26_00-01-38](https://github.com/user-attachments/assets/1cee342d-f3e6-4650-b45a-4cbf2199da17)

**Backport needed: v15**