### PR TITLE
fix: Always Calculate `sales_incoming_rate` for Internal Transfers

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -356,13 +356,13 @@ class BuyingController(SubcontractingController):
 		if not self.is_internal_transfer():
 			return
 
+		self.set_sales_incoming_rate_for_internal_transfer()
+
 		allow_at_arms_length_price = frappe.get_cached_value(
 			"Stock Settings", None, "allow_internal_transfer_at_arms_length_price"
 		)
 		if allow_at_arms_length_price:
 			return
-
-		self.set_sales_incoming_rate_for_internal_transfer()
 
 		for d in self.get("items"):
 			d.discount_percentage = 0.0

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -809,6 +809,7 @@ class TestAccountsController(IntegrationTestCase):
 		"Stock Settings", {"allow_internal_transfer_at_arms_length_price": 1}
 	)
 	def test_16_internal_transfer_at_arms_length_price(self):
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_inter_company_purchase_invoice
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
 		prepare_data_for_internal_transfer()
@@ -841,6 +842,31 @@ class TestAccountsController(IntegrationTestCase):
 		si.save()
 		# rate should reset to incoming rate
 		self.assertEqual(si.items[0].rate, 100)
+
+		si.update_stock = 0
+		si.save()
+		si.submit()
+
+		pi = make_inter_company_purchase_invoice(si.name)
+		pi.update_stock = 1
+		pi.items[0].rate = arms_length_price
+		pi.items[0].warehouse = target_warehouse
+		pi.items[0].from_warehouse = warehouse
+		pi.save()
+
+		self.assertEqual(pi.items[0].rate, 100)
+		self.assertEqual(pi.items[0].valuation_rate, 100)
+
+		frappe.db.set_single_value("Stock Settings", "allow_internal_transfer_at_arms_length_price", 1)
+		pi = make_inter_company_purchase_invoice(si.name)
+		pi.update_stock = 1
+		pi.items[0].rate = arms_length_price
+		pi.items[0].warehouse = target_warehouse
+		pi.items[0].from_warehouse = warehouse
+		pi.save()
+
+		self.assertEqual(pi.items[0].rate, arms_length_price)
+		self.assertEqual(pi.items[0].valuation_rate, 100)
 
 	def test_20_journal_against_sales_invoice(self):
 		# Invoice in Foreign Currency


### PR DESCRIPTION
### Fix (should have been done) in [this]( https://github.com/frappe/erpnext/pull/42050):

- For internal transfer in Buying workflow, if `allow_internal_transfer_at_arms_length_price` is set, then rate will not update to the valuation rate but accounting will be done at valuation rate.

### Problem in above PR:

- The Valuation rate is calculated based on the `sales_incoming_rate`, but the `sales_incoming_rate` is only set if `allow_internal_transfer_at_arms_length_price` is unset, due to which for internal transfers at `arms length price`, the valuation is set again to `arms length price` as `sales_incoming_rate` is not set.

