### PR TITLE
fix: adjusted incoming rate for zero rated item in purchase receipt

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1742,6 +1742,30 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 
 		frappe.db.set_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", 1)
 
+		# Cost of Item is zero in Purchase Receipt
+		pr = make_purchase_receipt(qty=1, rate=0)
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			"stock_value_difference",
+		)
+		self.assertEqual(stock_value_difference, 0)
+
+		pi = create_purchase_invoice_from_receipt(pr.name)
+		for row in pi.items:
+			row.rate = 150
+
+		pi.save()
+		pi.submit()
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name},
+			"stock_value_difference",
+		)
+		self.assertEqual(stock_value_difference, 150)
+
 		# Increase the cost of the item
 
 		pr = make_purchase_receipt(qty=1, rate=100)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1076,7 +1076,7 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 
 		if adjust_incoming_rate:
 			adjusted_amt = 0.0
-			if item.billed_amt and item.amount:
+			if item.billed_amt is not None and item.amount is not None:
 				adjusted_amt = flt(item.billed_amt) - flt(item.amount)
 
 			adjusted_amt = adjusted_amt * flt(pr_doc.conversion_rate)


### PR DESCRIPTION
The incoming rate is not adjusted when the Item rate is 0 in the Purchase Receipt.

Steps To Replicate:
To replicate the issue:
- In Buying Settings, enable Set Landed Cost Based on Purchase Invoice Rate (you have to disable Maintain Same Rate Throughout the Purchase Cycle first)
- Create a Purchase Receipt with a 0 rate in Item.
-  Create a Purchase Invoice for the same receipt with some rate now
-  Check the value in Stock Balance and Trial Balance


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/25152

backport version-15
backport version-14

