### PR TITLE
feat(UX): scroll to required field

### DIFF
--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -28,9 +28,13 @@ $.extend(erpnext.queries, {
 
 	customer_filter: function (doc) {
 		if (!doc.customer) {
-			frappe.throw(
-				__("Please set {0}", [__(frappe.meta.get_label(doc.doctype, "customer", doc.name))])
-			);
+			cur_frm.scroll_to_field("customer");
+			frappe.show_alert({
+				message: __("Please set {0} first.", [
+					__(frappe.meta.get_label(doc.doctype, "customer", doc.name)),
+				]),
+				indicator: "orange",
+			});
 		}
 
 		return { filters: { customer: doc.customer } };
@@ -39,11 +43,13 @@ $.extend(erpnext.queries, {
 	contact_query: function (doc) {
 		if (frappe.dynamic_link) {
 			if (!doc[frappe.dynamic_link.fieldname]) {
-				frappe.throw(
-					__("Please set {0}", [
+				cur_frm.scroll_to_field(frappe.dynamic_link.fieldname);
+				frappe.show_alert({
+					message: __("Please set {0} first.", [
 						__(frappe.meta.get_label(doc.doctype, frappe.dynamic_link.fieldname, doc.name)),
-					])
-				);
+					]),
+					indicator: "orange",
+				});
 			}
 
 			return {
@@ -59,11 +65,13 @@ $.extend(erpnext.queries, {
 	address_query: function (doc) {
 		if (frappe.dynamic_link) {
 			if (!doc[frappe.dynamic_link.fieldname]) {
-				frappe.throw(
-					__("Please set {0}", [
+				cur_frm.scroll_to_field(frappe.dynamic_link.fieldname);
+				frappe.show_alert({
+					message: __("Please set {0} first.", [
 						__(frappe.meta.get_label(doc.doctype, frappe.dynamic_link.fieldname, doc.name)),
-					])
-				);
+					]),
+					indicator: "orange",
+				});
 			}
 
 			return {
@@ -78,7 +86,13 @@ $.extend(erpnext.queries, {
 
 	company_address_query: function (doc) {
 		if (!doc.company) {
-			frappe.throw(__("Please set {0}", [__(frappe.meta.get_label(doc.doctype, "company", doc.name))]));
+			cur_frm.scroll_to_field("company");
+			frappe.show_alert({
+				message: __("Please set {0} first.", [
+					__(frappe.meta.get_label(doc.doctype, "company", doc.name)),
+				]),
+				indicator: "orange",
+			});
 		}
 
 		return {
@@ -96,9 +110,13 @@ $.extend(erpnext.queries, {
 
 	supplier_filter: function (doc) {
 		if (!doc.supplier) {
-			frappe.throw(
-				__("Please set {0}", [__(frappe.meta.get_label(doc.doctype, "supplier", doc.name))])
-			);
+			cur_frm.scroll_to_field("supplier");
+			frappe.show_alert({
+				message: __("Please set {0} first.", [
+					__(frappe.meta.get_label(doc.doctype, "supplier", doc.name)),
+				]),
+				indicator: "orange",
+			});
 		}
 
 		return { filters: { supplier: doc.supplier } };
@@ -106,9 +124,13 @@ $.extend(erpnext.queries, {
 
 	lead_filter: function (doc) {
 		if (!doc.lead) {
-			frappe.throw(
-				__("Please specify a {0}", [__(frappe.meta.get_label(doc.doctype, "lead", doc.name))])
-			);
+			cur_frm.scroll_to_field("lead");
+			frappe.show_alert({
+				message: __("Please specify a {0} first.", [
+					__(frappe.meta.get_label(doc.doctype, "lead", doc.name)),
+				]),
+				indicator: "orange",
+			});
 		}
 
 		return { filters: { lead: doc.lead } };


### PR DESCRIPTION
### Before

When the required field for a query is missing, we throw an error message.

https://github.com/user-attachments/assets/d5a8aeda-6581-43a8-b4c7-f0043e4f3ae9

### After

When the required field for a query is missing, we jump to the required field and show an alert.

https://github.com/user-attachments/assets/6a6a3b1e-c8b9-4902-bc11-8ccb1e9709df

I prefer this because it removes the burden of searching for the required field and reduces the number of errors that get thrown in the user's face.

Not sure how we could best avoid the use of `cur_frm` here.

> no-docs