### PR TITLE
fix: incorrect GL entry on sale of fully depreciated asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -916,13 +916,12 @@ class Asset(AccountsController):
 					].expected_value_after_useful_life
 					value_after_depreciation = self.finance_books[idx].value_after_depreciation
 
-				if (
-					flt(value_after_depreciation) <= expected_value_after_useful_life
-					or self.is_fully_depreciated
-				):
+				if flt(value_after_depreciation) <= expected_value_after_useful_life:
 					status = "Fully Depreciated"
+					self.is_fully_depreciated = 1
 				elif flt(value_after_depreciation) < flt(self.gross_purchase_amount):
 					status = "Partially Depreciated"
+					self.is_fully_depreciated = 0
 		elif self.docstatus == 2:
 			status = "Cancelled"
 		return status

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -454,7 +454,7 @@ def restore_asset(asset_name):
 
 
 def depreciate_asset(asset, date):
-	if not asset.calculate_depreciation:
+	if not asset.calculate_depreciation or asset.status == "Fully Depreciated":
 		return
 
 	asset.flags.ignore_validate_update_after_submit = True

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -454,7 +454,7 @@ def restore_asset(asset_name):
 
 
 def depreciate_asset(asset, date):
-	if not asset.calculate_depreciation or asset.status == "Fully Depreciated":
+	if not asset.calculate_depreciation or asset.is_fully_depreciated:
 		return
 
 	asset.flags.ignore_validate_update_after_submit = True


### PR DESCRIPTION
### Problem:
When selling a fully depreciated asset, the system continued depreciating it, leading to incorrect GL entries and unwanted changes in the asset.

### Solution:
- Added a condition to check if the asset is fully depreciated.

no-docs