### PR TITLE
fix: remove field precision in Sales and Purchase Order for percentage fields

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -93,10 +93,7 @@ frappe.ui.form.on("Purchase Order", {
 	get_materials_from_supplier: function (frm) {
 		let po_details = [];
 
-		if (
-			frm.doc.supplied_items &&
-			(flt(frm.doc.per_received, precision("per_received")) == 100 || frm.doc.status === "Closed")
-		) {
+		if (frm.doc.supplied_items && (flt(frm.doc.per_received) == 100 || frm.doc.status === "Closed")) {
 			frm.doc.supplied_items.forEach((d) => {
 				if (d.total_supplied_qty && d.total_supplied_qty != d.consumed_qty) {
 					po_details.push(d.name);
@@ -332,8 +329,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			if (!["Closed", "Delivered"].includes(doc.status)) {
 				if (
 					this.frm.doc.status !== "Closed" &&
-					flt(this.frm.doc.per_received, precision("per_received")) < 100 &&
-					flt(this.frm.doc.per_billed, precision("per_billed")) < 100
+					flt(this.frm.doc.per_received) < 100 &&
+					flt(this.frm.doc.per_billed) < 100
 				) {
 					if (!this.frm.doc.__onload || this.frm.doc.__onload.can_update_items) {
 						this.frm.add_custom_button(__("Update Items"), () => {
@@ -347,10 +344,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 					}
 				}
 				if (this.frm.has_perm("submit")) {
-					if (
-						flt(doc.per_billed, precision("per_billed")) < 100 ||
-						flt(doc.per_received, precision("per_received")) < 100
-					) {
+					if (flt(doc.per_billed) < 100 || flt(doc.per_received) < 100) {
 						if (doc.status != "On Hold") {
 							this.frm.add_custom_button(
 								__("Hold"),
@@ -388,7 +382,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			}
 			if (doc.status != "Closed") {
 				if (doc.status != "On Hold") {
-					if (flt(doc.per_received, precision("per_received")) < 100 && allow_receipt) {
+					if (flt(doc.per_received) < 100 && allow_receipt) {
 						this.frm.add_custom_button(
 							__("Purchase Receipt"),
 							() => {
@@ -419,7 +413,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						}
 					}
 					// Please do not add precision in the below flt function
-					if (flt(doc.per_billed, precision("per_billed")) < 100)
+					if (flt(doc.per_billed) < 100)
 						this.frm.add_custom_button(
 							__("Purchase Invoice"),
 							() => {
@@ -428,7 +422,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 							__("Create")
 						);
 
-					if (flt(doc.per_billed, precision("per_billed")) < 100 && doc.status != "Delivered") {
+					if (flt(doc.per_billed) < 100 && doc.status != "Delivered") {
 						this.frm.add_custom_button(
 							__("Payment"),
 							() => this.make_payment_entry(),
@@ -436,7 +430,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						);
 					}
 
-					if (flt(doc.per_billed, precision("per_billed")) < 100) {
+					if (flt(doc.per_billed) < 100) {
 						this.frm.add_custom_button(
 							__("Payment Request"),
 							function () {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -43,8 +43,8 @@ frappe.ui.form.on("Sales Order", {
 		if (frm.doc.docstatus === 1) {
 			if (
 				frm.doc.status !== "Closed" &&
-				flt(frm.doc.per_delivered, precision("per_delivered")) < 100 &&
-				flt(frm.doc.per_billed, precision("per_billed")) < 100 &&
+				flt(frm.doc.per_delivered) < 100 &&
+				flt(frm.doc.per_billed) < 100 &&
 				frm.has_perm("write")
 			) {
 				frm.add_custom_button(__("Update Items"), () => {
@@ -61,7 +61,7 @@ frappe.ui.form.on("Sales Order", {
 				if (
 					frm.doc.__onload &&
 					frm.doc.__onload.has_unreserved_stock &&
-					flt(frm.doc.per_picked, precision("per_picked")) === 0
+					flt(frm.doc.per_picked) === 0
 				) {
 					frm.add_custom_button(
 						__("Reserve"),
@@ -590,10 +590,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						__("Status")
 					);
 
-					if (
-						flt(doc.per_delivered, precision("per_delivered")) < 100 ||
-						flt(doc.per_billed, precision("per_billed")) < 100
-					) {
+					if (flt(doc.per_delivered) < 100 || flt(doc.per_billed) < 100) {
 						// close
 						this.frm.add_custom_button(__("Close"), () => this.close_sales_order(), __("Status"));
 					}
@@ -616,10 +613,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						) && !this.frm.doc.skip_delivery_note;
 
 					if (this.frm.has_perm("submit")) {
-						if (
-							flt(doc.per_delivered, precision("per_delivered")) < 100 ||
-							flt(doc.per_billed, precision("per_billed")) < 100
-						) {
+						if (flt(doc.per_delivered) < 100 || flt(doc.per_billed) < 100) {
 							// hold
 							this.frm.add_custom_button(
 								__("Hold"),
@@ -637,8 +631,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					if (
 						(!doc.__onload || !doc.__onload.has_reserved_stock) &&
-						flt(doc.per_picked, precision("per_picked")) < 100 &&
-						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
+						flt(doc.per_picked) < 100 &&
+						flt(doc.per_delivered) < 100 &&
 						frappe.model.can_create("Pick List")
 					) {
 						this.frm.add_custom_button(
@@ -656,7 +650,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					// delivery note
 					if (
-						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
+						flt(doc.per_delivered) < 100 &&
 						(order_is_a_sale || order_is_a_custom_sale) &&
 						allow_delivery
 					) {
@@ -678,10 +672,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// sales invoice
-					if (
-						flt(doc.per_billed, precision("per_billed")) < 100 &&
-						frappe.model.can_create("Sales Invoice")
-					) {
+					if (flt(doc.per_billed) < 100 && frappe.model.can_create("Sales Invoice")) {
 						this.frm.add_custom_button(
 							__("Sales Invoice"),
 							() => me.make_sales_invoice(),
@@ -692,8 +683,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					// material request
 					if (
 						(!doc.order_type ||
-							((order_is_a_sale || order_is_a_custom_sale) &&
-								flt(doc.per_delivered, precision("per_delivered")) < 100)) &&
+							((order_is_a_sale || order_is_a_custom_sale) && flt(doc.per_delivered) < 100)) &&
 						frappe.model.can_create("Material Request")
 					) {
 						this.frm.add_custom_button(
@@ -718,10 +708,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// maintenance
-					if (
-						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
-						(order_is_maintenance || order_is_a_custom_sale)
-					) {
+					if (flt(doc.per_delivered) < 100 && (order_is_maintenance || order_is_a_custom_sale)) {
 						if (frappe.model.can_create("Maintenance Visit")) {
 							this.frm.add_custom_button(
 								__("Maintenance Visit"),
@@ -739,10 +726,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// project
-					if (
-						flt(doc.per_delivered, precision("per_delivered")) < 100 &&
-						frappe.model.can_create("Project")
-					) {
+					if (flt(doc.per_delivered) < 100 && frappe.model.can_create("Project")) {
 						this.frm.add_custom_button(__("Project"), () => this.make_project(), __("Create"));
 					}
 
@@ -770,10 +754,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 				}
 				// payment request
-				if (
-					flt(doc.per_billed, precision("per_billed", doc)) <
-					100 + frappe.boot.sysdefaults.over_billing_allowance
-				) {
+				if (flt(doc.per_billed) < 100 + frappe.boot.sysdefaults.over_billing_allowance) {
 					this.frm.add_custom_button(
 						__("Payment Request"),
 						() => this.make_payment_request(),

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -23,14 +23,14 @@ frappe.listview_settings["Sales Order"] = {
 			return [__("Completed"), "green", "status,=,Completed"];
 		} else if (doc.advance_payment_status === "Requested") {
 			return [__("To Pay"), "gray", "advance_payment_status,=,Requested"];
-		} else if (!doc.skip_delivery_note && flt(doc.per_delivered, 2) < 100) {
+		} else if (!doc.skip_delivery_note && flt(doc.per_delivered) < 100) {
 			if (frappe.datetime.get_diff(doc.delivery_date) < 0) {
 				// not delivered & overdue
 				return [__("Overdue"), "red", "per_delivered,<,100|delivery_date,<,Today|status,!=,Closed"];
 			} else if (flt(doc.grand_total) === 0) {
 				// not delivered (zeroount order)
 				return [__("To Deliver"), "orange", "per_delivered,<,100|grand_total,=,0|status,!=,Closed"];
-			} else if (flt(doc.per_billed, 2) < 100) {
+			} else if (flt(doc.per_billed) < 100) {
 				// not delivered & not billed
 				return [
 					__("To Deliver and Bill"),
@@ -42,13 +42,13 @@ frappe.listview_settings["Sales Order"] = {
 				return [__("To Deliver"), "orange", "per_delivered,<,100|per_billed,=,100|status,!=,Closed"];
 			}
 		} else if (
-			flt(doc.per_delivered, 2) === 100 &&
+			flt(doc.per_delivered) === 100 &&
 			flt(doc.grand_total) !== 0 &&
-			flt(doc.per_billed, 2) < 100
+			flt(doc.per_billed) < 100
 		) {
 			// to bill
 			return [__("To Bill"), "orange", "per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
-		} else if (doc.skip_delivery_note && flt(doc.per_billed, 2) < 100) {
+		} else if (doc.skip_delivery_note && flt(doc.per_billed) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100|status,!=,Closed"];
 		}
 	},


### PR DESCRIPTION
Remove field precision for Sales Order and Purchase Order fields:
- % Delivered
- % Amount Billed
- % Picked
- % Received

This is to maintain consistency as precision is not used while setting **Status** on backend.

Undoing the changes made in: https://github.com/frappe/erpnext/pull/44319
Replicating the changes made in: https://github.com/frappe/erpnext/pull/43690 for `sales_order_list.js`
