### PR TITLE
fix: Reordered fields for asset doctype

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -8,25 +8,20 @@
  "document_type": "Document",
  "engine": "InnoDB",
  "field_order": [
-  "company",
+  "naming_series",
   "item_code",
   "item_name",
+  "asset_name",
+  "asset_category",
+  "location",
+  "image",
+  "column_break_3",
+  "status",
+  "company",
   "asset_owner",
   "asset_owner_company",
   "is_existing_asset",
   "is_composite_asset",
-  "supplier",
-  "customer",
-  "image",
-  "journal_entry_for_scrap",
-  "column_break_3",
-  "naming_series",
-  "asset_name",
-  "asset_category",
-  "location",
-  "split_from",
-  "custodian",
-  "department",
   "purchase_details_section",
   "purchase_receipt",
   "purchase_receipt_item",
@@ -34,12 +29,13 @@
   "purchase_invoice_item",
   "purchase_date",
   "available_for_use_date",
-  "disposal_date",
   "column_break_23",
   "gross_purchase_amount",
+  "purchase_amount",
   "asset_quantity",
   "additional_asset_cost",
   "total_asset_cost",
+  "disposal_date",
   "depreciation_tab",
   "calculate_depreciation",
   "column_break_33",
@@ -57,8 +53,6 @@
   "next_depreciation_date",
   "depreciation_schedule_sb",
   "depreciation_schedule_view",
-  "accounting_dimensions_tab",
-  "cost_center",
   "insurance_details_tab",
   "policy_number",
   "insurer",
@@ -68,21 +62,28 @@
   "insurance_end_date",
   "comprehensive_insurance",
   "other_info_tab",
-  "booked_fixed_asset",
-  "maintenance_required",
-  "column_break_51",
-  "status",
-  "purchase_amount",
+  "accounting_dimensions_section",
+  "cost_center",
+  "section_break_jtou",
+  "custodian",
   "default_finance_book",
   "depr_entry_posting_status",
+  "booked_fixed_asset",
+  "customer",
+  "supplier",
+  "column_break_51",
+  "department",
+  "split_from",
+  "journal_entry_for_scrap",
   "amended_from",
+  "maintenance_required",
   "connections_tab"
  ],
  "fields": [
   {
    "fieldname": "naming_series",
    "fieldtype": "Select",
-   "label": "Naming Series",
+   "label": "Series",
    "options": "ACC-ASS-.YYYY.-"
   },
   {
@@ -123,6 +124,7 @@
    "read_only": 1
   },
   {
+   "default": "Company",
    "fieldname": "asset_owner",
    "fieldtype": "Select",
    "label": "Asset Owner",
@@ -260,7 +262,6 @@
    "columns": 10,
    "fieldname": "finance_books",
    "fieldtype": "Table",
-   "label": "Finance Books",
    "options": "Asset Finance Book"
   },
   {
@@ -339,7 +340,6 @@
   {
    "allow_on_submit": 1,
    "default": "0",
-   "description": "Check if Asset requires Preventive Maintenance or Calibration",
    "fieldname": "maintenance_required",
    "fieldtype": "Check",
    "label": "Maintenance Required"
@@ -360,6 +360,7 @@
    "default": "0",
    "fieldname": "booked_fixed_asset",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Booked Fixed Asset",
    "no_copy": 1,
    "read_only": 1
@@ -519,14 +520,9 @@
    "options": "Purchase Invoice Item"
   },
   {
-   "fieldname": "accounting_dimensions_tab",
-   "fieldtype": "Tab Break",
-   "label": "Accounting Dimensions"
-  },
-  {
    "fieldname": "insurance_details_tab",
    "fieldtype": "Tab Break",
-   "label": "Insurance Details"
+   "label": "Insurance"
   },
   {
    "fieldname": "other_info_tab",
@@ -542,7 +538,17 @@
   {
    "fieldname": "depreciation_tab",
    "fieldtype": "Tab Break",
-   "label": "Depreciation Details"
+   "label": "Depreciation"
+  },
+  {
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "section_break_jtou",
+   "fieldtype": "Section Break",
+   "label": "Additional Info"
   }
  ],
  "idx": 72,
@@ -586,7 +592,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-11-20 11:52:06.332683",
+ "modified": "2024-11-29 14:25:56.436124",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -7,17 +7,19 @@
  "field_order": [
   "finance_book",
   "depreciation_method",
-  "total_number_of_depreciations",
-  "total_number_of_booked_depreciations",
-  "daily_prorata_based",
-  "shift_based",
-  "column_break_5",
   "frequency_of_depreciation",
+  "total_number_of_depreciations",
   "depreciation_start_date",
+  "column_break_5",
   "salvage_value_percentage",
   "expected_value_after_useful_life",
+  "rate_of_depreciation",
+  "daily_prorata_based",
+  "shift_based",
+  "section_break_jkdf",
   "value_after_depreciation",
-  "rate_of_depreciation"
+  "column_break_sigk",
+  "total_number_of_booked_depreciations"
  ],
  "fields": [
   {
@@ -67,9 +69,10 @@
    "columns": 1,
    "default": "0",
    "depends_on": "eval:parent.doctype == 'Asset'",
+   "description": "Expected Value After Useful Life",
    "fieldname": "expected_value_after_useful_life",
    "fieldtype": "Currency",
-   "label": "Expected Value After Useful Life",
+   "label": "Salvage Value",
    "options": "Company:company:default_currency"
   },
   {
@@ -83,10 +86,9 @@
   },
   {
    "depends_on": "eval:doc.depreciation_method == 'Written Down Value'",
-   "description": "In Percentage",
    "fieldname": "rate_of_depreciation",
    "fieldtype": "Percent",
-   "label": "Rate of Depreciation"
+   "label": "Rate of Depreciation (%)"
   },
   {
    "fieldname": "salvage_value_percentage",
@@ -108,16 +110,25 @@
   },
   {
    "default": "0",
+   "depends_on": "total_number_of_booked_depreciations",
    "fieldname": "total_number_of_booked_depreciations",
    "fieldtype": "Int",
    "label": "Total Number of Booked Depreciations ",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_jkdf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_sigk",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-21 15:48:20.907250",
+ "modified": "2024-11-29 14:36:54.399034",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
Reordered fields for asset doctype
<img width="1136" alt="Screenshot 2024-11-29 at 2 39 29 PM" src="https://github.com/user-attachments/assets/6098ddaa-1408-460e-9dbf-2ab0acbe1b91">
