### PR TITLE
feat: provision to disable item attribute

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -685,39 +685,41 @@ $.extend(erpnext.item, {
 		}
 
 		frm.doc.attributes.forEach(function (d) {
-			let p = new Promise((resolve) => {
-				if (!d.numeric_values) {
-					frappe
-						.call({
-							method: "frappe.client.get_list",
-							args: {
-								doctype: "Item Attribute Value",
-								filters: [["parent", "=", d.attribute]],
-								fields: ["attribute_value"],
-								limit_page_length: 0,
-								parent: "Item Attribute",
-								order_by: "idx",
-							},
-						})
-						.then((r) => {
-							if (r.message) {
-								attr_val_fields[d.attribute] = r.message.map(function (d) {
-									return d.attribute_value;
-								});
-								resolve();
-							}
-						});
-				} else {
-					let values = [];
-					for (var i = d.from_range; i <= d.to_range; i = flt(i + d.increment, 6)) {
-						values.push(i);
+			if (!d.disabled) {
+				let p = new Promise((resolve) => {
+					if (!d.numeric_values) {
+						frappe
+							.call({
+								method: "frappe.client.get_list",
+								args: {
+									doctype: "Item Attribute Value",
+									filters: [["parent", "=", d.attribute]],
+									fields: ["attribute_value"],
+									limit_page_length: 0,
+									parent: "Item Attribute",
+									order_by: "idx",
+								},
+							})
+							.then((r) => {
+								if (r.message) {
+									attr_val_fields[d.attribute] = r.message.map(function (d) {
+										return d.attribute_value;
+									});
+									resolve();
+								}
+							});
+					} else {
+						let values = [];
+						for (var i = d.from_range; i <= d.to_range; i = flt(i + d.increment, 6)) {
+							values.push(i);
+						}
+						attr_val_fields[d.attribute] = values;
+						resolve();
 					}
-					attr_val_fields[d.attribute] = values;
-					resolve();
-				}
-			});
+				});
 
-			promises.push(p);
+				promises.push(p);
+			}
 		}, this);
 
 		Promise.all(promises).then(() => {
@@ -732,26 +734,29 @@ $.extend(erpnext.item, {
 		for (var i = 0; i < frm.doc.attributes.length; i++) {
 			var fieldtype, desc;
 			var row = frm.doc.attributes[i];
-			if (row.numeric_values) {
-				fieldtype = "Float";
-				desc =
-					"Min Value: " +
-					row.from_range +
-					" , Max Value: " +
-					row.to_range +
-					", in Increments of: " +
-					row.increment;
-			} else {
-				fieldtype = "Data";
-				desc = "";
+
+			if (!row.disabled) {
+				if (row.numeric_values) {
+					fieldtype = "Float";
+					desc =
+						"Min Value: " +
+						row.from_range +
+						" , Max Value: " +
+						row.to_range +
+						", in Increments of: " +
+						row.increment;
+				} else {
+					fieldtype = "Data";
+					desc = "";
+				}
+				fields = fields.concat({
+					label: row.attribute,
+					fieldname: row.attribute,
+					fieldtype: fieldtype,
+					reqd: 0,
+					description: desc,
+				});
 			}
-			fields = fields.concat({
-				label: row.attribute,
-				fieldname: row.attribute,
-				fieldtype: fieldtype,
-				reqd: 0,
-				description: desc,
-			});
 		}
 
 		if (frm.doc.image) {

--- a/erpnext/stock/doctype/item_attribute/item_attribute.json
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.json
@@ -10,6 +10,8 @@
  "field_order": [
   "attribute_name",
   "numeric_values",
+  "column_break_vbik",
+  "disabled",
   "section_break_4",
   "from_range",
   "increment",
@@ -70,15 +72,26 @@
    "fieldtype": "Table",
    "label": "Item Attribute Values",
    "options": "Item Attribute Value"
+  },
+  {
+   "fieldname": "column_break_vbik",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "icon": "fa fa-edit",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:09:53.963494",
+ "modified": "2024-11-26 20:05:29.421714",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Attribute",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -30,6 +30,7 @@ class ItemAttribute(Document):
 		from erpnext.stock.doctype.item_attribute_value.item_attribute_value import ItemAttributeValue
 
 		attribute_name: DF.Data
+		disabled: DF.Check
 		from_range: DF.Float
 		increment: DF.Float
 		item_attribute_values: DF.Table[ItemAttributeValue]
@@ -44,6 +45,19 @@ class ItemAttribute(Document):
 
 	def on_update(self):
 		self.validate_exising_items()
+		self.set_enabled_disabled_in_items()
+
+	def set_enabled_disabled_in_items(self):
+		db_value = self.get_doc_before_save()
+		if not db_value or db_value.disabled != self.disabled:
+			item_variant_table = frappe.qb.DocType("Item Variant Attribute")
+			query = (
+				frappe.qb.update(item_variant_table)
+				.set(item_variant_table.disabled, self.disabled)
+				.where(item_variant_table.attribute == self.name)
+			)
+
+			query.run()
 
 	def validate_exising_items(self):
 		"""Validate that if there are existing items with attributes, they are valid"""

--- a/erpnext/stock/doctype/item_variant_attribute/item_variant_attribute.json
+++ b/erpnext/stock/doctype/item_variant_attribute/item_variant_attribute.json
@@ -11,6 +11,7 @@
   "column_break_2",
   "attribute_value",
   "numeric_values",
+  "disabled",
   "section_break_4",
   "from_range",
   "increment",
@@ -74,11 +75,18 @@
    "fieldname": "to_range",
    "fieldtype": "Float",
    "label": "To Range"
+  },
+  {
+   "default": "0",
+   "fetch_from": "attribute.disabled",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:55.966900",
+ "modified": "2024-11-26 20:10:49.873339",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Variant Attribute",

--- a/erpnext/stock/doctype/item_variant_attribute/item_variant_attribute.py
+++ b/erpnext/stock/doctype/item_variant_attribute/item_variant_attribute.py
@@ -16,6 +16,7 @@ class ItemVariantAttribute(Document):
 
 		attribute: DF.Link
 		attribute_value: DF.Data | None
+		disabled: DF.Check
 		from_range: DF.Float
 		increment: DF.Float
 		numeric_values: DF.Check


### PR DESCRIPTION
Added Disabled field in the item attribute to disable the item attribute in the item master

<img width="1126" alt="Screenshot 2024-11-26 at 9 08 46 PM" src="https://github.com/user-attachments/assets/62b9092a-5038-432e-96d5-fe3cb3fb79f7">



Use Case

Suppose there are attributes for t-shirt like

1. Size (S, M, L, XL)
2. Color (Red, Black, White)
3. Pocket (Yes, No)

The user created a few items with these attributes. Later, they decided that all new t-shirts should have a pocket. In this case, they don’t want to select the 'Pocket (Yes/No)' attribute while creating new items. Also they can't remove the 'Pocket (Yes/No)' attribute from the item template because the items exists against the Pocket attribute. So to fix this issue, we have given option to disabled the item attribute.


#No-docs