### PR TITLE
fix: unify company address query in sales transactions

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -740,20 +740,6 @@ frappe.ui.form.on("Sales Invoice", {
 			};
 		});
 
-		frm.set_query("company_address", function (doc) {
-			if (!doc.company) {
-				frappe.throw(__("Please set Company"));
-			}
-
-			return {
-				query: "frappe.contacts.doctype.address.address.address_query",
-				filters: {
-					link_doctype: "Company",
-					link_name: doc.company,
-				},
-			};
-		});
-
 		frm.set_query("pos_profile", function (doc) {
 			if (!doc.company) {
 				frappe.throw(__("Please set Company"));

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -78,7 +78,7 @@ $.extend(erpnext.queries, {
 
 	company_address_query: function (doc) {
 		if (!doc.company) {
-			frappe.throw(__("Please set Company"));
+			frappe.throw(__("Please set {0}", [__(frappe.meta.get_label(doc.doctype, "company", doc.name))]));
 		}
 
 		return {

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -77,9 +77,13 @@ $.extend(erpnext.queries, {
 	},
 
 	company_address_query: function (doc) {
+		if (!doc.company) {
+			frappe.throw(__("Please set Company"));
+		}
+
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",
-			filters: { is_your_company_address: 1, link_doctype: "Company", link_name: doc.company || "" },
+			filters: { link_doctype: "Company", link_name: doc.company },
 		};
 	},
 

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -52,6 +52,7 @@ erpnext.sales_common = {
 				me.frm.set_query("customer_address", erpnext.queries.address_query);
 				me.frm.set_query("shipping_address_name", erpnext.queries.address_query);
 				me.frm.set_query("dispatch_address_name", erpnext.queries.dispatch_address_query);
+				me.frm.set_query("company_address", erpnext.queries.company_address_query);
 
 				erpnext.accounts.dimensions.setup_dimension_filters(me.frm, me.frm.doctype);
 

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -24,20 +24,6 @@ frappe.ui.form.on("Quotation", {
 		frm.set_df_property("packed_items", "cannot_add_rows", true);
 		frm.set_df_property("packed_items", "cannot_delete_rows", true);
 
-		frm.set_query("company_address", function (doc) {
-			if (!doc.company) {
-				frappe.throw(__("Please set Company"));
-			}
-
-			return {
-				query: "frappe.contacts.doctype.address.address.address_query",
-				filters: {
-					link_doctype: "Company",
-					link_name: doc.company,
-				},
-			};
-		});
-
 		frm.set_query("serial_and_batch_bundle", "packed_items", (doc, cdt, cdn) => {
 			let row = locals[cdt][cdn];
 			return {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -26,20 +26,6 @@ frappe.ui.form.on("Sales Order", {
 			return doc.stock_qty <= doc.delivered_qty ? "green" : "orange";
 		});
 
-		frm.set_query("company_address", function (doc) {
-			if (!doc.company) {
-				frappe.throw(__("Please set Company"));
-			}
-
-			return {
-				query: "frappe.contacts.doctype.address.address.address_query",
-				filters: {
-					link_doctype: "Company",
-					link_name: doc.company,
-				},
-			};
-		});
-
 		frm.set_query("bom_no", "items", function (doc, cdt, cdn) {
 			var row = locals[cdt][cdn];
 			return {


### PR DESCRIPTION
**Quotation**, **Sales Order** and **Sales Invoice** each implemented their own query on _Company Address_. The standard `erpnext.queries.company_address_query` was not used. **Delivery Note** and **POS Invoice** were entirely lacking the query.

Now all use the same query, which has been adjusted to be closer to the previous individual implementations.