### PR TITLE
fix: unify company address query in sales transactions (backport #44361)

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -667,20 +667,6 @@ frappe.ui.form.on('Sales Invoice', {
 			}
 		}
 
-		frm.set_query('company_address', function(doc) {
-			if(!doc.company) {
-				frappe.throw(__('Please set Company'));
-			}
-
-			return {
-				query: 'frappe.contacts.doctype.address.address.address_query',
-				filters: {
-					link_doctype: 'Company',
-					link_name: doc.company
-				}
-			};
-		});
-
 		frm.set_query('pos_profile', function(doc) {
 			if(!doc.company) {
 				frappe.throw(_('Please set Company'));

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -91,7 +91,7 @@ $.extend(erpnext.queries, {
 
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",
-			filters: { link_doctype: "Company", link_name: doc.company},
+			filters: { link_doctype: "Company", link_name: doc.company },
 		};
 	},
 

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -85,9 +85,13 @@ $.extend(erpnext.queries, {
 	},
 
 	company_address_query: function (doc) {
+		if (!doc.company) {
+			frappe.throw(__("Please set {0}", [frappe.meta.get_label(doc.doctype, "company", doc.name)]));
+		}
+
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",
-			filters: { is_your_company_address: 1, link_doctype: "Company", link_name: doc.company || "" },
+			filters: { link_doctype: "Company", link_name: doc.company},
 		};
 	},
 

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -20,20 +20,6 @@ frappe.ui.form.on('Quotation', {
 
 		frm.set_df_property('packed_items', 'cannot_add_rows', true);
 		frm.set_df_property('packed_items', 'cannot_delete_rows', true);
-
-		frm.set_query('company_address', function(doc) {
-			if(!doc.company) {
-				frappe.throw(__('Please set Company'));
-			}
-
-			return {
-				query: 'frappe.contacts.doctype.address.address.address_query',
-				filters: {
-					link_doctype: 'Company',
-					link_name: doc.company
-				}
-			};
-		});
 	},
 
 	refresh: function(frm) {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -21,20 +21,6 @@ frappe.ui.form.on("Sales Order", {
 		frm.set_indicator_formatter('item_code',
 			function(doc) { return (doc.stock_qty<=doc.delivered_qty) ? "green" : "orange" })
 
-		frm.set_query('company_address', function(doc) {
-			if(!doc.company) {
-				frappe.throw(__('Please set Company'));
-			}
-
-			return {
-				query: 'frappe.contacts.doctype.address.address.address_query',
-				filters: {
-					link_doctype: 'Company',
-					link_name: doc.company
-				}
-			};
-		})
-
 		frm.set_query("bom_no", "items", function(doc, cdt, cdn) {
 			var row = locals[cdt][cdn];
 			return {

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -40,6 +40,7 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		me.frm.set_query('customer_address', erpnext.queries.address_query);
 		me.frm.set_query('shipping_address_name', erpnext.queries.address_query);
 		me.frm.set_query('dispatch_address_name', erpnext.queries.dispatch_address_query);
+		me.frm.set_query('company_address', erpnext.queries.company_address_query);
 
 		erpnext.accounts.dimensions.setup_dimension_filters(me.frm, me.frm.doctype);
 


### PR DESCRIPTION
**Quotation**, **Sales Order** and **Sales Invoice** each implemented their own query on _Company Address_. The standard `erpnext.queries.company_address_query` was not used. **Delivery Note** and **POS Invoice** were entirely lacking the query.

Now all use the same query, which has been adjusted to be closer to the previous individual implementations.

---

Manual backport (https://github.com/frappe/erpnext/pull/44364 had too many merge conflicts)