### PR TITLE
fix: added fieldname to avoid fieldname to translate

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -1013,7 +1013,7 @@ class ReceivablePayableReport:
 
 	def get_columns(self):
 		self.columns = []
-		self.add_column(_("Posting Date"), fieldtype="Date")
+		self.add_column(_("Posting Date"), fieldname="posting_date", fieldtype="Date")
 		self.add_column(
 			label=_("Party Type"),
 			fieldname="party_type",
@@ -1066,7 +1066,7 @@ class ReceivablePayableReport:
 			width=180,
 		)
 
-		self.add_column(label=_("Due Date"), fieldtype="Date")
+		self.add_column(label=_("Due Date"), fieldname="due_date", fieldtype="Date")
 
 		if self.account_type == "Payable":
 			self.add_column(label=_("Bill No"), fieldname="bill_no", fieldtype="Data")


### PR DESCRIPTION
**Issue:**

If `fieldname` is not given, it scrubs the field label. However, if the label is translated, it also translates the `fieldname`, which prevents data from being set in the datatable.

https://github.com/frappe/erpnext/blob/b80022133c0043d2ccfdcfef8770c2970adc9f0c/erpnext/accounts/report/accounts_receivable/accounts_receivable.py#L1134

<details>

<summary> View Difference </summary>

**Before:**
![image_2024-11-29_18-12-23](https://github.com/user-attachments/assets/9df36fef-7822-417e-9b2d-8070ed4b6776)


**After:**
![image_2024-11-29_18-09-43](https://github.com/user-attachments/assets/4fa65a3e-ad4d-4b9d-9a8b-ea158d246eb8)

</details>

> [!IMPORTANT]
> Backport require for both `V-15` and `V-14`