### PR TITLE
fix: calculate submitted payment entry amount for grand total

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -783,6 +783,8 @@ def get_existing_paid_amount(doctype, name):
 		.where(PL.against_voucher_type.eq(doctype))
 		.where(PL.against_voucher_no.eq(name))
 		.where(PL.amount < 0)
+		.where(PL.delinked == 0)
+		.where(PER.docstatus == 1)
 		.where(PER.payment_request.isnull())
 	)
 	response = query.run()

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -708,3 +708,30 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(dt="Sales Invoice", dn=si.name, mute_email=1)
 
 		self.assertEqual(pr.grand_total, si.outstanding_amount)
+
+
+def test_partial_paid_invoice_with_submitted_payment_entry(self):
+	pi = make_purchase_invoice(currency="INR", qty=1, rate=5000)
+	pi.save()
+	pi.submit()
+
+	pe = get_payment_entry("Purchase Invoice", pi.name, bank_account="_Test Bank - _TC")
+	pe.reference_no = "PURINV0001"
+	pe.reference_date = frappe.utils.nowdate()
+	pe.paid_amount = 2500
+	pe.references[0].allocated_amount = 2500
+	pe.save()
+	pe.submit()
+	pe.cancel()
+
+	pe = get_payment_entry("Purchase Invoice", pi.name, bank_account="_Test Bank - _TC")
+	pe.reference_no = "PURINV0002"
+	pe.reference_date = frappe.utils.nowdate()
+	pe.paid_amount = 2500
+	pe.references[0].allocated_amount = 2500
+	pe.save()
+	pe.submit()
+
+	pi.load_from_db()
+	pr = make_payment_request(dt="Purchase Invoice", dn=pi.name, mute_email=1)
+	self.assertEqual(pr.grand_total, pi.outstanding_amount)


### PR DESCRIPTION
Issue:
Cancelled payment entry amount also included in the grand total calculation of payment request.

Fix:
Get only submitted payment entry amount for grand total calculation in payment request.

Before:

[payment_request-(2).webm](https://github.com/user-attachments/assets/41832558-50ca-4cee-858a-8ccc224865e6)

After: 

[payment_request.webm](https://github.com/user-attachments/assets/fe1f2bc8-0467-49f1-944b-cf7fe8dbcd73)

Back port needed for v15.