### PR TITLE
feat(Dunning): separate tab "Address & Contact"

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.json
+++ b/erpnext/accounts/doctype/dunning/dunning.json
@@ -19,16 +19,6 @@
   "currency",
   "column_break_11",
   "conversion_rate",
-  "address_and_contact_section",
-  "customer_address",
-  "address_display",
-  "contact_person",
-  "contact_display",
-  "column_break_16",
-  "company_address",
-  "company_address_display",
-  "contact_mobile",
-  "contact_email",
   "section_break_6",
   "dunning_type",
   "column_break_8",
@@ -56,7 +46,21 @@
   "income_account",
   "column_break_48",
   "cost_center",
-  "amended_from"
+  "amended_from",
+  "address_and_contact_tab",
+  "address_and_contact_section",
+  "customer_address",
+  "address_display",
+  "column_break_vodj",
+  "contact_person",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "section_break_xban",
+  "column_break_16",
+  "company_address",
+  "company_address_display",
+  "column_break_lqmf"
  ],
  "fields": [
   {
@@ -178,10 +182,8 @@
    "label": "Rate of Interest (%) Yearly"
   },
   {
-   "collapsible": 1,
    "fieldname": "address_and_contact_section",
-   "fieldtype": "Section Break",
-   "label": "Address and Contact"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "address_display",
@@ -377,11 +379,28 @@
   {
    "fieldname": "column_break_48",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "address_and_contact_tab",
+   "fieldtype": "Tab Break",
+   "label": "Address & Contact"
+  },
+  {
+   "fieldname": "column_break_vodj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_xban",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_lqmf",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:08:19.176146",
+ "modified": "2024-11-26 13:46:07.760867",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning",


### PR DESCRIPTION
Before, there were no tabs. "Address and Contact" was a collapsible section.

![Bildschirmfoto 2024-11-26 um 19 48 43](https://github.com/user-attachments/assets/fe4df310-6007-4f43-9772-f07c06884f11)

> no-docs