### PR TITLE
fix: reduce paid amount from grand total

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -672,11 +672,9 @@ def get_amount(ref_doc, payment_account=None):
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if not ref_doc.get("is_pos"):
 			if ref_doc.party_account_currency == ref_doc.currency:
-				grand_total = flt(ref_doc.rounded_total or ref_doc.grand_total)
+				grand_total = flt(ref_doc.outstanding_amount)
 			else:
-				grand_total = flt(
-					flt(ref_doc.base_rounded_total or ref_doc.base_grand_total) / ref_doc.conversion_rate
-				)
+				grand_total = flt(flt(ref_doc.outstanding_amount) / ref_doc.conversion_rate)
 		elif dt == "Sales Invoice":
 			for pay in ref_doc.payments:
 				if pay.type == "Phone" and pay.account == payment_account:

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -3,7 +3,7 @@ import json
 import frappe
 from frappe import _, qb
 from frappe.model.document import Document
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import Abs, Sum
 from frappe.utils import flt, nowdate
 from frappe.utils.background_jobs import enqueue
 
@@ -563,6 +563,8 @@ def make_payment_request(**args):
 	# fetches existing payment request `grand_total` amount
 	existing_payment_request_amount = get_existing_payment_request_amount(ref_doc.doctype, ref_doc.name)
 
+	existing_paid_amount = get_existing_paid_amount(ref_doc.doctype, ref_doc.name)
+
 	def validate_and_calculate_grand_total(grand_total, existing_payment_request_amount):
 		grand_total -= existing_payment_request_amount
 		if not grand_total:
@@ -581,6 +583,15 @@ def make_payment_request(**args):
 				cancel_old_payment_requests(ref_doc.doctype, ref_doc.name)
 		else:
 			grand_total = validate_and_calculate_grand_total(grand_total, existing_payment_request_amount)
+
+	if existing_paid_amount:
+		if ref_doc.party_account_currency == ref_doc.currency:
+			if ref_doc.conversion_rate:
+				grand_total -= flt(existing_paid_amount / ref_doc.conversion_rate)
+			else:
+				grand_total -= flt(existing_paid_amount)
+		else:
+			grand_total -= flt(existing_paid_amount / ref_doc.conversion_rate)
 
 	if draft_payment_request:
 		frappe.db.set_value(
@@ -672,9 +683,11 @@ def get_amount(ref_doc, payment_account=None):
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if not ref_doc.get("is_pos"):
 			if ref_doc.party_account_currency == ref_doc.currency:
-				grand_total = flt(ref_doc.outstanding_amount)
+				grand_total = flt(ref_doc.rounded_total or ref_doc.grand_total)
 			else:
-				grand_total = flt(flt(ref_doc.outstanding_amount) / ref_doc.conversion_rate)
+				grand_total = flt(
+					flt(ref_doc.base_rounded_total or ref_doc.base_grand_total) / ref_doc.conversion_rate
+				)
 		elif dt == "Sales Invoice":
 			for pay in ref_doc.payments:
 				if pay.type == "Phone" and pay.account == payment_account:
@@ -751,6 +764,27 @@ def get_existing_payment_request_amount(ref_dt, ref_dn, statuses: list | None = 
 	if statuses:
 		query = query.where(PR.status.isin(statuses))
 
+	response = query.run()
+
+	return response[0][0] if response[0] else 0
+
+
+def get_existing_paid_amount(doctype, name):
+	PL = frappe.qb.DocType("Payment Ledger Entry")
+	PER = frappe.qb.DocType("Payment Entry Reference")
+
+	query = (
+		frappe.qb.from_(PL)
+		.left_join(PER)
+		.on(
+			(PER.reference_doctype == PL.against_voucher_type) & (PER.reference_name == PL.against_voucher_no)
+		)
+		.select(Abs(Sum(PL.amount)).as_("total_paid_amount"))
+		.where(PL.against_voucher_type.eq(doctype))
+		.where(PL.against_voucher_no.eq(name))
+		.where(PL.amount < 0)
+		.where(PER.payment_request.isnull())
+	)
 	response = query.run()
 
 	return response[0][0] if response[0] else 0


### PR DESCRIPTION
Issue:
For partly paid invoices, if we create new payment request, system takes full amount as payment amount.

ref: [26055](https://support.frappe.io/helpdesk/tickets/26055)

Before:

[payment_request-2024-11-26_15.55.30.webm](https://github.com/user-attachments/assets/b6835c18-56cd-4df7-a936-469d614e15a8)

After:

[payment_request-2024-11-26_15.47.26.webm](https://github.com/user-attachments/assets/50da85a3-cf45-43a2-a310-6b835d69235e)

Back port needed for v15.


