### PR TITLE
perf: cache product bundle items at document level

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -378,12 +378,32 @@ class SellingController(StockController):
 		return il
 
 	def has_product_bundle(self, item_code):
-		product_bundle = frappe.qb.DocType("Product Bundle")
-		return (
-			frappe.qb.from_(product_bundle)
-			.select(product_bundle.name)
-			.where((product_bundle.new_item_code == item_code) & (product_bundle.disabled == 0))
-		).run()
+		product_bundle_items = getattr(self, "_product_bundle_items", None)
+		if product_bundle_items is None:
+			self._product_bundle_items = product_bundle_items = {}
+
+		if item_code not in product_bundle_items:
+			self._fetch_product_bundle_items(item_code)
+
+		return product_bundle_items[item_code]
+
+	def _fetch_product_bundle_items(self, item_code):
+		product_bundle_items = self._product_bundle_items
+		items_to_fetch = {row.item_code for row in self.items if row.item_code not in product_bundle_items}
+		# fetch for requisite item_code even if it is not in items
+		items_to_fetch.add(item_code)
+
+		items_with_product_bundle = {
+			row.new_item_code
+			for row in frappe.get_all(
+				"Product Bundle",
+				filters={"new_item_code": ("in", items_to_fetch), "disabled": 0},
+				fields="new_item_code",
+			)
+		}
+
+		for item_code in items_to_fetch:
+			product_bundle_items[item_code] = item_code in items_with_product_bundle
 
 	def get_already_delivered_qty(self, current_docname, so, so_detail):
 		delivered_via_dn = frappe.db.sql(


### PR DESCRIPTION
**O(N) => O(1)**

This should help in faster submissions and validations.

### Before

```py
In [1]: doc = frappe.get_doc('Sales Invoice', 'SINV-24-00007')

In [2]: len(doc.items)
Out[2]: 16

In [3]: %timeit -n 10 doc.get_item_list()
2.79 ms ± 1.31 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: %timeit -n 10 doc.get_item_list()
2.48 ms ± 629 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### After

```py
In [1]: doc = frappe.get_doc('Sales Invoice', 'SINV-24-00007')

In [2]: len(doc.items)
Out[2]: 16

In [3]: %timeit -n 10 doc.get_item_list()
The slowest run took 11.67 times longer than the fastest. This could mean that an intermediate result is being cached.
162 µs ± 210 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: %timeit -n 10 doc.get_item_list()
66.1 µs ± 34.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```