### PR TITLE
fix: move `validate_total_debit_and_credit` from`validate` to`on_submit` in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -181,11 +181,12 @@ class JournalEntry(AccountsController):
 		else:
 			return self._cancel()
 
-	def on_submit(self):
+	def before_submit(self):
 		# Do not validate while importing via data import
 		if not frappe.flags.in_import:
 			self.validate_total_debit_and_credit()
 
+	def on_submit(self):
 		self.validate_cheque_info()
 		self.check_credit_limit()
 		self.make_gl_entries()

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -127,9 +127,6 @@ class JournalEntry(AccountsController):
 		self.set_amounts_in_company_currency()
 		self.validate_debit_credit_amount()
 		self.set_total_debit_credit()
-		# Do not validate while importing via data import
-		if not frappe.flags.in_import:
-			self.validate_total_debit_and_credit()
 
 		if not frappe.flags.is_reverse_depr_entry:
 			self.validate_against_jv()
@@ -185,6 +182,10 @@ class JournalEntry(AccountsController):
 			return self._cancel()
 
 	def on_submit(self):
+		# Do not validate while importing via data import
+		if not frappe.flags.in_import:
+			self.validate_total_debit_and_credit()
+
 		self.validate_cheque_info()
 		self.check_credit_limit()
 		self.make_gl_entries()


### PR DESCRIPTION
Issue: https://support.frappe.io/helpdesk/tickets/20084
![image](https://github.com/user-attachments/assets/cb5c34ae-05d9-4929-9b3b-b47bde2bbda9)

![image](https://github.com/user-attachments/assets/336b93c2-61a3-4c44-abba-e2a6cb14fdd0)
Total Debit and Credit are shown same even when there is a difference amount.

Solution:
Remove the validation `validate_total_debit_and_credit` and let the user save Journal Entry. This will recalculate and correct the amounts shown.

Instead, validate `validate_total_debit_and_credit` in `on_submit`