### PR TITLE
fix: Add translation for showing mandatory fields in error msg

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -570,7 +570,7 @@ def handle_mandatory_error(e, customer, lead_name):
 	from frappe.utils import get_link_to_form
 
 	mandatory_fields = e.args[0].split(":")[1].split(",")
-	mandatory_fields = [customer.meta.get_label(field.strip()) for field in mandatory_fields]
+	mandatory_fields = [_(customer.meta.get_label(field.strip())) for field in mandatory_fields]
 
 	frappe.local.message_log = []
 	message = _("Could not auto create Customer due to the following missing mandatory field(s):") + "<br>"


### PR DESCRIPTION
## Issue: [Support Ticket - 25936](https://support.frappe.io/helpdesk/tickets/25936)

> [!IMPORTANT]
> Backport require for both `V-15` and `V-14`