### PR TITLE
fix(Bank Transaction): error in party matching should not block submitting

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -208,13 +208,17 @@ class BankTransaction(Document):
 		if self.party_type and self.party:
 			return
 
-		result = AutoMatchParty(
-			bank_party_account_number=self.bank_party_account_number,
-			bank_party_iban=self.bank_party_iban,
-			bank_party_name=self.bank_party_name,
-			description=self.description,
-			deposit=self.deposit,
-		).match()
+		result = None
+		try:
+			result = AutoMatchParty(
+				bank_party_account_number=self.bank_party_account_number,
+				bank_party_iban=self.bank_party_iban,
+				bank_party_name=self.bank_party_name,
+				description=self.description,
+				deposit=self.deposit,
+			).match()
+		except Exception:
+			frappe.log_error(title=_("Error in party matching for Bank Transaction {0}").format(self.name))
 
 		if not result:
 			return


### PR DESCRIPTION
For **Bank Transactions** we have feature that can try to automatically find the related **Supplier** / **Customer** / **Employee**. This is a quality of life feature, missing matches are not critical. However, having an error in party matching block automated/bulk submission of **Bank Transactions**  is critical. Hence, we should better catch and log them.