### PR TITLE
fix: show cc on the process statement of accounts email

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -474,6 +474,7 @@ def send_emails(document_name, from_scheduler=False, posting_date=None):
 				reference_doctype="Process Statement Of Accounts",
 				reference_name=document_name,
 				attachments=attachments,
+				expose_recipients="header",
 			)
 
 		if doc.enable_auto_email and from_scheduler:


### PR DESCRIPTION
**Issue:**
cc email ID is not showing in the received email
**ref:** [25154](https://support.frappe.io/helpdesk/tickets/25154)

![image](https://github.com/user-attachments/assets/abb6f241-80de-4659-ace6-75623cc0cc40)
**Before:**
![image](https://github.com/user-attachments/assets/9742bc93-2edf-4e8f-a7a2-1dd4de856442)

**After:**
![image](https://github.com/user-attachments/assets/094edf70-e597-4731-8dd1-c350be502dc5)

**Backport needed for v15**