### PR TITLE
feat: Create Syscohada charts of accounts

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/bf_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/bf_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "bf",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/bf_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/bf_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "bf",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/bj_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/bj_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "bj",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/bj_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/bj_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "bj",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cd_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cd_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "cd",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cd_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cd_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "cd",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cf_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cf_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "cf",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cf_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cf_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "cf",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cg_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cg_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "cg",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cg_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cg_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "cg",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ci_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ci_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "ci",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ci_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ci_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "ci",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cm_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cm_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "cm",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/cm_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/cm_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "cm",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ga_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ga_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "ga",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ga_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ga_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "ga",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gn_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gn_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "gn",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gn_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gn_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "gn",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gq_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gq_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "gq",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gq_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gq_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "gq",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gw_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gw_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "gw",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gw_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gw_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "gw",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/km_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/km_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "km",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/km_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/km_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "km",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ml_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ml_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "ml",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ml_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ml_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "ml",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ne_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ne_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "ne",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ne_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ne_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "ne",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/sn_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/sn_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "sn",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/sn_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/sn_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "sn",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_chart_of_accounts.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+syscohada_countries = [
+	"bj",  # Bénin
+	"bf",  # Burkina-Faso
+	"cm",  # Cameroun
+	"cf",  # Centrafrique
+	"ci",  # Côte d'Ivoire
+	"cg",  # Congo
+	"km",  # Comores
+	"ga",  # Gabon
+	"gn",  # Guinée
+	"gw",  # Guinée-Bissau
+	"gq",  # Guinée Equatoriale
+	"ml",  # Mali
+	"ne",  # Niger
+	"cd",  # République Démocratique du Congo
+	"sn",  # Sénégal
+	"td",  # Tchad
+	"tg",  # Togo
+]
+
+folder = Path(__file__).parent
+generic_charts = Path(folder).glob("syscohada*.json")
+
+for file in generic_charts:
+	with open(file) as f:
+		chart = json.load(f)
+	for country in syscohada_countries:
+		chart["country_code"] = country
+		json_object = json.dumps(chart, indent=4)
+		with open(Path(folder, file.name.replace("syscohada", country)), "w") as outfile:
+			outfile.write(json_object)

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable.json
@@ -1,0 +1,2892 @@
+{
+    "country_code":"PLACEHOLDER",
+    "name":"Syscohada - Plan Comptable",
+    "tree":{
+        "1-Comptes de ressources durables":{
+            "10-Capital":{
+                "101-Capital social":{
+                    "1011-Capital souscrit, non appelé":{
+                    },
+                    "1012-Capital souscrit, appelé, non versé":{
+                    },
+                    "1013-Capital souscrit, appelé, versé, non amorti":{
+                    },
+                    "1014-Capital souscrit, appelé, versé, amorti":{
+                    },
+                    "1018-Capital souscrit soumis à des conditions particulières":{
+                    }
+                },
+                "102-Capital par dotation":{
+                    "1021-Dotation initiale":{
+                    },
+                    "1022-Dotations complémentaires":{
+                    },
+                    "1028-Autres dotations":{
+                    }
+                },
+                "103-Capital personnel":{
+                },
+                "104-Compte de l’exploitant":{
+                    "1041-Apports temporaires":{
+                    },
+                    "1042-Opérations courantes":{
+                    },
+                    "1043-Rémunérations, impôts et autres charges personnelles":{
+                    },
+                    "1047-Prélèvements d’autoconsommation":{
+                    },
+                    "1048-Autres prélèvements":{
+                    }
+                },
+                "105-Primes liées au capital social":{
+                    "1051-Primes d’émission":{
+                    },
+                    "1052-Primes d’apport":{
+                    },
+                    "1053-Primes de fusion":{
+                    },
+                    "1054-Primes de conversion":{
+                    },
+                    "1058-Autres primes":{
+                    }
+                },
+                "106-Écarts de réévaluation":{
+                    "1061-Écarts de réévaluation légale":{
+                    },
+                    "1062-Écarts de réévaluation libre":{
+                    }
+                },
+                "109-Apporteurs, capital souscrit, non appelé":{
+                }
+            },
+            "11-Réserves":{
+                "111-Réserve légale":{
+                },
+                "112-Réserves statutaires ou contractuelles":{
+                },
+                "113-Réserves réglementées":{
+                    "1131-Réserves de plus-values nettes à long terme":{
+                    },
+                    "1132-Réserves d’attribution gratuite d’actions au personnel salarié et aux dirigeants":{
+                    },
+                    "1133-Réserves consécutives à l’octroi de subventions d’investissement":{
+                    },
+                    "1134-Réserves des valeurs mobilières donnant accès au capital":{
+                    },
+                    "1135-Autres réserves réglementées":{
+                    }
+                },
+                "118-Autres réserves":{
+                    "1181-Réserves facultatives":{
+                    },
+                    "1188-Réserves diverses":{
+                    }
+                }
+            },
+            "12-Report à nouveau":{
+                "121-Report à nouveau créditeur":{
+                },
+                "129-Report à nouveau débiteur":{
+                    "1291-Perte nette à reporter":{
+                    },
+                    "1292-Perte Amortissements réputés différés":{
+                    }
+                }
+            },
+            "13-Résultat net de l’exercice":{
+                "130-Résultat en instance d’affectation":{
+                    "1301-Résultat en instance d’affectation : bénéfice":{
+                    },
+                    "1309-Résultat en instance d’affectation : perte":{
+                    }
+                },
+                "131-Résultat net : bénéfice":{
+                },
+                "132-Marge commerciale (MC)":{
+                },
+                "133-Valeur ajoutée (VA)":{
+                },
+                "134-Excédent brut d’exploitation (EBE)":{
+                },
+                "135-Résultat d’exploitation (RE)":{
+                },
+                "136-Résultat financier (RF)":{
+                },
+                "137-Résultat des activités ordinaires (RAO)":{
+                },
+                "138-Résultat hors activités ordinaires (RHAO)":{
+                    "1381-Résultat de fusion":{
+                    },
+                    "1382-Résultat d’apport partiel d’actif":{
+                    },
+                    "1383-Résultat de scission":{
+                    },
+                    "1384-Résultat de liquidation":{
+                    }
+                },
+                "139-Résultat net : perte":{
+                }
+            },
+            "14-Subventions d’investissement":{
+                "141-Subventions d’équipement":{
+                    "1411-État":{
+                    },
+                    "1412-Régions":{
+                    },
+                    "1413-Départements":{
+                    },
+                    "1414-Communes et collectivités publiques décentralisées":{
+                    },
+                    "1415-Entités publiques ou mixtes":{
+                    },
+                    "1416-Entités et organismes privés":{
+                    },
+                    "1417-Organismes internationaux":{
+                    },
+                    "1418-Autres":{
+                    }
+                },
+                "148-Autres subventions d’investissement":{
+                }
+            },
+            "15-Provisions réglementées et fonds assimilés":{
+                "151-Amortissements dérogatoires":{
+                },
+                "152-Plus-values de cession à réinvestir":{
+                },
+                "153-Fonds réglementés":{
+                    "1531-Fonds National":{
+                    },
+                    "1532-Prélèvement pour le Budget":{
+                    }
+                },
+                "154-Provisions spéciales de réévaluation":{
+                },
+                "155-Provisions réglementées relatives aux immobilisations":{
+                    "1551-Reconstitution des gisements miniers et pétroliers":{
+                    }
+                },
+                "156-Provisions réglementées relatives aux stocks":{
+                    "1561-Hausse de prix":{
+                    },
+                    "1562-Fluctuation des cours":{
+                    }
+                },
+                "157-Provisions pour investissement":{
+                },
+                "158-Autres provisions et fonds réglementés":{
+                }
+            },
+            "16-Emprunts et dettes assimilées":{
+                "161-Emprunts obligataires":{
+                    "1611-Emprunts obligataires ordinaires":{
+                    },
+                    "1612-Emprunts obligataires convertibles en actions":{
+                    },
+                    "1613-Emprunts obligataires remboursables en actions":{
+                    },
+                    "1618-Autres emprunts obligataires":{
+                    }
+                },
+                "162-Emprunts et dettes auprès des établissements de crédit":{
+                },
+                "163-Avances reçues de l’État":{
+                },
+                "164-Avances reçues et comptes courants bloqués":{
+                },
+                "165-Dépôts et cautionnements reçus":{
+                    "1651-Dépôts":{
+                    },
+                    "1652-Cautionnements":{
+                    }
+                },
+                "166-Intérêts courus":{
+                    "1661-Sur emprunts obligataires":{
+                    },
+                    "1662-Sur emprunts et dettes auprès des établissements de crédit":{
+                    },
+                    "1663-Sur avances reçues de l’État":{
+                    },
+                    "1664-Sur avances reçues et comptes courants bloqués":{
+                    },
+                    "1665-Sur dépôts et cautionnements reçus":{
+                    },
+                    "1667-Sur avances assorties de conditions particulières":{
+                    },
+                    "1668-Sur autres emprunts et dettes":{
+                    }
+                },
+                "167-Avances assorties de conditions particulières":{
+                    "1671-Avances bloquées pour augmentation du capital":{
+                    },
+                    "1672-Avances conditionnées par l’État":{
+                    },
+                    "1673-Avances conditionnées par les autres organismes africains":{
+                    },
+                    "1674-Avances conditionnées par les organismes internationaux":{
+                    }
+                },
+                "168-Autres emprunts et dettes":{
+                    "1681-Rentes viagères capitalisées":{
+                    },
+                    "1682-Billets de fonds":{
+                    },
+                    "1683-Dettes consécutives à des titres empruntés":{
+                    },
+                    "1684-Emprunts participatifs":{
+                    },
+                    "1685-Participation des travailleurs aux bénéfices":{
+                    },
+                    "1686-Emprunts et dettes contractés auprès des autres tiers":{
+                    }
+                }
+            },
+            "17-Dettes de location acquisition":{
+                "172-Dettes de location acquisition / crédit bail immobilier":{
+                },
+                "173-Dettes de location acquisition / crédit bail mobilier":{
+                },
+                "174-Dettes de location acquisition / location de vente":{
+                },
+                "176-Intérêts courus":{
+                    "1762-Sur dettes de location acquisition / crédit-bail immobilier":{
+                    },
+                    "1763-Sur dettes de location acquisition / crédit-bail mobilier":{
+                    },
+                    "1764-Sur dettes de location acquisition / location-vente":{
+                    },
+                    "1768-Sur autres dettes de location acquisition":{
+                    }
+                },
+                "178-Autres dettes de location acquisition":{
+                }
+            },
+            "18-Dettes liées à des participations et comptes de liaison des établissements et sociétés en participation":{
+                "181-Dettes liées à des participations":{
+                    "1811-Dettes liées à des participations (groupe)":{
+                    },
+                    "1812-Dettes liées à des participations (hors groupe)":{
+                    }
+                },
+                "182-Dettes liées à des sociétés en participation":{
+                },
+                "183-Intérêts courus sur dettes liées à des participations":{
+                },
+                "184-Comptes permanents bloqués des établissements et succursales":{
+                },
+                "185-Comptes permanents non bloqués des établissements et succursales":{
+                },
+                "186-Comptes de liaison charges":{
+                },
+                "187-Comptes de liaison produits":{
+                },
+                "188-Comptes de liaison des sociétés en participation":{
+                }
+            },
+            "19-Provisions pour risques et charges":{
+                "191-Provisions pour litiges":{
+                },
+                "192-Provisions pour garanties données aux clients":{
+                },
+                "193-Provisions pour pertes sur marchés à achèvement futur":{
+                },
+                "194-Provisions pour pertes de change":{
+                },
+                "195-Provisions pour impôts":{
+                },
+                "196-Provisions pour pensions et obligations similaires":{
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite":{
+                    },
+                    "1962-Actif du régime de retraite":{
+                    }
+                },
+                "197-Provisions pour restructuration":{
+                },
+                "198-Autres provisions pour risques et charges":{
+                    "1981-Provisions pour amendes et pénalités":{
+                    },
+                    "1983-Provisions pour propre assureur":{
+                    },
+                    "1984-Provisions pour démantèlement et remise en état":{
+                    },
+                    "1985-Provisions pour droits à réduction ou avantage en nature (chèques cadeau, cartes de fidélité...)":{
+                    },
+                    "1988-Provisions pour divers risques et charges":{
+                    }
+                }
+            },
+            "root_type":"Equity"
+        },
+        "2-Comptes d’actif immobilisé":{
+            "21-Immobilisations incorporelles":{
+                "account_type":"Fixed Asset",
+                "211-Frais de développement":{
+                    "account_type":"Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires":{
+                    "account_type":"Fixed Asset",
+                    "2121-Brevets":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2122-Licences":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2123-Concessions de service public":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet":{
+                    "account_type":"Fixed Asset",
+                    "2131-Logiciels":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2132-Sites internet":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "214-Marques":{
+                    "account_type":"Fixed Asset"
+                },
+                "215-Fonds commercial":{
+                    "account_type":"Fixed Asset"
+                },
+                "216-Droit au bail":{
+                    "account_type":"Fixed Asset"
+                },
+                "217-Investissements de création":{
+                    "account_type":"Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels":{
+                    "account_type":"Fixed Asset",
+                    "2181-Frais de prospection et d’évaluation de ressources minérales":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2182-Coûts d’obtention du contrat":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2184-Coûts des franchises":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours":{
+                    "account_type":"Fixed Asset",
+                    "2191-Frais de développement":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2193-Logiciels et internet":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels":{
+                        "account_type":"Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains":{
+                "account_type":"Fixed Asset",
+                "221-Terrains agricoles et forestiers":{
+                    "account_type":"Fixed Asset",
+                    "2211-Terrains d’exploitation agricole":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2212-Terrains d’exploitation forestière":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2218-Autres terrains":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "222-Terrains nus":{
+                    "account_type":"Fixed Asset",
+                    "2221-Terrains à bâtir":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2228-Autres terrains nus":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "223-Terrains bâtis":{
+                    "account_type":"Fixed Asset",
+                    "2231-Pour bâtiments industriels et agricoles":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2232-Pour bâtiments administratifs et commerciaux":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2234-Pour bâtiments affectés aux autres opérations professionnelles":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2235-Pour bâtiments affectés aux autres opérations non professionnelles":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2238-Autres terrains bâtis":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains":{
+                    "account_type":"Fixed Asset",
+                    "2241-Plantation d’arbres et d’arbustes":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2245-Améliorations du fonds":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2248-Autres travaux":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "225-Terrains de carrières tréfonds":{
+                    "account_type":"Fixed Asset",
+                    "2251-Carrières":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "226-Terrains aménagés":{
+                    "account_type":"Fixed Asset",
+                    "2261-Parkings":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession":{
+                    "account_type":"Fixed Asset"
+                },
+                "228-Autres terrains":{
+                    "account_type":"Fixed Asset",
+                    "2281-Terrains immeubles de placement":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2285-Terrains des logements affectés au personnel":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2288-Divers terrains":{
+                        "account_type":"Fixed Asset"
+                    }
+                },
+                "229-Aménagements de terrains en cours":{
+                    "account_type":"Fixed Asset",
+                    "2291-Terrains agricoles et forestiers":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2292-Terrains nus":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2295-Terrains de carrières tréfonds":{
+                        "account_type":"Fixed Asset"
+                    },
+                    "2298-Autres terrains":{
+                        "account_type":"Fixed Asset"
+                    }
+                }
+            },
+            "23-Bâtiments, installations techniques et agencements":{
+                "231-Bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                    "2311-Bâtiments industriels":{
+                    },
+                    "2312-Bâtiments agricoles":{
+                    },
+                    "2313-Bâtiments administratifs et commerciaux":{
+                    },
+                    "2314-Bâtiments affectés au logement du personnel":{
+                    },
+                    "2315-Bâtiments immeubles de placement":{
+                    },
+                    "2316-Bâtiments de location acquisition":{
+                    }
+                },
+                "232-Bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                    "2321-Bâtiments industriels":{
+                    },
+                    "2322-Bâtiments agricoles":{
+                    },
+                    "2323-Bâtiments administratifs et commerciaux":{
+                    },
+                    "2324-Bâtiments affectés au logement du personnel":{
+                    },
+                    "2325-Bâtiments immeubles de placement":{
+                    },
+                    "2326-Bâtiments de location acquisition":{
+                    }
+                },
+                "233-Ouvrages d’infrastructure":{
+                    "2331-Voies de terre":{
+                    },
+                    "2332-Voies de fer":{
+                    },
+                    "2333-Voies d’eau":{
+                    },
+                    "2334-Barrages, Digues":{
+                    },
+                    "2335-Pistes d’aérodrome":{
+                    },
+                    "2338-Autres ouvrages d’infrastructures":{
+                    }
+                },
+                "234-Aménagements, agencements et installations techniques":{
+                    "2341-Installations complexes spécialisées sur sol propre":{
+                    },
+                    "2342-Installations complexes spécialisées sur sol d’autrui":{
+                    },
+                    "2343-Installations à caractère spécifique sur sol propre":{
+                    },
+                    "2344-Installations à caractère spécifique sur sol d’autrui":{
+                    },
+                    "2345-Aménagements et agencements des bâtiments":{
+                    }
+                },
+                "235-Aménagements de bureaux":{
+                    "2351-Installations générales":{
+                    },
+                    "2358-Autres aménagements de bureaux":{
+                    }
+                },
+                "237-Bâtiments industriels, agricoles et commerciaux mis en concession":{
+                },
+                "238-Autres installations et agencements":{
+                },
+                "239-Bâtiments aménagements, agencements et installations en cours":{
+                    "2391-Bâtiments en cours":{
+                    },
+                    "2392-Installations en cours":{
+                    },
+                    "2393-Ouvrages d’infrastructure en cours":{
+                    },
+                    "2394-Aménagements et agencements et installations techniques en cours":{
+                    },
+                    "2395-Aménagements de bureaux en cours":{
+                    },
+                    "2398-Autres installations et agencements en cours":{
+                    }
+                }
+            },
+            "24-Matériel, mobilier et actifs biologiques":{
+                "241-Matériel et outillage industriel et commercial":{
+                    "2411-Matériel industriel":{
+                    },
+                    "2412-Outillage industriel":{
+                    },
+                    "2413-Matériel commercial":{
+                    },
+                    "2414-Outillage commercial":{
+                    },
+                    "2416-Matériel & outillage industriel et commercial de location-acquisition":{
+                    }
+                },
+                "242-Matériel et outillage agricole":{
+                    "2421-Matériel agricole":{
+                    },
+                    "2422-Outillage agricole":{
+                    },
+                    "2426-Matériel & outillage agricole de location-acquisition":{
+                    }
+                },
+                "243-Matériel d’emballage récupérable et identifiable":{
+                },
+                "244-Matériel et mobilier":{
+                    "2441-Matériel de bureau":{
+                    },
+                    "2442-Matériel informatique":{
+                    },
+                    "2443-Matériel bureautique":{
+                    },
+                    "2444-Mobilier de bureau":{
+                    },
+                    "2445-Matériel et mobilier immeubles de placement":{
+                    },
+                    "2446-Matériel et mobilier de location acquisition":{
+                    },
+                    "2447-Matériel et mobilier des logements du personnel":{
+                    }
+                },
+                "245-Matériel de transport":{
+                    "2451-Matériel automobile":{
+                    },
+                    "2452-Matériel ferroviaire":{
+                    },
+                    "2453-Matériel fluvial, lagunaire":{
+                    },
+                    "2454-Matériel naval":{
+                    },
+                    "2455-Matériel aérien":{
+                    },
+                    "2456-Matériel de transport de location-acquisition":{
+                    },
+                    "2457-Matériel hippomobile":{
+                    },
+                    "2458-Autres matériels de transport":{
+                    }
+                },
+                "246-Actifs biologiques":{
+                    "2461-Cheptel, animaux de trait":{
+                    },
+                    "2462-Cheptel, animaux reproducteurs":{
+                    },
+                    "2463-Animaux de garde":{
+                    },
+                    "2465-Plantations agricoles":{
+                    },
+                    "2468-Autres actifs biologiques":{
+                    }
+                },
+                "247-Agencements, aménagements du matériel et actifs biologiques":{
+                    "2471-Agencements et aménagements du matériel":{
+                    },
+                    "2472-Agencements et aménagements des actifs biologiques":{
+                    },
+                    "2478-Autres agencements, aménagements du matériel et actifs biologiques":{
+                    }
+                },
+                "248-Autres matériels et mobiliers":{
+                    "2481-Collections et œuvres d’art":{
+                    },
+                    "2488-Divers matériels mobiliers":{
+                    }
+                },
+                "249-Matériels et actifs biologiques en cours":{
+                    "2491-Matériel et outillage industriel et commercial":{
+                    },
+                    "2492-Matériel et outillage agricole":{
+                    },
+                    "2493-Matériel d’emballage récupérable et identifiable":{
+                    },
+                    "2494-Matériel et mobilier de bureau":{
+                    },
+                    "2495-Matériel de transport":{
+                    },
+                    "2496-Actifs biologiques":{
+                    },
+                    "2497-Agencements aménagements du matériel et actifs biologiques":{
+                    },
+                    "2498-Autres matériels et actifs biologiques en cours":{
+                    }
+                }
+            },
+            "25-Avances et acomptes versés sur immobilisations":{
+                "251-Avances et acomptes versés sur immobilisations incorporelles":{
+                },
+                "252-Avances et acomptes versés sur immobilisations corporelles":{
+                }
+            },
+            "26-Titres de participation":{
+                "261-Titres de participation dans des sociétés sous contrôle exclusif":{
+                },
+                "262-Titres de participation dans des sociétés sous contrôle conjoint":{
+                },
+                "263-Titres de participation dans des sociétés conférant une influence notable":{
+                },
+                "265-Participations dans des organismes professionnels":{
+                },
+                "266-Parts dans des groupements d’intérêt économique (GIE)":{
+                },
+                "268-Autres titres de participation":{
+                }
+            },
+            "27-Autres immobilisations financières":{
+                "271-Prêts et créances":{
+                    "2711-Prêts participatifs":{
+                    },
+                    "2712-Prêts aux associés":{
+                    },
+                    "2713-Billets de fonds":{
+                    },
+                    "2714-Titres prêtés":{
+                    },
+                    "2718-Autres prêts et créances":{
+                    }
+                },
+                "272-Prêts au personnel":{
+                    "2721-Prêts immobiliers":{
+                    },
+                    "2722-Prêts mobiliers et d’installation":{
+                    },
+                    "2728-Autres prêts au personnel":{
+                    }
+                },
+                "273-Créances sur l’État":{
+                    "2731-Retenues de garantie":{
+                    },
+                    "2733-Fonds réglementé":{
+                    },
+                    "2734-Créances sur le concédant":{
+                    },
+                    "2738-Autres créances sur l’État":{
+                    }
+                },
+                "274-Titres immobilisés":{
+                    "2741-Titres immobilisés de l’activité de portefeuille (TIAP)":{
+                    },
+                    "2742-Titres participatifs":{
+                    },
+                    "2743-Certificats d’investissement":{
+                    },
+                    "2744-Parts de fonds commun de placement (FCP)":{
+                    },
+                    "2745-Obligations":{
+                    },
+                    "2746-Actions ou parts propres":{
+                    },
+                    "2748-Autres titres immobilisés":{
+                    }
+                },
+                "275-Dépôts et cautionnements versés":{
+                    "2751-Dépôts pour loyers d’avance":{
+                    },
+                    "2752-Dépôts pour l’électricité":{
+                    },
+                    "2753-Dépôts pour l’eau":{
+                    },
+                    "2754-Dépôts pour le gaz":{
+                    },
+                    "2755-Dépôts pour le téléphone, le télex, la télécopie":{
+                    },
+                    "2756-Cautionnements sur marchés publics":{
+                    },
+                    "2757-Cautionnements sur autres opérations":{
+                    },
+                    "2758-Autres dépôts et cautionnements":{
+                    }
+                },
+                "276-Intérêts courus":{
+                    "2761-Prêts et créances non commerciales":{
+                    },
+                    "2762-Prêts au personnel":{
+                    },
+                    "2763-Créances sur l’État":{
+                    },
+                    "2764-Titres immobilisés":{
+                    },
+                    "2765-Dépôts et cautionnements versés":{
+                    },
+                    "2767-Créances rattachées à des participations":{
+                    },
+                    "2768-Immobilisations financières diverses":{
+                    }
+                },
+                "277-Créances rattachées à des participations et avances à des GIE":{
+                    "2771-Créances rattachées à des participations (groupe)":{
+                    },
+                    "2772-Créances rattachées à des participations (hors groupe)":{
+                    },
+                    "2773-Créances rattachées à des sociétés en participation":{
+                    },
+                    "2774-Avances à des Groupements d’intérêt économique (GIE)":{
+                    }
+                },
+                "278-Immobilisations financières diverses":{
+                    "2781-Créances diverses groupe":{
+                    },
+                    "2782-Créances diverses hors groupe":{
+                    },
+                    "2784-Banques dépôts à terme":{
+                    },
+                    "2785-Or et métaux précieux":{
+                    },
+                    "2788-Autres immobilisations financières":{
+                    }
+                }
+            },
+            "28-Amortissements":{
+                "account_type":"Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles":{
+                    "account_type":"Accumulated Depreciation",
+                    "2811-Amortissements des frais de développement":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de création":{
+                        "account_type":"Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels":{
+                        "account_type":"Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains":{
+                    "2824-Amortissements des travaux de mise en valeur des terrains":{
+                    }
+                },
+                "283-Amortissements des bâtiments, installations techniques et agencements":{
+                    "2831-Amortissements des bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                    },
+                    "2832-Amortissements des bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                    },
+                    "2833-Amortissements des ouvrages d’infrastructure":{
+                    },
+                    "2834-Amortissements des aménagements, agencements et installations techniques":{
+                    },
+                    "2835-Amortissements des aménagements de bureaux":{
+                    },
+                    "2837-Amortissements des bâtiments industriels, agricoles et commerciaux mis en concession":{
+                    },
+                    "2838-Amortissements des autres installations et agencements":{
+                    }
+                },
+                "284-Amortissements du matériel":{
+                    "2841-Amortissements du matériel et outillage industriel et commercial":{
+                    },
+                    "2842-Amortissements du matériel et outillage agricole":{
+                    },
+                    "2843-Amortissements du matériel d’emballage récupérable et identifiable":{
+                    },
+                    "2844-Amortissements du matériel et mobilier":{
+                    },
+                    "2845-Amortissements du matériel de transport":{
+                    },
+                    "2846-Amortissements des actifs biologiques":{
+                    },
+                    "2847-Amortissements des agencements et aménagements du matériel et des actifs biologiques":{
+                    },
+                    "2848-Amortissements des autres matériels":{
+                    }
+                }
+            },
+            "29-Dépréciations des immobilisations":{
+                "291-Dépréciations des immobilisations incorporelles":{
+                    "2911-Dépréciations des frais de développement":{
+                    },
+                    "2912-Dépréciations des brevets, licences, concessions et droits similaires":{
+                    },
+                    "2913-Dépréciations des logiciels et sites internet":{
+                    },
+                    "2914-Dépréciations des marques":{
+                    },
+                    "2915-Dépréciations du fonds commercial":{
+                    },
+                    "2916-Dépréciations du droit au bail":{
+                    },
+                    "2917-Dépréciations des investissements de création":{
+                    },
+                    "2918-Dépréciations des autres droits et valeurs incorporels":{
+                    },
+                    "2919-Dépréciations des immobilisations incorporelles en cours":{
+                    }
+                },
+                "292-Dépréciations des terrains":{
+                    "2921-Dépréciations des terrains agricoles et forestiers":{
+                    },
+                    "2922-Dépréciations des terrains nus":{
+                    },
+                    "2923-Dépréciations des terrains bâtis":{
+                    },
+                    "2924-Dépréciations des travaux de mise en valeur des terrains":{
+                    },
+                    "2925-Dépréciations des terrains de gisement":{
+                    },
+                    "2926-Dépréciations des terrains aménagés":{
+                    },
+                    "2927-Dépréciations des terrains mis en concession":{
+                    },
+                    "2928-Dépréciations des autres terrains":{
+                    },
+                    "2929-Dépréciations des aménagements de terrains en cours":{
+                    }
+                },
+                "293-Dépréciations des bâtiments, installations techniques et agencements":{
+                    "2931-Dépréciations des bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                    },
+                    "2932-Dépréciations des bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                    },
+                    "2933-Dépréciations des ouvrages d’infrastructures":{
+                    },
+                    "2934-Dépréciations des aménagements, agencements et installations techniques":{
+                    },
+                    "2935-Dépréciations des aménagements de bureaux":{
+                    },
+                    "2937-Dépréciations des bâtiments industriels, agricoles et commerciaux mis en concession":{
+                    },
+                    "2938-Dépréciations des autres installations et agencements":{
+                    },
+                    "2939-Dépréciations des bâtiments et installations en cours":{
+                    }
+                },
+                "294-Dépréciations de matériel, du mobilier et de l’actif biologique":{
+                    "2941-Dépréciations du matériel et outillage industriel et commercial":{
+                    },
+                    "2942-Dépréciations du matériel et outillage agricole":{
+                    },
+                    "2943-Dépréciations du matériel d’emballage récupérable et identifiable":{
+                    },
+                    "2944-Dépréciations du matériel et mobilier":{
+                    },
+                    "2945-Dépréciations du matériel de transport":{
+                    },
+                    "2946-Dépréciations des actifs biologiques":{
+                    },
+                    "2947-Dépréciations des agencements et aménagements du matériel et des actifs biologiques":{
+                    },
+                    "2948-Dépréciations des autres matériels":{
+                    },
+                    "2949-Dépréciations de matériel en cours":{
+                    }
+                },
+                "295-Dépréciations des avances et acomptes versés sur immobilisations":{
+                    "2951-Dépréciations des avances et acomptes versés sur immobilisations incorporelles":{
+                    },
+                    "2952-Dépréciations des avances et acomptes versés sur immobilisations corporelles":{
+                    }
+                },
+                "296-Dépréciations des titres de participation":{
+                    "2961-Dépréciations des titres de participation dans des sociétés sous contrôle exclusif":{
+                    },
+                    "2962-Dépréciations des titres de participation dans les sociétés sous contrôle conjoint":{
+                    },
+                    "2963-Dépréciations des titres de participation dans les sociétés conférant une influence notable":{
+                    },
+                    "2965-Dépréciations des participations dans des organismes professionnels":{
+                    },
+                    "2966-Dépréciations des parts dans des GIE":{
+                    },
+                    "2968-Dépréciations des autres titres de participation":{
+                    }
+                },
+                "297-Dépréciations des autres immobilisations financières":{
+                    "2971-Dépréciations des prêts et créances":{
+                    },
+                    "2972-Dépréciations des prêts au personnel":{
+                    },
+                    "2973-Dépréciations des créances sur l’État":{
+                    },
+                    "2974-Dépréciations des titres immobilisés":{
+                    },
+                    "2975-Dépréciations des dépôts et cautionnements versés":{
+                    },
+                    "2977-Dépréciations des créances rattachées à des participations et avances à des GIE":{
+                    },
+                    "2978-Dépréciations des créances financières diverses":{
+                    }
+                }
+            },
+            "root_type":"Asset"
+        },
+        "3-Comptes de Stocks":{
+            "31-Marchandises":{
+                "311-Marchandises A":{
+                    "3111-Marchandises A1":{
+                    },
+                    "3112-Marchandises A2":{
+                    }
+                },
+                "312-Marchandises B":{
+                    "3121-Marchandises B1":{
+                    },
+                    "3122-Marchandises B2":{
+                    }
+                },
+                "313-Actifs biologiques":{
+                    "3131-Animaux":{
+                    },
+                    "3132-Végétaux":{
+                    }
+                },
+                "318-Marchandises hors activités ordinaires (HAO)":{
+                }
+            },
+            "32-Matières premières et fournitures liées":{
+                "321-Matières A":{
+                },
+                "322-Matières B":{
+                },
+                "323-Fournitures (A, B)":{
+                }
+            },
+            "33-Autres approvisionnements":{
+                "331-Matières consommables":{
+                },
+                "332-Fournitures d’atelier et d’usine":{
+                },
+                "333-Fournitures de magasin":{
+                },
+                "334-Fournitures de bureau":{
+                },
+                "335-Emballages":{
+                    "3351-Emballages perdus":{
+                    },
+                    "3352-Emballages récupérables non identifiables":{
+                    },
+                    "3353-Emballages à usage mixte":{
+                    },
+                    "3358-Autres emballages":{
+                    }
+                },
+                "338-Autres matières":{
+                }
+            },
+            "34-Produits en cours":{
+                "341-Produits en cours":{
+                    "3411-Produits en cours P1":{
+                    },
+                    "3412-Produits en cours P2":{
+                    }
+                },
+                "342-Travaux en cours":{
+                    "3421-Travaux en cours T1":{
+                    },
+                    "3422-Travaux en cours T2":{
+                    }
+                },
+                "343-Produits intermédiaires en cours":{
+                    "3431-Produits intermédiaires A":{
+                    },
+                    "3432-Produits intermédiaires B":{
+                    }
+                },
+                "344-Produits résiduels en cours":{
+                    "3441-Produits résiduels A":{
+                    },
+                    "3442-Produits résiduels B":{
+                    }
+                },
+                "345-Actifs biologiques en cours":{
+                    "3451-Animaux":{
+                    },
+                    "3452-Végétaux":{
+                    }
+                }
+            },
+            "35-Services en cours":{
+                "351-Études en cours":{
+                    "3511-Études en cours E1":{
+                    },
+                    "3512-Études en cours E2":{
+                    }
+                },
+                "352-Prestations de services en cours":{
+                    "3521-Prestations de services S1":{
+                    },
+                    "3522-Prestations de services S2":{
+                    }
+                }
+            },
+            "36-Produits finis":{
+                "361-Produits finis A":{
+                },
+                "362-Produits finis B":{
+                },
+                "363-Actifs biologiques":{
+                    "3631-Animaux":{
+                    },
+                    "3632-Végétaux":{
+                    },
+                    "3638-Autres stocks (activités annexes)":{
+                    }
+                }
+            },
+            "37-Produits intermédiaires et résiduels":{
+                "371-Produits intermédiaires":{
+                    "3711-Produits intermédiaires A":{
+                    },
+                    "3712-Produits intermédiaires B":{
+                    }
+                },
+                "372-Produits résiduels":{
+                    "3721-Déchets":{
+                    },
+                    "3722-Rebuts":{
+                    },
+                    "3723-Matières de Récupération":{
+                    }
+                },
+                "373-Actifs biologiques":{
+                    "3731-Animaux":{
+                    },
+                    "3732-Végétaux":{
+                    },
+                    "3738-Autres stocks (activités annexes)":{
+                    }
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en dépôt":{
+                "account_type":"Stock",
+                "381-Marchandises en cours de route":{
+                },
+                "382-Matières premières et fournitures liées en cours de route":{
+                },
+                "383-Autres approvisionnements en cours de route":{
+                },
+                "386-Produits finis en cours de route":{
+                },
+                "387-Stock en consignation ou en dépôt":{
+                    "3871-Stock en consignation":{
+                    },
+                    "3872-Stock en dépôt":{
+                    }
+                },
+                "388-Stock provenant d’immobilisations mises hors service ou au rebut":{
+                }
+            },
+            "39-Dépréciations des stocks et encours de production":{
+                "391-Dépréciations des stocks de marchandises":{
+                },
+                "392-Dépréciations des stocks de matières premières et fournitures liées":{
+                },
+                "393-Dépréciations des stocks d’autres approvisionnements":{
+                },
+                "394-Dépréciations des productions en cours":{
+                },
+                "395-Dépréciations des services en cours":{
+                },
+                "396-Dépréciations des stocks de produits finis":{
+                },
+                "397-Dépréciations des stocks de produits intermédiaires et résiduels":{
+                },
+                "398-Dépréciations des stocks en cours de route, en consignation ou en dépôt":{
+                }
+            },
+            "root_type":"Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)":{
+            "40-Fournisseurs et comptes rattachés (ACTIF)":{
+                "409-Fournisseurs débiteurs":{
+                    "4091-Fournisseurs Avances et acomptes versés":{
+                    },
+                    "4092-Fournisseurs Groupe avances et acomptes versés":{
+                    },
+                    "4093-Fournisseurs Sous-traitants avances et acomptes versés":{
+                    },
+                    "4094-Fournisseurs Créances pour emballages et matériels à rendre":{
+                    },
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs à obtenir":{
+                    }
+                }
+            },
+            "41-Clients et comptes rattachés (ACTIF)":{
+                "411-Clients":{
+                    "4111-Clients":{
+                        "account_type":"Receivable"
+                    },
+                    "4112-Clients groupe":{
+                        "account_type":"Receivable"
+                    },
+                    "4114-Clients, État et Collectivités publiques":{
+                        "account_type":"Receivable"
+                    },
+                    "4115-Clients, organismes internationaux":{
+                        "account_type":"Receivable"
+                    },
+                    "4116-Clients, réserve de propriété":{
+                        "account_type":"Receivable"
+                    },
+                    "4117-Client, retenues de garantie":{
+                        "account_type":"Receivable"
+                    },
+                    "4118-Clients, dégrèvement de taxes sur la valeur ajoutée (TVA)":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "412-Clients, effets à recevoir en portefeuille":{
+                    "4121-Clients, effets à recevoir":{
+                        "account_type":"Receivable"
+                    },
+                    "4122-Clients Groupe, effets à recevoir":{
+                        "account_type":"Receivable"
+                    },
+                    "4124-État et Collectivités publiques, effets à recevoir":{
+                        "account_type":"Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets à recevoir":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "413-Clients, chèques, effets et autres valeurs impayées":{
+                    "4131-Clients, chèques impayés":{
+                        "account_type":"Receivable"
+                    },
+                    "4132-Clients, effets impayés":{
+                        "account_type":"Receivable"
+                    },
+                    "4133-Clients, cartes de crédit impayées":{
+                        "account_type":"Receivable"
+                    },
+                    "4138-Clients, autres valeurs impayées":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "414-Créances sur cessions courantes d’immobilisations":{
+                    "4141-Créances en compte, immobilisations incorporelles":{
+                        "account_type":"Receivable"
+                    },
+                    "4142-Créances en compte, immobilisations corporelles":{
+                        "account_type":"Receivable"
+                    },
+                    "4146-Effets à recevoir, immobilisations incorporelles":{
+                        "account_type":"Receivable"
+                    },
+                    "4147-Effets à recevoir, immobilisations corporelles":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "415-Clients, effets escomptés non échus":{
+                    "account_type":"Receivable"
+                },
+                "416-Créances clients litigieuses ou douteuses":{
+                    "4161-Créances litigieuses":{
+                        "account_type":"Receivable"
+                    },
+                    "4162-Créances douteuses":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "418-Clients, produits à recevoir":{
+                    "4181-Clients, factures à établir":{
+                        "account_type":"Receivable"
+                    },
+                    "4186-Clients, intérêts courus":{
+                        "account_type":"Receivable"
+                    },
+                    "account_type":"Receivable"
+                },
+                "account_type":"Receivable"
+            },
+            "42-Personnel (ACTIF)":{
+                "421-Personnel, avances et acomptes":{
+                    "4211-Personnel, avances":{
+                    },
+                    "4212-Personnel, acomptes":{
+                    },
+                    "4213-Frais avancés et fournitures au personnel":{
+                    }
+                }
+            },
+            "43-Organismes sociaux (ACTIF)":{
+                "431-Sécurité sociale":{
+                    "4311-Prestations familiales":{
+                    },
+                    "4312-Accidents de travail":{
+                    },
+                    "4313-Caisse de retraite obligatoire":{
+                    },
+                    "4314-Caisse de retraite facultative":{
+                    },
+                    "4318-Autres cotisations sociales":{
+                    }
+                },
+                "432-Caisses de retraite complémentaire":{
+                },
+                "433-Autres organismes sociaux":{
+                    "4331-Mutuelle":{
+                    },
+                    "4332-Assurances retraite":{
+                    },
+                    "4333-Assurances et organismes de santé":{
+                    }
+                },
+                "438-Organismes sociaux, charges à payer et produits à recevoir":{
+                    "4387-Produits à recevoir":{
+                    }
+                }
+            },
+            "44-État et collectivités publiques (ACTIF)":{
+                "443-État, TVA facturée":{
+                    "4431-TVA facturée sur ventes":{
+                    },
+                    "4432-TVA facturée sur prestations de services":{
+                    },
+                    "4433-TVA facturée sur travaux":{
+                    },
+                    "4434-TVA facturée sur production livrée à soi-même":{
+                    },
+                    "4435-TVA sur factures à établir":{
+                    }
+                },
+                "445-État, TVA récupérable":{
+                    "4451-TVA récupérable sur immobilisations":{
+                    },
+                    "4452-TVA récupérable sur achats":{
+                    },
+                    "4453-TVA récupérable sur transport":{
+                    },
+                    "4454-TVA récupérable sur services extérieurs et autres charges":{
+                    },
+                    "4455-TVA récupérable sur factures non parvenues":{
+                    },
+                    "4456-TVA transférée par d’autres entités":{
+                    }
+                },
+                "448-État, charges à payer et produits à recevoir":{
+                    "4486-Charges à payer":{
+                    },
+                    "4487-Produits à recevoir":{
+                    }
+                },
+                "449-État, créances et dettes diverses":{
+                    "4491-État, obligations cautionnées":{
+                    },
+                    "4492-État, avances et acomptes versés sur impôts":{
+                    },
+                    "4493-État, fonds de dotation à recevoir":{
+                    },
+                    "4494-État, subventions investissement à recevoir":{
+                    },
+                    "4495-État, subventions d’exploitation à recevoir":{
+                    },
+                    "4496-État, subventions d’équilibre à recevoir":{
+                    },
+                    "4497-État, avances sur subventions":{
+                    },
+                    "4499-État, fonds réglementés provisionnés":{
+                    }
+                }
+            },
+            "45-Organismes internationaux (ACTIF)":{
+                "451-Opérations avec les organismes africains":{
+                },
+                "452-Opérations avec les autres organismes internationaux":{
+                },
+                "458-Organismes internationaux, fonds de dotation et subventions à recevoir":{
+                    "4581-Organismes internationaux, fonds de dotation à recevoir":{
+                    },
+                    "4582-Organismes internationaux, subventions à recevoir":{
+                    }
+                }
+            },
+            "46-Apporteurs, associés et groupe (ACTIF)":{
+                "461-Apporteurs, opérations sur le capital":{
+                    "4613-Apporteurs, capital appelé, non versé":{
+                    },
+                    "4614-Apporteurs, compte d’apport, opérations de restructuration (fusion...)":{
+                    },
+                    "4618-Apporteurs, titres à échanger":{
+                    }
+                },
+                "467-Apporteurs, restant dû sur capital appelé":{
+                }
+            },
+            "47-Débiteurs et créditeurs divers (ACTIF)":{
+                "472-Créances et dettes sur titres de placement":{
+                    "4721-Créances sur cessions de titres de placement":{
+                    },
+                    "4726-Versements restant à effectuer sur titres de placement non libérés":{
+                    }
+                },
+                "473-Intermédiaires Opérations faites pour compte de tiers":{
+                    "4731-Mandants":{
+                    },
+                    "4732-Mandataires":{
+                    },
+                    "4733-Commettants":{
+                    },
+                    "4734-Commissionnaires":{
+                    },
+                    "4739-État, Collectivités publiques, fonds global d’allocation":{
+                    }
+                },
+                "474-Compte de répartition périodique des charges et des produits":{
+                    "4747-Compte de répartition périodique des produits":{
+                    }
+                },
+                "475-Compte transitoire, ajustement spécial lié à la révision du SYSCOHADA":{
+                    "4751-Compte actif":{
+                        "account_type":"Temporary"
+                    }
+                },
+                "476-Charges constatées d’avance":{
+                },
+                "478-Écarts de conversion actif":{
+                    "4781-Diminution des créances d’exploitation":{
+                    },
+                    "4782-Diminution des créances financières":{
+                    },
+                    "4783-Augmentation des dettes d’exploitation":{
+                    },
+                    "4784-Augmentation des dettes financières":{
+                    },
+                    "4786-Différences d’évaluation sur instruments de trésorerie":{
+                    },
+                    "4788-Différences compensées par couverture de change":{
+                    }
+                }
+            },
+            "48-Créances et dettes hors activités ordinaires (ACTIF)":{
+                "485-Créances sur cessions d’immobilisations":{
+                    "4851-En compte, immobilisations incorporelles":{
+                    },
+                    "4852-En compte, immobilisations corporelles":{
+                    },
+                    "4853-Effets à recevoir, immobilisations incorporelles":{
+                    },
+                    "4854-Effets à recevoir, immobilisations corporelles":{
+                    },
+                    "4855-Effets escomptés non échus":{
+                    },
+                    "4857-Retenues de garantie":{
+                    },
+                    "4858-Factures à établir":{
+                    }
+                },
+                "488-Autres créances hors activités ordinaires (HAO)":{
+                }
+            },
+            "49-Dépréciations et provisions pour risques à court terme (tiers) (ACTIF)":{
+                "491-Dépréciations des comptes clients":{
+                    "4911-Créances litigieuses":{
+                    },
+                    "4912-Créances douteuses":{
+                    }
+                },
+                "495-Dépréciations des comptes organismes internationaux":{
+                },
+                "496-Dépréciations des comptes apporteurs, associés et groupe":{
+                    "4962-Associés, comptes courants":{
+                    },
+                    "4963-Associés, opérations faites en commun":{
+                    },
+                    "4966-Groupe, comptes courants":{
+                    }
+                },
+                "497-Dépréciations des comptes débiteurs divers":{
+                },
+                "498-Dépréciations des comptes de créances HAO":{
+                    "4985-Créances sur cessions d’immobilisations":{
+                    },
+                    "4986-Créances sur cessions de titres de placement":{
+                    },
+                    "4988-Autres créances HAO":{
+                    }
+                },
+                "499-Provisions pour risques à court terme":{
+                    "4991-Sur opérations d’exploitation":{
+                    },
+                    "4997-Sur opérations financières":{
+                    },
+                    "4998-Sur opérations HAO":{
+                    }
+                }
+            },
+            "root_type":"Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)":{
+            "40-Fournisseurs et comptes rattachés (PASSIF)":{
+                "401-Fournisseurs, dettes en compte":{
+                    "4011-Fournisseurs":{
+                        "account_type":"Payable"
+                    },
+                    "4012-Fournisseurs groupe":{
+                        "account_type":"Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants":{
+                        "account_type":"Payable"
+                    },
+                    "4016-Fournisseurs, réserve de propriété":{
+                        "account_type":"Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie":{
+                        "account_type":"Payable"
+                    },
+                    "account_type":"Payable"
+                },
+                "402-Fournisseurs, effets à payer":{
+                    "4021-Fournisseurs Effets à payer":{
+                        "account_type":"Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets à payer":{
+                        "account_type":"Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets à payer":{
+                        "account_type":"Payable"
+                    },
+                    "account_type":"Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d’immobilisations":{
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles":{
+                        "account_type":"Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles":{
+                        "account_type":"Payable"
+                    },
+                    "4046-Fournisseurs Effets à payer, immobilisations incorporelles":{
+                        "account_type":"Payable"
+                    },
+                    "4047-Fournisseurs Effets à payer, immobilisations corporelles":{
+                        "account_type":"Payable"
+                    },
+                    "account_type":"Payable"
+                },
+                "408-Fournisseurs, factures non parvenues":{
+                    "4081-Fournisseurs":{
+                        "account_type":"Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe":{
+                        "account_type":"Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants":{
+                        "account_type":"Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, intérêts courus":{
+                        "account_type":"Stock Received But Not Billed"
+                    },
+                    "account_type":"Stock Received But Not Billed"
+                },
+                "account_type":"Payable"
+            },
+            "41-Clients et comptes rattachés (PASSIF)":{
+                "419-Clients créditeurs":{
+                    "4191-Clients, avances et acomptes reçus":{
+                    },
+                    "4192-Clients groupe, avances et acomptes reçus":{
+                    },
+                    "4194-Clients, dettes pour emballages et matériels consignés":{
+                    },
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs à accorder":{
+                    }
+                }
+            },
+            "42-Personnel (PASSIF)":{
+                "422-Personnel, rémunérations dues":{
+                },
+                "423-Personnel, oppositions, saisies-arrêts":{
+                    "4231-Personnel, oppositions":{
+                    },
+                    "4232-Personnel, saisies-arrêts":{
+                    },
+                    "4233-Personnel, avis à tiers détenteur":{
+                    }
+                },
+                "424-Personnel, œuvres sociales internes":{
+                    "4241-Assistance médicale":{
+                    },
+                    "4242-Allocations familiales":{
+                    },
+                    "4245-Organismes sociaux rattachés à l’entité":{
+                    },
+                    "4248-Autres œuvres sociales internes":{
+                    }
+                },
+                "425-Représentants du personnel":{
+                    "4251-Délégués du personnel":{
+                    },
+                    "4252-Syndicats et Comités d’entreprises, d’Établissement":{
+                    },
+                    "4258-Autres représentants du personnel":{
+                    }
+                },
+                "426-Personnel, participation aux bénéfices et au capital":{
+                    "4261-Participation aux bénéfices":{
+                    },
+                    "4264-Participation au capital":{
+                    }
+                },
+                "427-Personnel dépôts":{
+                },
+                "428-Personnel, charges à payer et produits à recevoir":{
+                    "4281-Dettes provisionnées pour congés à payer":{
+                    },
+                    "4286-Autres charges à payer":{
+                    },
+                    "4287-Produits à recevoir":{
+                    }
+                }
+            },
+            "43-Organismes sociaux (PASSIF)":{
+                "438-Organismes sociaux, charges à payer et produits à recevoir":{
+                    "4381-Charges sociales sur gratifications à payer":{
+                    },
+                    "4382-Charges sociales sur congés à payer":{
+                    },
+                    "4386-Autres charges à payer":{
+                    }
+                }
+            },
+            "44-État et collectivités publiques (PASSIF)":{
+                "441-État, impôt sur les bénéfices":{
+                },
+                "442-État, autres impôts et taxes":{
+                    "4421-Impôts et taxes d’État":{
+                    },
+                    "4422-Impôts et taxes pour les collectivités publiques":{
+                    },
+                    "4423-Impôts et taxes recouvrables sur des obligataires":{
+                    },
+                    "4424-Impôts et taxes recouvrables sur des associés":{
+                    },
+                    "4426-Droits de douane":{
+                    },
+                    "4428-Autres impôts et taxes":{
+                    }
+                },
+                "444-État, TVA due ou crédit de TVA":{
+                    "4441-État, TVA due":{
+                    },
+                    "4449-État, crédit de TVA à reporter":{
+                    }
+                },
+                "446-État, autres taxes sur le chiffre d’affaires":{
+                },
+                "447-État, impôts retenus à la source":{
+                    "4471-Impôt Général sur le revenu":{
+                    },
+                    "4472-Impôts sur salaires":{
+                    },
+                    "4473-Contribution nationale":{
+                    },
+                    "4474-Contribution nationale de solidarité":{
+                    },
+                    "4478-Autres impôts et contributions":{
+                    }
+                }
+            },
+            "46-Apporteurs, associés et groupe (PASSIF)":{
+                "461-Apporteurs, opérations sur le capital (PASSIF)":{
+                    "4611-Apporteurs, apports en nature":{
+                    },
+                    "4612-Apporteurs, apports en numéraire":{
+                    },
+                    "4615-Apporteurs, versements reçus sur augmentation de capital":{
+                    },
+                    "4616-Apporteurs, versements anticipés":{
+                    },
+                    "4617-Apporteurs défaillants":{
+                    },
+                    "4619-Apporteurs, capital à rembourser":{
+                    }
+                },
+                "462-Associés, comptes courants":{
+                    "4621-Principal":{
+                    },
+                    "4626-Intérêts courus":{
+                    }
+                },
+                "463-Associés, opérations faites en commun et GIE":{
+                    "4631-Opérations courantes":{
+                    },
+                    "4636-Intérêts courus":{
+                    }
+                },
+                "465-Associés, dividendes à payer":{
+                },
+                "466-Groupe, comptes courants":{
+                }
+            },
+            "47-Débiteurs et créditeurs divers (PASSIF)":{
+                "471-Débiteurs et créditeurs divers":{
+                    "4711-Débiteurs divers":{
+                    },
+                    "4712-Créditeurs divers":{
+                    },
+                    "4713-Obligataires":{
+                    },
+                    "4715-Rémunérations d’administrateurs":{
+                    },
+                    "4716-Compte d’affacturage":{
+                    },
+                    "4717-Débiteurs divers retenues de garantie":{
+                    },
+                    "4718-Apport, compte de fusion et opérations assimilées":{
+                    },
+                    "4719-Bons de souscription d’actions et d’obligations":{
+                    }
+                },
+                "474-Compte de répartition périodique des charges et des produits (PASSIF)":{
+                    "4746-Compte de répartition périodique des charges":{
+                    }
+                },
+                "475-Compte transitoire, ajustement spécial lié à la révision du SYSCOHADA (PASSIF)":{
+                    "4752-Compte passif":{
+                    }
+                },
+                "477-Produits constatés d’avance":{
+                },
+                "479-Écarts de conversion passif":{
+                    "4791-Augmentation des créances d’exploitation":{
+                    },
+                    "4792-Augmentation des créances financières":{
+                    },
+                    "4793-Diminution des dettes d’exploitation":{
+                    },
+                    "4794-Diminution des dettes financières":{
+                    },
+                    "4797-Différences d’évaluation sur instruments de trésorerie":{
+                    },
+                    "4798-Différences compensées par couverture de change":{
+                    }
+                }
+            },
+            "48-Créances et dettes hors activités ordinaires (HAO) (PASSIF)":{
+                "481-Fournisseurs d’investissements":{
+                    "4811-Immobilisations incorporelles":{
+                    },
+                    "4812-Immobilisations corporelles":{
+                    },
+                    "4813-Versements restant à effectuer sur titres de participation et titres immobilisés non libérés":{
+                    },
+                    "4816-Réserve de propriété":{
+                    },
+                    "4817-Retenues de garantie":{
+                    },
+                    "4818-Factures non parvenues":{
+                    }
+                },
+                "482-Fournisseurs d’investissements, effets à payer":{
+                    "4821-Immobilisations incorporelles":{
+                    },
+                    "4822-Immobilisations corporelles":{
+                    }
+                },
+                "484-Autres dettes hors activités ordinaires (HAO)":{
+                    "4887-Produits":{
+                    }
+                }
+            },
+            "49-Dépréciations et provisions pour risques à court terme (tiers) (PASSIF)":{
+                "490-Dépréciations des comptes fournisseurs":{
+                },
+                "492-Dépréciations des comptes personnel":{
+                },
+                "493-Dépréciations des comptes organismes sociaux":{
+                },
+                "494-Dépréciations des comptes État et collectivités publiques":{
+                },
+                "495-Dépréciations des comptes organismes internationaux":{
+                }
+            },
+            "root_type":"Liability"
+        },
+        "5-Comptes de trésorerie":{
+            "50-Titres de placement":{
+                "501-Titres du trésor et bons de caisse à court terme":{
+                    "5011-Titres du Trésor à court terme":{
+                    },
+                    "5012-Titres d’organismes financiers":{
+                    },
+                    "5013-Bons de caisse à court terme":{
+                    },
+                    "5016-Frais d’acquisition des titres de trésor et bons de caisse":{
+                    }
+                },
+                "502-Actions":{
+                    "5021-Actions ou parts propres":{
+                    },
+                    "5022-Actions cotées":{
+                    },
+                    "5023-Actions non cotées":{
+                    },
+                    "5024-Actions démembrées (certificats d’investissement, droits de vote)":{
+                    },
+                    "5025-Autres actions":{
+                    },
+                    "5026-Frais d’acquisition des actions":{
+                    }
+                },
+                "503-Obligations":{
+                    "5031-Obligations émises par la société et rachetées par elle":{
+                    },
+                    "5032-Obligations cotées":{
+                    },
+                    "5033-Obligations non cotées":{
+                    },
+                    "5035-Autres obligations":{
+                    },
+                    "5036-Frais d’acquisition des obligations":{
+                    }
+                },
+                "504-Bons de souscription":{
+                    "5042-Bons de souscription d’actions":{
+                    },
+                    "5043-Bons de souscription d’obligations":{
+                    }
+                },
+                "505-Titres négociables hors région":{
+                },
+                "506-Intérêts courus":{
+                    "5061-Titres du Trésor et bons de caisse à court terme":{
+                    },
+                    "5062-Actions":{
+                    },
+                    "5063-Obligations":{
+                    }
+                },
+                "508-Autres titres de placement et créances assimilées":{
+                }
+            },
+            "51-Valeurs à encaisser":{
+                "511-Effets à encaisser":{
+                },
+                "512-Effets à l’encaissement":{
+                },
+                "513-Chèques à encaisser":{
+                },
+                "514-Chèques à l’encaissement":{
+                },
+                "515-Cartes de crédit à encaisser":{
+                },
+                "518-Autres valeurs à l’encaissement":{
+                    "5181-Warrants":{
+                    },
+                    "5182-Billets de fonds":{
+                    },
+                    "5185-Chèques de voyage":{
+                    },
+                    "5186-Coupons échus":{
+                    },
+                    "5187-Intérêts échus des obligations":{
+                    }
+                }
+            },
+            "52-Banques":{
+                "521-Banques locales":{
+                    "5211-Banques en monnaie nationale":{
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises":{
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres États région":{
+                },
+                "523-Banques autres États zone monétaire":{
+                },
+                "524-Banques hors zone monétaire":{
+                },
+                "525-Banques dépôt à terme":{
+                },
+                "526-Banques, intérêts courus":{
+                    "5261-Banque, intérêts courus, charges à payer":{
+                    },
+                    "5267-Banque, intérêts courus, produits à recevoir":{
+                    }
+                }
+            },
+            "53-Établissements financiers et assimilés":{
+                "531-Chèques postaux":{
+                },
+                "532-Trésor":{
+                },
+                "533-Sociétés de gestion et d’intermédiation (SGI)":{
+                },
+                "536-Établissements financiers, intérêts courus":{
+                },
+                "538-Autres organismes financiers":{
+                }
+            },
+            "54-Instruments de trésorerie":{
+                "541-Options de taux d’intérêt":{
+                },
+                "542-Options de taux de change":{
+                },
+                "543-Options de taux boursiers":{
+                },
+                "544-Instruments de marchés à terme":{
+                },
+                "545-Avoirs d’or et autres métaux précieux":{
+                }
+            },
+            "55-Instruments de monnaie électronique":{
+                "551-Monnaie électronique carte carburant":{
+                },
+                "552-Monnaie électronique téléphone portable":{
+                },
+                "553-Monnaie électronique carte péage":{
+                },
+                "554-Porte-monnaie électronique":{
+                },
+                "558-Autres instruments de monnaies électroniques":{
+                }
+            },
+            "56-Banques, crédits de trésorerie et d’escompte":{
+                "561-Crédits de trésorerie":{
+                },
+                "564-Escompte de crédits de campagne":{
+                },
+                "565-Escompte de crédits ordinaires":{
+                },
+                "566-Banques, crédits de trésorerie, intérêts courus":{
+                }
+            },
+            "57-Caisse":{
+                "571-Caisse siège social":{
+                    "5711-Caisse en monnaie nationale":{
+                    },
+                    "5712-Caisse en devises":{
+                    }
+                },
+                "572-Caisse succursale A":{
+                    "5721-En monnaie nationale":{
+                    },
+                    "5722-En devises":{
+                    }
+                },
+                "573-Caisse succursale B":{
+                    "5731-En monnaie nationale":{
+                    },
+                    "5732-En devises":{
+                    }
+                }
+            },
+            "58-Régies d’avances, accréditifs et virements internes":{
+                "581-Régies d’avance":{
+                },
+                "582-Accréditifs":{
+                },
+                "585-Virements de fonds":{
+                },
+                "588-Autres virements internes":{
+                }
+            },
+            "59-Dépréciations et provisions pour risque à court terme":{
+                "590-Dépréciations des titres de placement":{
+                },
+                "591-Dépréciations des titres et valeurs à encaisser":{
+                },
+                "592-Dépréciations des comptes banques":{
+                },
+                "593-Dépréciations des comptes établissements financiers et assimilés":{
+                },
+                "594-Dépréciations des comptes d’instruments de trésorerie":{
+                },
+                "599-Provisions pour risque à court terme à caractère financier":{
+                }
+            },
+            "root_type":"Asset"
+        },
+        "6-Comptes de charges des activités ordinaires":{
+            "60-Achats et variations de stocks":{
+                "601-Achats de marchandises":{
+                    "6011-Dans la Région":{
+                    },
+                    "6012-Hors Région":{
+                    },
+                    "6013-Aux entités du groupe dans la Région":{
+                    },
+                    "6014-Aux entités du groupe hors Région":{
+                    },
+                    "6015-Frais sur achats":{
+                    },
+                    "6019-Rabais, remises et ristournes obtenus (non ventilés)":{
+                    }
+                },
+                "602-Achats de matières premières et fournitures liées":{
+                    "6021-Dans la Région":{
+                    },
+                    "6022-Hors Région":{
+                    },
+                    "6023-Aux entités du groupe dans la Région":{
+                    },
+                    "6024-Aux entités du groupe hors Région":{
+                    },
+                    "6025-Frais sur achats":{
+                    },
+                    "6029-Rabais, remises et ristournes obtenus (non ventilés)":{
+                    }
+                },
+                "603-Variations des stocks de biens achetés":{
+                    "6031-Variations des stocks de marchandises":{
+                    },
+                    "6032-Variations des stocks de matières premières et fournitures liées":{
+                    },
+                    "6033-Variations des stocks d’autres approvisionnements":{
+                    }
+                },
+                "604-Achats stockés de matières et fournitures consommables":{
+                    "6041-Matières consommables":{
+                    },
+                    "6042-Matières combustibles":{
+                    },
+                    "6043-Produits d’entretien":{
+                    },
+                    "6044-Fournitures d’atelier et d’usine":{
+                    },
+                    "6045-Frais sur achat":{
+                    },
+                    "6046-Fournitures de magasin":{
+                    },
+                    "6047-Fournitures de bureau":{
+                    },
+                    "6049-Rabais, remises et ristournes obtenus (non ventilés)":{
+                    }
+                },
+                "605-Autres achats":{
+                    "6051-Fournitures non stockables Eau":{
+                    },
+                    "6052-Fournitures non stockables Électricité":{
+                    },
+                    "6053-Fournitures non stockables Autres énergies":{
+                    },
+                    "6054-Fournitures d’entretien non stockables":{
+                    },
+                    "6055-Fournitures de bureau non stockables":{
+                    },
+                    "6056-Achats de petit matériel et outillage":{
+                    },
+                    "6057-Achats d’études et prestations de services":{
+                    },
+                    "6058-Achats de travaux, matériels et équipements":{
+                    },
+                    "6059-Rabais, remises et ristournes obtenus (non ventilés)":{
+                    }
+                },
+                "608-Achats d’emballages":{
+                    "6081-Emballages perdus":{
+                    },
+                    "6082-Emballages récupérables non identifiables":{
+                    },
+                    "6083-Emballages à usage mixte":{
+                    },
+                    "6085-Frais sur achats":{
+                    },
+                    "6089-Rabais, remises et ristournes obtenus (non ventilés)":{
+                    }
+                }
+            },
+            "61-Transports":{
+                "612-Transports sur ventes":{
+                },
+                "613-Transports pour le compte de tiers":{
+                },
+                "614-Transports du personnel":{
+                },
+                "616-Transports de plis":{
+                },
+                "618-Autres frais de transport":{
+                    "6181-Voyages et déplacements":{
+                    },
+                    "6182-Transports entre établissements ou chantiers":{
+                    },
+                    "6183-Transports administratifs":{
+                    }
+                }
+            },
+            "62-Services extérieurs":{
+                "621-Sous-traitance générale":{
+                },
+                "622-Locations, charges locatives":{
+                    "6221-Locations de terrains":{
+                    },
+                    "6222-Locations de bâtiments":{
+                    },
+                    "6223-Locations de matériels et outillages":{
+                    },
+                    "6224-Malis sur emballages":{
+                    },
+                    "6225-Locations d’emballages":{
+                    },
+                    "6226-Fermages et loyers du foncier":{
+                    },
+                    "6228-Locations et charges locatives diverses":{
+                    }
+                },
+                "623-Redevances de location acquisition":{
+                    "6232-Crédit-bail immobilier":{
+                    },
+                    "6233-Crédit-bail mobilier":{
+                    },
+                    "6234-Location-vente":{
+                    },
+                    "6238-Autres contrats de location acquisition":{
+                    }
+                },
+                "624-Entretien, réparations, remise en état et maintenance":{
+                    "6241-Entretien et réparations des biens immobiliers":{
+                    },
+                    "6242-Entretien et réparations des biens mobiliers":{
+                    },
+                    "6243-Maintenance":{
+                    },
+                    "6244-Charges de démantèlement et remise en état":{
+                    },
+                    "6248-Autres entretiens et réparations":{
+                    }
+                },
+                "625-Primes d’assurance":{
+                    "6251-Assurances multirisques":{
+                    },
+                    "6252-Assurances matériel de transport":{
+                    },
+                    "6253-Assurances risques d’exploitation":{
+                    },
+                    "6254-Assurances responsabilité du producteur":{
+                    },
+                    "6255-Assurances insolvabilité clients":{
+                    },
+                    "6257-Assurances transport sur ventes":{
+                    },
+                    "6258-Autres primes d’assurances":{
+                    }
+                },
+                "626-Études, recherches et documentation":{
+                    "6261-Études et recherches":{
+                    },
+                    "6265-Documentation générale":{
+                    },
+                    "6266-Documentation technique":{
+                    }
+                },
+                "627-Publicité, publications, relations publiques":{
+                    "6271-Annonces, insertions":{
+                    },
+                    "6272-Catalogues, imprimés publicitaires":{
+                    },
+                    "6273-Échantillons":{
+                    },
+                    "6274-Foires et expositions":{
+                    },
+                    "6275-Publications":{
+                    },
+                    "6276-Cadeaux à la clientèle":{
+                    },
+                    "6277-Frais de colloques, séminaires, conférences":{
+                    },
+                    "6278-Autres charges de publicité et relations publiques":{
+                    }
+                },
+                "628-Frais de télécommunications":{
+                    "6281-Frais de téléphone":{
+                    },
+                    "6282-Frais de télex":{
+                    },
+                    "6283-Frais de télécopie":{
+                    },
+                    "6288-Autres frais de télécommunications":{
+                    }
+                }
+            },
+            "63-Autres services extérieurs":{
+                "631-Frais bancaires":{
+                    "6311-Frais sur titres (vente, garde)":{
+                    },
+                    "6312-Frais sur effets":{
+                    },
+                    "6313-Location de coffres":{
+                    },
+                    "6314-Commissions d’affacturage":{
+                    },
+                    "6315-Commissions sur cartes de crédit":{
+                    },
+                    "6316-Frais d’émission d’emprunts":{
+                    },
+                    "6317-Frais sur instruments monnaie électronique":{
+                    },
+                    "6318-Autres frais bancaires":{
+                    }
+                },
+                "632-Rémunérations d’intermédiaires et de conseils":{
+                    "6322-Commissions et courtages sur ventes":{
+                    },
+                    "6324-Honoraires des professions réglementées":{
+                    },
+                    "6325-Frais d’actes et de contentieux":{
+                    },
+                    "6326-Rémunérations d’affacturage":{
+                    },
+                    "6327-Rémunérations des autres prestataires de services":{
+                    },
+                    "6328-Divers frais":{
+                    }
+                },
+                "633-Frais de formation du personnel":{
+                },
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires":{
+                    "6342-Redevances pour brevets, licences":{
+                    },
+                    "6343-Redevances pour logiciels":{
+                    },
+                    "6344-Redevances pour marques":{
+                    },
+                    "6345-Redevances pour sites internet":{
+                    },
+                    "6346-Redevances pour concessions, droits et valeurs similaires":{
+                    }
+                },
+                "635-Cotisations":{
+                    "6351-Cotisations":{
+                    },
+                    "6358-Concours divers":{
+                    }
+                },
+                "637-Rémunérations de personnel extérieur à l’entité":{
+                    "6371-Personnel intérimaire":{
+                    },
+                    "6372-Personnel détaché ou prêté à l’entité":{
+                    }
+                },
+                "638-Autres charges externes":{
+                    "6381-Frais de recrutement du personnel":{
+                    },
+                    "6382-Frais de déménagement":{
+                    },
+                    "6383-Réceptions":{
+                    },
+                    "6384-Missions":{
+                    },
+                    "6385-Charges de copropriété":{
+                    }
+                }
+            },
+            "64-Impôts et taxes":{
+                "641-Impôts et taxes directs":{
+                    "6411-Impôts fonciers et taxes annexes":{
+                    },
+                    "6412-Patentes, licences et taxes annexes":{
+                    },
+                    "6413-Taxes sur appointements et salaires":{
+                    },
+                    "6414-Taxes d’apprentissage":{
+                    },
+                    "6415-Formation professionnelle continue":{
+                    },
+                    "6418-Autres impôts et taxes directs":{
+                    }
+                },
+                "645-Impôts et taxes indirects":{
+                },
+                "646-Droits d’enregistrement":{
+                    "6461-Droits de mutation":{
+                    },
+                    "6462-Droits de timbre":{
+                    },
+                    "6463-Taxes sur les véhicules de société":{
+                    },
+                    "6464-Vignettes":{
+                    },
+                    "6468-Autres droits":{
+                    }
+                },
+                "647-Pénalités, amendes fiscales":{
+                    "6471-Pénalités d’assiette, impôts directs":{
+                    },
+                    "6472-Pénalités d’assiette, impôts indirects":{
+                    },
+                    "6473-Pénalités de recouvrement, impôts directs":{
+                    },
+                    "6474-Pénalités de recouvrement, impôts indirects":{
+                    },
+                    "6478-Autres pénalités et amendes fiscales":{
+                    }
+                },
+                "648-Autres impôts et taxes":{
+                }
+            },
+            "65-Autres charges":{
+                "651-Pertes sur créances clients et autres débiteurs":{
+                    "6511-Clients":{
+                    },
+                    "6515-Autres débiteurs":{
+                    }
+                },
+                "652-Quote-part de résultat sur opérations faites en commun":{
+                    "6521-Quote-part transférée de bénéfices (comptabilité du gérant)":{
+                    },
+                    "6525-Pertes imputées par transfert (comptabilité des associés non gérants)":{
+                    }
+                },
+                "654-Valeurs comptables des cessions courantes d’immobilisations":{
+                    "6541-Immobilisations incorporelles":{
+                    },
+                    "6542-Immobilisations corporelles":{
+                    }
+                },
+                "656-Perte de change sur créances et dettes commerciale":{
+                },
+                "657-Pénalités et amendes pénales":{
+                },
+                "658-Charges diverses":{
+                    "6581-Indemnités de fonction et autres rémunérations d’administrateurs":{
+                    },
+                    "6582-Dons":{
+                    },
+                    "6583-Mécénat":{
+                    },
+                    "6588-Autres charges diverses":{
+                    }
+                },
+                "659-Charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                    "6591-Sur risques à court terme":{
+                    },
+                    "6593-Sur stocks":{
+                    },
+                    "6594-Sur créances":{
+                    },
+                    "6598-Autres charges pour dépréciations et provisions pour risques à court terme":{
+                    }
+                }
+            },
+            "66-Charges de personnel":{
+                "661-Rémunérations directes versées au personnel national":{
+                    "6611-Appointements salaires et commissions":{
+                    },
+                    "6612-Primes et gratifications":{
+                    },
+                    "6613-Congés payés":{
+                    },
+                    "6614-Indemnités de préavis, de licenciement et de recherche d’embauche":{
+                    },
+                    "6615-Indemnités de maladie versées aux travailleurs":{
+                    },
+                    "6616-Supplément familial":{
+                    },
+                    "6617-Avantages en nature":{
+                    },
+                    "6618-Autres rémunérations directes":{
+                    }
+                },
+                "662-Rémunérations directes versées au personnel non national":{
+                    "6621-Appointements salaires et commissions":{
+                    },
+                    "6622-Primes et gratifications":{
+                    },
+                    "6623-Congés payés":{
+                    },
+                    "6624-Indemnités de préavis, de licenciement et de recherche d’embauche":{
+                    },
+                    "6625-Indemnités de maladie versées aux travailleurs":{
+                    },
+                    "6626-Supplément familial":{
+                    },
+                    "6627-Avantages en nature":{
+                    },
+                    "6628-Autres rémunérations directes":{
+                    }
+                },
+                "663-Indemnités forfaitaires versées au personnel":{
+                    "6631-Indemnités de logement":{
+                    },
+                    "6632-Indemnités de représentation":{
+                    },
+                    "6633-Indemnités d’expatriation":{
+                    },
+                    "6634-Indemnités de transport":{
+                    },
+                    "6638-Autres indemnités et avantages divers":{
+                    }
+                },
+                "664-Charges sociales":{
+                    "6641-Charges sociales sur rémunération du personnel national":{
+                    },
+                    "6642-Charges sociales sur rémunération du personnel non national":{
+                    }
+                },
+                "666-Rémunérations et charges sociales de l’exploitant individuel":{
+                    "6661-Rémunération du travail de l’exploitant":{
+                    },
+                    "6662-Charges sociales":{
+                    }
+                },
+                "667-Rémunération transférée de personnel extérieur":{
+                    "6671-Personnel intérimaire":{
+                    },
+                    "6672-Personnel détaché ou prêté à l’entité":{
+                    }
+                },
+                "668-Autres charges sociales":{
+                    "6681-Versements aux syndicats et comités d’entreprise, d’établissement":{
+                    },
+                    "6682-Versements aux comités d’hygiène et de sécurité":{
+                    },
+                    "6683-Versements et contributions aux autres œuvres sociales":{
+                    },
+                    "6684-Médecine du travail et pharmacie":{
+                    },
+                    "6685-Assurances et organismes de santé":{
+                    },
+                    "6686-Assurances retraite et fonds de pension":{
+                    },
+                    "6687-Majorations et pénalités sociales":{
+                    },
+                    "6688-Charges sociales diverses":{
+                    }
+                }
+            },
+            "67-Frais financiers et charges assimilées":{
+                "671-Intérêts des emprunts":{
+                    "6711-Emprunts obligataires":{
+                    },
+                    "6712-Emprunts auprès des établissements de crédit":{
+                    },
+                    "6713-Dettes liées à des participations":{
+                    },
+                    "6714-Primes de remboursement des obligations":{
+                    }
+                },
+                "672-Intérêts dans loyers de location acquisition":{
+                    "6722-Intérêts dans loyers de location acquisition / crédit-bail immobilier":{
+                    },
+                    "6723-Intérêts dans loyers de location acquisition / crédit-bail mobilier":{
+                    },
+                    "6724-Intérêts dans loyers de location acquisition / location-vente":{
+                    },
+                    "6728-Intérêts dans loyers des autres locations acquisition":{
+                    }
+                },
+                "673-Escomptes accordés":{
+                },
+                "674-Autres intérêts":{
+                    "6741-Avances reçues et dépôts créditeurs":{
+                    },
+                    "6742-Comptes courants bloqués":{
+                    },
+                    "6743-Intérêts sur obligations cautionnées":{
+                    },
+                    "6744-Intérêts sur dettes commerciales":{
+                    },
+                    "6745-Intérêts bancaires et sur opérations de financement (escompte...)":{
+                    },
+                    "6748-Intérêts sur dettes diverses":{
+                    }
+                },
+                "675-Escomptes des effets de commerce":{
+                },
+                "676-Pertes de change financières":{
+                },
+                "677-Pertes sur titres de placement":{
+                    "6771-Pertes sur cessions de titres de placement":{
+                    },
+                    "6772-Mali provenant d’attribution gratuite d’actions au personnel salarié et aux dirigeants":{
+                    }
+                },
+                "678-Pertes et charges sur risques financiers":{
+                    "6781-Sur rentes viagères":{
+                    },
+                    "6782-Sur opérations financières":{
+                    },
+                    "6784-Sur instruments de trésorerie":{
+                    }
+                },
+                "679-Charges pour dépréciations et provisions pour risques à court terme financières":{
+                    "6791-Sur risques financiers":{
+                    },
+                    "6795-Sur titres de placement":{
+                    },
+                    "6798-Autres charges pour dépréciations et provisions pour risques à court terme financières":{
+                    }
+                }
+            },
+            "68-Dotations aux amortissements":{
+                "681-Dotations aux amortissements d’exploitation":{
+                    "6812-Dotations aux amortissements des immobilisations incorporelles":{
+                    },
+                    "6813-Dotations aux amortissements des immobilisations corporelles":{
+                    }
+                }
+            },
+            "69-Dotations aux provisions et aux dépréciations":{
+                "691-Dotations aux provisions et aux dépréciations d’exploitation":{
+                    "6911-Dotations aux provisions pour risques et charges":{
+                    },
+                    "6913-Dotations aux dépréciations des immobilisations incorporelles":{
+                    },
+                    "6914-Dotations aux dépréciations des immobilisations corporelles":{
+                    }
+                },
+                "697-Dotations aux provisions et aux dépréciations financières":{
+                    "6971-Dotations aux provisions pour risques et charges":{
+                    },
+                    "6972-Dotations aux dépréciations des immobilisations financières":{
+                    }
+                }
+            },
+            "root_type":"Expense"
+        },
+        "7-Comptes de produits des activités ordinaires":{
+            "70-Ventes":{
+                "701-Ventes de marchandises":{
+                    "7011-Dans la Région":{
+                    },
+                    "7012-Hors Région":{
+                    },
+                    "7013-Aux entités du groupe dans la Région":{
+                    },
+                    "7014-Aux entités du groupe hors Région":{
+                    },
+                    "7015-Sur internet":{
+                    },
+                    "7019-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "702-Ventes de produits finis":{
+                    "7021-Dans la Région":{
+                    },
+                    "7022-Hors Région":{
+                    },
+                    "7023-Aux entités du groupe dans la Région":{
+                    },
+                    "7024-Aux entités du groupe hors Région":{
+                    },
+                    "7025-Sur internet":{
+                    },
+                    "7029-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "703-Ventes de produits intermédiaires":{
+                    "7031-Dans la Région":{
+                    },
+                    "7032-Hors Région":{
+                    },
+                    "7033-Aux entités du groupe dans la Région":{
+                    },
+                    "7034-Aux entités du groupe hors Région":{
+                    },
+                    "7035-Sur internet":{
+                    },
+                    "7039-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "704-Ventes de produits résiduels":{
+                    "7041-Dans la Région":{
+                    },
+                    "7042-Hors Région":{
+                    },
+                    "7043-Aux entités du groupe dans la Région":{
+                    },
+                    "7044-Aux entités du groupe hors Région":{
+                    },
+                    "7045-Sur internet":{
+                    },
+                    "7049-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "705-Travaux facturés":{
+                    "7051-Dans la Région":{
+                    },
+                    "7052-Hors Région":{
+                    },
+                    "7053-Aux entités du groupe dans la Région":{
+                    },
+                    "7054-Aux entités du groupe hors Région":{
+                    },
+                    "7055-Sur internet":{
+                    },
+                    "7059-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "706-Services vendus":{
+                    "7061-Dans la Région":{
+                    },
+                    "7062-Hors Région":{
+                    },
+                    "7063-Aux entités du groupe dans la Région":{
+                    },
+                    "7064-Aux entités du groupe hors Région":{
+                    },
+                    "7065-Sur internet":{
+                    },
+                    "7069-Rabais, remises, ristournes accordés (non ventilés)":{
+                    }
+                },
+                "707-Produits accessoires":{
+                    "7071-Ports, emballages perdus et autres frais facturés":{
+                    },
+                    "7072-Commissions et courtages":{
+                    },
+                    "7073-Locations":{
+                    },
+                    "7074-Bonis sur reprises et cessions d’emballages":{
+                    },
+                    "7075-Mise à disposition de personnel":{
+                    },
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires":{
+                    },
+                    "7077-Services exploités dans l’intérêt du personnel":{
+                    },
+                    "7078-Autres produits accessoires":{
+                    }
+                }
+            },
+            "71-Subventions d’exploitation":{
+                "711-Sur produits à l’exportation":{
+                },
+                "712-Sur produits à l’importation":{
+                },
+                "713-Sur produits de péréquation":{
+                },
+                "714-Indemnités et subventions d’exploitation (entité agricole)":{
+                },
+                "718-Autres subventions d’exploitation":{
+                    "7181-Versées par l’État et les collectivités publiques":{
+                    },
+                    "7182-Versées par les organismes internationaux":{
+                    },
+                    "7183-Versées par des tiers":{
+                    }
+                }
+            },
+            "72-Production immobilisée":{
+                "721-Immobilisations incorporelles":{
+                },
+                "722-Immobilisations corporelles":{
+                    "7221-Immobilisations corporelles (hors actifs biologiques)":{
+                    },
+                    "7222-Immobilisations corporelles (actifs biologiques)":{
+                    }
+                },
+                "724-Production auto-consommée":{
+                },
+                "726-Immobilisations financières":{
+                }
+            },
+            "73-Variations des stocks de biens et de services produits":{
+                "734-Variations des stocks de produits en cours":{
+                    "7341-Produits en cours":{
+                    },
+                    "7342-Travaux en cours":{
+                    }
+                },
+                "735-Variations des en-cours de services":{
+                    "7351-Études en cours":{
+                    },
+                    "7352-Prestations de services en cours":{
+                    }
+                },
+                "736-Variations des stocks de produits finis":{
+                },
+                "737-Variations des stocks de produits intermédiaires et résiduels":{
+                    "7371-Produits intermédiaires":{
+                    },
+                    "7372-Produits résiduels":{
+                    }
+                }
+            },
+            "75-Autres produits":{
+                "751-Profits sur créances clients et autres débiteurs":{
+                },
+                "752-Quote-part de résultat sur opérations faites en commun":{
+                    "7521-Quote-part transférée de pertes (comptabilité du gérant)":{
+                    },
+                    "7525-Bénéfices attribués par transfert (comptabilité des associés non gérants)":{
+                    }
+                },
+                "754-Produits des cessions courantes d’immobilisations":{
+                    "7541-Immobilisations incorporelles":{
+                    },
+                    "7542-Immobilisations corporelles":{
+                    }
+                },
+                "756-Gains de change sur créances et dettes commerciales":{
+                },
+                "758-Produits divers":{
+                    "7581-Indemnités de fonction et autres rémunérations d’administrateurs":{
+                    },
+                    "7582-Indemnités d’assurances reçues":{
+                    },
+                    "7588-Autres produits divers":{
+                    }
+                },
+                "759-Reprises de charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                    "7591-Sur risques à court terme":{
+                    },
+                    "7593-Sur stocks":{
+                    },
+                    "7594-Sur créances":{
+                    },
+                    "7598-Sur autres charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                    }
+                }
+            },
+            "77-Revenus financiers et produits assimilés":{
+                "771-Intérêts de prêts et créances diverses":{
+                    "7712-Intérêts de prêts":{
+                    },
+                    "7713-Intérêts sur créances diverses":{
+                    }
+                },
+                "772-Revenus de participations et autres titres immobilisés":{
+                    "7721-Revenus des titres de participation":{
+                    },
+                    "7722-Revenus autres titres immobilisés":{
+                    }
+                },
+                "773-Escomptes obtenus":{
+                },
+                "774-Revenus de placement":{
+                    "7745-Revenus des obligations":{
+                    },
+                    "7746-Revenus des titres de placement":{
+                    }
+                },
+                "775-Intérêts dans loyers de location acquisition":{
+                },
+                "776-Gains de change financiers":{
+                },
+                "777-Gains sur cessions de titres de placement":{
+                },
+                "778-Gains sur risques financiers":{
+                    "7781-Sur rentes viagères":{
+                    },
+                    "7782-Sur opérations financières":{
+                    },
+                    "7784-Sur instruments de trésorerie":{
+                    }
+                },
+                "779-Reprises de charges pour dépréciations et provisions à court terme financières":{
+                    "7791-Sur risques financiers":{
+                    },
+                    "7795-Sur titres de placement":{
+                    },
+                    "7798-Sur autres charges pour dépréciations et provisions pour risques à court terme financières":{
+                    }
+                }
+            },
+            "78-Transferts de charges":{
+                "781-Transferts de charges d’exploitation":{
+                },
+                "787-Transferts de charges financières":{
+                }
+            },
+            "79-Reprises de provisions, de dépréciations et autres":{
+                "791-Reprises de provisions et dépréciations d’exploitation":{
+                    "7911-Pour risques et charges":{
+                    },
+                    "7913-Des immobilisations incorporelles":{
+                    },
+                    "7914-Des immobilisations corporelles":{
+                    }
+                },
+                "797-Reprises de provisions et dépréciations financières":{
+                    "7971-Pour risques et charges":{
+                    },
+                    "7972-Des immobilisations financières":{
+                    }
+                },
+                "798-Reprises d’amortissements":{
+                },
+                "799-Reprises de subventions d’investissement":{
+                }
+            },
+            "root_type":"Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)":{
+            "81-Valeurs comptables des cessions d’immobilisations":{
+                "811-Immobilisations incorporelles":{
+                },
+                "812-Immobilisations corporelles":{
+                },
+                "816-Immobilisations financières":{
+                }
+            },
+            "83-Charges hors activités ordinaires":{
+                "831-Charges HAO constatées":{
+                },
+                "833-Charges liées aux opérations de restructuration":{
+                },
+                "834-Pertes sur créances HAO":{
+                },
+                "835-Dons et libéralités accordés":{
+                },
+                "836-Abandons de créances consentis":{
+                },
+                "837-Charges liées aux opérations de liquidation":{
+                },
+                "839-Charges pour dépréciations et provisions pour risques à court terme HAO":{
+                }
+            },
+            "85-Dotations hors activités ordinaires":{
+                "851-Dotations aux provisions réglementées":{
+                },
+                "852-Dotations aux amortissements HAO":{
+                },
+                "853-Dotations aux dépréciations HAO":{
+                },
+                "854-Dotations aux provisions pour risques et charges HAO":{
+                },
+                "858-Autres dotations HAO":{
+                }
+            },
+            "87-Participation des travailleurs":{
+                "871-Participation légale aux bénéfices":{
+                },
+                "874-Participation contractuelle aux bénéfices":{
+                },
+                "878-Autres participations":{
+                }
+            },
+            "89-Impôts sur le résultat":{
+                "891-Impôts sur les bénéfices de l’exercice":{
+                    "8911-Activités exercées dans l’État":{
+                    },
+                    "8912-Activités exercées dans les autres États de la Région":{
+                    },
+                    "8913-Activités exercées hors Région":{
+                    }
+                },
+                "892-Rappel d’impôts sur résultats antérieurs":{
+                },
+                "895-Impôt minimum forfaitaire IMF":{
+                },
+                "899-Dégrèvements et annulations d’impôts sur résultats antérieurs":{
+                    "8991-Dégrèvements":{
+                    },
+                    "8994-Annulations pour pertes rétroactives":{
+                    }
+                }
+            },
+            "root_type":"Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)":{
+            "82-Produits des cessions d’immobilisations":{
+                "821-Immobilisations incorporelles":{
+                },
+                "822-Immobilisations corporelles":{
+                },
+                "826-Immobilisations financières":{
+                }
+            },
+            "84-Produits hors activités ordinaires":{
+                "841-Produits HAO constatés":{
+                },
+                "843-Produits liés aux opérations de restructuration":{
+                },
+                "844-Indemnités et subventions HAO (entité agricole)":{
+                },
+                "845-Dons et libéralités obtenus":{
+                },
+                "846-Abandons de créances obtenus":{
+                },
+                "847-Produits liés aux opérations de liquidation":{
+                },
+                "848-Transferts de charges HAO":{
+                },
+                "849-Reprises de charges pour dépréciations et provisions pour risques à court terme HAO":{
+                }
+            },
+            "86-Reprises de charges, provisions et dépréciations HAO":{
+                "861-Reprises de provisions réglementées":{
+                },
+                "862-Reprises d’amortissements HAO":{
+                },
+                "863-Reprises de dépréciations HAO":{
+                },
+                "864-Reprises de provisions pour risques et charges HAO":{
+                },
+                "868-Autres reprises HAO":{
+                }
+            },
+            "88-Subventions d’équilibre":{
+                "881-État":{
+                },
+                "884-Collectivités publiques":{
+                },
+                "886-Groupe":{
+                },
+                "888-Autres":{
+                }
+            },
+            "root_type":"Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable_avec_code.json
@@ -1,0 +1,4209 @@
+{
+    "country_code":"PLACEHOLDER",
+    "name":"Syscohada - Plan Comptable avec code",
+    "tree":{
+        "Comptes de ressources durables":{
+            "Capital":{
+                "Capital social":{
+                    "Capital souscrit, non appelé":{
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appelé, non versé":{
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appelé, versé, non amorti":{
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appelé, versé, amorti":{
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis à des conditions particulières":{
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation":{
+                    "Dotation initiale":{
+                        "account_number": "1021"
+                    },
+                    "Dotations complémentaires":{
+                        "account_number": "1022"
+                    },
+                    "Autres dotations":{
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel":{
+                    "account_number": "103"
+                },
+                "Compte de l’exploitant":{
+                    "Apports temporaires":{
+                        "account_number": "1041"
+                    },
+                    "Opérations courantes":{
+                        "account_number": "1042"
+                    },
+                    "Rémunérations, impôts et autres charges personnelles":{
+                        "account_number": "1043"
+                    },
+                    "Prélèvements d’autoconsommation":{
+                        "account_number": "1047"
+                    },
+                    "Autres prélèvements":{
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes liées au capital social":{
+                    "Primes d’émission":{
+                        "account_number": "1051"
+                    },
+                    "Primes d’apport":{
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion":{
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion":{
+                        "account_number": "1054"
+                    },
+                    "Autres primes":{
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "Écarts de réévaluation":{
+                    "Écarts de réévaluation légale":{
+                        "account_number": "1061"
+                    },
+                    "Écarts de réévaluation libre":{
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appelé":{
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "Réserves":{
+                "Réserve légale":{
+                    "account_number": "111"
+                },
+                "Réserves statutaires ou contractuelles":{
+                    "account_number": "112"
+                },
+                "Réserves réglementées":{
+                    "Réserves de plus-values nettes à long terme":{
+                        "account_number": "1131"
+                    },
+                    "Réserves d’attribution gratuite d’actions au personnel salarié et aux dirigeants":{
+                        "account_number": "1132"
+                    },
+                    "Réserves consécutives à l’octroi de subventions d’investissement":{
+                        "account_number": "1133"
+                    },
+                    "Réserves des valeurs mobilières donnant accès au capital":{
+                        "account_number": "1134"
+                    },
+                    "Autres réserves réglementées":{
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres réserves":{
+                    "Réserves facultatives":{
+                        "account_number": "1181"
+                    },
+                    "Réserves diverses":{
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report à nouveau":{
+                "Report à nouveau créditeur":{
+                    "account_number": "121"
+                },
+                "Report à nouveau débiteur":{
+                    "Perte nette à reporter":{
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements réputés différés":{
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "Résultat net de l’exercice":{
+                "Résultat en instance d’affectation":{
+                    "Résultat en instance d’affectation : bénéfice":{
+                        "account_number": "1301"
+                    },
+                    "Résultat en instance d’affectation : perte":{
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "Résultat net : bénéfice":{
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)":{
+                    "account_number": "132"
+                },
+                "Valeur ajoutée (VA)":{
+                    "account_number": "133"
+                },
+                "Excédent brut d’exploitation (EBE)":{
+                    "account_number": "134"
+                },
+                "Résultat d’exploitation (RE)":{
+                    "account_number": "135"
+                },
+                "Résultat financier (RF)":{
+                    "account_number": "136"
+                },
+                "Résultat des activités ordinaires (RAO)":{
+                    "account_number": "137"
+                },
+                "Résultat hors activités ordinaires (RHAO)":{
+                    "Résultat de fusion":{
+                        "account_number": "1381"
+                    },
+                    "Résultat d’apport partiel d’actif":{
+                        "account_number": "1382"
+                    },
+                    "Résultat de scission":{
+                        "account_number": "1383"
+                    },
+                    "Résultat de liquidation":{
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "Résultat net : perte":{
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d’investissement":{
+                "Subventions d’équipement":{
+                    "État":{
+                        "account_number": "1411"
+                    },
+                    "Régions":{
+                        "account_number": "1412"
+                    },
+                    "Départements":{
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivités publiques décentralisées":{
+                        "account_number": "1414"
+                    },
+                    "Entités publiques ou mixtes":{
+                        "account_number": "1415"
+                    },
+                    "Entités et organismes privés":{
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux":{
+                        "account_number": "1417"
+                    },
+                    "Autres":{
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d’investissement":{
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions réglementées et fonds assimilés":{
+                "Amortissements dérogatoires":{
+                    "account_number": "151"
+                },
+                "Plus-values de cession à réinvestir":{
+                    "account_number": "152"
+                },
+                "Fonds réglementés":{
+                    "Fonds National":{
+                        "account_number": "1531"
+                    },
+                    "Prélèvement pour le Budget":{
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions spéciales de réévaluation":{
+                    "account_number": "154"
+                },
+                "Provisions réglementées relatives aux immobilisations":{
+                    "Reconstitution des gisements miniers et pétroliers":{
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions réglementées relatives aux stocks":{
+                    "Hausse de prix":{
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours":{
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement":{
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds réglementés":{
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimilées":{
+                "Emprunts obligataires":{
+                    "Emprunts obligataires ordinaires":{
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions":{
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions":{
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires":{
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes auprès des établissements de crédit":{
+                    "account_number": "162"
+                },
+                "Avances reçues de l’État":{
+                    "account_number": "163"
+                },
+                "Avances reçues et comptes courants bloqués":{
+                    "account_number": "164"
+                },
+                "Dépôts et cautionnements reçus":{
+                    "Dépôts":{
+                        "account_number": "1651"
+                    },
+                    "Cautionnements":{
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Intérêts courus":{
+                    "Sur emprunts obligataires":{
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes auprès des établissements de crédit":{
+                        "account_number": "1662"
+                    },
+                    "Sur avances reçues de l’État":{
+                        "account_number": "1663"
+                    },
+                    "Sur avances reçues et comptes courants bloqués":{
+                        "account_number": "1664"
+                    },
+                    "Sur dépôts et cautionnements reçus":{
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particulières":{
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes":{
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particulières":{
+                    "Avances bloquées pour augmentation du capital":{
+                        "account_number": "1671"
+                    },
+                    "Avances conditionnées par l’État":{
+                        "account_number": "1672"
+                    },
+                    "Avances conditionnées par les autres organismes africains":{
+                        "account_number": "1673"
+                    },
+                    "Avances conditionnées par les organismes internationaux":{
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes":{
+                    "Rentes viagères capitalisées":{
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds":{
+                        "account_number": "1682"
+                    },
+                    "Dettes consécutives à des titres empruntés":{
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs":{
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux bénéfices":{
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contractés auprès des autres tiers":{
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition":{
+                "Dettes de location acquisition / crédit bail immobilier":{
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / crédit bail mobilier":{
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente":{
+                    "account_number": "174"
+                },
+                "Intérêts courus":{
+                    "Sur dettes de location acquisition / crédit-bail immobilier":{
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / crédit-bail mobilier":{
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente":{
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition":{
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition":{
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes liées à des participations et comptes de liaison des établissements et sociétés en participation":{
+                "Dettes liées à des participations":{
+                    "Dettes liées à des participations (groupe)":{
+                        "account_number": "1811"
+                    },
+                    "Dettes liées à des participations (hors groupe)":{
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes liées à des sociétés en participation":{
+                    "account_number": "182"
+                },
+                "Intérêts courus sur dettes liées à des participations":{
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqués des établissements et succursales":{
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqués des établissements et succursales":{
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges":{
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits":{
+                    "account_number": "187"
+                },
+                "Comptes de liaison des sociétés en participation":{
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges":{
+                "Provisions pour litiges":{
+                    "account_number": "191"
+                },
+                "Provisions pour garanties données aux clients":{
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur marchés à achèvement futur":{
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change":{
+                    "account_number": "194"
+                },
+                "Provisions pour impôts":{
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires":{
+                    "Provisions pour pensions et obligations similaires engagement de retraite":{
+                        "account_number": "1961"
+                    },
+                    "Actif du régime de retraite":{
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration":{
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges":{
+                    "Provisions pour amendes et pénalités":{
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur":{
+                        "account_number": "1983"
+                    },
+                    "Provisions pour démantèlement et remise en état":{
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits à réduction ou avantage en nature (chèques cadeau, cartes de fidélité...)":{
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges":{
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type":"Equity",
+            "account_number": "1"
+        },
+        "Comptes d’actif immobilisé":{
+            "Immobilisations incorporelles":{
+                "account_type":"Fixed Asset",
+                "Frais de développement":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires":{
+                    "account_type":"Fixed Asset",
+                    "Brevets":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet":{
+                    "account_type":"Fixed Asset",
+                    "Logiciels":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de création":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels":{
+                    "account_type":"Fixed Asset",
+                    "Frais de prospection et d’évaluation de ressources minérales":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Coûts d’obtention du contrat":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Coûts des franchises":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours":{
+                    "account_type":"Fixed Asset",
+                    "Frais de développement":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains":{
+                "account_type":"Fixed Asset",
+                "Terrains agricoles et forestiers":{
+                    "account_type":"Fixed Asset",
+                    "Terrains d’exploitation agricole":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d’exploitation forestière":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus":{
+                    "account_type":"Fixed Asset",
+                    "Terrains à bâtir":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains bâtis":{
+                    "account_type":"Fixed Asset",
+                    "Pour bâtiments industriels et agricoles":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour bâtiments administratifs et commerciaux":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour bâtiments affectés aux autres opérations professionnelles":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour bâtiments affectés aux autres opérations non professionnelles":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains bâtis":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains":{
+                    "account_type":"Fixed Asset",
+                    "Plantation d’arbres et d’arbustes":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Améliorations du fonds":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carrières tréfonds":{
+                    "account_type":"Fixed Asset",
+                    "Carrières":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains aménagés":{
+                    "account_type":"Fixed Asset",
+                    "Parkings":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession":{
+                    "account_type":"Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains":{
+                    "account_type":"Fixed Asset",
+                    "Terrains immeubles de placement":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affectés au personnel":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Aménagements de terrains en cours":{
+                    "account_type":"Fixed Asset",
+                    "Terrains agricoles et forestiers":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carrières tréfonds":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains":{
+                        "account_type":"Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "Bâtiments, installations techniques et agencements":{
+                "Bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                    "Bâtiments industriels":{
+                        "account_number": "2311"
+                    },
+                    "Bâtiments agricoles":{
+                        "account_number": "2312"
+                    },
+                    "Bâtiments administratifs et commerciaux":{
+                        "account_number": "2313"
+                    },
+                    "Bâtiments affectés au logement du personnel":{
+                        "account_number": "2314"
+                    },
+                    "Bâtiments immeubles de placement":{
+                        "account_number": "2315"
+                    },
+                    "Bâtiments de location acquisition":{
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "Bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                    "Bâtiments industriels":{
+                        "account_number": "2321"
+                    },
+                    "Bâtiments agricoles":{
+                        "account_number": "2322"
+                    },
+                    "Bâtiments administratifs et commerciaux":{
+                        "account_number": "2323"
+                    },
+                    "Bâtiments affectés au logement du personnel":{
+                        "account_number": "2324"
+                    },
+                    "Bâtiments immeubles de placement":{
+                        "account_number": "2325"
+                    },
+                    "Bâtiments de location acquisition":{
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d’infrastructure":{
+                    "Voies de terre":{
+                        "account_number": "2331"
+                    },
+                    "Voies de fer":{
+                        "account_number": "2332"
+                    },
+                    "Voies d’eau":{
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues":{
+                        "account_number": "2334"
+                    },
+                    "Pistes d’aérodrome":{
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d’infrastructures":{
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Aménagements, agencements et installations techniques":{
+                    "Installations complexes spécialisées sur sol propre":{
+                        "account_number": "2341"
+                    },
+                    "Installations complexes spécialisées sur sol d’autrui":{
+                        "account_number": "2342"
+                    },
+                    "Installations à caractère spécifique sur sol propre":{
+                        "account_number": "2343"
+                    },
+                    "Installations à caractère spécifique sur sol d’autrui":{
+                        "account_number": "2344"
+                    },
+                    "Aménagements et agencements des bâtiments":{
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Aménagements de bureaux":{
+                    "Installations générales":{
+                        "account_number": "2351"
+                    },
+                    "Autres aménagements de bureaux":{
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "Bâtiments industriels, agricoles et commerciaux mis en concession":{
+                    "account_number": "237"
+                },
+                "Autres installations et agencements":{
+                    "account_number": "238"
+                },
+                "Bâtiments aménagements, agencements et installations en cours":{
+                    "Bâtiments en cours":{
+                        "account_number": "2391"
+                    },
+                    "Installations en cours":{
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d’infrastructure en cours":{
+                        "account_number": "2393"
+                    },
+                    "Aménagements et agencements et installations techniques en cours":{
+                        "account_number": "2394"
+                    },
+                    "Aménagements de bureaux en cours":{
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours":{
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Matériel, mobilier et actifs biologiques":{
+                "Matériel et outillage industriel et commercial":{
+                    "Matériel industriel":{
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel":{
+                        "account_number": "2412"
+                    },
+                    "Matériel commercial":{
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial":{
+                        "account_number": "2414"
+                    },
+                    "Matériel & outillage industriel et commercial de location-acquisition":{
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Matériel et outillage agricole":{
+                    "Matériel agricole":{
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole":{
+                        "account_number": "2422"
+                    },
+                    "Matériel & outillage agricole de location-acquisition":{
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Matériel d’emballage récupérable et identifiable":{
+                    "account_number": "243"
+                },
+                "Matériel et mobilier":{
+                    "Matériel de bureau":{
+                        "account_number": "2441"
+                    },
+                    "Matériel informatique":{
+                        "account_number": "2442"
+                    },
+                    "Matériel bureautique":{
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau":{
+                        "account_number": "2444"
+                    },
+                    "Matériel et mobilier immeubles de placement":{
+                        "account_number": "2445"
+                    },
+                    "Matériel et mobilier de location acquisition":{
+                        "account_number": "2446"
+                    },
+                    "Matériel et mobilier des logements du personnel":{
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Matériel de transport":{
+                    "Matériel automobile":{
+                        "account_number": "2451"
+                    },
+                    "Matériel ferroviaire":{
+                        "account_number": "2452"
+                    },
+                    "Matériel fluvial, lagunaire":{
+                        "account_number": "2453"
+                    },
+                    "Matériel naval":{
+                        "account_number": "2454"
+                    },
+                    "Matériel aérien":{
+                        "account_number": "2455"
+                    },
+                    "Matériel de transport de location-acquisition":{
+                        "account_number": "2456"
+                    },
+                    "Matériel hippomobile":{
+                        "account_number": "2457"
+                    },
+                    "Autres matériels de transport":{
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques":{
+                    "Cheptel, animaux de trait":{
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs":{
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde":{
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles":{
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques":{
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, aménagements du matériel et actifs biologiques":{
+                    "Agencements et aménagements du matériel":{
+                        "account_number": "2471"
+                    },
+                    "Agencements et aménagements des actifs biologiques":{
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, aménagements du matériel et actifs biologiques":{
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres matériels et mobiliers":{
+                    "Collections et œuvres d’art":{
+                        "account_number": "2481"
+                    },
+                    "Divers matériels mobiliers":{
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Matériels et actifs biologiques en cours":{
+                    "Matériel et outillage industriel et commercial":{
+                        "account_number": "2491"
+                    },
+                    "Matériel et outillage agricole":{
+                        "account_number": "2492"
+                    },
+                    "Matériel d’emballage récupérable et identifiable":{
+                        "account_number": "2493"
+                    },
+                    "Matériel et mobilier de bureau":{
+                        "account_number": "2494"
+                    },
+                    "Matériel de transport":{
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques":{
+                        "account_number": "2496"
+                    },
+                    "Agencements aménagements du matériel et actifs biologiques":{
+                        "account_number": "2497"
+                    },
+                    "Autres matériels et actifs biologiques en cours":{
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes versés sur immobilisations":{
+                "Avances et acomptes versés sur immobilisations incorporelles":{
+                    "account_number": "251"
+                },
+                "Avances et acomptes versés sur immobilisations corporelles":{
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation":{
+                "Titres de participation dans des sociétés sous contrôle exclusif":{
+                    "account_number": "261"
+                },
+                "Titres de participation dans des sociétés sous contrôle conjoint":{
+                    "account_number": "262"
+                },
+                "Titres de participation dans des sociétés conférant une influence notable":{
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels":{
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d’intérêt économique (GIE)":{
+                    "account_number": "266"
+                },
+                "Autres titres de participation":{
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financières":{
+                "Prêts et créances":{
+                    "Prêts participatifs":{
+                        "account_number": "2711"
+                    },
+                    "Prêts aux associés":{
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds":{
+                        "account_number": "2713"
+                    },
+                    "Titres prêtés":{
+                        "account_number": "2714"
+                    },
+                    "Autres prêts et créances":{
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Prêts au personnel":{
+                    "Prêts immobiliers":{
+                        "account_number": "2721"
+                    },
+                    "Prêts mobiliers et d’installation":{
+                        "account_number": "2722"
+                    },
+                    "Autres prêts au personnel":{
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Créances sur l’État":{
+                    "Retenues de garantie":{
+                        "account_number": "2731"
+                    },
+                    "Fonds réglementé":{
+                        "account_number": "2733"
+                    },
+                    "Créances sur le concédant":{
+                        "account_number": "2734"
+                    },
+                    "Autres créances sur l’État":{
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilisés":{
+                    "Titres immobilisés de l’activité de portefeuille (TIAP)":{
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs":{
+                        "account_number": "2742"
+                    },
+                    "Certificats d’investissement":{
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)":{
+                        "account_number": "2744"
+                    },
+                    "Obligations":{
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres":{
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilisés":{
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "Dépôts et cautionnements versés":{
+                    "Dépôts pour loyers d’avance":{
+                        "account_number": "2751"
+                    },
+                    "Dépôts pour l’électricité":{
+                        "account_number": "2752"
+                    },
+                    "Dépôts pour l’eau":{
+                        "account_number": "2753"
+                    },
+                    "Dépôts pour le gaz":{
+                        "account_number": "2754"
+                    },
+                    "Dépôts pour le téléphone, le télex, la télécopie":{
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur marchés publics":{
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres opérations":{
+                        "account_number": "2757"
+                    },
+                    "Autres dépôts et cautionnements":{
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Intérêts courus":{
+                    "Prêts et créances non commerciales":{
+                        "account_number": "2761"
+                    },
+                    "Prêts au personnel":{
+                        "account_number": "2762"
+                    },
+                    "Créances sur l’État":{
+                        "account_number": "2763"
+                    },
+                    "Titres immobilisés":{
+                        "account_number": "2764"
+                    },
+                    "Dépôts et cautionnements versés":{
+                        "account_number": "2765"
+                    },
+                    "Créances rattachées à des participations":{
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financières diverses":{
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Créances rattachées à des participations et avances à des GIE":{
+                    "Créances rattachées à des participations (groupe)":{
+                        "account_number": "2771"
+                    },
+                    "Créances rattachées à des participations (hors groupe)":{
+                        "account_number": "2772"
+                    },
+                    "Créances rattachées à des sociétés en participation":{
+                        "account_number": "2773"
+                    },
+                    "Avances à des Groupements d’intérêt économique (GIE)":{
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financières diverses":{
+                    "Créances diverses groupe":{
+                        "account_number": "2781"
+                    },
+                    "Créances diverses hors groupe":{
+                        "account_number": "2782"
+                    },
+                    "Banques dépôts à terme":{
+                        "account_number": "2784"
+                    },
+                    "Or et métaux précieux":{
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financières":{
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements":{
+                "account_type":"Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles":{
+                    "account_type":"Accumulated Depreciation",
+                    "Amortissements des frais de développement":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de création":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels":{
+                        "account_type":"Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains":{
+                    "Amortissements des travaux de mise en valeur des terrains":{
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des bâtiments, installations techniques et agencements":{
+                    "Amortissements des bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                        "account_number": "2831"
+                    },
+                    "Amortissements des bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d’infrastructure":{
+                        "account_number": "2833"
+                    },
+                    "Amortissements des aménagements, agencements et installations techniques":{
+                        "account_number": "2834"
+                    },
+                    "Amortissements des aménagements de bureaux":{
+                        "account_number": "2835"
+                    },
+                    "Amortissements des bâtiments industriels, agricoles et commerciaux mis en concession":{
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements":{
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du matériel":{
+                    "Amortissements du matériel et outillage industriel et commercial":{
+                        "account_number": "2841"
+                    },
+                    "Amortissements du matériel et outillage agricole":{
+                        "account_number": "2842"
+                    },
+                    "Amortissements du matériel d’emballage récupérable et identifiable":{
+                        "account_number": "2843"
+                    },
+                    "Amortissements du matériel et mobilier":{
+                        "account_number": "2844"
+                    },
+                    "Amortissements du matériel de transport":{
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques":{
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et aménagements du matériel et des actifs biologiques":{
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres matériels":{
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "Dépréciations des immobilisations":{
+                "Dépréciations des immobilisations incorporelles":{
+                    "Dépréciations des frais de développement":{
+                        "account_number": "2911"
+                    },
+                    "Dépréciations des brevets, licences, concessions et droits similaires":{
+                        "account_number": "2912"
+                    },
+                    "Dépréciations des logiciels et sites internet":{
+                        "account_number": "2913"
+                    },
+                    "Dépréciations des marques":{
+                        "account_number": "2914"
+                    },
+                    "Dépréciations du fonds commercial":{
+                        "account_number": "2915"
+                    },
+                    "Dépréciations du droit au bail":{
+                        "account_number": "2916"
+                    },
+                    "Dépréciations des investissements de création":{
+                        "account_number": "2917"
+                    },
+                    "Dépréciations des autres droits et valeurs incorporels":{
+                        "account_number": "2918"
+                    },
+                    "Dépréciations des immobilisations incorporelles en cours":{
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "Dépréciations des terrains":{
+                    "Dépréciations des terrains agricoles et forestiers":{
+                        "account_number": "2921"
+                    },
+                    "Dépréciations des terrains nus":{
+                        "account_number": "2922"
+                    },
+                    "Dépréciations des terrains bâtis":{
+                        "account_number": "2923"
+                    },
+                    "Dépréciations des travaux de mise en valeur des terrains":{
+                        "account_number": "2924"
+                    },
+                    "Dépréciations des terrains de gisement":{
+                        "account_number": "2925"
+                    },
+                    "Dépréciations des terrains aménagés":{
+                        "account_number": "2926"
+                    },
+                    "Dépréciations des terrains mis en concession":{
+                        "account_number": "2927"
+                    },
+                    "Dépréciations des autres terrains":{
+                        "account_number": "2928"
+                    },
+                    "Dépréciations des aménagements de terrains en cours":{
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "Dépréciations des bâtiments, installations techniques et agencements":{
+                    "Dépréciations des bâtiments industriels, agricoles, administratifs et commerciaux sur sol propre":{
+                        "account_number": "2931"
+                    },
+                    "Dépréciations des bâtiments industriels, agricoles, administratifs et commerciaux sur sol d’autrui":{
+                        "account_number": "2932"
+                    },
+                    "Dépréciations des ouvrages d’infrastructures":{
+                        "account_number": "2933"
+                    },
+                    "Dépréciations des aménagements, agencements et installations techniques":{
+                        "account_number": "2934"
+                    },
+                    "Dépréciations des aménagements de bureaux":{
+                        "account_number": "2935"
+                    },
+                    "Dépréciations des bâtiments industriels, agricoles et commerciaux mis en concession":{
+                        "account_number": "2937"
+                    },
+                    "Dépréciations des autres installations et agencements":{
+                        "account_number": "2938"
+                    },
+                    "Dépréciations des bâtiments et installations en cours":{
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "Dépréciations de matériel, du mobilier et de l’actif biologique":{
+                    "Dépréciations du matériel et outillage industriel et commercial":{
+                        "account_number": "2941"
+                    },
+                    "Dépréciations du matériel et outillage agricole":{
+                        "account_number": "2942"
+                    },
+                    "Dépréciations du matériel d’emballage récupérable et identifiable":{
+                        "account_number": "2943"
+                    },
+                    "Dépréciations du matériel et mobilier":{
+                        "account_number": "2944"
+                    },
+                    "Dépréciations du matériel de transport":{
+                        "account_number": "2945"
+                    },
+                    "Dépréciations des actifs biologiques":{
+                        "account_number": "2946"
+                    },
+                    "Dépréciations des agencements et aménagements du matériel et des actifs biologiques":{
+                        "account_number": "2947"
+                    },
+                    "Dépréciations des autres matériels":{
+                        "account_number": "2948"
+                    },
+                    "Dépréciations de matériel en cours":{
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "Dépréciations des avances et acomptes versés sur immobilisations":{
+                    "Dépréciations des avances et acomptes versés sur immobilisations incorporelles":{
+                        "account_number": "2951"
+                    },
+                    "Dépréciations des avances et acomptes versés sur immobilisations corporelles":{
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "Dépréciations des titres de participation":{
+                    "Dépréciations des titres de participation dans des sociétés sous contrôle exclusif":{
+                        "account_number": "2961"
+                    },
+                    "Dépréciations des titres de participation dans les sociétés sous contrôle conjoint":{
+                        "account_number": "2962"
+                    },
+                    "Dépréciations des titres de participation dans les sociétés conférant une influence notable":{
+                        "account_number": "2963"
+                    },
+                    "Dépréciations des participations dans des organismes professionnels":{
+                        "account_number": "2965"
+                    },
+                    "Dépréciations des parts dans des GIE":{
+                        "account_number": "2966"
+                    },
+                    "Dépréciations des autres titres de participation":{
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "Dépréciations des autres immobilisations financières":{
+                    "Dépréciations des prêts et créances":{
+                        "account_number": "2971"
+                    },
+                    "Dépréciations des prêts au personnel":{
+                        "account_number": "2972"
+                    },
+                    "Dépréciations des créances sur l’État":{
+                        "account_number": "2973"
+                    },
+                    "Dépréciations des titres immobilisés":{
+                        "account_number": "2974"
+                    },
+                    "Dépréciations des dépôts et cautionnements versés":{
+                        "account_number": "2975"
+                    },
+                    "Dépréciations des créances rattachées à des participations et avances à des GIE":{
+                        "account_number": "2977"
+                    },
+                    "Dépréciations des créances financières diverses":{
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type":"Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks":{
+            "Marchandises":{
+                "Marchandises A":{
+                    "Marchandises A1":{
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2":{
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B":{
+                    "Marchandises B1":{
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2":{
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques":{
+                    "Animaux":{
+                        "account_number": "3131"
+                    },
+                    "Végétaux":{
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activités ordinaires (HAO)":{
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Matières premières et fournitures liées":{
+                "Matières A":{
+                    "account_number": "321"
+                },
+                "Matières B":{
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)":{
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements":{
+                "Matières consommables":{
+                    "account_number": "331"
+                },
+                "Fournitures d’atelier et d’usine":{
+                    "account_number": "332"
+                },
+                "Fournitures de magasin":{
+                    "account_number": "333"
+                },
+                "Fournitures de bureau":{
+                    "account_number": "334"
+                },
+                "Emballages":{
+                    "Emballages perdus":{
+                        "account_number": "3351"
+                    },
+                    "Emballages récupérables non identifiables":{
+                        "account_number": "3352"
+                    },
+                    "Emballages à usage mixte":{
+                        "account_number": "3353"
+                    },
+                    "Autres emballages":{
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres matières":{
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours":{
+                "Produits en cours":{
+                    "Produits en cours P1":{
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2":{
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours":{
+                    "Travaux en cours T1":{
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2":{
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits intermédiaires en cours":{
+                    "Produits intermédiaires A":{
+                        "account_number": "3431"
+                    },
+                    "Produits intermédiaires B":{
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits résiduels en cours":{
+                    "Produits résiduels A":{
+                        "account_number": "3441"
+                    },
+                    "Produits résiduels B":{
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours":{
+                    "Animaux":{
+                        "account_number": "3451"
+                    },
+                    "Végétaux":{
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours":{
+                "Études en cours":{
+                    "Études en cours E1":{
+                        "account_number": "3511"
+                    },
+                    "Études en cours E2":{
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours":{
+                    "Prestations de services S1":{
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2":{
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis":{
+                "Produits finis A":{
+                    "account_number": "361"
+                },
+                "Produits finis B":{
+                    "account_number": "362"
+                },
+                "Actifs biologiques":{
+                    "Animaux":{
+                        "account_number": "3631"
+                    },
+                    "Végétaux":{
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activités annexes)":{
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits intermédiaires et résiduels":{
+                "Produits intermédiaires":{
+                    "Produits intermédiaires A":{
+                        "account_number": "3711"
+                    },
+                    "Produits intermédiaires B":{
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits résiduels":{
+                    "Déchets":{
+                        "account_number": "3721"
+                    },
+                    "Rebuts":{
+                        "account_number": "3722"
+                    },
+                    "Matières de Récupération":{
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques":{
+                    "Animaux":{
+                        "account_number": "3731"
+                    },
+                    "Végétaux":{
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activités annexes)":{
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en dépôt":{
+                "account_type":"Stock",
+                "Marchandises en cours de route":{
+                    "account_number": "381"
+                },
+                "Matières premières et fournitures liées en cours de route":{
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route":{
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route":{
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en dépôt":{
+                    "Stock en consignation":{
+                        "account_number": "3871"
+                    },
+                    "Stock en dépôt":{
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d’immobilisations mises hors service ou au rebut":{
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "Dépréciations des stocks et encours de production":{
+                "Dépréciations des stocks de marchandises":{
+                    "account_number": "391"
+                },
+                "Dépréciations des stocks de matières premières et fournitures liées":{
+                    "account_number": "392"
+                },
+                "Dépréciations des stocks d’autres approvisionnements":{
+                    "account_number": "393"
+                },
+                "Dépréciations des productions en cours":{
+                    "account_number": "394"
+                },
+                "Dépréciations des services en cours":{
+                    "account_number": "395"
+                },
+                "Dépréciations des stocks de produits finis":{
+                    "account_number": "396"
+                },
+                "Dépréciations des stocks de produits intermédiaires et résiduels":{
+                    "account_number": "397"
+                },
+                "Dépréciations des stocks en cours de route, en consignation ou en dépôt":{
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type":"Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)":{
+            "40-Fournisseurs et comptes rattachés (ACTIF)":{
+                "Fournisseurs débiteurs":{
+                    "Fournisseurs Avances et acomptes versés":{
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes versés":{
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes versés":{
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Créances pour emballages et matériels à rendre":{
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs à obtenir":{
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattachés (ACTIF)":{
+                "Clients":{
+                    "Clients":{
+                        "account_type":"Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe":{
+                        "account_type":"Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, État et Collectivités publiques":{
+                        "account_type":"Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux":{
+                        "account_type":"Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, réserve de propriété":{
+                        "account_type":"Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie":{
+                        "account_type":"Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, dégrèvement de taxes sur la valeur ajoutée (TVA)":{
+                        "account_type":"Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets à recevoir en portefeuille":{
+                    "Clients, effets à recevoir":{
+                        "account_type":"Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets à recevoir":{
+                        "account_type":"Receivable",
+                        "account_number": "4122"
+                    },
+                    "État et Collectivités publiques, effets à recevoir":{
+                        "account_type":"Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets à recevoir":{
+                        "account_type":"Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "412"
+                },
+                "Clients, chèques, effets et autres valeurs impayées":{
+                    "Clients, chèques impayés":{
+                        "account_type":"Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impayés":{
+                        "account_type":"Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de crédit impayées":{
+                        "account_type":"Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impayées":{
+                        "account_type":"Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "413"
+                },
+                "Créances sur cessions courantes d’immobilisations":{
+                    "Créances en compte, immobilisations incorporelles":{
+                        "account_type":"Receivable",
+                        "account_number": "4141"
+                    },
+                    "Créances en compte, immobilisations corporelles":{
+                        "account_type":"Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets à recevoir, immobilisations incorporelles":{
+                        "account_type":"Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets à recevoir, immobilisations corporelles":{
+                        "account_type":"Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escomptés non échus":{
+                    "account_type":"Receivable",
+                    "account_number": "415"
+                },
+                "Créances clients litigieuses ou douteuses":{
+                    "Créances litigieuses":{
+                        "account_type":"Receivable",
+                        "account_number": "4161"
+                    },
+                    "Créances douteuses":{
+                        "account_type":"Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits à recevoir":{
+                    "Clients, factures à établir":{
+                        "account_type":"Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, intérêts courus":{
+                        "account_type":"Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type":"Receivable",
+                    "account_number": "418"
+                },
+                "account_type":"Receivable"
+            },
+            "42-Personnel (ACTIF)":{
+                "Personnel, avances et acomptes":{
+                    "Personnel, avances":{
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes":{
+                        "account_number": "4212"
+                    },
+                    "Frais avancés et fournitures au personnel":{
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)":{
+                "431-Sécurité sociale":{
+                    "Prestations familiales":{
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail":{
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire":{
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative":{
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales":{
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite complémentaire":{
+                },
+                "433-Autres organismes sociaux":{
+                    "Mutuelle":{
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite":{
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de santé":{
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges à payer et produits à recevoir":{
+                    "Produits à recevoir":{
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-État et collectivités publiques (ACTIF)":{
+                "État, TVA facturée":{
+                    "TVA facturée sur ventes":{
+                        "account_number": "4431"
+                    },
+                    "TVA facturée sur prestations de services":{
+                        "account_number": "4432"
+                    },
+                    "TVA facturée sur travaux":{
+                        "account_number": "4433"
+                    },
+                    "TVA facturée sur production livrée à soi-même":{
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures à établir":{
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "État, TVA récupérable":{
+                    "TVA récupérable sur immobilisations":{
+                        "account_number": "4451"
+                    },
+                    "TVA récupérable sur achats":{
+                        "account_number": "4452"
+                    },
+                    "TVA récupérable sur transport":{
+                        "account_number": "4453"
+                    },
+                    "TVA récupérable sur services extérieurs et autres charges":{
+                        "account_number": "4454"
+                    },
+                    "TVA récupérable sur factures non parvenues":{
+                        "account_number": "4455"
+                    },
+                    "TVA transférée par d’autres entités":{
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "État, charges à payer et produits à recevoir":{
+                    "Charges à payer":{
+                        "account_number": "4486"
+                    },
+                    "Produits à recevoir":{
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "État, créances et dettes diverses":{
+                    "État, obligations cautionnées":{
+                        "account_number": "4491"
+                    },
+                    "État, avances et acomptes versés sur impôts":{
+                        "account_number": "4492"
+                    },
+                    "État, fonds de dotation à recevoir":{
+                        "account_number": "4493"
+                    },
+                    "État, subventions investissement à recevoir":{
+                        "account_number": "4494"
+                    },
+                    "État, subventions d’exploitation à recevoir":{
+                        "account_number": "4495"
+                    },
+                    "État, subventions d’équilibre à recevoir":{
+                        "account_number": "4496"
+                    },
+                    "État, avances sur subventions":{
+                        "account_number": "4497"
+                    },
+                    "État, fonds réglementés provisionnés":{
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)":{
+                "Opérations avec les organismes africains":{
+                    "account_number": "451"
+                },
+                "Opérations avec les autres organismes internationaux":{
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions à recevoir":{
+                    "Organismes internationaux, fonds de dotation à recevoir":{
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions à recevoir":{
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associés et groupe (ACTIF)":{
+                "461-Apporteurs, opérations sur le capital":{
+                    "Apporteurs, capital appelé, non versé":{
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d’apport, opérations de restructuration (fusion...)":{
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres à échanger":{
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant dû sur capital appelé":{
+                    "account_number": "467"
+                }
+            },
+            "47-Débiteurs et créditeurs divers (ACTIF)":{
+                "472-Créances et dettes sur titres de placement":{
+                    "Créances sur cessions de titres de placement":{
+                        "account_number": "4721"
+                    },
+                    "Versements restant à effectuer sur titres de placement non libérés":{
+                        "account_number": "4726"
+                    }
+                },
+                "473-Intermédiaires Opérations faites pour compte de tiers":{
+                    "Mandants":{
+                        "account_number": "4731"
+                    },
+                    "Mandataires":{
+                        "account_number": "4732"
+                    },
+                    "Commettants":{
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires":{
+                        "account_number": "4734"
+                    },
+                    "État, Collectivités publiques, fonds global d’allocation":{
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de répartition périodique des charges et des produits":{
+                    "Compte de répartition périodique des produits":{
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement spécial lié à la révision du SYSCOHADA":{
+                    "Compte actif":{
+                        "account_type":"Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constatées d’avance":{
+                    "account_number": "476"
+                },
+                "478-Écarts de conversion actif":{
+                    "Diminution des créances d’exploitation":{
+                        "account_number": "4781"
+                    },
+                    "Diminution des créances financières":{
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d’exploitation":{
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financières":{
+                        "account_number": "4784"
+                    },
+                    "Différences d’évaluation sur instruments de trésorerie":{
+                        "account_number": "4786"
+                    },
+                    "Différences compensées par couverture de change":{
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Créances et dettes hors activités ordinaires (ACTIF)":{
+                "Créances sur cessions d’immobilisations":{
+                    "En compte, immobilisations incorporelles":{
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles":{
+                        "account_number": "4852"
+                    },
+                    "Effets à recevoir, immobilisations incorporelles":{
+                        "account_number": "4853"
+                    },
+                    "Effets à recevoir, immobilisations corporelles":{
+                        "account_number": "4854"
+                    },
+                    "Effets escomptés non échus":{
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie":{
+                        "account_number": "4857"
+                    },
+                    "Factures à établir":{
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres créances hors activités ordinaires (HAO)":{
+                    "account_number": "488"
+                }
+            },
+            "49-Dépréciations et provisions pour risques à court terme (tiers) (ACTIF)":{
+                "Dépréciations des comptes clients":{
+                    "Créances litigieuses":{
+                        "account_number": "4911"
+                    },
+                    "Créances douteuses":{
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "Dépréciations des comptes organismes internationaux":{
+                    "account_number": "495"
+                },
+                "Dépréciations des comptes apporteurs, associés et groupe":{
+                    "Associés, comptes courants":{
+                        "account_number": "4962"
+                    },
+                    "Associés, opérations faites en commun":{
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants":{
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "Dépréciations des comptes débiteurs divers":{
+                    "account_number": "497"
+                },
+                "Dépréciations des comptes de créances HAO":{
+                    "Créances sur cessions d’immobilisations":{
+                        "account_number": "4985"
+                    },
+                    "Créances sur cessions de titres de placement":{
+                        "account_number": "4986"
+                    },
+                    "Autres créances HAO":{
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques à court terme":{
+                    "Sur opérations d’exploitation":{
+                        "account_number": "4991"
+                    },
+                    "Sur opérations financières":{
+                        "account_number": "4997"
+                    },
+                    "Sur opérations HAO":{
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type":"Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)":{
+            "40-Fournisseurs et comptes rattachés (PASSIF)":{
+                "Fournisseurs, dettes en compte":{
+                    "Fournisseurs":{
+                        "account_type":"Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe":{
+                        "account_type":"Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants":{
+                        "account_type":"Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, réserve de propriété":{
+                        "account_type":"Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie":{
+                        "account_type":"Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type":"Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets à payer":{
+                    "Fournisseurs Effets à payer":{
+                        "account_type":"Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets à payer":{
+                        "account_type":"Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets à payer":{
+                        "account_type":"Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type":"Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d’immobilisations":{
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles":{
+                        "account_type":"Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles":{
+                        "account_type":"Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets à payer, immobilisations incorporelles":{
+                        "account_type":"Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets à payer, immobilisations corporelles":{
+                        "account_type":"Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type":"Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues":{
+                    "Fournisseurs":{
+                        "account_type":"Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe":{
+                        "account_type":"Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants":{
+                        "account_type":"Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, intérêts courus":{
+                        "account_type":"Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type":"Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type":"Payable"
+            },
+            "41-Clients et comptes rattachés (PASSIF)":{
+                "Clients créditeurs":{
+                    "Clients, avances et acomptes reçus":{
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes reçus":{
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et matériels consignés":{
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs à accorder":{
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)":{
+                "Personnel, rémunérations dues":{
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arrêts":{
+                    "Personnel, oppositions":{
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arrêts":{
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis à tiers détenteur":{
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, œuvres sociales internes":{
+                    "Assistance médicale":{
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales":{
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattachés à l’entité":{
+                        "account_number": "4245"
+                    },
+                    "Autres œuvres sociales internes":{
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Représentants du personnel":{
+                    "Délégués du personnel":{
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comités d’entreprises, d’Établissement":{
+                        "account_number": "4252"
+                    },
+                    "Autres représentants du personnel":{
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux bénéfices et au capital":{
+                    "Participation aux bénéfices":{
+                        "account_number": "4261"
+                    },
+                    "Participation au capital":{
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel dépôts":{
+                    "account_number": "427"
+                },
+                "Personnel, charges à payer et produits à recevoir":{
+                    "Dettes provisionnées pour congés à payer":{
+                        "account_number": "4281"
+                    },
+                    "Autres charges à payer":{
+                        "account_number": "4286"
+                    },
+                    "Produits à recevoir":{
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)":{
+                "438-Organismes sociaux, charges à payer et produits à recevoir":{
+                    "Charges sociales sur gratifications à payer":{
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur congés à payer":{
+                        "account_number": "4382"
+                    },
+                    "Autres charges à payer":{
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-État et collectivités publiques (PASSIF)":{
+                "État, impôt sur les bénéfices":{
+                    "account_number": "441"
+                },
+                "État, autres impôts et taxes":{
+                    "Impôts et taxes d’État":{
+                        "account_number": "4421"
+                    },
+                    "Impôts et taxes pour les collectivités publiques":{
+                        "account_number": "4422"
+                    },
+                    "Impôts et taxes recouvrables sur des obligataires":{
+                        "account_number": "4423"
+                    },
+                    "Impôts et taxes recouvrables sur des associés":{
+                        "account_number": "4424"
+                    },
+                    "Droits de douane":{
+                        "account_number": "4426"
+                    },
+                    "Autres impôts et taxes":{
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "État, TVA due ou crédit de TVA":{
+                    "État, TVA due":{
+                        "account_number": "4441"
+                    },
+                    "État, crédit de TVA à reporter":{
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "État, autres taxes sur le chiffre d’affaires":{
+                    "account_number": "446"
+                },
+                "État, impôts retenus à la source":{
+                    "Impôt Général sur le revenu":{
+                        "account_number": "4471"
+                    },
+                    "Impôts sur salaires":{
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale":{
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarité":{
+                        "account_number": "4474"
+                    },
+                    "Autres impôts et contributions":{
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associés et groupe (PASSIF)":{
+                "461-Apporteurs, opérations sur le capital (PASSIF)":{
+                    "Apporteurs, apports en nature":{
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en numéraire":{
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements reçus sur augmentation de capital":{
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticipés":{
+                        "account_number": "4616"
+                    },
+                    "Apporteurs défaillants":{
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital à rembourser":{
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associés, comptes courants":{
+                    "Principal":{
+                        "account_number": "4621"
+                    },
+                    "Intérêts courus":{
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associés, opérations faites en commun et GIE":{
+                    "Opérations courantes":{
+                        "account_number": "4631"
+                    },
+                    "Intérêts courus":{
+                        "account_number": "4636"
+                    }
+                },
+                "Associés, dividendes à payer":{
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants":{
+                    "account_number": "466"
+                }
+            },
+            "47-Débiteurs et créditeurs divers (PASSIF)":{
+                "471-Débiteurs et créditeurs divers":{
+                    "Débiteurs divers":{
+                        "account_number": "4711"
+                    },
+                    "Créditeurs divers":{
+                        "account_number": "4712"
+                    },
+                    "Obligataires":{
+                        "account_number": "4713"
+                    },
+                    "Rémunérations d’administrateurs":{
+                        "account_number": "4715"
+                    },
+                    "Compte d’affacturage":{
+                        "account_number": "4716"
+                    },
+                    "Débiteurs divers retenues de garantie":{
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et opérations assimilées":{
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d’actions et d’obligations":{
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de répartition périodique des charges et des produits (PASSIF)":{
+                    "Compte de répartition périodique des charges":{
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement spécial lié à la révision du SYSCOHADA (PASSIF)":{
+                    "Compte passif":{
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constatés d’avance":{
+                    "account_number": "477"
+                },
+                "479-Écarts de conversion passif":{
+                    "Augmentation des créances d’exploitation":{
+                        "account_number": "4791"
+                    },
+                    "Augmentation des créances financières":{
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d’exploitation":{
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financières":{
+                        "account_number": "4794"
+                    },
+                    "Différences d’évaluation sur instruments de trésorerie":{
+                        "account_number": "4797"
+                    },
+                    "Différences compensées par couverture de change":{
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Créances et dettes hors activités ordinaires (HAO) (PASSIF)":{
+                "Fournisseurs d’investissements":{
+                    "Immobilisations incorporelles":{
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles":{
+                        "account_number": "4812"
+                    },
+                    "Versements restant à effectuer sur titres de participation et titres immobilisés non libérés":{
+                        "account_number": "4813"
+                    },
+                    "Réserve de propriété":{
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie":{
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues":{
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d’investissements, effets à payer":{
+                    "Immobilisations incorporelles":{
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles":{
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activités ordinaires (HAO)":{
+                    "Produits":{
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type":"Liability"
+        },
+        "Comptes de trésorerie":{
+            "Titres de placement":{
+                "Titres du trésor et bons de caisse à court terme":{
+                    "Titres du Trésor à court terme":{
+                        "account_number": "5011"
+                    },
+                    "Titres d’organismes financiers":{
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse à court terme":{
+                        "account_number": "5013"
+                    },
+                    "Frais d’acquisition des titres de trésor et bons de caisse":{
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions":{
+                    "Actions ou parts propres":{
+                        "account_number": "5021"
+                    },
+                    "Actions cotées":{
+                        "account_number": "5022"
+                    },
+                    "Actions non cotées":{
+                        "account_number": "5023"
+                    },
+                    "Actions démembrées (certificats d’investissement, droits de vote)":{
+                        "account_number": "5024"
+                    },
+                    "Autres actions":{
+                        "account_number": "5025"
+                    },
+                    "Frais d’acquisition des actions":{
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations":{
+                    "Obligations émises par la société et rachetées par elle":{
+                        "account_number": "5031"
+                    },
+                    "Obligations cotées":{
+                        "account_number": "5032"
+                    },
+                    "Obligations non cotées":{
+                        "account_number": "5033"
+                    },
+                    "Autres obligations":{
+                        "account_number": "5035"
+                    },
+                    "Frais d’acquisition des obligations":{
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription":{
+                    "Bons de souscription d’actions":{
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d’obligations":{
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres négociables hors région":{
+                    "account_number": "505"
+                },
+                "Intérêts courus":{
+                    "Titres du Trésor et bons de caisse à court terme":{
+                        "account_number": "5061"
+                    },
+                    "Actions":{
+                        "account_number": "5062"
+                    },
+                    "Obligations":{
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et créances assimilées":{
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs à encaisser":{
+                "Effets à encaisser":{
+                    "account_number": "511"
+                },
+                "Effets à l’encaissement":{
+                    "account_number": "512"
+                },
+                "Chèques à encaisser":{
+                    "account_number": "513"
+                },
+                "Chèques à l’encaissement":{
+                    "account_number": "514"
+                },
+                "Cartes de crédit à encaisser":{
+                    "account_number": "515"
+                },
+                "Autres valeurs à l’encaissement":{
+                    "Warrants":{
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds":{
+                        "account_number": "5182"
+                    },
+                    "Chèques de voyage":{
+                        "account_number": "5185"
+                    },
+                    "Coupons échus":{
+                        "account_number": "5186"
+                    },
+                    "Intérêts échus des obligations":{
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques":{
+                "Banques locales":{
+                    "Banques en monnaie nationale":{
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises":{
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres États région":{
+                    "account_number": "522"
+                },
+                "Banques autres États zone monétaire":{
+                    "account_number": "523"
+                },
+                "Banques hors zone monétaire":{
+                    "account_number": "524"
+                },
+                "Banques dépôt à terme":{
+                    "account_number": "525"
+                },
+                "Banques, intérêts courus":{
+                    "Banque, intérêts courus, charges à payer":{
+                        "account_number": "5261"
+                    },
+                    "Banque, intérêts courus, produits à recevoir":{
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "Établissements financiers et assimilés":{
+                "Chèques postaux":{
+                    "account_number": "531"
+                },
+                "Trésor":{
+                    "account_number": "532"
+                },
+                "Sociétés de gestion et d’intermédiation (SGI)":{
+                    "account_number": "533"
+                },
+                "Établissements financiers, intérêts courus":{
+                    "account_number": "536"
+                },
+                "Autres organismes financiers":{
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de trésorerie":{
+                "Options de taux d’intérêt":{
+                    "account_number": "541"
+                },
+                "Options de taux de change":{
+                    "account_number": "542"
+                },
+                "Options de taux boursiers":{
+                    "account_number": "543"
+                },
+                "Instruments de marchés à terme":{
+                    "account_number": "544"
+                },
+                "Avoirs d’or et autres métaux précieux":{
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie électronique":{
+                "Monnaie électronique carte carburant":{
+                    "account_number": "551"
+                },
+                "Monnaie électronique téléphone portable":{
+                    "account_number": "552"
+                },
+                "Monnaie électronique carte péage":{
+                    "account_number": "553"
+                },
+                "Porte-monnaie électronique":{
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies électroniques":{
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, crédits de trésorerie et d’escompte":{
+                "Crédits de trésorerie":{
+                    "account_number": "561"
+                },
+                "Escompte de crédits de campagne":{
+                    "account_number": "564"
+                },
+                "Escompte de crédits ordinaires":{
+                    "account_number": "565"
+                },
+                "Banques, crédits de trésorerie, intérêts courus":{
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse":{
+                "Caisse siège social":{
+                    "Caisse en monnaie nationale":{
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises":{
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A":{
+                    "En monnaie nationale":{
+                        "account_number": "5721"
+                    },
+                    "En devises":{
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B":{
+                    "En monnaie nationale":{
+                        "account_number": "5731"
+                    },
+                    "En devises":{
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "Régies d’avances, accréditifs et virements internes":{
+                "Régies d’avance":{
+                    "account_number": "581"
+                },
+                "Accréditifs":{
+                    "account_number": "582"
+                },
+                "Virements de fonds":{
+                    "account_number": "585"
+                },
+                "Autres virements internes":{
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "Dépréciations et provisions pour risque à court terme":{
+                "Dépréciations des titres de placement":{
+                    "account_number": "590"
+                },
+                "Dépréciations des titres et valeurs à encaisser":{
+                    "account_number": "591"
+                },
+                "Dépréciations des comptes banques":{
+                    "account_number": "592"
+                },
+                "Dépréciations des comptes établissements financiers et assimilés":{
+                    "account_number": "593"
+                },
+                "Dépréciations des comptes d’instruments de trésorerie":{
+                    "account_number": "594"
+                },
+                "Provisions pour risque à court terme à caractère financier":{
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type":"Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activités ordinaires":{
+            "Achats et variations de stocks":{
+                "Achats de marchandises":{
+                    "Dans la Région":{
+                        "account_number": "6011"
+                    },
+                    "Hors Région":{
+                        "account_number": "6012"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "6013"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats":{
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventilés)":{
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de matières premières et fournitures liées":{
+                    "Dans la Région":{
+                        "account_number": "6021"
+                    },
+                    "Hors Région":{
+                        "account_number": "6022"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "6023"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats":{
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventilés)":{
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achetés":{
+                    "Variations des stocks de marchandises":{
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de matières premières et fournitures liées":{
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d’autres approvisionnements":{
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stockés de matières et fournitures consommables":{
+                    "Matières consommables":{
+                        "account_number": "6041"
+                    },
+                    "Matières combustibles":{
+                        "account_number": "6042"
+                    },
+                    "Produits d’entretien":{
+                        "account_number": "6043"
+                    },
+                    "Fournitures d’atelier et d’usine":{
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat":{
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin":{
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau":{
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventilés)":{
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats":{
+                    "Fournitures non stockables Eau":{
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables Électricité":{
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres énergies":{
+                        "account_number": "6053"
+                    },
+                    "Fournitures d’entretien non stockables":{
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables":{
+                        "account_number": "6055"
+                    },
+                    "Achats de petit matériel et outillage":{
+                        "account_number": "6056"
+                    },
+                    "Achats d’études et prestations de services":{
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, matériels et équipements":{
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventilés)":{
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d’emballages":{
+                    "Emballages perdus":{
+                        "account_number": "6081"
+                    },
+                    "Emballages récupérables non identifiables":{
+                        "account_number": "6082"
+                    },
+                    "Emballages à usage mixte":{
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats":{
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventilés)":{
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports":{
+                "Transports sur ventes":{
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers":{
+                    "account_number": "613"
+                },
+                "Transports du personnel":{
+                    "account_number": "614"
+                },
+                "Transports de plis":{
+                    "account_number": "616"
+                },
+                "Autres frais de transport":{
+                    "Voyages et déplacements":{
+                        "account_number": "6181"
+                    },
+                    "Transports entre établissements ou chantiers":{
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs":{
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services extérieurs":{
+                "Sous-traitance générale":{
+                    "account_number": "621"
+                },
+                "Locations, charges locatives":{
+                    "Locations de terrains":{
+                        "account_number": "6221"
+                    },
+                    "Locations de bâtiments":{
+                        "account_number": "6222"
+                    },
+                    "Locations de matériels et outillages":{
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages":{
+                        "account_number": "6224"
+                    },
+                    "Locations d’emballages":{
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier":{
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses":{
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition":{
+                    "Crédit-bail immobilier":{
+                        "account_number": "6232"
+                    },
+                    "Crédit-bail mobilier":{
+                        "account_number": "6233"
+                    },
+                    "Location-vente":{
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition":{
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, réparations, remise en état et maintenance":{
+                    "Entretien et réparations des biens immobiliers":{
+                        "account_number": "6241"
+                    },
+                    "Entretien et réparations des biens mobiliers":{
+                        "account_number": "6242"
+                    },
+                    "Maintenance":{
+                        "account_number": "6243"
+                    },
+                    "Charges de démantèlement et remise en état":{
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et réparations":{
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d’assurance":{
+                    "Assurances multirisques":{
+                        "account_number": "6251"
+                    },
+                    "Assurances matériel de transport":{
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d’exploitation":{
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilité du producteur":{
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilité clients":{
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes":{
+                        "account_number": "6257"
+                    },
+                    "Autres primes d’assurances":{
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "Études, recherches et documentation":{
+                    "Études et recherches":{
+                        "account_number": "6261"
+                    },
+                    "Documentation générale":{
+                        "account_number": "6265"
+                    },
+                    "Documentation technique":{
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicité, publications, relations publiques":{
+                    "Annonces, insertions":{
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprimés publicitaires":{
+                        "account_number": "6272"
+                    },
+                    "Échantillons":{
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions":{
+                        "account_number": "6274"
+                    },
+                    "Publications":{
+                        "account_number": "6275"
+                    },
+                    "Cadeaux à la clientèle":{
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, séminaires, conférences":{
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicité et relations publiques":{
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de télécommunications":{
+                    "Frais de téléphone":{
+                        "account_number": "6281"
+                    },
+                    "Frais de télex":{
+                        "account_number": "6282"
+                    },
+                    "Frais de télécopie":{
+                        "account_number": "6283"
+                    },
+                    "Autres frais de télécommunications":{
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services extérieurs":{
+                "Frais bancaires":{
+                    "Frais sur titres (vente, garde)":{
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets":{
+                        "account_number": "6312"
+                    },
+                    "Location de coffres":{
+                        "account_number": "6313"
+                    },
+                    "Commissions d’affacturage":{
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de crédit":{
+                        "account_number": "6315"
+                    },
+                    "Frais d’émission d’emprunts":{
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie électronique":{
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires":{
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "Rémunérations d’intermédiaires et de conseils":{
+                    "Commissions et courtages sur ventes":{
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions réglementées":{
+                        "account_number": "6324"
+                    },
+                    "Frais d’actes et de contentieux":{
+                        "account_number": "6325"
+                    },
+                    "Rémunérations d’affacturage":{
+                        "account_number": "6326"
+                    },
+                    "Rémunérations des autres prestataires de services":{
+                        "account_number": "6327"
+                    },
+                    "Divers frais":{
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel":{
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires":{
+                    "Redevances pour brevets, licences":{
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels":{
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques":{
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet":{
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires":{
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations":{
+                    "Cotisations":{
+                        "account_number": "6351"
+                    },
+                    "Concours divers":{
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "Rémunérations de personnel extérieur à l’entité":{
+                    "Personnel intérimaire":{
+                        "account_number": "6371"
+                    },
+                    "Personnel détaché ou prêté à l’entité":{
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes":{
+                    "Frais de recrutement du personnel":{
+                        "account_number": "6381"
+                    },
+                    "Frais de déménagement":{
+                        "account_number": "6382"
+                    },
+                    "Réceptions":{
+                        "account_number": "6383"
+                    },
+                    "Missions":{
+                        "account_number": "6384"
+                    },
+                    "Charges de copropriété":{
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Impôts et taxes":{
+                "Impôts et taxes directs":{
+                    "Impôts fonciers et taxes annexes":{
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes":{
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires":{
+                        "account_number": "6413"
+                    },
+                    "Taxes d’apprentissage":{
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue":{
+                        "account_number": "6415"
+                    },
+                    "Autres impôts et taxes directs":{
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Impôts et taxes indirects":{
+                    "account_number": "645"
+                },
+                "Droits d’enregistrement":{
+                    "Droits de mutation":{
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre":{
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les véhicules de société":{
+                        "account_number": "6463"
+                    },
+                    "Vignettes":{
+                        "account_number": "6464"
+                    },
+                    "Autres droits":{
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "Pénalités, amendes fiscales":{
+                    "Pénalités d’assiette, impôts directs":{
+                        "account_number": "6471"
+                    },
+                    "Pénalités d’assiette, impôts indirects":{
+                        "account_number": "6472"
+                    },
+                    "Pénalités de recouvrement, impôts directs":{
+                        "account_number": "6473"
+                    },
+                    "Pénalités de recouvrement, impôts indirects":{
+                        "account_number": "6474"
+                    },
+                    "Autres pénalités et amendes fiscales":{
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres impôts et taxes":{
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges":{
+                "Pertes sur créances clients et autres débiteurs":{
+                    "Clients":{
+                        "account_number": "6511"
+                    },
+                    "Autres débiteurs":{
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de résultat sur opérations faites en commun":{
+                    "Quote-part transférée de bénéfices (comptabilité du gérant)":{
+                        "account_number": "6521"
+                    },
+                    "Pertes imputées par transfert (comptabilité des associés non gérants)":{
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d’immobilisations":{
+                    "Immobilisations incorporelles":{
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles":{
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur créances et dettes commerciale":{
+                    "account_number": "656"
+                },
+                "Pénalités et amendes pénales":{
+                    "account_number": "657"
+                },
+                "Charges diverses":{
+                    "Indemnités de fonction et autres rémunérations d’administrateurs":{
+                        "account_number": "6581"
+                    },
+                    "Dons":{
+                        "account_number": "6582"
+                    },
+                    "Mécénat":{
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses":{
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                    "Sur risques à court terme":{
+                        "account_number": "6591"
+                    },
+                    "Sur stocks":{
+                        "account_number": "6593"
+                    },
+                    "Sur créances":{
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour dépréciations et provisions pour risques à court terme":{
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel":{
+                "Rémunérations directes versées au personnel national":{
+                    "Appointements salaires et commissions":{
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications":{
+                        "account_number": "6612"
+                    },
+                    "Congés payés":{
+                        "account_number": "6613"
+                    },
+                    "Indemnités de préavis, de licenciement et de recherche d’embauche":{
+                        "account_number": "6614"
+                    },
+                    "Indemnités de maladie versées aux travailleurs":{
+                        "account_number": "6615"
+                    },
+                    "Supplément familial":{
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature":{
+                        "account_number": "6617"
+                    },
+                    "Autres rémunérations directes":{
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "Rémunérations directes versées au personnel non national":{
+                    "Appointements salaires et commissions":{
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications":{
+                        "account_number": "6622"
+                    },
+                    "Congés payés":{
+                        "account_number": "6623"
+                    },
+                    "Indemnités de préavis, de licenciement et de recherche d’embauche":{
+                        "account_number": "6624"
+                    },
+                    "Indemnités de maladie versées aux travailleurs":{
+                        "account_number": "6625"
+                    },
+                    "Supplément familial":{
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature":{
+                        "account_number": "6627"
+                    },
+                    "Autres rémunérations directes":{
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnités forfaitaires versées au personnel":{
+                    "Indemnités de logement":{
+                        "account_number": "6631"
+                    },
+                    "Indemnités de représentation":{
+                        "account_number": "6632"
+                    },
+                    "Indemnités d’expatriation":{
+                        "account_number": "6633"
+                    },
+                    "Indemnités de transport":{
+                        "account_number": "6634"
+                    },
+                    "Autres indemnités et avantages divers":{
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales":{
+                    "Charges sociales sur rémunération du personnel national":{
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur rémunération du personnel non national":{
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "Rémunérations et charges sociales de l’exploitant individuel":{
+                    "Rémunération du travail de l’exploitant":{
+                        "account_number": "6661"
+                    },
+                    "Charges sociales":{
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "Rémunération transférée de personnel extérieur":{
+                    "Personnel intérimaire":{
+                        "account_number": "6671"
+                    },
+                    "Personnel détaché ou prêté à l’entité":{
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales":{
+                    "Versements aux syndicats et comités d’entreprise, d’établissement":{
+                        "account_number": "6681"
+                    },
+                    "Versements aux comités d’hygiène et de sécurité":{
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres œuvres sociales":{
+                        "account_number": "6683"
+                    },
+                    "Médecine du travail et pharmacie":{
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de santé":{
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension":{
+                        "account_number": "6686"
+                    },
+                    "Majorations et pénalités sociales":{
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses":{
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimilées":{
+                "Intérêts des emprunts":{
+                    "Emprunts obligataires":{
+                        "account_number": "6711"
+                    },
+                    "Emprunts auprès des établissements de crédit":{
+                        "account_number": "6712"
+                    },
+                    "Dettes liées à des participations":{
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations":{
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Intérêts dans loyers de location acquisition":{
+                    "Intérêts dans loyers de location acquisition / crédit-bail immobilier":{
+                        "account_number": "6722"
+                    },
+                    "Intérêts dans loyers de location acquisition / crédit-bail mobilier":{
+                        "account_number": "6723"
+                    },
+                    "Intérêts dans loyers de location acquisition / location-vente":{
+                        "account_number": "6724"
+                    },
+                    "Intérêts dans loyers des autres locations acquisition":{
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accordés":{
+                    "account_number": "673"
+                },
+                "Autres intérêts":{
+                    "Avances reçues et dépôts créditeurs":{
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqués":{
+                        "account_number": "6742"
+                    },
+                    "Intérêts sur obligations cautionnées":{
+                        "account_number": "6743"
+                    },
+                    "Intérêts sur dettes commerciales":{
+                        "account_number": "6744"
+                    },
+                    "Intérêts bancaires et sur opérations de financement (escompte...)":{
+                        "account_number": "6745"
+                    },
+                    "Intérêts sur dettes diverses":{
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce":{
+                    "account_number": "675"
+                },
+                "Pertes de change financières":{
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement":{
+                    "Pertes sur cessions de titres de placement":{
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d’attribution gratuite d’actions au personnel salarié et aux dirigeants":{
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers":{
+                    "Sur rentes viagères":{
+                        "account_number": "6781"
+                    },
+                    "Sur opérations financières":{
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de trésorerie":{
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour dépréciations et provisions pour risques à court terme financières":{
+                    "Sur risques financiers":{
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement":{
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour dépréciations et provisions pour risques à court terme financières":{
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements":{
+                "Dotations aux amortissements d’exploitation":{
+                    "Dotations aux amortissements des immobilisations incorporelles":{
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles":{
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux dépréciations":{
+                "Dotations aux provisions et aux dépréciations d’exploitation":{
+                    "Dotations aux provisions pour risques et charges":{
+                        "account_number": "6911"
+                    },
+                    "Dotations aux dépréciations des immobilisations incorporelles":{
+                        "account_number": "6913"
+                    },
+                    "Dotations aux dépréciations des immobilisations corporelles":{
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux dépréciations financières":{
+                    "Dotations aux provisions pour risques et charges":{
+                        "account_number": "6971"
+                    },
+                    "Dotations aux dépréciations des immobilisations financières":{
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type":"Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activités ordinaires":{
+            "Ventes":{
+                "Ventes de marchandises":{
+                    "Dans la Région":{
+                        "account_number": "7011"
+                    },
+                    "Hors Région":{
+                        "account_number": "7012"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7013"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7014"
+                    },
+                    "Sur internet":{
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis":{
+                    "Dans la Région":{
+                        "account_number": "7021"
+                    },
+                    "Hors Région":{
+                        "account_number": "7022"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7023"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7024"
+                    },
+                    "Sur internet":{
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits intermédiaires":{
+                    "Dans la Région":{
+                        "account_number": "7031"
+                    },
+                    "Hors Région":{
+                        "account_number": "7032"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7033"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7034"
+                    },
+                    "Sur internet":{
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits résiduels":{
+                    "Dans la Région":{
+                        "account_number": "7041"
+                    },
+                    "Hors Région":{
+                        "account_number": "7042"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7043"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7044"
+                    },
+                    "Sur internet":{
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux facturés":{
+                    "Dans la Région":{
+                        "account_number": "7051"
+                    },
+                    "Hors Région":{
+                        "account_number": "7052"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7053"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7054"
+                    },
+                    "Sur internet":{
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus":{
+                    "Dans la Région":{
+                        "account_number": "7061"
+                    },
+                    "Hors Région":{
+                        "account_number": "7062"
+                    },
+                    "Aux entités du groupe dans la Région":{
+                        "account_number": "7063"
+                    },
+                    "Aux entités du groupe hors Région":{
+                        "account_number": "7064"
+                    },
+                    "Sur internet":{
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accordés (non ventilés)":{
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires":{
+                    "Ports, emballages perdus et autres frais facturés":{
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages":{
+                        "account_number": "7072"
+                    },
+                    "Locations":{
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d’emballages":{
+                        "account_number": "7074"
+                    },
+                    "Mise à disposition de personnel":{
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires":{
+                        "account_number": "7076"
+                    },
+                    "Services exploités dans l’intérêt du personnel":{
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires":{
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d’exploitation":{
+                "Sur produits à l’exportation":{
+                    "account_number": "711"
+                },
+                "Sur produits à l’importation":{
+                    "account_number": "712"
+                },
+                "Sur produits de péréquation":{
+                    "account_number": "713"
+                },
+                "Indemnités et subventions d’exploitation (entité agricole)":{
+                    "account_number": "714"
+                },
+                "Autres subventions d’exploitation":{
+                    "Versées par l’État et les collectivités publiques":{
+                        "account_number": "7181"
+                    },
+                    "Versées par les organismes internationaux":{
+                        "account_number": "7182"
+                    },
+                    "Versées par des tiers":{
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilisée":{
+                "Immobilisations incorporelles":{
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles":{
+                    "Immobilisations corporelles (hors actifs biologiques)":{
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)":{
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consommée":{
+                    "account_number": "724"
+                },
+                "Immobilisations financières":{
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits":{
+                "Variations des stocks de produits en cours":{
+                    "Produits en cours":{
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours":{
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services":{
+                    "Études en cours":{
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours":{
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis":{
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits intermédiaires et résiduels":{
+                    "Produits intermédiaires":{
+                        "account_number": "7371"
+                    },
+                    "Produits résiduels":{
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits":{
+                "Profits sur créances clients et autres débiteurs":{
+                    "account_number": "751"
+                },
+                "Quote-part de résultat sur opérations faites en commun":{
+                    "Quote-part transférée de pertes (comptabilité du gérant)":{
+                        "account_number": "7521"
+                    },
+                    "Bénéfices attribués par transfert (comptabilité des associés non gérants)":{
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d’immobilisations":{
+                    "Immobilisations incorporelles":{
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles":{
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur créances et dettes commerciales":{
+                    "account_number": "756"
+                },
+                "Produits divers":{
+                    "Indemnités de fonction et autres rémunérations d’administrateurs":{
+                        "account_number": "7581"
+                    },
+                    "Indemnités d’assurances reçues":{
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers":{
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                    "Sur risques à court terme":{
+                        "account_number": "7591"
+                    },
+                    "Sur stocks":{
+                        "account_number": "7593"
+                    },
+                    "Sur créances":{
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour dépréciations et provisions pour risques à court terme d’exploitation":{
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimilés":{
+                "Intérêts de prêts et créances diverses":{
+                    "Intérêts de prêts":{
+                        "account_number": "7712"
+                    },
+                    "Intérêts sur créances diverses":{
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilisés":{
+                    "Revenus des titres de participation":{
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilisés":{
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus":{
+                    "account_number": "773"
+                },
+                "Revenus de placement":{
+                    "Revenus des obligations":{
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement":{
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Intérêts dans loyers de location acquisition":{
+                    "account_number": "775"
+                },
+                "Gains de change financiers":{
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement":{
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers":{
+                    "Sur rentes viagères":{
+                        "account_number": "7781"
+                    },
+                    "Sur opérations financières":{
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de trésorerie":{
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour dépréciations et provisions à court terme financières":{
+                    "Sur risques financiers":{
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement":{
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour dépréciations et provisions pour risques à court terme financières":{
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges":{
+                "Transferts de charges d’exploitation":{
+                    "account_number": "781"
+                },
+                "Transferts de charges financières":{
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de dépréciations et autres":{
+                "Reprises de provisions et dépréciations d’exploitation":{
+                    "Pour risques et charges":{
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles":{
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles":{
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et dépréciations financières":{
+                    "Pour risques et charges":{
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financières":{
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d’amortissements":{
+                    "account_number": "798"
+                },
+                "Reprises de subventions d’investissement":{
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type":"Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)":{
+            "Valeurs comptables des cessions d’immobilisations":{
+                "Immobilisations incorporelles":{
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles":{
+                    "account_number": "812"
+                },
+                "Immobilisations financières":{
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activités ordinaires":{
+                "Charges HAO constatées":{
+                    "account_number": "831"
+                },
+                "Charges liées aux opérations de restructuration":{
+                    "account_number": "833"
+                },
+                "Pertes sur créances HAO":{
+                    "account_number": "834"
+                },
+                "Dons et libéralités accordés":{
+                    "account_number": "835"
+                },
+                "Abandons de créances consentis":{
+                    "account_number": "836"
+                },
+                "Charges liées aux opérations de liquidation":{
+                    "account_number": "837"
+                },
+                "Charges pour dépréciations et provisions pour risques à court terme HAO":{
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activités ordinaires":{
+                "Dotations aux provisions réglementées":{
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO":{
+                    "account_number": "852"
+                },
+                "Dotations aux dépréciations HAO":{
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO":{
+                    "account_number": "854"
+                },
+                "Autres dotations HAO":{
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs":{
+                "Participation légale aux bénéfices":{
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux bénéfices":{
+                    "account_number": "874"
+                },
+                "Autres participations":{
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Impôts sur le résultat":{
+                "Impôts sur les bénéfices de l’exercice":{
+                    "Activités exercées dans l’État":{
+                        "account_number": "8911"
+                    },
+                    "Activités exercées dans les autres États de la Région":{
+                        "account_number": "8912"
+                    },
+                    "Activités exercées hors Région":{
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d’impôts sur résultats antérieurs":{
+                    "account_number": "892"
+                },
+                "Impôt minimum forfaitaire IMF":{
+                    "account_number": "895"
+                },
+                "Dégrèvements et annulations d’impôts sur résultats antérieurs":{
+                    "Dégrèvements":{
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes rétroactives":{
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type":"Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)":{
+            "Produits des cessions d’immobilisations":{
+                "Immobilisations incorporelles":{
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles":{
+                    "account_number": "822"
+                },
+                "Immobilisations financières":{
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activités ordinaires":{
+                "Produits HAO constatés":{
+                    "account_number": "841"
+                },
+                "Produits liés aux opérations de restructuration":{
+                    "account_number": "843"
+                },
+                "Indemnités et subventions HAO (entité agricole)":{
+                    "account_number": "844"
+                },
+                "Dons et libéralités obtenus":{
+                    "account_number": "845"
+                },
+                "Abandons de créances obtenus":{
+                    "account_number": "846"
+                },
+                "Produits liés aux opérations de liquidation":{
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO":{
+                    "account_number": "848"
+                },
+                "Reprises de charges pour dépréciations et provisions pour risques à court terme HAO":{
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et dépréciations HAO":{
+                "Reprises de provisions réglementées":{
+                    "account_number": "861"
+                },
+                "Reprises d’amortissements HAO":{
+                    "account_number": "862"
+                },
+                "Reprises de dépréciations HAO":{
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO":{
+                    "account_number": "864"
+                },
+                "Autres reprises HAO":{
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d’équilibre":{
+                "État":{
+                    "account_number": "881"
+                },
+                "Collectivités publiques":{
+                    "account_number": "884"
+                },
+                "Groupe":{
+                    "account_number": "886"
+                },
+                "Autres":{
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type":"Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/td_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/td_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "td",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/td_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/td_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "td",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/tg_plan_comptable.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/tg_plan_comptable.json
@@ -1,0 +1,1919 @@
+{
+    "country_code": "tg",
+    "name": "Syscohada - Plan Comptable",
+    "tree": {
+        "1-Comptes de ressources durables": {
+            "10-Capital": {
+                "101-Capital social": {
+                    "1011-Capital souscrit, non appel\u00e9": {},
+                    "1012-Capital souscrit, appel\u00e9, non vers\u00e9": {},
+                    "1013-Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {},
+                    "1014-Capital souscrit, appel\u00e9, vers\u00e9, amorti": {},
+                    "1018-Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {}
+                },
+                "102-Capital par dotation": {
+                    "1021-Dotation initiale": {},
+                    "1022-Dotations compl\u00e9mentaires": {},
+                    "1028-Autres dotations": {}
+                },
+                "103-Capital personnel": {},
+                "104-Compte de l\u2019exploitant": {
+                    "1041-Apports temporaires": {},
+                    "1042-Op\u00e9rations courantes": {},
+                    "1043-R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {},
+                    "1047-Pr\u00e9l\u00e8vements d\u2019autoconsommation": {},
+                    "1048-Autres pr\u00e9l\u00e8vements": {}
+                },
+                "105-Primes li\u00e9es au capital social": {
+                    "1051-Primes d\u2019\u00e9mission": {},
+                    "1052-Primes d\u2019apport": {},
+                    "1053-Primes de fusion": {},
+                    "1054-Primes de conversion": {},
+                    "1058-Autres primes": {}
+                },
+                "106-\u00c9carts de r\u00e9\u00e9valuation": {
+                    "1061-\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {},
+                    "1062-\u00c9carts de r\u00e9\u00e9valuation libre": {}
+                },
+                "109-Apporteurs, capital souscrit, non appel\u00e9": {}
+            },
+            "11-R\u00e9serves": {
+                "111-R\u00e9serve l\u00e9gale": {},
+                "112-R\u00e9serves statutaires ou contractuelles": {},
+                "113-R\u00e9serves r\u00e9glement\u00e9es": {
+                    "1131-R\u00e9serves de plus-values nettes \u00e0 long terme": {},
+                    "1132-R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {},
+                    "1133-R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {},
+                    "1134-R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {},
+                    "1135-Autres r\u00e9serves r\u00e9glement\u00e9es": {}
+                },
+                "118-Autres r\u00e9serves": {
+                    "1181-R\u00e9serves facultatives": {},
+                    "1188-R\u00e9serves diverses": {}
+                }
+            },
+            "12-Report \u00e0 nouveau": {
+                "121-Report \u00e0 nouveau cr\u00e9diteur": {},
+                "129-Report \u00e0 nouveau d\u00e9biteur": {
+                    "1291-Perte nette \u00e0 reporter": {},
+                    "1292-Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {}
+                }
+            },
+            "13-R\u00e9sultat net de l\u2019exercice": {
+                "130-R\u00e9sultat en instance d\u2019affectation": {
+                    "1301-R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {},
+                    "1309-R\u00e9sultat en instance d\u2019affectation : perte": {}
+                },
+                "131-R\u00e9sultat net : b\u00e9n\u00e9fice": {},
+                "132-Marge commerciale (MC)": {},
+                "133-Valeur ajout\u00e9e (VA)": {},
+                "134-Exc\u00e9dent brut d\u2019exploitation (EBE)": {},
+                "135-R\u00e9sultat d\u2019exploitation (RE)": {},
+                "136-R\u00e9sultat financier (RF)": {},
+                "137-R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {},
+                "138-R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "1381-R\u00e9sultat de fusion": {},
+                    "1382-R\u00e9sultat d\u2019apport partiel d\u2019actif": {},
+                    "1383-R\u00e9sultat de scission": {},
+                    "1384-R\u00e9sultat de liquidation": {}
+                },
+                "139-R\u00e9sultat net : perte": {}
+            },
+            "14-Subventions d\u2019investissement": {
+                "141-Subventions d\u2019\u00e9quipement": {
+                    "1411-\u00c9tat": {},
+                    "1412-R\u00e9gions": {},
+                    "1413-D\u00e9partements": {},
+                    "1414-Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {},
+                    "1415-Entit\u00e9s publiques ou mixtes": {},
+                    "1416-Entit\u00e9s et organismes priv\u00e9s": {},
+                    "1417-Organismes internationaux": {},
+                    "1418-Autres": {}
+                },
+                "148-Autres subventions d\u2019investissement": {}
+            },
+            "15-Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "151-Amortissements d\u00e9rogatoires": {},
+                "152-Plus-values de cession \u00e0 r\u00e9investir": {},
+                "153-Fonds r\u00e9glement\u00e9s": {
+                    "1531-Fonds National": {},
+                    "1532-Pr\u00e9l\u00e8vement pour le Budget": {}
+                },
+                "154-Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {},
+                "155-Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "1551-Reconstitution des gisements miniers et p\u00e9troliers": {}
+                },
+                "156-Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "1561-Hausse de prix": {},
+                    "1562-Fluctuation des cours": {}
+                },
+                "157-Provisions pour investissement": {},
+                "158-Autres provisions et fonds r\u00e9glement\u00e9s": {}
+            },
+            "16-Emprunts et dettes assimil\u00e9es": {
+                "161-Emprunts obligataires": {
+                    "1611-Emprunts obligataires ordinaires": {},
+                    "1612-Emprunts obligataires convertibles en actions": {},
+                    "1613-Emprunts obligataires remboursables en actions": {},
+                    "1618-Autres emprunts obligataires": {}
+                },
+                "162-Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                "163-Avances re\u00e7ues de l\u2019\u00c9tat": {},
+                "164-Avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                "165-D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "1651-D\u00e9p\u00f4ts": {},
+                    "1652-Cautionnements": {}
+                },
+                "166-Int\u00e9r\u00eats courus": {
+                    "1661-Sur emprunts obligataires": {},
+                    "1662-Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "1663-Sur avances re\u00e7ues de l\u2019\u00c9tat": {},
+                    "1664-Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {},
+                    "1665-Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {},
+                    "1667-Sur avances assorties de conditions particuli\u00e8res": {},
+                    "1668-Sur autres emprunts et dettes": {}
+                },
+                "167-Avances assorties de conditions particuli\u00e8res": {
+                    "1671-Avances bloqu\u00e9es pour augmentation du capital": {},
+                    "1672-Avances conditionn\u00e9es par l\u2019\u00c9tat": {},
+                    "1673-Avances conditionn\u00e9es par les autres organismes africains": {},
+                    "1674-Avances conditionn\u00e9es par les organismes internationaux": {}
+                },
+                "168-Autres emprunts et dettes": {
+                    "1681-Rentes viag\u00e8res capitalis\u00e9es": {},
+                    "1682-Billets de fonds": {},
+                    "1683-Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {},
+                    "1684-Emprunts participatifs": {},
+                    "1685-Participation des travailleurs aux b\u00e9n\u00e9fices": {},
+                    "1686-Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {}
+                }
+            },
+            "17-Dettes de location acquisition": {
+                "172-Dettes de location acquisition / cr\u00e9dit bail immobilier": {},
+                "173-Dettes de location acquisition / cr\u00e9dit bail mobilier": {},
+                "174-Dettes de location acquisition / location de vente": {},
+                "176-Int\u00e9r\u00eats courus": {
+                    "1762-Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "1763-Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "1764-Sur dettes de location acquisition / location-vente": {},
+                    "1768-Sur autres dettes de location acquisition": {}
+                },
+                "178-Autres dettes de location acquisition": {}
+            },
+            "18-Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "181-Dettes li\u00e9es \u00e0 des participations": {
+                    "1811-Dettes li\u00e9es \u00e0 des participations (groupe)": {},
+                    "1812-Dettes li\u00e9es \u00e0 des participations (hors groupe)": {}
+                },
+                "182-Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                "183-Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {},
+                "184-Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "185-Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {},
+                "186-Comptes de liaison charges": {},
+                "187-Comptes de liaison produits": {},
+                "188-Comptes de liaison des soci\u00e9t\u00e9s en participation": {}
+            },
+            "19-Provisions pour risques et charges": {
+                "191-Provisions pour litiges": {},
+                "192-Provisions pour garanties donn\u00e9es aux clients": {},
+                "193-Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {},
+                "194-Provisions pour pertes de change": {},
+                "195-Provisions pour imp\u00f4ts": {},
+                "196-Provisions pour pensions et obligations similaires": {
+                    "1961-Provisions pour pensions et obligations similaires engagement de retraite": {},
+                    "1962-Actif du r\u00e9gime de retraite": {}
+                },
+                "197-Provisions pour restructuration": {},
+                "198-Autres provisions pour risques et charges": {
+                    "1981-Provisions pour amendes et p\u00e9nalit\u00e9s": {},
+                    "1983-Provisions pour propre assureur": {},
+                    "1984-Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "1985-Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {},
+                    "1988-Provisions pour divers risques et charges": {}
+                }
+            },
+            "root_type": "Equity"
+        },
+        "2-Comptes d\u2019actif immobilis\u00e9": {
+            "21-Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "211-Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset"
+                },
+                "212-Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "2121-Brevets": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2122-Licences": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2123-Concessions de service public": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2128-Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "213-Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "2131-Logiciels": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2132-Sites internet": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "214-Marques": {
+                    "account_type": "Fixed Asset"
+                },
+                "215-Fonds commercial": {
+                    "account_type": "Fixed Asset"
+                },
+                "216-Droit au bail": {
+                    "account_type": "Fixed Asset"
+                },
+                "217-Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset"
+                },
+                "218-Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "2181-Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2182-Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2183-Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2184-Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2188-Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "219-Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "2191-Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2193-Logiciels et internet": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2198-Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "22-Terrains": {
+                "account_type": "Fixed Asset",
+                "221-Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "2211-Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2212-Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2218-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "222-Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "2221-Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2228-Autres terrains nus": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "223-Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "2231-Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2232-Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2234-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2235-Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2238-Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "224-Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "2241-Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2245-Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2248-Autres travaux": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "225-Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "2251-Carri\u00e8res": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "226-Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "2261-Parkings": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "227-Terrains mis en concession": {
+                    "account_type": "Fixed Asset"
+                },
+                "228-Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "2281-Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2285-Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2286-Terrains de location acquisition": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2288-Divers terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "229-Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "2291-Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2292-Terrains nus": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2295-Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset"
+                    },
+                    "2298-Autres terrains": {
+                        "account_type": "Fixed Asset"
+                    }
+                }
+            },
+            "23-B\u00e2timents, installations techniques et agencements": {
+                "231-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "2311-B\u00e2timents industriels": {},
+                    "2312-B\u00e2timents agricoles": {},
+                    "2313-B\u00e2timents administratifs et commerciaux": {},
+                    "2314-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2315-B\u00e2timents immeubles de placement": {},
+                    "2316-B\u00e2timents de location acquisition": {}
+                },
+                "232-B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "2321-B\u00e2timents industriels": {},
+                    "2322-B\u00e2timents agricoles": {},
+                    "2323-B\u00e2timents administratifs et commerciaux": {},
+                    "2324-B\u00e2timents affect\u00e9s au logement du personnel": {},
+                    "2325-B\u00e2timents immeubles de placement": {},
+                    "2326-B\u00e2timents de location acquisition": {}
+                },
+                "233-Ouvrages d\u2019infrastructure": {
+                    "2331-Voies de terre": {},
+                    "2332-Voies de fer": {},
+                    "2333-Voies d\u2019eau": {},
+                    "2334-Barrages, Digues": {},
+                    "2335-Pistes d\u2019a\u00e9rodrome": {},
+                    "2338-Autres ouvrages d\u2019infrastructures": {}
+                },
+                "234-Am\u00e9nagements, agencements et installations techniques": {
+                    "2341-Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {},
+                    "2342-Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {},
+                    "2343-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {},
+                    "2344-Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {},
+                    "2345-Am\u00e9nagements et agencements des b\u00e2timents": {}
+                },
+                "235-Am\u00e9nagements de bureaux": {
+                    "2351-Installations g\u00e9n\u00e9rales": {},
+                    "2358-Autres am\u00e9nagements de bureaux": {}
+                },
+                "237-B\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                "238-Autres installations et agencements": {},
+                "239-B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "2391-B\u00e2timents en cours": {},
+                    "2392-Installations en cours": {},
+                    "2393-Ouvrages d\u2019infrastructure en cours": {},
+                    "2394-Am\u00e9nagements et agencements et installations techniques en cours": {},
+                    "2395-Am\u00e9nagements de bureaux en cours": {},
+                    "2398-Autres installations et agencements en cours": {}
+                }
+            },
+            "24-Mat\u00e9riel, mobilier et actifs biologiques": {
+                "241-Mat\u00e9riel et outillage industriel et commercial": {
+                    "2411-Mat\u00e9riel industriel": {},
+                    "2412-Outillage industriel": {},
+                    "2413-Mat\u00e9riel commercial": {},
+                    "2414-Outillage commercial": {},
+                    "2416-Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {}
+                },
+                "242-Mat\u00e9riel et outillage agricole": {
+                    "2421-Mat\u00e9riel agricole": {},
+                    "2422-Outillage agricole": {},
+                    "2426-Mat\u00e9riel & outillage agricole de location-acquisition": {}
+                },
+                "243-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                "244-Mat\u00e9riel et mobilier": {
+                    "2441-Mat\u00e9riel de bureau": {},
+                    "2442-Mat\u00e9riel informatique": {},
+                    "2443-Mat\u00e9riel bureautique": {},
+                    "2444-Mobilier de bureau": {},
+                    "2445-Mat\u00e9riel et mobilier immeubles de placement": {},
+                    "2446-Mat\u00e9riel et mobilier de location acquisition": {},
+                    "2447-Mat\u00e9riel et mobilier des logements du personnel": {}
+                },
+                "245-Mat\u00e9riel de transport": {
+                    "2451-Mat\u00e9riel automobile": {},
+                    "2452-Mat\u00e9riel ferroviaire": {},
+                    "2453-Mat\u00e9riel fluvial, lagunaire": {},
+                    "2454-Mat\u00e9riel naval": {},
+                    "2455-Mat\u00e9riel a\u00e9rien": {},
+                    "2456-Mat\u00e9riel de transport de location-acquisition": {},
+                    "2457-Mat\u00e9riel hippomobile": {},
+                    "2458-Autres mat\u00e9riels de transport": {}
+                },
+                "246-Actifs biologiques": {
+                    "2461-Cheptel, animaux de trait": {},
+                    "2462-Cheptel, animaux reproducteurs": {},
+                    "2463-Animaux de garde": {},
+                    "2465-Plantations agricoles": {},
+                    "2468-Autres actifs biologiques": {}
+                },
+                "247-Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "2471-Agencements et am\u00e9nagements du mat\u00e9riel": {},
+                    "2472-Agencements et am\u00e9nagements des actifs biologiques": {},
+                    "2478-Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {}
+                },
+                "248-Autres mat\u00e9riels et mobiliers": {
+                    "2481-Collections et \u0153uvres d\u2019art": {},
+                    "2488-Divers mat\u00e9riels mobiliers": {}
+                },
+                "249-Mat\u00e9riels et actifs biologiques en cours": {
+                    "2491-Mat\u00e9riel et outillage industriel et commercial": {},
+                    "2492-Mat\u00e9riel et outillage agricole": {},
+                    "2493-Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2494-Mat\u00e9riel et mobilier de bureau": {},
+                    "2495-Mat\u00e9riel de transport": {},
+                    "2496-Actifs biologiques": {},
+                    "2497-Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {},
+                    "2498-Autres mat\u00e9riels et actifs biologiques en cours": {}
+                }
+            },
+            "25-Avances et acomptes vers\u00e9s sur immobilisations": {
+                "251-Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                "252-Avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+            },
+            "26-Titres de participation": {
+                "261-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                "262-Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                "263-Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                "265-Participations dans des organismes professionnels": {},
+                "266-Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {},
+                "268-Autres titres de participation": {}
+            },
+            "27-Autres immobilisations financi\u00e8res": {
+                "271-Pr\u00eats et cr\u00e9ances": {
+                    "2711-Pr\u00eats participatifs": {},
+                    "2712-Pr\u00eats aux associ\u00e9s": {},
+                    "2713-Billets de fonds": {},
+                    "2714-Titres pr\u00eat\u00e9s": {},
+                    "2718-Autres pr\u00eats et cr\u00e9ances": {}
+                },
+                "272-Pr\u00eats au personnel": {
+                    "2721-Pr\u00eats immobiliers": {},
+                    "2722-Pr\u00eats mobiliers et d\u2019installation": {},
+                    "2728-Autres pr\u00eats au personnel": {}
+                },
+                "273-Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "2731-Retenues de garantie": {},
+                    "2733-Fonds r\u00e9glement\u00e9": {},
+                    "2734-Cr\u00e9ances sur le conc\u00e9dant": {},
+                    "2738-Autres cr\u00e9ances sur l\u2019\u00c9tat": {}
+                },
+                "274-Titres immobilis\u00e9s": {
+                    "2741-Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {},
+                    "2742-Titres participatifs": {},
+                    "2743-Certificats d\u2019investissement": {},
+                    "2744-Parts de fonds commun de placement (FCP)": {},
+                    "2745-Obligations": {},
+                    "2746-Actions ou parts propres": {},
+                    "2748-Autres titres immobilis\u00e9s": {}
+                },
+                "275-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "2751-D\u00e9p\u00f4ts pour loyers d\u2019avance": {},
+                    "2752-D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {},
+                    "2753-D\u00e9p\u00f4ts pour l\u2019eau": {},
+                    "2754-D\u00e9p\u00f4ts pour le gaz": {},
+                    "2755-D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {},
+                    "2756-Cautionnements sur march\u00e9s publics": {},
+                    "2757-Cautionnements sur autres op\u00e9rations": {},
+                    "2758-Autres d\u00e9p\u00f4ts et cautionnements": {}
+                },
+                "276-Int\u00e9r\u00eats courus": {
+                    "2761-Pr\u00eats et cr\u00e9ances non commerciales": {},
+                    "2762-Pr\u00eats au personnel": {},
+                    "2763-Cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2764-Titres immobilis\u00e9s": {},
+                    "2765-D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2767-Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {},
+                    "2768-Immobilisations financi\u00e8res diverses": {}
+                },
+                "277-Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "2771-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {},
+                    "2772-Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {},
+                    "2773-Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {},
+                    "2774-Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {}
+                },
+                "278-Immobilisations financi\u00e8res diverses": {
+                    "2781-Cr\u00e9ances diverses groupe": {},
+                    "2782-Cr\u00e9ances diverses hors groupe": {},
+                    "2784-Banques d\u00e9p\u00f4ts \u00e0 terme": {},
+                    "2785-Or et m\u00e9taux pr\u00e9cieux": {},
+                    "2788-Autres immobilisations financi\u00e8res": {}
+                }
+            },
+            "28-Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "281-Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "2811-Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2812-Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2813-Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2814-Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2815-Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2816-Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2817-Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation"
+                    },
+                    "2818-Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                },
+                "282-Amortissements des terrains": {
+                    "2824-Amortissements des travaux de mise en valeur des terrains": {}
+                },
+                "283-Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "2831-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2832-Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2833-Amortissements des ouvrages d\u2019infrastructure": {},
+                    "2834-Amortissements des am\u00e9nagements, agencements et installations techniques": {},
+                    "2835-Amortissements des am\u00e9nagements de bureaux": {},
+                    "2837-Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2838-Amortissements des autres installations et agencements": {}
+                },
+                "284-Amortissements du mat\u00e9riel": {
+                    "2841-Amortissements du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2842-Amortissements du mat\u00e9riel et outillage agricole": {},
+                    "2843-Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2844-Amortissements du mat\u00e9riel et mobilier": {},
+                    "2845-Amortissements du mat\u00e9riel de transport": {},
+                    "2846-Amortissements des actifs biologiques": {},
+                    "2847-Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2848-Amortissements des autres mat\u00e9riels": {}
+                }
+            },
+            "29-D\u00e9pr\u00e9ciations des immobilisations": {
+                "291-D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "2911-D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {},
+                    "2912-D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {},
+                    "2913-D\u00e9pr\u00e9ciations des logiciels et sites internet": {},
+                    "2914-D\u00e9pr\u00e9ciations des marques": {},
+                    "2915-D\u00e9pr\u00e9ciations du fonds commercial": {},
+                    "2916-D\u00e9pr\u00e9ciations du droit au bail": {},
+                    "2917-D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {},
+                    "2918-D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {},
+                    "2919-D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {}
+                },
+                "292-D\u00e9pr\u00e9ciations des terrains": {
+                    "2921-D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {},
+                    "2922-D\u00e9pr\u00e9ciations des terrains nus": {},
+                    "2923-D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {},
+                    "2924-D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {},
+                    "2925-D\u00e9pr\u00e9ciations des terrains de gisement": {},
+                    "2926-D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {},
+                    "2927-D\u00e9pr\u00e9ciations des terrains mis en concession": {},
+                    "2928-D\u00e9pr\u00e9ciations des autres terrains": {},
+                    "2929-D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {}
+                },
+                "293-D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "2931-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {},
+                    "2932-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {},
+                    "2933-D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {},
+                    "2934-D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {},
+                    "2935-D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {},
+                    "2937-D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {},
+                    "2938-D\u00e9pr\u00e9ciations des autres installations et agencements": {},
+                    "2939-D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {}
+                },
+                "294-D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "2941-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {},
+                    "2942-D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {},
+                    "2943-D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {},
+                    "2944-D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {},
+                    "2945-D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {},
+                    "2946-D\u00e9pr\u00e9ciations des actifs biologiques": {},
+                    "2947-D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {},
+                    "2948-D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {},
+                    "2949-D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {}
+                },
+                "295-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "2951-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {},
+                    "2952-D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {}
+                },
+                "296-D\u00e9pr\u00e9ciations des titres de participation": {
+                    "2961-D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {},
+                    "2962-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {},
+                    "2963-D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {},
+                    "2965-D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {},
+                    "2966-D\u00e9pr\u00e9ciations des parts dans des GIE": {},
+                    "2968-D\u00e9pr\u00e9ciations des autres titres de participation": {}
+                },
+                "297-D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "2971-D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {},
+                    "2972-D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {},
+                    "2973-D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {},
+                    "2974-D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {},
+                    "2975-D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {},
+                    "2977-D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {},
+                    "2978-D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "3-Comptes de Stocks": {
+            "31-Marchandises": {
+                "311-Marchandises A": {
+                    "3111-Marchandises A1": {},
+                    "3112-Marchandises A2": {}
+                },
+                "312-Marchandises B": {
+                    "3121-Marchandises B1": {},
+                    "3122-Marchandises B2": {}
+                },
+                "313-Actifs biologiques": {
+                    "3131-Animaux": {},
+                    "3132-V\u00e9g\u00e9taux": {}
+                },
+                "318-Marchandises hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "32-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "321-Mati\u00e8res A": {},
+                "322-Mati\u00e8res B": {},
+                "323-Fournitures (A, B)": {}
+            },
+            "33-Autres approvisionnements": {
+                "331-Mati\u00e8res consommables": {},
+                "332-Fournitures d\u2019atelier et d\u2019usine": {},
+                "333-Fournitures de magasin": {},
+                "334-Fournitures de bureau": {},
+                "335-Emballages": {
+                    "3351-Emballages perdus": {},
+                    "3352-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "3353-Emballages \u00e0 usage mixte": {},
+                    "3358-Autres emballages": {}
+                },
+                "338-Autres mati\u00e8res": {}
+            },
+            "34-Produits en cours": {
+                "341-Produits en cours": {
+                    "3411-Produits en cours P1": {},
+                    "3412-Produits en cours P2": {}
+                },
+                "342-Travaux en cours": {
+                    "3421-Travaux en cours T1": {},
+                    "3422-Travaux en cours T2": {}
+                },
+                "343-Produits interm\u00e9diaires en cours": {
+                    "3431-Produits interm\u00e9diaires A": {},
+                    "3432-Produits interm\u00e9diaires B": {}
+                },
+                "344-Produits r\u00e9siduels en cours": {
+                    "3441-Produits r\u00e9siduels A": {},
+                    "3442-Produits r\u00e9siduels B": {}
+                },
+                "345-Actifs biologiques en cours": {
+                    "3451-Animaux": {},
+                    "3452-V\u00e9g\u00e9taux": {}
+                }
+            },
+            "35-Services en cours": {
+                "351-\u00c9tudes en cours": {
+                    "3511-\u00c9tudes en cours E1": {},
+                    "3512-\u00c9tudes en cours E2": {}
+                },
+                "352-Prestations de services en cours": {
+                    "3521-Prestations de services S1": {},
+                    "3522-Prestations de services S2": {}
+                }
+            },
+            "36-Produits finis": {
+                "361-Produits finis A": {},
+                "362-Produits finis B": {},
+                "363-Actifs biologiques": {
+                    "3631-Animaux": {},
+                    "3632-V\u00e9g\u00e9taux": {},
+                    "3638-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "37-Produits interm\u00e9diaires et r\u00e9siduels": {
+                "371-Produits interm\u00e9diaires": {
+                    "3711-Produits interm\u00e9diaires A": {},
+                    "3712-Produits interm\u00e9diaires B": {}
+                },
+                "372-Produits r\u00e9siduels": {
+                    "3721-D\u00e9chets": {},
+                    "3722-Rebuts": {},
+                    "3723-Mati\u00e8res de R\u00e9cup\u00e9ration": {}
+                },
+                "373-Actifs biologiques": {
+                    "3731-Animaux": {},
+                    "3732-V\u00e9g\u00e9taux": {},
+                    "3738-Autres stocks (activit\u00e9s annexes)": {}
+                }
+            },
+            "38-Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "381-Marchandises en cours de route": {},
+                "382-Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {},
+                "383-Autres approvisionnements en cours de route": {},
+                "386-Produits finis en cours de route": {},
+                "387-Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "3871-Stock en consignation": {},
+                    "3872-Stock en d\u00e9p\u00f4t": {}
+                },
+                "388-Stock provenant d\u2019immobilisations mises hors service ou au rebut": {}
+            },
+            "39-D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "391-D\u00e9pr\u00e9ciations des stocks de marchandises": {},
+                "392-D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                "393-D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {},
+                "394-D\u00e9pr\u00e9ciations des productions en cours": {},
+                "395-D\u00e9pr\u00e9ciations des services en cours": {},
+                "396-D\u00e9pr\u00e9ciations des stocks de produits finis": {},
+                "397-D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {},
+                "398-D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {}
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "409-Fournisseurs d\u00e9biteurs": {
+                    "4091-Fournisseurs Avances et acomptes vers\u00e9s": {},
+                    "4092-Fournisseurs Groupe avances et acomptes vers\u00e9s": {},
+                    "4093-Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {},
+                    "4094-Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {},
+                    "4098-Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {}
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "411-Clients": {
+                    "4111-Clients": {
+                        "account_type": "Receivable"
+                    },
+                    "4112-Clients groupe": {
+                        "account_type": "Receivable"
+                    },
+                    "4114-Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable"
+                    },
+                    "4115-Clients, organismes internationaux": {
+                        "account_type": "Receivable"
+                    },
+                    "4116-Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable"
+                    },
+                    "4117-Client, retenues de garantie": {
+                        "account_type": "Receivable"
+                    },
+                    "4118-Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "412-Clients, effets \u00e0 recevoir en portefeuille": {
+                    "4121-Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4122-Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4124-\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "4125-Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "413-Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "4131-Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4132-Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable"
+                    },
+                    "4133-Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "4138-Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "414-Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "4141-Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4142-Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4146-Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "4147-Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "415-Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable"
+                },
+                "416-Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "4161-Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable"
+                    },
+                    "4162-Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "418-Clients, produits \u00e0 recevoir": {
+                    "4181-Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable"
+                    },
+                    "4186-Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable"
+                    },
+                    "account_type": "Receivable"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "421-Personnel, avances et acomptes": {
+                    "4211-Personnel, avances": {},
+                    "4212-Personnel, acomptes": {},
+                    "4213-Frais avanc\u00e9s et fournitures au personnel": {}
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "4311-Prestations familiales": {},
+                    "4312-Accidents de travail": {},
+                    "4313-Caisse de retraite obligatoire": {},
+                    "4314-Caisse de retraite facultative": {},
+                    "4318-Autres cotisations sociales": {}
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "4331-Mutuelle": {},
+                    "4332-Assurances retraite": {},
+                    "4333-Assurances et organismes de sant\u00e9": {}
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4387-Produits \u00e0 recevoir": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "443-\u00c9tat, TVA factur\u00e9e": {
+                    "4431-TVA factur\u00e9e sur ventes": {},
+                    "4432-TVA factur\u00e9e sur prestations de services": {},
+                    "4433-TVA factur\u00e9e sur travaux": {},
+                    "4434-TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {},
+                    "4435-TVA sur factures \u00e0 \u00e9tablir": {}
+                },
+                "445-\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "4451-TVA r\u00e9cup\u00e9rable sur immobilisations": {},
+                    "4452-TVA r\u00e9cup\u00e9rable sur achats": {},
+                    "4453-TVA r\u00e9cup\u00e9rable sur transport": {},
+                    "4454-TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {},
+                    "4455-TVA r\u00e9cup\u00e9rable sur factures non parvenues": {},
+                    "4456-TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {}
+                },
+                "448-\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4486-Charges \u00e0 payer": {},
+                    "4487-Produits \u00e0 recevoir": {}
+                },
+                "449-\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "4491-\u00c9tat, obligations cautionn\u00e9es": {},
+                    "4492-\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {},
+                    "4493-\u00c9tat, fonds de dotation \u00e0 recevoir": {},
+                    "4494-\u00c9tat, subventions investissement \u00e0 recevoir": {},
+                    "4495-\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {},
+                    "4496-\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {},
+                    "4497-\u00c9tat, avances sur subventions": {},
+                    "4499-\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {}
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "451-Op\u00e9rations avec les organismes africains": {},
+                "452-Op\u00e9rations avec les autres organismes internationaux": {},
+                "458-Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "4581-Organismes internationaux, fonds de dotation \u00e0 recevoir": {},
+                    "4582-Organismes internationaux, subventions \u00e0 recevoir": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "4613-Apporteurs, capital appel\u00e9, non vers\u00e9": {},
+                    "4614-Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {},
+                    "4618-Apporteurs, titres \u00e0 \u00e9changer": {}
+                },
+                "467-Apporteurs, restant d\u00fb sur capital appel\u00e9": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "4721-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4726-Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {}
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "4731-Mandants": {},
+                    "4732-Mandataires": {},
+                    "4733-Commettants": {},
+                    "4734-Commissionnaires": {},
+                    "4739-\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "4747-Compte de r\u00e9partition p\u00e9riodique des produits": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "4751-Compte actif": {
+                        "account_type": "Temporary"
+                    }
+                },
+                "476-Charges constat\u00e9es d\u2019avance": {},
+                "478-\u00c9carts de conversion actif": {
+                    "4781-Diminution des cr\u00e9ances d\u2019exploitation": {},
+                    "4782-Diminution des cr\u00e9ances financi\u00e8res": {},
+                    "4783-Augmentation des dettes d\u2019exploitation": {},
+                    "4784-Augmentation des dettes financi\u00e8res": {},
+                    "4786-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4788-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "485-Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "4851-En compte, immobilisations incorporelles": {},
+                    "4852-En compte, immobilisations corporelles": {},
+                    "4853-Effets \u00e0 recevoir, immobilisations incorporelles": {},
+                    "4854-Effets \u00e0 recevoir, immobilisations corporelles": {},
+                    "4855-Effets escompt\u00e9s non \u00e9chus": {},
+                    "4857-Retenues de garantie": {},
+                    "4858-Factures \u00e0 \u00e9tablir": {}
+                },
+                "488-Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {}
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "491-D\u00e9pr\u00e9ciations des comptes clients": {
+                    "4911-Cr\u00e9ances litigieuses": {},
+                    "4912-Cr\u00e9ances douteuses": {}
+                },
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {},
+                "496-D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "4962-Associ\u00e9s, comptes courants": {},
+                    "4963-Associ\u00e9s, op\u00e9rations faites en commun": {},
+                    "4966-Groupe, comptes courants": {}
+                },
+                "497-D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {},
+                "498-D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "4985-Cr\u00e9ances sur cessions d\u2019immobilisations": {},
+                    "4986-Cr\u00e9ances sur cessions de titres de placement": {},
+                    "4988-Autres cr\u00e9ances HAO": {}
+                },
+                "499-Provisions pour risques \u00e0 court terme": {
+                    "4991-Sur op\u00e9rations d\u2019exploitation": {},
+                    "4997-Sur op\u00e9rations financi\u00e8res": {},
+                    "4998-Sur op\u00e9rations HAO": {}
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "401-Fournisseurs, dettes en compte": {
+                    "4011-Fournisseurs": {
+                        "account_type": "Payable"
+                    },
+                    "4012-Fournisseurs groupe": {
+                        "account_type": "Payable"
+                    },
+                    "4013-Fournisseurs sous-traitants": {
+                        "account_type": "Payable"
+                    },
+                    "4016-Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable"
+                    },
+                    "4017-Fournisseur, retenues de garantie": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "402-Fournisseurs, effets \u00e0 payer": {
+                    "4021-Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4022-Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "4023-Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "404-Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "4041-Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4042-Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4046-Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable"
+                    },
+                    "4047-Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable"
+                    },
+                    "account_type": "Payable"
+                },
+                "408-Fournisseurs, factures non parvenues": {
+                    "4081-Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4082-Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4083-Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "4086-Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "account_type": "Stock Received But Not Billed"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "419-Clients cr\u00e9diteurs": {
+                    "4191-Clients, avances et acomptes re\u00e7us": {},
+                    "4192-Clients groupe, avances et acomptes re\u00e7us": {},
+                    "4194-Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {},
+                    "4198-Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {}
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "422-Personnel, r\u00e9mun\u00e9rations dues": {},
+                "423-Personnel, oppositions, saisies-arr\u00eats": {
+                    "4231-Personnel, oppositions": {},
+                    "4232-Personnel, saisies-arr\u00eats": {},
+                    "4233-Personnel, avis \u00e0 tiers d\u00e9tenteur": {}
+                },
+                "424-Personnel, \u0153uvres sociales internes": {
+                    "4241-Assistance m\u00e9dicale": {},
+                    "4242-Allocations familiales": {},
+                    "4245-Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {},
+                    "4248-Autres \u0153uvres sociales internes": {}
+                },
+                "425-Repr\u00e9sentants du personnel": {
+                    "4251-D\u00e9l\u00e9gu\u00e9s du personnel": {},
+                    "4252-Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {},
+                    "4258-Autres repr\u00e9sentants du personnel": {}
+                },
+                "426-Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "4261-Participation aux b\u00e9n\u00e9fices": {},
+                    "4264-Participation au capital": {}
+                },
+                "427-Personnel d\u00e9p\u00f4ts": {},
+                "428-Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4281-Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {},
+                    "4286-Autres charges \u00e0 payer": {},
+                    "4287-Produits \u00e0 recevoir": {}
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "4381-Charges sociales sur gratifications \u00e0 payer": {},
+                    "4382-Charges sociales sur cong\u00e9s \u00e0 payer": {},
+                    "4386-Autres charges \u00e0 payer": {}
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "441-\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {},
+                "442-\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "4421-Imp\u00f4ts et taxes d\u2019\u00c9tat": {},
+                    "4422-Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {},
+                    "4423-Imp\u00f4ts et taxes recouvrables sur des obligataires": {},
+                    "4424-Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {},
+                    "4426-Droits de douane": {},
+                    "4428-Autres imp\u00f4ts et taxes": {}
+                },
+                "444-\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "4441-\u00c9tat, TVA due": {},
+                    "4449-\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {}
+                },
+                "446-\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {},
+                "447-\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "4471-Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {},
+                    "4472-Imp\u00f4ts sur salaires": {},
+                    "4473-Contribution nationale": {},
+                    "4474-Contribution nationale de solidarit\u00e9": {},
+                    "4478-Autres imp\u00f4ts et contributions": {}
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "4611-Apporteurs, apports en nature": {},
+                    "4612-Apporteurs, apports en num\u00e9raire": {},
+                    "4615-Apporteurs, versements re\u00e7us sur augmentation de capital": {},
+                    "4616-Apporteurs, versements anticip\u00e9s": {},
+                    "4617-Apporteurs d\u00e9faillants": {},
+                    "4619-Apporteurs, capital \u00e0 rembourser": {}
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "4621-Principal": {},
+                    "4626-Int\u00e9r\u00eats courus": {}
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "4631-Op\u00e9rations courantes": {},
+                    "4636-Int\u00e9r\u00eats courus": {}
+                },
+                "465-Associ\u00e9s, dividendes \u00e0 payer": {},
+                "466-Groupe, comptes courants": {}
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "4711-D\u00e9biteurs divers": {},
+                    "4712-Cr\u00e9diteurs divers": {},
+                    "4713-Obligataires": {},
+                    "4715-R\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "4716-Compte d\u2019affacturage": {},
+                    "4717-D\u00e9biteurs divers retenues de garantie": {},
+                    "4718-Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {},
+                    "4719-Bons de souscription d\u2019actions et d\u2019obligations": {}
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "4746-Compte de r\u00e9partition p\u00e9riodique des charges": {}
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "4752-Compte passif": {}
+                },
+                "477-Produits constat\u00e9s d\u2019avance": {},
+                "479-\u00c9carts de conversion passif": {
+                    "4791-Augmentation des cr\u00e9ances d\u2019exploitation": {},
+                    "4792-Augmentation des cr\u00e9ances financi\u00e8res": {},
+                    "4793-Diminution des dettes d\u2019exploitation": {},
+                    "4794-Diminution des dettes financi\u00e8res": {},
+                    "4797-Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {},
+                    "4798-Diff\u00e9rences compens\u00e9es par couverture de change": {}
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "481-Fournisseurs d\u2019investissements": {
+                    "4811-Immobilisations incorporelles": {},
+                    "4812-Immobilisations corporelles": {},
+                    "4813-Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {},
+                    "4816-R\u00e9serve de propri\u00e9t\u00e9": {},
+                    "4817-Retenues de garantie": {},
+                    "4818-Factures non parvenues": {}
+                },
+                "482-Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "4821-Immobilisations incorporelles": {},
+                    "4822-Immobilisations corporelles": {}
+                },
+                "484-Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "4887-Produits": {}
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (PASSIF)": {
+                "490-D\u00e9pr\u00e9ciations des comptes fournisseurs": {},
+                "492-D\u00e9pr\u00e9ciations des comptes personnel": {},
+                "493-D\u00e9pr\u00e9ciations des comptes organismes sociaux": {},
+                "494-D\u00e9pr\u00e9ciations des comptes \u00c9tat et collectivit\u00e9s publiques": {},
+                "495-D\u00e9pr\u00e9ciations des comptes organismes internationaux": {}
+            },
+            "root_type": "Liability"
+        },
+        "5-Comptes de tr\u00e9sorerie": {
+            "50-Titres de placement": {
+                "501-Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "5011-Titres du Tr\u00e9sor \u00e0 court terme": {},
+                    "5012-Titres d\u2019organismes financiers": {},
+                    "5013-Bons de caisse \u00e0 court terme": {},
+                    "5016-Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {}
+                },
+                "502-Actions": {
+                    "5021-Actions ou parts propres": {},
+                    "5022-Actions cot\u00e9es": {},
+                    "5023-Actions non cot\u00e9es": {},
+                    "5024-Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {},
+                    "5025-Autres actions": {},
+                    "5026-Frais d\u2019acquisition des actions": {}
+                },
+                "503-Obligations": {
+                    "5031-Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {},
+                    "5032-Obligations cot\u00e9es": {},
+                    "5033-Obligations non cot\u00e9es": {},
+                    "5035-Autres obligations": {},
+                    "5036-Frais d\u2019acquisition des obligations": {}
+                },
+                "504-Bons de souscription": {
+                    "5042-Bons de souscription d\u2019actions": {},
+                    "5043-Bons de souscription d\u2019obligations": {}
+                },
+                "505-Titres n\u00e9gociables hors r\u00e9gion": {},
+                "506-Int\u00e9r\u00eats courus": {
+                    "5061-Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {},
+                    "5062-Actions": {},
+                    "5063-Obligations": {}
+                },
+                "508-Autres titres de placement et cr\u00e9ances assimil\u00e9es": {}
+            },
+            "51-Valeurs \u00e0 encaisser": {
+                "511-Effets \u00e0 encaisser": {},
+                "512-Effets \u00e0 l\u2019encaissement": {},
+                "513-Ch\u00e8ques \u00e0 encaisser": {},
+                "514-Ch\u00e8ques \u00e0 l\u2019encaissement": {},
+                "515-Cartes de cr\u00e9dit \u00e0 encaisser": {},
+                "518-Autres valeurs \u00e0 l\u2019encaissement": {
+                    "5181-Warrants": {},
+                    "5182-Billets de fonds": {},
+                    "5185-Ch\u00e8ques de voyage": {},
+                    "5186-Coupons \u00e9chus": {},
+                    "5187-Int\u00e9r\u00eats \u00e9chus des obligations": {}
+                }
+            },
+            "52-Banques": {
+                "521-Banques locales": {
+                    "5211-Banques en monnaie nationale": {
+                        "account_type": "Bank"
+                    },
+                    "5215-Banques en devises": {
+                        "account_type": "Bank"
+                    },
+                    "account_type": "Bank"
+                },
+                "522-Banques autres \u00c9tats r\u00e9gion": {},
+                "523-Banques autres \u00c9tats zone mon\u00e9taire": {},
+                "524-Banques hors zone mon\u00e9taire": {},
+                "525-Banques d\u00e9p\u00f4t \u00e0 terme": {},
+                "526-Banques, int\u00e9r\u00eats courus": {
+                    "5261-Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {},
+                    "5267-Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {}
+                }
+            },
+            "53-\u00c9tablissements financiers et assimil\u00e9s": {
+                "531-Ch\u00e8ques postaux": {},
+                "532-Tr\u00e9sor": {},
+                "533-Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {},
+                "536-\u00c9tablissements financiers, int\u00e9r\u00eats courus": {},
+                "538-Autres organismes financiers": {}
+            },
+            "54-Instruments de tr\u00e9sorerie": {
+                "541-Options de taux d\u2019int\u00e9r\u00eat": {},
+                "542-Options de taux de change": {},
+                "543-Options de taux boursiers": {},
+                "544-Instruments de march\u00e9s \u00e0 terme": {},
+                "545-Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {}
+            },
+            "55-Instruments de monnaie \u00e9lectronique": {
+                "551-Monnaie \u00e9lectronique carte carburant": {},
+                "552-Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {},
+                "553-Monnaie \u00e9lectronique carte p\u00e9age": {},
+                "554-Porte-monnaie \u00e9lectronique": {},
+                "558-Autres instruments de monnaies \u00e9lectroniques": {}
+            },
+            "56-Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "561-Cr\u00e9dits de tr\u00e9sorerie": {},
+                "564-Escompte de cr\u00e9dits de campagne": {},
+                "565-Escompte de cr\u00e9dits ordinaires": {},
+                "566-Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {}
+            },
+            "57-Caisse": {
+                "571-Caisse si\u00e8ge social": {
+                    "5711-Caisse en monnaie nationale": {},
+                    "5712-Caisse en devises": {}
+                },
+                "572-Caisse succursale A": {
+                    "5721-En monnaie nationale": {},
+                    "5722-En devises": {}
+                },
+                "573-Caisse succursale B": {
+                    "5731-En monnaie nationale": {},
+                    "5732-En devises": {}
+                }
+            },
+            "58-R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "581-R\u00e9gies d\u2019avance": {},
+                "582-Accr\u00e9ditifs": {},
+                "585-Virements de fonds": {},
+                "588-Autres virements internes": {}
+            },
+            "59-D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "590-D\u00e9pr\u00e9ciations des titres de placement": {},
+                "591-D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {},
+                "592-D\u00e9pr\u00e9ciations des comptes banques": {},
+                "593-D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {},
+                "594-D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {},
+                "599-Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {}
+            },
+            "root_type": "Asset"
+        },
+        "6-Comptes de charges des activit\u00e9s ordinaires": {
+            "60-Achats et variations de stocks": {
+                "601-Achats de marchandises": {
+                    "6011-Dans la R\u00e9gion": {},
+                    "6012-Hors R\u00e9gion": {},
+                    "6013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6015-Frais sur achats": {},
+                    "6019-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "602-Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "6021-Dans la R\u00e9gion": {},
+                    "6022-Hors R\u00e9gion": {},
+                    "6023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "6024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "6025-Frais sur achats": {},
+                    "6029-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "603-Variations des stocks de biens achet\u00e9s": {
+                    "6031-Variations des stocks de marchandises": {},
+                    "6032-Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {},
+                    "6033-Variations des stocks d\u2019autres approvisionnements": {}
+                },
+                "604-Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "6041-Mati\u00e8res consommables": {},
+                    "6042-Mati\u00e8res combustibles": {},
+                    "6043-Produits d\u2019entretien": {},
+                    "6044-Fournitures d\u2019atelier et d\u2019usine": {},
+                    "6045-Frais sur achat": {},
+                    "6046-Fournitures de magasin": {},
+                    "6047-Fournitures de bureau": {},
+                    "6049-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "605-Autres achats": {
+                    "6051-Fournitures non stockables Eau": {},
+                    "6052-Fournitures non stockables \u00c9lectricit\u00e9": {},
+                    "6053-Fournitures non stockables Autres \u00e9nergies": {},
+                    "6054-Fournitures d\u2019entretien non stockables": {},
+                    "6055-Fournitures de bureau non stockables": {},
+                    "6056-Achats de petit mat\u00e9riel et outillage": {},
+                    "6057-Achats d\u2019\u00e9tudes et prestations de services": {},
+                    "6058-Achats de travaux, mat\u00e9riels et \u00e9quipements": {},
+                    "6059-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                },
+                "608-Achats d\u2019emballages": {
+                    "6081-Emballages perdus": {},
+                    "6082-Emballages r\u00e9cup\u00e9rables non identifiables": {},
+                    "6083-Emballages \u00e0 usage mixte": {},
+                    "6085-Frais sur achats": {},
+                    "6089-Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {}
+                }
+            },
+            "61-Transports": {
+                "612-Transports sur ventes": {},
+                "613-Transports pour le compte de tiers": {},
+                "614-Transports du personnel": {},
+                "616-Transports de plis": {},
+                "618-Autres frais de transport": {
+                    "6181-Voyages et d\u00e9placements": {},
+                    "6182-Transports entre \u00e9tablissements ou chantiers": {},
+                    "6183-Transports administratifs": {}
+                }
+            },
+            "62-Services ext\u00e9rieurs": {
+                "621-Sous-traitance g\u00e9n\u00e9rale": {},
+                "622-Locations, charges locatives": {
+                    "6221-Locations de terrains": {},
+                    "6222-Locations de b\u00e2timents": {},
+                    "6223-Locations de mat\u00e9riels et outillages": {},
+                    "6224-Malis sur emballages": {},
+                    "6225-Locations d\u2019emballages": {},
+                    "6226-Fermages et loyers du foncier": {},
+                    "6228-Locations et charges locatives diverses": {}
+                },
+                "623-Redevances de location acquisition": {
+                    "6232-Cr\u00e9dit-bail immobilier": {},
+                    "6233-Cr\u00e9dit-bail mobilier": {},
+                    "6234-Location-vente": {},
+                    "6238-Autres contrats de location acquisition": {}
+                },
+                "624-Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "6241-Entretien et r\u00e9parations des biens immobiliers": {},
+                    "6242-Entretien et r\u00e9parations des biens mobiliers": {},
+                    "6243-Maintenance": {},
+                    "6244-Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {},
+                    "6248-Autres entretiens et r\u00e9parations": {}
+                },
+                "625-Primes d\u2019assurance": {
+                    "6251-Assurances multirisques": {},
+                    "6252-Assurances mat\u00e9riel de transport": {},
+                    "6253-Assurances risques d\u2019exploitation": {},
+                    "6254-Assurances responsabilit\u00e9 du producteur": {},
+                    "6255-Assurances insolvabilit\u00e9 clients": {},
+                    "6257-Assurances transport sur ventes": {},
+                    "6258-Autres primes d\u2019assurances": {}
+                },
+                "626-\u00c9tudes, recherches et documentation": {
+                    "6261-\u00c9tudes et recherches": {},
+                    "6265-Documentation g\u00e9n\u00e9rale": {},
+                    "6266-Documentation technique": {}
+                },
+                "627-Publicit\u00e9, publications, relations publiques": {
+                    "6271-Annonces, insertions": {},
+                    "6272-Catalogues, imprim\u00e9s publicitaires": {},
+                    "6273-\u00c9chantillons": {},
+                    "6274-Foires et expositions": {},
+                    "6275-Publications": {},
+                    "6276-Cadeaux \u00e0 la client\u00e8le": {},
+                    "6277-Frais de colloques, s\u00e9minaires, conf\u00e9rences": {},
+                    "6278-Autres charges de publicit\u00e9 et relations publiques": {}
+                },
+                "628-Frais de t\u00e9l\u00e9communications": {
+                    "6281-Frais de t\u00e9l\u00e9phone": {},
+                    "6282-Frais de t\u00e9lex": {},
+                    "6283-Frais de t\u00e9l\u00e9copie": {},
+                    "6288-Autres frais de t\u00e9l\u00e9communications": {}
+                }
+            },
+            "63-Autres services ext\u00e9rieurs": {
+                "631-Frais bancaires": {
+                    "6311-Frais sur titres (vente, garde)": {},
+                    "6312-Frais sur effets": {},
+                    "6313-Location de coffres": {},
+                    "6314-Commissions d\u2019affacturage": {},
+                    "6315-Commissions sur cartes de cr\u00e9dit": {},
+                    "6316-Frais d\u2019\u00e9mission d\u2019emprunts": {},
+                    "6317-Frais sur instruments monnaie \u00e9lectronique": {},
+                    "6318-Autres frais bancaires": {}
+                },
+                "632-R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "6322-Commissions et courtages sur ventes": {},
+                    "6324-Honoraires des professions r\u00e9glement\u00e9es": {},
+                    "6325-Frais d\u2019actes et de contentieux": {},
+                    "6326-R\u00e9mun\u00e9rations d\u2019affacturage": {},
+                    "6327-R\u00e9mun\u00e9rations des autres prestataires de services": {},
+                    "6328-Divers frais": {}
+                },
+                "633-Frais de formation du personnel": {},
+                "634-Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "6342-Redevances pour brevets, licences": {},
+                    "6343-Redevances pour logiciels": {},
+                    "6344-Redevances pour marques": {},
+                    "6345-Redevances pour sites internet": {},
+                    "6346-Redevances pour concessions, droits et valeurs similaires": {}
+                },
+                "635-Cotisations": {
+                    "6351-Cotisations": {},
+                    "6358-Concours divers": {}
+                },
+                "637-R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "6371-Personnel int\u00e9rimaire": {},
+                    "6372-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "638-Autres charges externes": {
+                    "6381-Frais de recrutement du personnel": {},
+                    "6382-Frais de d\u00e9m\u00e9nagement": {},
+                    "6383-R\u00e9ceptions": {},
+                    "6384-Missions": {},
+                    "6385-Charges de copropri\u00e9t\u00e9": {}
+                }
+            },
+            "64-Imp\u00f4ts et taxes": {
+                "641-Imp\u00f4ts et taxes directs": {
+                    "6411-Imp\u00f4ts fonciers et taxes annexes": {},
+                    "6412-Patentes, licences et taxes annexes": {},
+                    "6413-Taxes sur appointements et salaires": {},
+                    "6414-Taxes d\u2019apprentissage": {},
+                    "6415-Formation professionnelle continue": {},
+                    "6418-Autres imp\u00f4ts et taxes directs": {}
+                },
+                "645-Imp\u00f4ts et taxes indirects": {},
+                "646-Droits d\u2019enregistrement": {
+                    "6461-Droits de mutation": {},
+                    "6462-Droits de timbre": {},
+                    "6463-Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {},
+                    "6464-Vignettes": {},
+                    "6468-Autres droits": {}
+                },
+                "647-P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "6471-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {},
+                    "6472-P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {},
+                    "6473-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {},
+                    "6474-P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {},
+                    "6478-Autres p\u00e9nalit\u00e9s et amendes fiscales": {}
+                },
+                "648-Autres imp\u00f4ts et taxes": {}
+            },
+            "65-Autres charges": {
+                "651-Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "6511-Clients": {},
+                    "6515-Autres d\u00e9biteurs": {}
+                },
+                "652-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "6521-Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "6525-Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "654-Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "6541-Immobilisations incorporelles": {},
+                    "6542-Immobilisations corporelles": {}
+                },
+                "656-Perte de change sur cr\u00e9ances et dettes commerciale": {},
+                "657-P\u00e9nalit\u00e9s et amendes p\u00e9nales": {},
+                "658-Charges diverses": {
+                    "6581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "6582-Dons": {},
+                    "6583-M\u00e9c\u00e9nat": {},
+                    "6588-Autres charges diverses": {}
+                },
+                "659-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "6591-Sur risques \u00e0 court terme": {},
+                    "6593-Sur stocks": {},
+                    "6594-Sur cr\u00e9ances": {},
+                    "6598-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {}
+                }
+            },
+            "66-Charges de personnel": {
+                "661-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "6611-Appointements salaires et commissions": {},
+                    "6612-Primes et gratifications": {},
+                    "6613-Cong\u00e9s pay\u00e9s": {},
+                    "6614-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6615-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6616-Suppl\u00e9ment familial": {},
+                    "6617-Avantages en nature": {},
+                    "6618-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "662-R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "6621-Appointements salaires et commissions": {},
+                    "6622-Primes et gratifications": {},
+                    "6623-Cong\u00e9s pay\u00e9s": {},
+                    "6624-Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {},
+                    "6625-Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {},
+                    "6626-Suppl\u00e9ment familial": {},
+                    "6627-Avantages en nature": {},
+                    "6628-Autres r\u00e9mun\u00e9rations directes": {}
+                },
+                "663-Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "6631-Indemnit\u00e9s de logement": {},
+                    "6632-Indemnit\u00e9s de repr\u00e9sentation": {},
+                    "6633-Indemnit\u00e9s d\u2019expatriation": {},
+                    "6634-Indemnit\u00e9s de transport": {},
+                    "6638-Autres indemnit\u00e9s et avantages divers": {}
+                },
+                "664-Charges sociales": {
+                    "6641-Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {},
+                    "6642-Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {}
+                },
+                "666-R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "6661-R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {},
+                    "6662-Charges sociales": {}
+                },
+                "667-R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "6671-Personnel int\u00e9rimaire": {},
+                    "6672-Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {}
+                },
+                "668-Autres charges sociales": {
+                    "6681-Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {},
+                    "6682-Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {},
+                    "6683-Versements et contributions aux autres \u0153uvres sociales": {},
+                    "6684-M\u00e9decine du travail et pharmacie": {},
+                    "6685-Assurances et organismes de sant\u00e9": {},
+                    "6686-Assurances retraite et fonds de pension": {},
+                    "6687-Majorations et p\u00e9nalit\u00e9s sociales": {},
+                    "6688-Charges sociales diverses": {}
+                }
+            },
+            "67-Frais financiers et charges assimil\u00e9es": {
+                "671-Int\u00e9r\u00eats des emprunts": {
+                    "6711-Emprunts obligataires": {},
+                    "6712-Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {},
+                    "6713-Dettes li\u00e9es \u00e0 des participations": {},
+                    "6714-Primes de remboursement des obligations": {}
+                },
+                "672-Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "6722-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {},
+                    "6723-Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {},
+                    "6724-Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {},
+                    "6728-Int\u00e9r\u00eats dans loyers des autres locations acquisition": {}
+                },
+                "673-Escomptes accord\u00e9s": {},
+                "674-Autres int\u00e9r\u00eats": {
+                    "6741-Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {},
+                    "6742-Comptes courants bloqu\u00e9s": {},
+                    "6743-Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {},
+                    "6744-Int\u00e9r\u00eats sur dettes commerciales": {},
+                    "6745-Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {},
+                    "6748-Int\u00e9r\u00eats sur dettes diverses": {}
+                },
+                "675-Escomptes des effets de commerce": {},
+                "676-Pertes de change financi\u00e8res": {},
+                "677-Pertes sur titres de placement": {
+                    "6771-Pertes sur cessions de titres de placement": {},
+                    "6772-Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {}
+                },
+                "678-Pertes et charges sur risques financiers": {
+                    "6781-Sur rentes viag\u00e8res": {},
+                    "6782-Sur op\u00e9rations financi\u00e8res": {},
+                    "6784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "679-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "6791-Sur risques financiers": {},
+                    "6795-Sur titres de placement": {},
+                    "6798-Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "68-Dotations aux amortissements": {
+                "681-Dotations aux amortissements d\u2019exploitation": {
+                    "6812-Dotations aux amortissements des immobilisations incorporelles": {},
+                    "6813-Dotations aux amortissements des immobilisations corporelles": {}
+                }
+            },
+            "69-Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "691-Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "6911-Dotations aux provisions pour risques et charges": {},
+                    "6913-Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {},
+                    "6914-Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {}
+                },
+                "697-Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "6971-Dotations aux provisions pour risques et charges": {},
+                    "6972-Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "7-Comptes de produits des activit\u00e9s ordinaires": {
+            "70-Ventes": {
+                "701-Ventes de marchandises": {
+                    "7011-Dans la R\u00e9gion": {},
+                    "7012-Hors R\u00e9gion": {},
+                    "7013-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7014-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7015-Sur internet": {},
+                    "7019-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "702-Ventes de produits finis": {
+                    "7021-Dans la R\u00e9gion": {},
+                    "7022-Hors R\u00e9gion": {},
+                    "7023-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7024-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7025-Sur internet": {},
+                    "7029-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "703-Ventes de produits interm\u00e9diaires": {
+                    "7031-Dans la R\u00e9gion": {},
+                    "7032-Hors R\u00e9gion": {},
+                    "7033-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7034-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7035-Sur internet": {},
+                    "7039-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "704-Ventes de produits r\u00e9siduels": {
+                    "7041-Dans la R\u00e9gion": {},
+                    "7042-Hors R\u00e9gion": {},
+                    "7043-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7044-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7045-Sur internet": {},
+                    "7049-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "705-Travaux factur\u00e9s": {
+                    "7051-Dans la R\u00e9gion": {},
+                    "7052-Hors R\u00e9gion": {},
+                    "7053-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7054-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7055-Sur internet": {},
+                    "7059-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "706-Services vendus": {
+                    "7061-Dans la R\u00e9gion": {},
+                    "7062-Hors R\u00e9gion": {},
+                    "7063-Aux entit\u00e9s du groupe dans la R\u00e9gion": {},
+                    "7064-Aux entit\u00e9s du groupe hors R\u00e9gion": {},
+                    "7065-Sur internet": {},
+                    "7069-Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {}
+                },
+                "707-Produits accessoires": {
+                    "7071-Ports, emballages perdus et autres frais factur\u00e9s": {},
+                    "7072-Commissions et courtages": {},
+                    "7073-Locations": {},
+                    "7074-Bonis sur reprises et cessions d\u2019emballages": {},
+                    "7075-Mise \u00e0 disposition de personnel": {},
+                    "7076-Redevances pour brevets, logiciels, marques et droits similaires": {},
+                    "7077-Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {},
+                    "7078-Autres produits accessoires": {}
+                }
+            },
+            "71-Subventions d\u2019exploitation": {
+                "711-Sur produits \u00e0 l\u2019exportation": {},
+                "712-Sur produits \u00e0 l\u2019importation": {},
+                "713-Sur produits de p\u00e9r\u00e9quation": {},
+                "714-Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {},
+                "718-Autres subventions d\u2019exploitation": {
+                    "7181-Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {},
+                    "7182-Vers\u00e9es par les organismes internationaux": {},
+                    "7183-Vers\u00e9es par des tiers": {}
+                }
+            },
+            "72-Production immobilis\u00e9e": {
+                "721-Immobilisations incorporelles": {},
+                "722-Immobilisations corporelles": {
+                    "7221-Immobilisations corporelles (hors actifs biologiques)": {},
+                    "7222-Immobilisations corporelles (actifs biologiques)": {}
+                },
+                "724-Production auto-consomm\u00e9e": {},
+                "726-Immobilisations financi\u00e8res": {}
+            },
+            "73-Variations des stocks de biens et de services produits": {
+                "734-Variations des stocks de produits en cours": {
+                    "7341-Produits en cours": {},
+                    "7342-Travaux en cours": {}
+                },
+                "735-Variations des en-cours de services": {
+                    "7351-\u00c9tudes en cours": {},
+                    "7352-Prestations de services en cours": {}
+                },
+                "736-Variations des stocks de produits finis": {},
+                "737-Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "7371-Produits interm\u00e9diaires": {},
+                    "7372-Produits r\u00e9siduels": {}
+                }
+            },
+            "75-Autres produits": {
+                "751-Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {},
+                "752-Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "7521-Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {},
+                    "7525-B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {}
+                },
+                "754-Produits des cessions courantes d\u2019immobilisations": {
+                    "7541-Immobilisations incorporelles": {},
+                    "7542-Immobilisations corporelles": {}
+                },
+                "756-Gains de change sur cr\u00e9ances et dettes commerciales": {},
+                "758-Produits divers": {
+                    "7581-Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {},
+                    "7582-Indemnit\u00e9s d\u2019assurances re\u00e7ues": {},
+                    "7588-Autres produits divers": {}
+                },
+                "759-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "7591-Sur risques \u00e0 court terme": {},
+                    "7593-Sur stocks": {},
+                    "7594-Sur cr\u00e9ances": {},
+                    "7598-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {}
+                }
+            },
+            "77-Revenus financiers et produits assimil\u00e9s": {
+                "771-Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "7712-Int\u00e9r\u00eats de pr\u00eats": {},
+                    "7713-Int\u00e9r\u00eats sur cr\u00e9ances diverses": {}
+                },
+                "772-Revenus de participations et autres titres immobilis\u00e9s": {
+                    "7721-Revenus des titres de participation": {},
+                    "7722-Revenus autres titres immobilis\u00e9s": {}
+                },
+                "773-Escomptes obtenus": {},
+                "774-Revenus de placement": {
+                    "7745-Revenus des obligations": {},
+                    "7746-Revenus des titres de placement": {}
+                },
+                "775-Int\u00e9r\u00eats dans loyers de location acquisition": {},
+                "776-Gains de change financiers": {},
+                "777-Gains sur cessions de titres de placement": {},
+                "778-Gains sur risques financiers": {
+                    "7781-Sur rentes viag\u00e8res": {},
+                    "7782-Sur op\u00e9rations financi\u00e8res": {},
+                    "7784-Sur instruments de tr\u00e9sorerie": {}
+                },
+                "779-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "7791-Sur risques financiers": {},
+                    "7795-Sur titres de placement": {},
+                    "7798-Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {}
+                }
+            },
+            "78-Transferts de charges": {
+                "781-Transferts de charges d\u2019exploitation": {},
+                "787-Transferts de charges financi\u00e8res": {}
+            },
+            "79-Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "791-Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "7911-Pour risques et charges": {},
+                    "7913-Des immobilisations incorporelles": {},
+                    "7914-Des immobilisations corporelles": {}
+                },
+                "797-Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "7971-Pour risques et charges": {},
+                    "7972-Des immobilisations financi\u00e8res": {}
+                },
+                "798-Reprises d\u2019amortissements": {},
+                "799-Reprises de subventions d\u2019investissement": {}
+            },
+            "root_type": "Income"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "81-Valeurs comptables des cessions d\u2019immobilisations": {
+                "811-Immobilisations incorporelles": {},
+                "812-Immobilisations corporelles": {},
+                "816-Immobilisations financi\u00e8res": {}
+            },
+            "83-Charges hors activit\u00e9s ordinaires": {
+                "831-Charges HAO constat\u00e9es": {},
+                "833-Charges li\u00e9es aux op\u00e9rations de restructuration": {},
+                "834-Pertes sur cr\u00e9ances HAO": {},
+                "835-Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {},
+                "836-Abandons de cr\u00e9ances consentis": {},
+                "837-Charges li\u00e9es aux op\u00e9rations de liquidation": {},
+                "839-Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "85-Dotations hors activit\u00e9s ordinaires": {
+                "851-Dotations aux provisions r\u00e9glement\u00e9es": {},
+                "852-Dotations aux amortissements HAO": {},
+                "853-Dotations aux d\u00e9pr\u00e9ciations HAO": {},
+                "854-Dotations aux provisions pour risques et charges HAO": {},
+                "858-Autres dotations HAO": {}
+            },
+            "87-Participation des travailleurs": {
+                "871-Participation l\u00e9gale aux b\u00e9n\u00e9fices": {},
+                "874-Participation contractuelle aux b\u00e9n\u00e9fices": {},
+                "878-Autres participations": {}
+            },
+            "89-Imp\u00f4ts sur le r\u00e9sultat": {
+                "891-Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "8911-Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {},
+                    "8912-Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {},
+                    "8913-Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {}
+                },
+                "892-Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {},
+                "895-Imp\u00f4t minimum forfaitaire IMF": {},
+                "899-D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "8991-D\u00e9gr\u00e8vements": {},
+                    "8994-Annulations pour pertes r\u00e9troactives": {}
+                }
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "82-Produits des cessions d\u2019immobilisations": {
+                "821-Immobilisations incorporelles": {},
+                "822-Immobilisations corporelles": {},
+                "826-Immobilisations financi\u00e8res": {}
+            },
+            "84-Produits hors activit\u00e9s ordinaires": {
+                "841-Produits HAO constat\u00e9s": {},
+                "843-Produits li\u00e9s aux op\u00e9rations de restructuration": {},
+                "844-Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {},
+                "845-Dons et lib\u00e9ralit\u00e9s obtenus": {},
+                "846-Abandons de cr\u00e9ances obtenus": {},
+                "847-Produits li\u00e9s aux op\u00e9rations de liquidation": {},
+                "848-Transferts de charges HAO": {},
+                "849-Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {}
+            },
+            "86-Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "861-Reprises de provisions r\u00e9glement\u00e9es": {},
+                "862-Reprises d\u2019amortissements HAO": {},
+                "863-Reprises de d\u00e9pr\u00e9ciations HAO": {},
+                "864-Reprises de provisions pour risques et charges HAO": {},
+                "868-Autres reprises HAO": {}
+            },
+            "88-Subventions d\u2019\u00e9quilibre": {
+                "881-\u00c9tat": {},
+                "884-Collectivit\u00e9s publiques": {},
+                "886-Groupe": {},
+                "888-Autres": {}
+            },
+            "root_type": "Income"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/tg_plan_comptable_avec_code.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/tg_plan_comptable_avec_code.json
@@ -1,0 +1,4208 @@
+{
+    "country_code": "tg",
+    "name": "Syscohada - Plan Comptable avec code",
+    "tree": {
+        "Comptes de ressources durables": {
+            "Capital": {
+                "Capital social": {
+                    "Capital souscrit, non appel\u00e9": {
+                        "account_number": "1011"
+                    },
+                    "Capital souscrit, appel\u00e9, non vers\u00e9": {
+                        "account_number": "1012"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, non amorti": {
+                        "account_number": "1013"
+                    },
+                    "Capital souscrit, appel\u00e9, vers\u00e9, amorti": {
+                        "account_number": "1014"
+                    },
+                    "Capital souscrit soumis \u00e0 des conditions particuli\u00e8res": {
+                        "account_number": "1018"
+                    },
+                    "account_number": "101"
+                },
+                "Capital par dotation": {
+                    "Dotation initiale": {
+                        "account_number": "1021"
+                    },
+                    "Dotations compl\u00e9mentaires": {
+                        "account_number": "1022"
+                    },
+                    "Autres dotations": {
+                        "account_number": "1028"
+                    },
+                    "account_number": "102"
+                },
+                "Capital personnel": {
+                    "account_number": "103"
+                },
+                "Compte de l\u2019exploitant": {
+                    "Apports temporaires": {
+                        "account_number": "1041"
+                    },
+                    "Op\u00e9rations courantes": {
+                        "account_number": "1042"
+                    },
+                    "R\u00e9mun\u00e9rations, imp\u00f4ts et autres charges personnelles": {
+                        "account_number": "1043"
+                    },
+                    "Pr\u00e9l\u00e8vements d\u2019autoconsommation": {
+                        "account_number": "1047"
+                    },
+                    "Autres pr\u00e9l\u00e8vements": {
+                        "account_number": "1048"
+                    },
+                    "account_number": "104"
+                },
+                "Primes li\u00e9es au capital social": {
+                    "Primes d\u2019\u00e9mission": {
+                        "account_number": "1051"
+                    },
+                    "Primes d\u2019apport": {
+                        "account_number": "1052"
+                    },
+                    "Primes de fusion": {
+                        "account_number": "1053"
+                    },
+                    "Primes de conversion": {
+                        "account_number": "1054"
+                    },
+                    "Autres primes": {
+                        "account_number": "1058"
+                    },
+                    "account_number": "105"
+                },
+                "\u00c9carts de r\u00e9\u00e9valuation": {
+                    "\u00c9carts de r\u00e9\u00e9valuation l\u00e9gale": {
+                        "account_number": "1061"
+                    },
+                    "\u00c9carts de r\u00e9\u00e9valuation libre": {
+                        "account_number": "1062"
+                    },
+                    "account_number": "106"
+                },
+                "Apporteurs, capital souscrit, non appel\u00e9": {
+                    "account_number": "109"
+                },
+                "account_number": "10"
+            },
+            "R\u00e9serves": {
+                "R\u00e9serve l\u00e9gale": {
+                    "account_number": "111"
+                },
+                "R\u00e9serves statutaires ou contractuelles": {
+                    "account_number": "112"
+                },
+                "R\u00e9serves r\u00e9glement\u00e9es": {
+                    "R\u00e9serves de plus-values nettes \u00e0 long terme": {
+                        "account_number": "1131"
+                    },
+                    "R\u00e9serves d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "1132"
+                    },
+                    "R\u00e9serves cons\u00e9cutives \u00e0 l\u2019octroi de subventions d\u2019investissement": {
+                        "account_number": "1133"
+                    },
+                    "R\u00e9serves des valeurs mobili\u00e8res donnant acc\u00e8s au capital": {
+                        "account_number": "1134"
+                    },
+                    "Autres r\u00e9serves r\u00e9glement\u00e9es": {
+                        "account_number": "1135"
+                    },
+                    "account_number": "113"
+                },
+                "Autres r\u00e9serves": {
+                    "R\u00e9serves facultatives": {
+                        "account_number": "1181"
+                    },
+                    "R\u00e9serves diverses": {
+                        "account_number": "1188"
+                    },
+                    "account_number": "118"
+                },
+                "account_number": "11"
+            },
+            "Report \u00e0 nouveau": {
+                "Report \u00e0 nouveau cr\u00e9diteur": {
+                    "account_number": "121"
+                },
+                "Report \u00e0 nouveau d\u00e9biteur": {
+                    "Perte nette \u00e0 reporter": {
+                        "account_number": "1291"
+                    },
+                    "Perte Amortissements r\u00e9put\u00e9s diff\u00e9r\u00e9s": {
+                        "account_number": "1292"
+                    },
+                    "account_number": "129"
+                },
+                "account_number": "12"
+            },
+            "R\u00e9sultat net de l\u2019exercice": {
+                "R\u00e9sultat en instance d\u2019affectation": {
+                    "R\u00e9sultat en instance d\u2019affectation : b\u00e9n\u00e9fice": {
+                        "account_number": "1301"
+                    },
+                    "R\u00e9sultat en instance d\u2019affectation : perte": {
+                        "account_number": "1309"
+                    },
+                    "account_number": "130"
+                },
+                "R\u00e9sultat net : b\u00e9n\u00e9fice": {
+                    "account_number": "131"
+                },
+                "Marge commerciale (MC)": {
+                    "account_number": "132"
+                },
+                "Valeur ajout\u00e9e (VA)": {
+                    "account_number": "133"
+                },
+                "Exc\u00e9dent brut d\u2019exploitation (EBE)": {
+                    "account_number": "134"
+                },
+                "R\u00e9sultat d\u2019exploitation (RE)": {
+                    "account_number": "135"
+                },
+                "R\u00e9sultat financier (RF)": {
+                    "account_number": "136"
+                },
+                "R\u00e9sultat des activit\u00e9s ordinaires (RAO)": {
+                    "account_number": "137"
+                },
+                "R\u00e9sultat hors activit\u00e9s ordinaires (RHAO)": {
+                    "R\u00e9sultat de fusion": {
+                        "account_number": "1381"
+                    },
+                    "R\u00e9sultat d\u2019apport partiel d\u2019actif": {
+                        "account_number": "1382"
+                    },
+                    "R\u00e9sultat de scission": {
+                        "account_number": "1383"
+                    },
+                    "R\u00e9sultat de liquidation": {
+                        "account_number": "1384"
+                    },
+                    "account_number": "138"
+                },
+                "R\u00e9sultat net : perte": {
+                    "account_number": "139"
+                },
+                "account_number": "13"
+            },
+            "Subventions d\u2019investissement": {
+                "Subventions d\u2019\u00e9quipement": {
+                    "\u00c9tat": {
+                        "account_number": "1411"
+                    },
+                    "R\u00e9gions": {
+                        "account_number": "1412"
+                    },
+                    "D\u00e9partements": {
+                        "account_number": "1413"
+                    },
+                    "Communes et collectivit\u00e9s publiques d\u00e9centralis\u00e9es": {
+                        "account_number": "1414"
+                    },
+                    "Entit\u00e9s publiques ou mixtes": {
+                        "account_number": "1415"
+                    },
+                    "Entit\u00e9s et organismes priv\u00e9s": {
+                        "account_number": "1416"
+                    },
+                    "Organismes internationaux": {
+                        "account_number": "1417"
+                    },
+                    "Autres": {
+                        "account_number": "1418"
+                    },
+                    "account_number": "141"
+                },
+                "Autres subventions d\u2019investissement": {
+                    "account_number": "148"
+                },
+                "account_number": "14"
+            },
+            "Provisions r\u00e9glement\u00e9es et fonds assimil\u00e9s": {
+                "Amortissements d\u00e9rogatoires": {
+                    "account_number": "151"
+                },
+                "Plus-values de cession \u00e0 r\u00e9investir": {
+                    "account_number": "152"
+                },
+                "Fonds r\u00e9glement\u00e9s": {
+                    "Fonds National": {
+                        "account_number": "1531"
+                    },
+                    "Pr\u00e9l\u00e8vement pour le Budget": {
+                        "account_number": "1532"
+                    },
+                    "account_number": "153"
+                },
+                "Provisions sp\u00e9ciales de r\u00e9\u00e9valuation": {
+                    "account_number": "154"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux immobilisations": {
+                    "Reconstitution des gisements miniers et p\u00e9troliers": {
+                        "account_number": "1551"
+                    },
+                    "account_number": "155"
+                },
+                "Provisions r\u00e9glement\u00e9es relatives aux stocks": {
+                    "Hausse de prix": {
+                        "account_number": "1561"
+                    },
+                    "Fluctuation des cours": {
+                        "account_number": "1562"
+                    },
+                    "account_number": "156"
+                },
+                "Provisions pour investissement": {
+                    "account_number": "157"
+                },
+                "Autres provisions et fonds r\u00e9glement\u00e9s": {
+                    "account_number": "158"
+                },
+                "account_number": "15"
+            },
+            "Emprunts et dettes assimil\u00e9es": {
+                "Emprunts obligataires": {
+                    "Emprunts obligataires ordinaires": {
+                        "account_number": "1611"
+                    },
+                    "Emprunts obligataires convertibles en actions": {
+                        "account_number": "1612"
+                    },
+                    "Emprunts obligataires remboursables en actions": {
+                        "account_number": "1613"
+                    },
+                    "Autres emprunts obligataires": {
+                        "account_number": "1618"
+                    },
+                    "account_number": "161"
+                },
+                "Emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                    "account_number": "162"
+                },
+                "Avances re\u00e7ues de l\u2019\u00c9tat": {
+                    "account_number": "163"
+                },
+                "Avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                    "account_number": "164"
+                },
+                "D\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                    "D\u00e9p\u00f4ts": {
+                        "account_number": "1651"
+                    },
+                    "Cautionnements": {
+                        "account_number": "1652"
+                    },
+                    "account_number": "165"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur emprunts obligataires": {
+                        "account_number": "1661"
+                    },
+                    "Sur emprunts et dettes aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "1662"
+                    },
+                    "Sur avances re\u00e7ues de l\u2019\u00c9tat": {
+                        "account_number": "1663"
+                    },
+                    "Sur avances re\u00e7ues et comptes courants bloqu\u00e9s": {
+                        "account_number": "1664"
+                    },
+                    "Sur d\u00e9p\u00f4ts et cautionnements re\u00e7us": {
+                        "account_number": "1665"
+                    },
+                    "Sur avances assorties de conditions particuli\u00e8res": {
+                        "account_number": "1667"
+                    },
+                    "Sur autres emprunts et dettes": {
+                        "account_number": "1668"
+                    },
+                    "account_number": "166"
+                },
+                "Avances assorties de conditions particuli\u00e8res": {
+                    "Avances bloqu\u00e9es pour augmentation du capital": {
+                        "account_number": "1671"
+                    },
+                    "Avances conditionn\u00e9es par l\u2019\u00c9tat": {
+                        "account_number": "1672"
+                    },
+                    "Avances conditionn\u00e9es par les autres organismes africains": {
+                        "account_number": "1673"
+                    },
+                    "Avances conditionn\u00e9es par les organismes internationaux": {
+                        "account_number": "1674"
+                    },
+                    "account_number": "167"
+                },
+                "Autres emprunts et dettes": {
+                    "Rentes viag\u00e8res capitalis\u00e9es": {
+                        "account_number": "1681"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "1682"
+                    },
+                    "Dettes cons\u00e9cutives \u00e0 des titres emprunt\u00e9s": {
+                        "account_number": "1683"
+                    },
+                    "Emprunts participatifs": {
+                        "account_number": "1684"
+                    },
+                    "Participation des travailleurs aux b\u00e9n\u00e9fices": {
+                        "account_number": "1685"
+                    },
+                    "Emprunts et dettes contract\u00e9s aupr\u00e8s des autres tiers": {
+                        "account_number": "1686"
+                    },
+                    "account_number": "168"
+                },
+                "account_number": "16"
+            },
+            "Dettes de location acquisition": {
+                "Dettes de location acquisition / cr\u00e9dit bail immobilier": {
+                    "account_number": "172"
+                },
+                "Dettes de location acquisition / cr\u00e9dit bail mobilier": {
+                    "account_number": "173"
+                },
+                "Dettes de location acquisition / location de vente": {
+                    "account_number": "174"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "1762"
+                    },
+                    "Sur dettes de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "1763"
+                    },
+                    "Sur dettes de location acquisition / location-vente": {
+                        "account_number": "1764"
+                    },
+                    "Sur autres dettes de location acquisition": {
+                        "account_number": "1768"
+                    },
+                    "account_number": "176"
+                },
+                "Autres dettes de location acquisition": {
+                    "account_number": "178"
+                },
+                "account_number": "17"
+            },
+            "Dettes li\u00e9es \u00e0 des participations et comptes de liaison des \u00e9tablissements et soci\u00e9t\u00e9s en participation": {
+                "Dettes li\u00e9es \u00e0 des participations": {
+                    "Dettes li\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "1811"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "1812"
+                    },
+                    "account_number": "181"
+                },
+                "Dettes li\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "182"
+                },
+                "Int\u00e9r\u00eats courus sur dettes li\u00e9es \u00e0 des participations": {
+                    "account_number": "183"
+                },
+                "Comptes permanents bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "184"
+                },
+                "Comptes permanents non bloqu\u00e9s des \u00e9tablissements et succursales": {
+                    "account_number": "185"
+                },
+                "Comptes de liaison charges": {
+                    "account_number": "186"
+                },
+                "Comptes de liaison produits": {
+                    "account_number": "187"
+                },
+                "Comptes de liaison des soci\u00e9t\u00e9s en participation": {
+                    "account_number": "188"
+                },
+                "account_number": "18"
+            },
+            "Provisions pour risques et charges": {
+                "Provisions pour litiges": {
+                    "account_number": "191"
+                },
+                "Provisions pour garanties donn\u00e9es aux clients": {
+                    "account_number": "192"
+                },
+                "Provisions pour pertes sur march\u00e9s \u00e0 ach\u00e8vement futur": {
+                    "account_number": "193"
+                },
+                "Provisions pour pertes de change": {
+                    "account_number": "194"
+                },
+                "Provisions pour imp\u00f4ts": {
+                    "account_number": "195"
+                },
+                "Provisions pour pensions et obligations similaires": {
+                    "Provisions pour pensions et obligations similaires engagement de retraite": {
+                        "account_number": "1961"
+                    },
+                    "Actif du r\u00e9gime de retraite": {
+                        "account_number": "1962"
+                    },
+                    "account_number": "196"
+                },
+                "Provisions pour restructuration": {
+                    "account_number": "197"
+                },
+                "Autres provisions pour risques et charges": {
+                    "Provisions pour amendes et p\u00e9nalit\u00e9s": {
+                        "account_number": "1981"
+                    },
+                    "Provisions pour propre assureur": {
+                        "account_number": "1983"
+                    },
+                    "Provisions pour d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "1984"
+                    },
+                    "Provisions pour droits \u00e0 r\u00e9duction ou avantage en nature (ch\u00e8ques cadeau, cartes de fid\u00e9lit\u00e9...)": {
+                        "account_number": "1985"
+                    },
+                    "Provisions pour divers risques et charges": {
+                        "account_number": "1988"
+                    },
+                    "account_number": "198"
+                },
+                "account_number": "19"
+            },
+            "root_type": "Equity",
+            "account_number": "1"
+        },
+        "Comptes d\u2019actif immobilis\u00e9": {
+            "Immobilisations incorporelles": {
+                "account_type": "Fixed Asset",
+                "Frais de d\u00e9veloppement": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "211"
+                },
+                "Brevets, licences, concessions et droits similaires": {
+                    "account_type": "Fixed Asset",
+                    "Brevets": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2121"
+                    },
+                    "Licences": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2122"
+                    },
+                    "Concessions de service public": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2123"
+                    },
+                    "Autres concessions et droits similaires": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2128"
+                    },
+                    "account_number": "212"
+                },
+                "Logiciels et sites internet": {
+                    "account_type": "Fixed Asset",
+                    "Logiciels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2131"
+                    },
+                    "Sites internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2132"
+                    },
+                    "account_number": "213"
+                },
+                "Marques": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "214"
+                },
+                "Fonds commercial": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "215"
+                },
+                "Droit au bail": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "216"
+                },
+                "Investissements de cr\u00e9ation": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "217"
+                },
+                "Autres droits et valeurs incorporels": {
+                    "account_type": "Fixed Asset",
+                    "Frais de prospection et d\u2019\u00e9valuation de ressources min\u00e9rales": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2181"
+                    },
+                    "Co\u00fbts d\u2019obtention du contrat": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2182"
+                    },
+                    "Fichiers clients, notices, titres de journaux et magazines": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2183"
+                    },
+                    "Co\u00fbts des franchises": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2184"
+                    },
+                    "Divers droits et valeurs incorporelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2188"
+                    },
+                    "account_number": "218"
+                },
+                "Immobilisations incorporelles en cours": {
+                    "account_type": "Fixed Asset",
+                    "Frais de d\u00e9veloppement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2191"
+                    },
+                    "Logiciels et internet": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2193"
+                    },
+                    "Autres droits et valeurs incorporels": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2198"
+                    },
+                    "account_number": "219"
+                },
+                "account_number": "21"
+            },
+            "Terrains": {
+                "account_type": "Fixed Asset",
+                "Terrains agricoles et forestiers": {
+                    "account_type": "Fixed Asset",
+                    "Terrains d\u2019exploitation agricole": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2211"
+                    },
+                    "Terrains d\u2019exploitation foresti\u00e8re": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2212"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2218"
+                    },
+                    "account_number": "221"
+                },
+                "Terrains nus": {
+                    "account_type": "Fixed Asset",
+                    "Terrains \u00e0 b\u00e2tir": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2221"
+                    },
+                    "Autres terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2228"
+                    },
+                    "account_number": "222"
+                },
+                "Terrains b\u00e2tis": {
+                    "account_type": "Fixed Asset",
+                    "Pour b\u00e2timents industriels et agricoles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2231"
+                    },
+                    "Pour b\u00e2timents administratifs et commerciaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2232"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2234"
+                    },
+                    "Pour b\u00e2timents affect\u00e9s aux autres op\u00e9rations non professionnelles": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2235"
+                    },
+                    "Autres terrains b\u00e2tis": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2238"
+                    },
+                    "account_number": "223"
+                },
+                "Travaux de mise en valeur des terrains": {
+                    "account_type": "Fixed Asset",
+                    "Plantation d\u2019arbres et d\u2019arbustes": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2241"
+                    },
+                    "Am\u00e9liorations du fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2245"
+                    },
+                    "Autres travaux": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2248"
+                    },
+                    "account_number": "224"
+                },
+                "Terrains de carri\u00e8res tr\u00e9fonds": {
+                    "account_type": "Fixed Asset",
+                    "Carri\u00e8res": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2251"
+                    },
+                    "account_number": "225"
+                },
+                "Terrains am\u00e9nag\u00e9s": {
+                    "account_type": "Fixed Asset",
+                    "Parkings": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2261"
+                    },
+                    "account_number": "226"
+                },
+                "Terrains mis en concession": {
+                    "account_type": "Fixed Asset",
+                    "account_number": "227"
+                },
+                "Autres terrains": {
+                    "account_type": "Fixed Asset",
+                    "Terrains immeubles de placement": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2281"
+                    },
+                    "Terrains des logements affect\u00e9s au personnel": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2285"
+                    },
+                    "Terrains de location acquisition": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2286"
+                    },
+                    "Divers terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2288"
+                    },
+                    "account_number": "228"
+                },
+                "Am\u00e9nagements de terrains en cours": {
+                    "account_type": "Fixed Asset",
+                    "Terrains agricoles et forestiers": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2291"
+                    },
+                    "Terrains nus": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2292"
+                    },
+                    "Terrains de carri\u00e8res tr\u00e9fonds": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2295"
+                    },
+                    "Autres terrains": {
+                        "account_type": "Fixed Asset",
+                        "account_number": "2298"
+                    },
+                    "account_number": "229"
+                },
+                "account_number": "22"
+            },
+            "B\u00e2timents, installations techniques et agencements": {
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2311"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2312"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2313"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2314"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2315"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2316"
+                    },
+                    "account_number": "231"
+                },
+                "B\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                    "B\u00e2timents industriels": {
+                        "account_number": "2321"
+                    },
+                    "B\u00e2timents agricoles": {
+                        "account_number": "2322"
+                    },
+                    "B\u00e2timents administratifs et commerciaux": {
+                        "account_number": "2323"
+                    },
+                    "B\u00e2timents affect\u00e9s au logement du personnel": {
+                        "account_number": "2324"
+                    },
+                    "B\u00e2timents immeubles de placement": {
+                        "account_number": "2325"
+                    },
+                    "B\u00e2timents de location acquisition": {
+                        "account_number": "2326"
+                    },
+                    "account_number": "232"
+                },
+                "Ouvrages d\u2019infrastructure": {
+                    "Voies de terre": {
+                        "account_number": "2331"
+                    },
+                    "Voies de fer": {
+                        "account_number": "2332"
+                    },
+                    "Voies d\u2019eau": {
+                        "account_number": "2333"
+                    },
+                    "Barrages, Digues": {
+                        "account_number": "2334"
+                    },
+                    "Pistes d\u2019a\u00e9rodrome": {
+                        "account_number": "2335"
+                    },
+                    "Autres ouvrages d\u2019infrastructures": {
+                        "account_number": "2338"
+                    },
+                    "account_number": "233"
+                },
+                "Am\u00e9nagements, agencements et installations techniques": {
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol propre": {
+                        "account_number": "2341"
+                    },
+                    "Installations complexes sp\u00e9cialis\u00e9es sur sol d\u2019autrui": {
+                        "account_number": "2342"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol propre": {
+                        "account_number": "2343"
+                    },
+                    "Installations \u00e0 caract\u00e8re sp\u00e9cifique sur sol d\u2019autrui": {
+                        "account_number": "2344"
+                    },
+                    "Am\u00e9nagements et agencements des b\u00e2timents": {
+                        "account_number": "2345"
+                    },
+                    "account_number": "234"
+                },
+                "Am\u00e9nagements de bureaux": {
+                    "Installations g\u00e9n\u00e9rales": {
+                        "account_number": "2351"
+                    },
+                    "Autres am\u00e9nagements de bureaux": {
+                        "account_number": "2358"
+                    },
+                    "account_number": "235"
+                },
+                "B\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                    "account_number": "237"
+                },
+                "Autres installations et agencements": {
+                    "account_number": "238"
+                },
+                "B\u00e2timents am\u00e9nagements, agencements et installations en cours": {
+                    "B\u00e2timents en cours": {
+                        "account_number": "2391"
+                    },
+                    "Installations en cours": {
+                        "account_number": "2392"
+                    },
+                    "Ouvrages d\u2019infrastructure en cours": {
+                        "account_number": "2393"
+                    },
+                    "Am\u00e9nagements et agencements et installations techniques en cours": {
+                        "account_number": "2394"
+                    },
+                    "Am\u00e9nagements de bureaux en cours": {
+                        "account_number": "2395"
+                    },
+                    "Autres installations et agencements en cours": {
+                        "account_number": "2398"
+                    },
+                    "account_number": "239"
+                },
+                "account_number": "23"
+            },
+            "Mat\u00e9riel, mobilier et actifs biologiques": {
+                "Mat\u00e9riel et outillage industriel et commercial": {
+                    "Mat\u00e9riel industriel": {
+                        "account_number": "2411"
+                    },
+                    "Outillage industriel": {
+                        "account_number": "2412"
+                    },
+                    "Mat\u00e9riel commercial": {
+                        "account_number": "2413"
+                    },
+                    "Outillage commercial": {
+                        "account_number": "2414"
+                    },
+                    "Mat\u00e9riel & outillage industriel et commercial de location-acquisition": {
+                        "account_number": "2416"
+                    },
+                    "account_number": "241"
+                },
+                "Mat\u00e9riel et outillage agricole": {
+                    "Mat\u00e9riel agricole": {
+                        "account_number": "2421"
+                    },
+                    "Outillage agricole": {
+                        "account_number": "2422"
+                    },
+                    "Mat\u00e9riel & outillage agricole de location-acquisition": {
+                        "account_number": "2426"
+                    },
+                    "account_number": "242"
+                },
+                "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                    "account_number": "243"
+                },
+                "Mat\u00e9riel et mobilier": {
+                    "Mat\u00e9riel de bureau": {
+                        "account_number": "2441"
+                    },
+                    "Mat\u00e9riel informatique": {
+                        "account_number": "2442"
+                    },
+                    "Mat\u00e9riel bureautique": {
+                        "account_number": "2443"
+                    },
+                    "Mobilier de bureau": {
+                        "account_number": "2444"
+                    },
+                    "Mat\u00e9riel et mobilier immeubles de placement": {
+                        "account_number": "2445"
+                    },
+                    "Mat\u00e9riel et mobilier de location acquisition": {
+                        "account_number": "2446"
+                    },
+                    "Mat\u00e9riel et mobilier des logements du personnel": {
+                        "account_number": "2447"
+                    },
+                    "account_number": "244"
+                },
+                "Mat\u00e9riel de transport": {
+                    "Mat\u00e9riel automobile": {
+                        "account_number": "2451"
+                    },
+                    "Mat\u00e9riel ferroviaire": {
+                        "account_number": "2452"
+                    },
+                    "Mat\u00e9riel fluvial, lagunaire": {
+                        "account_number": "2453"
+                    },
+                    "Mat\u00e9riel naval": {
+                        "account_number": "2454"
+                    },
+                    "Mat\u00e9riel a\u00e9rien": {
+                        "account_number": "2455"
+                    },
+                    "Mat\u00e9riel de transport de location-acquisition": {
+                        "account_number": "2456"
+                    },
+                    "Mat\u00e9riel hippomobile": {
+                        "account_number": "2457"
+                    },
+                    "Autres mat\u00e9riels de transport": {
+                        "account_number": "2458"
+                    },
+                    "account_number": "245"
+                },
+                "Actifs biologiques": {
+                    "Cheptel, animaux de trait": {
+                        "account_number": "2461"
+                    },
+                    "Cheptel, animaux reproducteurs": {
+                        "account_number": "2462"
+                    },
+                    "Animaux de garde": {
+                        "account_number": "2463"
+                    },
+                    "Plantations agricoles": {
+                        "account_number": "2465"
+                    },
+                    "Autres actifs biologiques": {
+                        "account_number": "2468"
+                    },
+                    "account_number": "246"
+                },
+                "Agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                    "Agencements et am\u00e9nagements du mat\u00e9riel": {
+                        "account_number": "2471"
+                    },
+                    "Agencements et am\u00e9nagements des actifs biologiques": {
+                        "account_number": "2472"
+                    },
+                    "Autres agencements, am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2478"
+                    },
+                    "account_number": "247"
+                },
+                "Autres mat\u00e9riels et mobiliers": {
+                    "Collections et \u0153uvres d\u2019art": {
+                        "account_number": "2481"
+                    },
+                    "Divers mat\u00e9riels mobiliers": {
+                        "account_number": "2488"
+                    },
+                    "account_number": "248"
+                },
+                "Mat\u00e9riels et actifs biologiques en cours": {
+                    "Mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2491"
+                    },
+                    "Mat\u00e9riel et outillage agricole": {
+                        "account_number": "2492"
+                    },
+                    "Mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2493"
+                    },
+                    "Mat\u00e9riel et mobilier de bureau": {
+                        "account_number": "2494"
+                    },
+                    "Mat\u00e9riel de transport": {
+                        "account_number": "2495"
+                    },
+                    "Actifs biologiques": {
+                        "account_number": "2496"
+                    },
+                    "Agencements am\u00e9nagements du mat\u00e9riel et actifs biologiques": {
+                        "account_number": "2497"
+                    },
+                    "Autres mat\u00e9riels et actifs biologiques en cours": {
+                        "account_number": "2498"
+                    },
+                    "account_number": "249"
+                },
+                "account_number": "24"
+            },
+            "Avances et acomptes vers\u00e9s sur immobilisations": {
+                "Avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                    "account_number": "251"
+                },
+                "Avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                    "account_number": "252"
+                },
+                "account_number": "25"
+            },
+            "Titres de participation": {
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                    "account_number": "261"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                    "account_number": "262"
+                },
+                "Titres de participation dans des soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                    "account_number": "263"
+                },
+                "Participations dans des organismes professionnels": {
+                    "account_number": "265"
+                },
+                "Parts dans des groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                    "account_number": "266"
+                },
+                "Autres titres de participation": {
+                    "account_number": "268"
+                },
+                "account_number": "26"
+            },
+            "Autres immobilisations financi\u00e8res": {
+                "Pr\u00eats et cr\u00e9ances": {
+                    "Pr\u00eats participatifs": {
+                        "account_number": "2711"
+                    },
+                    "Pr\u00eats aux associ\u00e9s": {
+                        "account_number": "2712"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "2713"
+                    },
+                    "Titres pr\u00eat\u00e9s": {
+                        "account_number": "2714"
+                    },
+                    "Autres pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2718"
+                    },
+                    "account_number": "271"
+                },
+                "Pr\u00eats au personnel": {
+                    "Pr\u00eats immobiliers": {
+                        "account_number": "2721"
+                    },
+                    "Pr\u00eats mobiliers et d\u2019installation": {
+                        "account_number": "2722"
+                    },
+                    "Autres pr\u00eats au personnel": {
+                        "account_number": "2728"
+                    },
+                    "account_number": "272"
+                },
+                "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                    "Retenues de garantie": {
+                        "account_number": "2731"
+                    },
+                    "Fonds r\u00e9glement\u00e9": {
+                        "account_number": "2733"
+                    },
+                    "Cr\u00e9ances sur le conc\u00e9dant": {
+                        "account_number": "2734"
+                    },
+                    "Autres cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2738"
+                    },
+                    "account_number": "273"
+                },
+                "Titres immobilis\u00e9s": {
+                    "Titres immobilis\u00e9s de l\u2019activit\u00e9 de portefeuille (TIAP)": {
+                        "account_number": "2741"
+                    },
+                    "Titres participatifs": {
+                        "account_number": "2742"
+                    },
+                    "Certificats d\u2019investissement": {
+                        "account_number": "2743"
+                    },
+                    "Parts de fonds commun de placement (FCP)": {
+                        "account_number": "2744"
+                    },
+                    "Obligations": {
+                        "account_number": "2745"
+                    },
+                    "Actions ou parts propres": {
+                        "account_number": "2746"
+                    },
+                    "Autres titres immobilis\u00e9s": {
+                        "account_number": "2748"
+                    },
+                    "account_number": "274"
+                },
+                "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                    "D\u00e9p\u00f4ts pour loyers d\u2019avance": {
+                        "account_number": "2751"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019\u00e9lectricit\u00e9": {
+                        "account_number": "2752"
+                    },
+                    "D\u00e9p\u00f4ts pour l\u2019eau": {
+                        "account_number": "2753"
+                    },
+                    "D\u00e9p\u00f4ts pour le gaz": {
+                        "account_number": "2754"
+                    },
+                    "D\u00e9p\u00f4ts pour le t\u00e9l\u00e9phone, le t\u00e9lex, la t\u00e9l\u00e9copie": {
+                        "account_number": "2755"
+                    },
+                    "Cautionnements sur march\u00e9s publics": {
+                        "account_number": "2756"
+                    },
+                    "Cautionnements sur autres op\u00e9rations": {
+                        "account_number": "2757"
+                    },
+                    "Autres d\u00e9p\u00f4ts et cautionnements": {
+                        "account_number": "2758"
+                    },
+                    "account_number": "275"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Pr\u00eats et cr\u00e9ances non commerciales": {
+                        "account_number": "2761"
+                    },
+                    "Pr\u00eats au personnel": {
+                        "account_number": "2762"
+                    },
+                    "Cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2763"
+                    },
+                    "Titres immobilis\u00e9s": {
+                        "account_number": "2764"
+                    },
+                    "D\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2765"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations": {
+                        "account_number": "2767"
+                    },
+                    "Immobilisations financi\u00e8res diverses": {
+                        "account_number": "2768"
+                    },
+                    "account_number": "276"
+                },
+                "Cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (groupe)": {
+                        "account_number": "2771"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des participations (hors groupe)": {
+                        "account_number": "2772"
+                    },
+                    "Cr\u00e9ances rattach\u00e9es \u00e0 des soci\u00e9t\u00e9s en participation": {
+                        "account_number": "2773"
+                    },
+                    "Avances \u00e0 des Groupements d\u2019int\u00e9r\u00eat \u00e9conomique (GIE)": {
+                        "account_number": "2774"
+                    },
+                    "account_number": "277"
+                },
+                "Immobilisations financi\u00e8res diverses": {
+                    "Cr\u00e9ances diverses groupe": {
+                        "account_number": "2781"
+                    },
+                    "Cr\u00e9ances diverses hors groupe": {
+                        "account_number": "2782"
+                    },
+                    "Banques d\u00e9p\u00f4ts \u00e0 terme": {
+                        "account_number": "2784"
+                    },
+                    "Or et m\u00e9taux pr\u00e9cieux": {
+                        "account_number": "2785"
+                    },
+                    "Autres immobilisations financi\u00e8res": {
+                        "account_number": "2788"
+                    },
+                    "account_number": "278"
+                },
+                "account_number": "27"
+            },
+            "Amortissements": {
+                "account_type": "Accumulated Depreciation",
+                "Amortissements des immobilisations corporelles": {
+                    "account_type": "Accumulated Depreciation",
+                    "Amortissements des frais de d\u00e9veloppement": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2811"
+                    },
+                    "Amortissements des brevets, licences, concessions et droits similaires": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2812"
+                    },
+                    "Amortissements des logiciels et sites internet": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2813"
+                    },
+                    "Amortissements des marques": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2814"
+                    },
+                    "Amortissements du fonds commercial": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2815"
+                    },
+                    "Amortissements du droit au bail": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2816"
+                    },
+                    "Amortissements des investissements de cr\u00e9ation": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2817"
+                    },
+                    "Amortissements des autres droits et valeurs incorporels": {
+                        "account_type": "Accumulated Depreciation",
+                        "account_number": "2818"
+                    },
+                    "account_number": "281"
+                },
+                "Amortissements des terrains": {
+                    "Amortissements des travaux de mise en valeur des terrains": {
+                        "account_number": "2824"
+                    },
+                    "account_number": "282"
+                },
+                "Amortissements des b\u00e2timents, installations techniques et agencements": {
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2831"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2832"
+                    },
+                    "Amortissements des ouvrages d\u2019infrastructure": {
+                        "account_number": "2833"
+                    },
+                    "Amortissements des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2834"
+                    },
+                    "Amortissements des am\u00e9nagements de bureaux": {
+                        "account_number": "2835"
+                    },
+                    "Amortissements des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2837"
+                    },
+                    "Amortissements des autres installations et agencements": {
+                        "account_number": "2838"
+                    },
+                    "account_number": "283"
+                },
+                "Amortissements du mat\u00e9riel": {
+                    "Amortissements du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2841"
+                    },
+                    "Amortissements du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2842"
+                    },
+                    "Amortissements du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2843"
+                    },
+                    "Amortissements du mat\u00e9riel et mobilier": {
+                        "account_number": "2844"
+                    },
+                    "Amortissements du mat\u00e9riel de transport": {
+                        "account_number": "2845"
+                    },
+                    "Amortissements des actifs biologiques": {
+                        "account_number": "2846"
+                    },
+                    "Amortissements des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2847"
+                    },
+                    "Amortissements des autres mat\u00e9riels": {
+                        "account_number": "2848"
+                    },
+                    "account_number": "284"
+                },
+                "account_number": "28"
+            },
+            "D\u00e9pr\u00e9ciations des immobilisations": {
+                "D\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                    "D\u00e9pr\u00e9ciations des frais de d\u00e9veloppement": {
+                        "account_number": "2911"
+                    },
+                    "D\u00e9pr\u00e9ciations des brevets, licences, concessions et droits similaires": {
+                        "account_number": "2912"
+                    },
+                    "D\u00e9pr\u00e9ciations des logiciels et sites internet": {
+                        "account_number": "2913"
+                    },
+                    "D\u00e9pr\u00e9ciations des marques": {
+                        "account_number": "2914"
+                    },
+                    "D\u00e9pr\u00e9ciations du fonds commercial": {
+                        "account_number": "2915"
+                    },
+                    "D\u00e9pr\u00e9ciations du droit au bail": {
+                        "account_number": "2916"
+                    },
+                    "D\u00e9pr\u00e9ciations des investissements de cr\u00e9ation": {
+                        "account_number": "2917"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres droits et valeurs incorporels": {
+                        "account_number": "2918"
+                    },
+                    "D\u00e9pr\u00e9ciations des immobilisations incorporelles en cours": {
+                        "account_number": "2919"
+                    },
+                    "account_number": "291"
+                },
+                "D\u00e9pr\u00e9ciations des terrains": {
+                    "D\u00e9pr\u00e9ciations des terrains agricoles et forestiers": {
+                        "account_number": "2921"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains nus": {
+                        "account_number": "2922"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains b\u00e2tis": {
+                        "account_number": "2923"
+                    },
+                    "D\u00e9pr\u00e9ciations des travaux de mise en valeur des terrains": {
+                        "account_number": "2924"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains de gisement": {
+                        "account_number": "2925"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains am\u00e9nag\u00e9s": {
+                        "account_number": "2926"
+                    },
+                    "D\u00e9pr\u00e9ciations des terrains mis en concession": {
+                        "account_number": "2927"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres terrains": {
+                        "account_number": "2928"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de terrains en cours": {
+                        "account_number": "2929"
+                    },
+                    "account_number": "292"
+                },
+                "D\u00e9pr\u00e9ciations des b\u00e2timents, installations techniques et agencements": {
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol propre": {
+                        "account_number": "2931"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles, administratifs et commerciaux sur sol d\u2019autrui": {
+                        "account_number": "2932"
+                    },
+                    "D\u00e9pr\u00e9ciations des ouvrages d\u2019infrastructures": {
+                        "account_number": "2933"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements, agencements et installations techniques": {
+                        "account_number": "2934"
+                    },
+                    "D\u00e9pr\u00e9ciations des am\u00e9nagements de bureaux": {
+                        "account_number": "2935"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents industriels, agricoles et commerciaux mis en concession": {
+                        "account_number": "2937"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres installations et agencements": {
+                        "account_number": "2938"
+                    },
+                    "D\u00e9pr\u00e9ciations des b\u00e2timents et installations en cours": {
+                        "account_number": "2939"
+                    },
+                    "account_number": "293"
+                },
+                "D\u00e9pr\u00e9ciations de mat\u00e9riel, du mobilier et de l\u2019actif biologique": {
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage industriel et commercial": {
+                        "account_number": "2941"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et outillage agricole": {
+                        "account_number": "2942"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel d\u2019emballage r\u00e9cup\u00e9rable et identifiable": {
+                        "account_number": "2943"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel et mobilier": {
+                        "account_number": "2944"
+                    },
+                    "D\u00e9pr\u00e9ciations du mat\u00e9riel de transport": {
+                        "account_number": "2945"
+                    },
+                    "D\u00e9pr\u00e9ciations des actifs biologiques": {
+                        "account_number": "2946"
+                    },
+                    "D\u00e9pr\u00e9ciations des agencements et am\u00e9nagements du mat\u00e9riel et des actifs biologiques": {
+                        "account_number": "2947"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres mat\u00e9riels": {
+                        "account_number": "2948"
+                    },
+                    "D\u00e9pr\u00e9ciations de mat\u00e9riel en cours": {
+                        "account_number": "2949"
+                    },
+                    "account_number": "294"
+                },
+                "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations": {
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations incorporelles": {
+                        "account_number": "2951"
+                    },
+                    "D\u00e9pr\u00e9ciations des avances et acomptes vers\u00e9s sur immobilisations corporelles": {
+                        "account_number": "2952"
+                    },
+                    "account_number": "295"
+                },
+                "D\u00e9pr\u00e9ciations des titres de participation": {
+                    "D\u00e9pr\u00e9ciations des titres de participation dans des soci\u00e9t\u00e9s sous contr\u00f4le exclusif": {
+                        "account_number": "2961"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s sous contr\u00f4le conjoint": {
+                        "account_number": "2962"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres de participation dans les soci\u00e9t\u00e9s conf\u00e9rant une influence notable": {
+                        "account_number": "2963"
+                    },
+                    "D\u00e9pr\u00e9ciations des participations dans des organismes professionnels": {
+                        "account_number": "2965"
+                    },
+                    "D\u00e9pr\u00e9ciations des parts dans des GIE": {
+                        "account_number": "2966"
+                    },
+                    "D\u00e9pr\u00e9ciations des autres titres de participation": {
+                        "account_number": "2968"
+                    },
+                    "account_number": "296"
+                },
+                "D\u00e9pr\u00e9ciations des autres immobilisations financi\u00e8res": {
+                    "D\u00e9pr\u00e9ciations des pr\u00eats et cr\u00e9ances": {
+                        "account_number": "2971"
+                    },
+                    "D\u00e9pr\u00e9ciations des pr\u00eats au personnel": {
+                        "account_number": "2972"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances sur l\u2019\u00c9tat": {
+                        "account_number": "2973"
+                    },
+                    "D\u00e9pr\u00e9ciations des titres immobilis\u00e9s": {
+                        "account_number": "2974"
+                    },
+                    "D\u00e9pr\u00e9ciations des d\u00e9p\u00f4ts et cautionnements vers\u00e9s": {
+                        "account_number": "2975"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances rattach\u00e9es \u00e0 des participations et avances \u00e0 des GIE": {
+                        "account_number": "2977"
+                    },
+                    "D\u00e9pr\u00e9ciations des cr\u00e9ances financi\u00e8res diverses": {
+                        "account_number": "2978"
+                    },
+                    "account_number": "297"
+                },
+                "account_number": "29"
+            },
+            "root_type": "Asset",
+            "account_number": "2"
+        },
+        "Comptes de Stocks": {
+            "Marchandises": {
+                "Marchandises A": {
+                    "Marchandises A1": {
+                        "account_number": "3111"
+                    },
+                    "Marchandises A2": {
+                        "account_number": "3112"
+                    },
+                    "account_number": "311"
+                },
+                "Marchandises B": {
+                    "Marchandises B1": {
+                        "account_number": "3121"
+                    },
+                    "Marchandises B2": {
+                        "account_number": "3122"
+                    },
+                    "account_number": "312"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3131"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3132"
+                    },
+                    "account_number": "313"
+                },
+                "Marchandises hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "318"
+                },
+                "account_number": "31"
+            },
+            "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                "Mati\u00e8res A": {
+                    "account_number": "321"
+                },
+                "Mati\u00e8res B": {
+                    "account_number": "322"
+                },
+                "Fournitures (A, B)": {
+                    "account_number": "323"
+                },
+                "account_number": "32"
+            },
+            "Autres approvisionnements": {
+                "Mati\u00e8res consommables": {
+                    "account_number": "331"
+                },
+                "Fournitures d\u2019atelier et d\u2019usine": {
+                    "account_number": "332"
+                },
+                "Fournitures de magasin": {
+                    "account_number": "333"
+                },
+                "Fournitures de bureau": {
+                    "account_number": "334"
+                },
+                "Emballages": {
+                    "Emballages perdus": {
+                        "account_number": "3351"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "3352"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "3353"
+                    },
+                    "Autres emballages": {
+                        "account_number": "3358"
+                    },
+                    "account_number": "335"
+                },
+                "Autres mati\u00e8res": {
+                    "account_number": "338"
+                },
+                "account_number": "33"
+            },
+            "Produits en cours": {
+                "Produits en cours": {
+                    "Produits en cours P1": {
+                        "account_number": "3411"
+                    },
+                    "Produits en cours P2": {
+                        "account_number": "3412"
+                    },
+                    "account_number": "341"
+                },
+                "Travaux en cours": {
+                    "Travaux en cours T1": {
+                        "account_number": "3421"
+                    },
+                    "Travaux en cours T2": {
+                        "account_number": "3422"
+                    },
+                    "account_number": "342"
+                },
+                "Produits interm\u00e9diaires en cours": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3431"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3432"
+                    },
+                    "account_number": "343"
+                },
+                "Produits r\u00e9siduels en cours": {
+                    "Produits r\u00e9siduels A": {
+                        "account_number": "3441"
+                    },
+                    "Produits r\u00e9siduels B": {
+                        "account_number": "3442"
+                    },
+                    "account_number": "344"
+                },
+                "Actifs biologiques en cours": {
+                    "Animaux": {
+                        "account_number": "3451"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3452"
+                    },
+                    "account_number": "345"
+                },
+                "account_number": "34"
+            },
+            "Services en cours": {
+                "\u00c9tudes en cours": {
+                    "\u00c9tudes en cours E1": {
+                        "account_number": "3511"
+                    },
+                    "\u00c9tudes en cours E2": {
+                        "account_number": "3512"
+                    },
+                    "account_number": "351"
+                },
+                "Prestations de services en cours": {
+                    "Prestations de services S1": {
+                        "account_number": "3521"
+                    },
+                    "Prestations de services S2": {
+                        "account_number": "3522"
+                    }
+                },
+                "account_number": "35"
+            },
+            "Produits finis": {
+                "Produits finis A": {
+                    "account_number": "361"
+                },
+                "Produits finis B": {
+                    "account_number": "362"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3631"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3632"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3638"
+                    },
+                    "account_number": "363"
+                },
+                "account_number": "36"
+            },
+            "Produits interm\u00e9diaires et r\u00e9siduels": {
+                "Produits interm\u00e9diaires": {
+                    "Produits interm\u00e9diaires A": {
+                        "account_number": "3711"
+                    },
+                    "Produits interm\u00e9diaires B": {
+                        "account_number": "3712"
+                    },
+                    "account_number": "371"
+                },
+                "Produits r\u00e9siduels": {
+                    "D\u00e9chets": {
+                        "account_number": "3721"
+                    },
+                    "Rebuts": {
+                        "account_number": "3722"
+                    },
+                    "Mati\u00e8res de R\u00e9cup\u00e9ration": {
+                        "account_number": "3723"
+                    },
+                    "account_number": "372"
+                },
+                "Actifs biologiques": {
+                    "Animaux": {
+                        "account_number": "3731"
+                    },
+                    "V\u00e9g\u00e9taux": {
+                        "account_number": "3732"
+                    },
+                    "Autres stocks (activit\u00e9s annexes)": {
+                        "account_number": "3738"
+                    },
+                    "account_number": "373"
+                },
+                "account_number": "37"
+            },
+            "Stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                "account_type": "Stock",
+                "Marchandises en cours de route": {
+                    "account_number": "381"
+                },
+                "Mati\u00e8res premi\u00e8res et fournitures li\u00e9es en cours de route": {
+                    "account_number": "382"
+                },
+                "Autres approvisionnements en cours de route": {
+                    "account_number": "383"
+                },
+                "Produits finis en cours de route": {
+                    "account_number": "386"
+                },
+                "Stock en consignation ou en d\u00e9p\u00f4t": {
+                    "Stock en consignation": {
+                        "account_number": "3871"
+                    },
+                    "Stock en d\u00e9p\u00f4t": {
+                        "account_number": "3872"
+                    },
+                    "account_number": "387"
+                },
+                "Stock provenant d\u2019immobilisations mises hors service ou au rebut": {
+                    "account_number": "388"
+                },
+                "account_number": "38"
+            },
+            "D\u00e9pr\u00e9ciations des stocks et encours de production": {
+                "D\u00e9pr\u00e9ciations des stocks de marchandises": {
+                    "account_number": "391"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "account_number": "392"
+                },
+                "D\u00e9pr\u00e9ciations des stocks d\u2019autres approvisionnements": {
+                    "account_number": "393"
+                },
+                "D\u00e9pr\u00e9ciations des productions en cours": {
+                    "account_number": "394"
+                },
+                "D\u00e9pr\u00e9ciations des services en cours": {
+                    "account_number": "395"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits finis": {
+                    "account_number": "396"
+                },
+                "D\u00e9pr\u00e9ciations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "account_number": "397"
+                },
+                "D\u00e9pr\u00e9ciations des stocks en cours de route, en consignation ou en d\u00e9p\u00f4t": {
+                    "account_number": "398"
+                },
+                "account_number": "39"
+            },
+            "root_type": "Asset",
+            "account_number": "3"
+        },
+        "4-Comptes de Tiers (ACTIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (ACTIF)": {
+                "Fournisseurs d\u00e9biteurs": {
+                    "Fournisseurs Avances et acomptes vers\u00e9s": {
+                        "account_number": "4091"
+                    },
+                    "Fournisseurs Groupe avances et acomptes vers\u00e9s": {
+                        "account_number": "4092"
+                    },
+                    "Fournisseurs Sous-traitants avances et acomptes vers\u00e9s": {
+                        "account_number": "4093"
+                    },
+                    "Fournisseurs Cr\u00e9ances pour emballages et mat\u00e9riels \u00e0 rendre": {
+                        "account_number": "4094"
+                    },
+                    "Fournisseurs Rabais, remises, ristournes et autres avoirs \u00e0 obtenir": {
+                        "account_number": "4098"
+                    },
+                    "account_number": "409"
+                }
+            },
+            "41-Clients et comptes rattach\u00e9s (ACTIF)": {
+                "Clients": {
+                    "Clients": {
+                        "account_type": "Receivable",
+                        "account_number": "4111"
+                    },
+                    "Clients groupe": {
+                        "account_type": "Receivable",
+                        "account_number": "4112"
+                    },
+                    "Clients, \u00c9tat et Collectivit\u00e9s publiques": {
+                        "account_type": "Receivable",
+                        "account_number": "4114"
+                    },
+                    "Clients, organismes internationaux": {
+                        "account_type": "Receivable",
+                        "account_number": "4115"
+                    },
+                    "Clients, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Receivable",
+                        "account_number": "4116"
+                    },
+                    "Client, retenues de garantie": {
+                        "account_type": "Receivable",
+                        "account_number": "4117"
+                    },
+                    "Clients, d\u00e9gr\u00e8vement de taxes sur la valeur ajout\u00e9e (TVA)": {
+                        "account_type": "Receivable",
+                        "account_number": "4118"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "411"
+                },
+                "Clients, effets \u00e0 recevoir en portefeuille": {
+                    "Clients, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4121"
+                    },
+                    "Clients Groupe, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4122"
+                    },
+                    "\u00c9tat et Collectivit\u00e9s publiques, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4124"
+                    },
+                    "Organismes Internationaux, effets \u00e0 recevoir": {
+                        "account_type": "Receivable",
+                        "account_number": "4125"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "412"
+                },
+                "Clients, ch\u00e8ques, effets et autres valeurs impay\u00e9es": {
+                    "Clients, ch\u00e8ques impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4131"
+                    },
+                    "Clients, effets impay\u00e9s": {
+                        "account_type": "Receivable",
+                        "account_number": "4132"
+                    },
+                    "Clients, cartes de cr\u00e9dit impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4133"
+                    },
+                    "Clients, autres valeurs impay\u00e9es": {
+                        "account_type": "Receivable",
+                        "account_number": "4138"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "413"
+                },
+                "Cr\u00e9ances sur cessions courantes d\u2019immobilisations": {
+                    "Cr\u00e9ances en compte, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4141"
+                    },
+                    "Cr\u00e9ances en compte, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4142"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4146"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_type": "Receivable",
+                        "account_number": "4147"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "414"
+                },
+                "Clients, effets escompt\u00e9s non \u00e9chus": {
+                    "account_type": "Receivable",
+                    "account_number": "415"
+                },
+                "Cr\u00e9ances clients litigieuses ou douteuses": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4161"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_type": "Receivable",
+                        "account_number": "4162"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "416"
+                },
+                "Clients, produits \u00e0 recevoir": {
+                    "Clients, factures \u00e0 \u00e9tablir": {
+                        "account_type": "Receivable",
+                        "account_number": "4181"
+                    },
+                    "Clients, int\u00e9r\u00eats courus": {
+                        "account_type": "Receivable",
+                        "account_number": "4186"
+                    },
+                    "account_type": "Receivable",
+                    "account_number": "418"
+                },
+                "account_type": "Receivable"
+            },
+            "42-Personnel (ACTIF)": {
+                "Personnel, avances et acomptes": {
+                    "Personnel, avances": {
+                        "account_number": "4211"
+                    },
+                    "Personnel, acomptes": {
+                        "account_number": "4212"
+                    },
+                    "Frais avanc\u00e9s et fournitures au personnel": {
+                        "account_number": "4213"
+                    },
+                    "account_number": "421"
+                }
+            },
+            "43-Organismes sociaux (ACTIF)": {
+                "431-S\u00e9curit\u00e9 sociale": {
+                    "Prestations familiales": {
+                        "account_number": "4311"
+                    },
+                    "Accidents de travail": {
+                        "account_number": "4312"
+                    },
+                    "Caisse de retraite obligatoire": {
+                        "account_number": "4313"
+                    },
+                    "Caisse de retraite facultative": {
+                        "account_number": "4314"
+                    },
+                    "Autres cotisations sociales": {
+                        "account_number": "4318"
+                    }
+                },
+                "432-Caisses de retraite compl\u00e9mentaire": {},
+                "433-Autres organismes sociaux": {
+                    "Mutuelle": {
+                        "account_number": "4331"
+                    },
+                    "Assurances retraite": {
+                        "account_number": "4332"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "4333"
+                    }
+                },
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4387"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (ACTIF)": {
+                "\u00c9tat, TVA factur\u00e9e": {
+                    "TVA factur\u00e9e sur ventes": {
+                        "account_number": "4431"
+                    },
+                    "TVA factur\u00e9e sur prestations de services": {
+                        "account_number": "4432"
+                    },
+                    "TVA factur\u00e9e sur travaux": {
+                        "account_number": "4433"
+                    },
+                    "TVA factur\u00e9e sur production livr\u00e9e \u00e0 soi-m\u00eame": {
+                        "account_number": "4434"
+                    },
+                    "TVA sur factures \u00e0 \u00e9tablir": {
+                        "account_number": "4435"
+                    },
+                    "account_number": "443"
+                },
+                "\u00c9tat, TVA r\u00e9cup\u00e9rable": {
+                    "TVA r\u00e9cup\u00e9rable sur immobilisations": {
+                        "account_number": "4451"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur achats": {
+                        "account_number": "4452"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur transport": {
+                        "account_number": "4453"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur services ext\u00e9rieurs et autres charges": {
+                        "account_number": "4454"
+                    },
+                    "TVA r\u00e9cup\u00e9rable sur factures non parvenues": {
+                        "account_number": "4455"
+                    },
+                    "TVA transf\u00e9r\u00e9e par d\u2019autres entit\u00e9s": {
+                        "account_number": "4456"
+                    },
+                    "account_number": "445"
+                },
+                "\u00c9tat, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges \u00e0 payer": {
+                        "account_number": "4486"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4487"
+                    },
+                    "account_number": "448"
+                },
+                "\u00c9tat, cr\u00e9ances et dettes diverses": {
+                    "\u00c9tat, obligations cautionn\u00e9es": {
+                        "account_number": "4491"
+                    },
+                    "\u00c9tat, avances et acomptes vers\u00e9s sur imp\u00f4ts": {
+                        "account_number": "4492"
+                    },
+                    "\u00c9tat, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4493"
+                    },
+                    "\u00c9tat, subventions investissement \u00e0 recevoir": {
+                        "account_number": "4494"
+                    },
+                    "\u00c9tat, subventions d\u2019exploitation \u00e0 recevoir": {
+                        "account_number": "4495"
+                    },
+                    "\u00c9tat, subventions d\u2019\u00e9quilibre \u00e0 recevoir": {
+                        "account_number": "4496"
+                    },
+                    "\u00c9tat, avances sur subventions": {
+                        "account_number": "4497"
+                    },
+                    "\u00c9tat, fonds r\u00e9glement\u00e9s provisionn\u00e9s": {
+                        "account_number": "4499"
+                    },
+                    "account_number": "449"
+                }
+            },
+            "45-Organismes internationaux (ACTIF)": {
+                "Op\u00e9rations avec les organismes africains": {
+                    "account_number": "451"
+                },
+                "Op\u00e9rations avec les autres organismes internationaux": {
+                    "account_number": "452"
+                },
+                "Organismes internationaux, fonds de dotation et subventions \u00e0 recevoir": {
+                    "Organismes internationaux, fonds de dotation \u00e0 recevoir": {
+                        "account_number": "4581"
+                    },
+                    "Organismes internationaux, subventions \u00e0 recevoir": {
+                        "account_number": "4582"
+                    },
+                    "account_number": "458"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (ACTIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital": {
+                    "Apporteurs, capital appel\u00e9, non vers\u00e9": {
+                        "account_number": "4613"
+                    },
+                    "Apporteurs, compte d\u2019apport, op\u00e9rations de restructuration (fusion...)": {
+                        "account_number": "4614"
+                    },
+                    "Apporteurs, titres \u00e0 \u00e9changer": {
+                        "account_number": "4618"
+                    }
+                },
+                "Apporteurs, restant d\u00fb sur capital appel\u00e9": {
+                    "account_number": "467"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (ACTIF)": {
+                "472-Cr\u00e9ances et dettes sur titres de placement": {
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4721"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de placement non lib\u00e9r\u00e9s": {
+                        "account_number": "4726"
+                    }
+                },
+                "473-Interm\u00e9diaires Op\u00e9rations faites pour compte de tiers": {
+                    "Mandants": {
+                        "account_number": "4731"
+                    },
+                    "Mandataires": {
+                        "account_number": "4732"
+                    },
+                    "Commettants": {
+                        "account_number": "4733"
+                    },
+                    "Commissionnaires": {
+                        "account_number": "4734"
+                    },
+                    "\u00c9tat, Collectivit\u00e9s publiques, fonds global d\u2019allocation": {
+                        "account_number": "4739"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits": {
+                    "Compte de r\u00e9partition p\u00e9riodique des produits": {
+                        "account_number": "4747"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA": {
+                    "Compte actif": {
+                        "account_type": "Temporary",
+                        "account_number": "4751"
+                    }
+                },
+                "Charges constat\u00e9es d\u2019avance": {
+                    "account_number": "476"
+                },
+                "478-\u00c9carts de conversion actif": {
+                    "Diminution des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4781"
+                    },
+                    "Diminution des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4782"
+                    },
+                    "Augmentation des dettes d\u2019exploitation": {
+                        "account_number": "4783"
+                    },
+                    "Augmentation des dettes financi\u00e8res": {
+                        "account_number": "4784"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4786"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4788"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (ACTIF)": {
+                "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                    "En compte, immobilisations incorporelles": {
+                        "account_number": "4851"
+                    },
+                    "En compte, immobilisations corporelles": {
+                        "account_number": "4852"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations incorporelles": {
+                        "account_number": "4853"
+                    },
+                    "Effets \u00e0 recevoir, immobilisations corporelles": {
+                        "account_number": "4854"
+                    },
+                    "Effets escompt\u00e9s non \u00e9chus": {
+                        "account_number": "4855"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4857"
+                    },
+                    "Factures \u00e0 \u00e9tablir": {
+                        "account_number": "4858"
+                    },
+                    "account_number": "485"
+                },
+                "Autres cr\u00e9ances hors activit\u00e9s ordinaires (HAO)": {
+                    "account_number": "488"
+                }
+            },
+            "49-D\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme (tiers) (ACTIF)": {
+                "D\u00e9pr\u00e9ciations des comptes clients": {
+                    "Cr\u00e9ances litigieuses": {
+                        "account_number": "4911"
+                    },
+                    "Cr\u00e9ances douteuses": {
+                        "account_number": "4912"
+                    },
+                    "account_number": "491"
+                },
+                "D\u00e9pr\u00e9ciations des comptes organismes internationaux": {
+                    "account_number": "495"
+                },
+                "D\u00e9pr\u00e9ciations des comptes apporteurs, associ\u00e9s et groupe": {
+                    "Associ\u00e9s, comptes courants": {
+                        "account_number": "4962"
+                    },
+                    "Associ\u00e9s, op\u00e9rations faites en commun": {
+                        "account_number": "4963"
+                    },
+                    "Groupe, comptes courants": {
+                        "account_number": "4966"
+                    },
+                    "account_number": "496"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u00e9biteurs divers": {
+                    "account_number": "497"
+                },
+                "D\u00e9pr\u00e9ciations des comptes de cr\u00e9ances HAO": {
+                    "Cr\u00e9ances sur cessions d\u2019immobilisations": {
+                        "account_number": "4985"
+                    },
+                    "Cr\u00e9ances sur cessions de titres de placement": {
+                        "account_number": "4986"
+                    },
+                    "Autres cr\u00e9ances HAO": {
+                        "account_number": "4988"
+                    },
+                    "account_number": "498"
+                },
+                "Provisions pour risques \u00e0 court terme": {
+                    "Sur op\u00e9rations d\u2019exploitation": {
+                        "account_number": "4991"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "4997"
+                    },
+                    "Sur op\u00e9rations HAO": {
+                        "account_number": "4998"
+                    },
+                    "account_number": "499"
+                }
+            },
+            "root_type": "Asset"
+        },
+        "4-Comptes de Tiers (PASSIF)": {
+            "40-Fournisseurs et comptes rattach\u00e9s (PASSIF)": {
+                "Fournisseurs, dettes en compte": {
+                    "Fournisseurs": {
+                        "account_type": "Payable",
+                        "account_number": "4011"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Payable",
+                        "account_number": "4012"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Payable",
+                        "account_number": "4013"
+                    },
+                    "Fournisseurs, r\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_type": "Payable",
+                        "account_number": "4016"
+                    },
+                    "Fournisseur, retenues de garantie": {
+                        "account_type": "Payable",
+                        "account_number": "4017"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "401"
+                },
+                "Fournisseurs, effets \u00e0 payer": {
+                    "Fournisseurs Effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4021"
+                    },
+                    "Fournisseurs Groupe, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4022"
+                    },
+                    "Fournisseurs Sous-traitants, effets \u00e0 payer": {
+                        "account_type": "Payable",
+                        "account_number": "4023"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "402"
+                },
+                "Fournisseurs, acquisitions courantes d\u2019immobilisations": {
+                    "Fournisseurs Dettes en comptes, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4041"
+                    },
+                    "Fournisseurs Dettes en comptes, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4042"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations incorporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4046"
+                    },
+                    "Fournisseurs Effets \u00e0 payer, immobilisations corporelles": {
+                        "account_type": "Payable",
+                        "account_number": "4047"
+                    },
+                    "account_type": "Payable",
+                    "account_number": "404"
+                },
+                "Fournisseurs, factures non parvenues": {
+                    "Fournisseurs": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4081"
+                    },
+                    "Fournisseurs groupe": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4082"
+                    },
+                    "Fournisseurs sous-traitants": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4083"
+                    },
+                    "Fournisseurs, int\u00e9r\u00eats courus": {
+                        "account_type": "Stock Received But Not Billed",
+                        "account_number": "4086"
+                    },
+                    "account_type": "Stock Received But Not Billed",
+                    "account_number": "408"
+                },
+                "account_type": "Payable"
+            },
+            "41-Clients et comptes rattach\u00e9s (PASSIF)": {
+                "Clients cr\u00e9diteurs": {
+                    "Clients, avances et acomptes re\u00e7us": {
+                        "account_number": "4191"
+                    },
+                    "Clients groupe, avances et acomptes re\u00e7us": {
+                        "account_number": "4192"
+                    },
+                    "Clients, dettes pour emballages et mat\u00e9riels consign\u00e9s": {
+                        "account_number": "4194"
+                    },
+                    "Clients, rabais, remises, ristournes et autres avoirs \u00e0 accorder": {
+                        "account_number": "4198"
+                    },
+                    "account_number": "419"
+                }
+            },
+            "42-Personnel (PASSIF)": {
+                "Personnel, r\u00e9mun\u00e9rations dues": {
+                    "account_number": "422"
+                },
+                "Personnel, oppositions, saisies-arr\u00eats": {
+                    "Personnel, oppositions": {
+                        "account_number": "4231"
+                    },
+                    "Personnel, saisies-arr\u00eats": {
+                        "account_number": "4232"
+                    },
+                    "Personnel, avis \u00e0 tiers d\u00e9tenteur": {
+                        "account_number": "4233"
+                    },
+                    "account_number": "423"
+                },
+                "Personnel, \u0153uvres sociales internes": {
+                    "Assistance m\u00e9dicale": {
+                        "account_number": "4241"
+                    },
+                    "Allocations familiales": {
+                        "account_number": "4242"
+                    },
+                    "Organismes sociaux rattach\u00e9s \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "4245"
+                    },
+                    "Autres \u0153uvres sociales internes": {
+                        "account_number": "4248"
+                    },
+                    "account_number": "424"
+                },
+                "Repr\u00e9sentants du personnel": {
+                    "D\u00e9l\u00e9gu\u00e9s du personnel": {
+                        "account_number": "4251"
+                    },
+                    "Syndicats et Comit\u00e9s d\u2019entreprises, d\u2019\u00c9tablissement": {
+                        "account_number": "4252"
+                    },
+                    "Autres repr\u00e9sentants du personnel": {
+                        "account_number": "4258"
+                    },
+                    "account_number": "425"
+                },
+                "Personnel, participation aux b\u00e9n\u00e9fices et au capital": {
+                    "Participation aux b\u00e9n\u00e9fices": {
+                        "account_number": "4261"
+                    },
+                    "Participation au capital": {
+                        "account_number": "4264"
+                    },
+                    "account_number": "426"
+                },
+                "Personnel d\u00e9p\u00f4ts": {
+                    "account_number": "427"
+                },
+                "Personnel, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Dettes provisionn\u00e9es pour cong\u00e9s \u00e0 payer": {
+                        "account_number": "4281"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4286"
+                    },
+                    "Produits \u00e0 recevoir": {
+                        "account_number": "4287"
+                    },
+                    "account_number": "428"
+                }
+            },
+            "43-Organismes sociaux (PASSIF)": {
+                "438-Organismes sociaux, charges \u00e0 payer et produits \u00e0 recevoir": {
+                    "Charges sociales sur gratifications \u00e0 payer": {
+                        "account_number": "4381"
+                    },
+                    "Charges sociales sur cong\u00e9s \u00e0 payer": {
+                        "account_number": "4382"
+                    },
+                    "Autres charges \u00e0 payer": {
+                        "account_number": "4386"
+                    }
+                }
+            },
+            "44-\u00c9tat et collectivit\u00e9s publiques (PASSIF)": {
+                "\u00c9tat, imp\u00f4t sur les b\u00e9n\u00e9fices": {
+                    "account_number": "441"
+                },
+                "\u00c9tat, autres imp\u00f4ts et taxes": {
+                    "Imp\u00f4ts et taxes d\u2019\u00c9tat": {
+                        "account_number": "4421"
+                    },
+                    "Imp\u00f4ts et taxes pour les collectivit\u00e9s publiques": {
+                        "account_number": "4422"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des obligataires": {
+                        "account_number": "4423"
+                    },
+                    "Imp\u00f4ts et taxes recouvrables sur des associ\u00e9s": {
+                        "account_number": "4424"
+                    },
+                    "Droits de douane": {
+                        "account_number": "4426"
+                    },
+                    "Autres imp\u00f4ts et taxes": {
+                        "account_number": "4428"
+                    },
+                    "account_number": "442"
+                },
+                "\u00c9tat, TVA due ou cr\u00e9dit de TVA": {
+                    "\u00c9tat, TVA due": {
+                        "account_number": "4441"
+                    },
+                    "\u00c9tat, cr\u00e9dit de TVA \u00e0 reporter": {
+                        "account_number": "4449"
+                    },
+                    "account_number": "444"
+                },
+                "\u00c9tat, autres taxes sur le chiffre d\u2019affaires": {
+                    "account_number": "446"
+                },
+                "\u00c9tat, imp\u00f4ts retenus \u00e0 la source": {
+                    "Imp\u00f4t G\u00e9n\u00e9ral sur le revenu": {
+                        "account_number": "4471"
+                    },
+                    "Imp\u00f4ts sur salaires": {
+                        "account_number": "4472"
+                    },
+                    "Contribution nationale": {
+                        "account_number": "4473"
+                    },
+                    "Contribution nationale de solidarit\u00e9": {
+                        "account_number": "4474"
+                    },
+                    "Autres imp\u00f4ts et contributions": {
+                        "account_number": "4478"
+                    },
+                    "account_number": "447"
+                }
+            },
+            "46-Apporteurs, associ\u00e9s et groupe (PASSIF)": {
+                "461-Apporteurs, op\u00e9rations sur le capital (PASSIF)": {
+                    "Apporteurs, apports en nature": {
+                        "account_number": "4611"
+                    },
+                    "Apporteurs, apports en num\u00e9raire": {
+                        "account_number": "4612"
+                    },
+                    "Apporteurs, versements re\u00e7us sur augmentation de capital": {
+                        "account_number": "4615"
+                    },
+                    "Apporteurs, versements anticip\u00e9s": {
+                        "account_number": "4616"
+                    },
+                    "Apporteurs d\u00e9faillants": {
+                        "account_number": "4617"
+                    },
+                    "Apporteurs, capital \u00e0 rembourser": {
+                        "account_number": "4619"
+                    }
+                },
+                "462-Associ\u00e9s, comptes courants": {
+                    "Principal": {
+                        "account_number": "4621"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4626"
+                    }
+                },
+                "463-Associ\u00e9s, op\u00e9rations faites en commun et GIE": {
+                    "Op\u00e9rations courantes": {
+                        "account_number": "4631"
+                    },
+                    "Int\u00e9r\u00eats courus": {
+                        "account_number": "4636"
+                    }
+                },
+                "Associ\u00e9s, dividendes \u00e0 payer": {
+                    "account_number": "465"
+                },
+                "Groupe, comptes courants": {
+                    "account_number": "466"
+                }
+            },
+            "47-D\u00e9biteurs et cr\u00e9diteurs divers (PASSIF)": {
+                "471-D\u00e9biteurs et cr\u00e9diteurs divers": {
+                    "D\u00e9biteurs divers": {
+                        "account_number": "4711"
+                    },
+                    "Cr\u00e9diteurs divers": {
+                        "account_number": "4712"
+                    },
+                    "Obligataires": {
+                        "account_number": "4713"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "4715"
+                    },
+                    "Compte d\u2019affacturage": {
+                        "account_number": "4716"
+                    },
+                    "D\u00e9biteurs divers retenues de garantie": {
+                        "account_number": "4717"
+                    },
+                    "Apport, compte de fusion et op\u00e9rations assimil\u00e9es": {
+                        "account_number": "4718"
+                    },
+                    "Bons de souscription d\u2019actions et d\u2019obligations": {
+                        "account_number": "4719"
+                    }
+                },
+                "474-Compte de r\u00e9partition p\u00e9riodique des charges et des produits (PASSIF)": {
+                    "Compte de r\u00e9partition p\u00e9riodique des charges": {
+                        "account_number": "4746"
+                    }
+                },
+                "475-Compte transitoire, ajustement sp\u00e9cial li\u00e9 \u00e0 la r\u00e9vision du SYSCOHADA (PASSIF)": {
+                    "Compte passif": {
+                        "account_number": "4752"
+                    }
+                },
+                "Produits constat\u00e9s d\u2019avance": {
+                    "account_number": "477"
+                },
+                "479-\u00c9carts de conversion passif": {
+                    "Augmentation des cr\u00e9ances d\u2019exploitation": {
+                        "account_number": "4791"
+                    },
+                    "Augmentation des cr\u00e9ances financi\u00e8res": {
+                        "account_number": "4792"
+                    },
+                    "Diminution des dettes d\u2019exploitation": {
+                        "account_number": "4793"
+                    },
+                    "Diminution des dettes financi\u00e8res": {
+                        "account_number": "4794"
+                    },
+                    "Diff\u00e9rences d\u2019\u00e9valuation sur instruments de tr\u00e9sorerie": {
+                        "account_number": "4797"
+                    },
+                    "Diff\u00e9rences compens\u00e9es par couverture de change": {
+                        "account_number": "4798"
+                    }
+                }
+            },
+            "48-Cr\u00e9ances et dettes hors activit\u00e9s ordinaires (HAO) (PASSIF)": {
+                "Fournisseurs d\u2019investissements": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4811"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4812"
+                    },
+                    "Versements restant \u00e0 effectuer sur titres de participation et titres immobilis\u00e9s non lib\u00e9r\u00e9s": {
+                        "account_number": "4813"
+                    },
+                    "R\u00e9serve de propri\u00e9t\u00e9": {
+                        "account_number": "4816"
+                    },
+                    "Retenues de garantie": {
+                        "account_number": "4817"
+                    },
+                    "Factures non parvenues": {
+                        "account_number": "4818"
+                    },
+                    "account_number": "481"
+                },
+                "Fournisseurs d\u2019investissements, effets \u00e0 payer": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "4821"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "4822"
+                    },
+                    "account_number": "482"
+                },
+                "Autres dettes hors activit\u00e9s ordinaires (HAO)": {
+                    "Produits": {
+                        "account_number": "4887"
+                    },
+                    "account_number": "484"
+                }
+            },
+            "root_type": "Liability"
+        },
+        "Comptes de tr\u00e9sorerie": {
+            "Titres de placement": {
+                "Titres du tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                    "Titres du Tr\u00e9sor \u00e0 court terme": {
+                        "account_number": "5011"
+                    },
+                    "Titres d\u2019organismes financiers": {
+                        "account_number": "5012"
+                    },
+                    "Bons de caisse \u00e0 court terme": {
+                        "account_number": "5013"
+                    },
+                    "Frais d\u2019acquisition des titres de tr\u00e9sor et bons de caisse": {
+                        "account_number": "5016"
+                    },
+                    "account_number": "501"
+                },
+                "Actions": {
+                    "Actions ou parts propres": {
+                        "account_number": "5021"
+                    },
+                    "Actions cot\u00e9es": {
+                        "account_number": "5022"
+                    },
+                    "Actions non cot\u00e9es": {
+                        "account_number": "5023"
+                    },
+                    "Actions d\u00e9membr\u00e9es (certificats d\u2019investissement, droits de vote)": {
+                        "account_number": "5024"
+                    },
+                    "Autres actions": {
+                        "account_number": "5025"
+                    },
+                    "Frais d\u2019acquisition des actions": {
+                        "account_number": "5026"
+                    },
+                    "account_number": "502"
+                },
+                "Obligations": {
+                    "Obligations \u00e9mises par la soci\u00e9t\u00e9 et rachet\u00e9es par elle": {
+                        "account_number": "5031"
+                    },
+                    "Obligations cot\u00e9es": {
+                        "account_number": "5032"
+                    },
+                    "Obligations non cot\u00e9es": {
+                        "account_number": "5033"
+                    },
+                    "Autres obligations": {
+                        "account_number": "5035"
+                    },
+                    "Frais d\u2019acquisition des obligations": {
+                        "account_number": "5036"
+                    },
+                    "account_number": "503"
+                },
+                "Bons de souscription": {
+                    "Bons de souscription d\u2019actions": {
+                        "account_number": "5042"
+                    },
+                    "Bons de souscription d\u2019obligations": {
+                        "account_number": "5043"
+                    },
+                    "account_number": "504"
+                },
+                "Titres n\u00e9gociables hors r\u00e9gion": {
+                    "account_number": "505"
+                },
+                "Int\u00e9r\u00eats courus": {
+                    "Titres du Tr\u00e9sor et bons de caisse \u00e0 court terme": {
+                        "account_number": "5061"
+                    },
+                    "Actions": {
+                        "account_number": "5062"
+                    },
+                    "Obligations": {
+                        "account_number": "5063"
+                    },
+                    "account_number": "506"
+                },
+                "Autres titres de placement et cr\u00e9ances assimil\u00e9es": {
+                    "account_number": "508"
+                },
+                "account_number": "50"
+            },
+            "Valeurs \u00e0 encaisser": {
+                "Effets \u00e0 encaisser": {
+                    "account_number": "511"
+                },
+                "Effets \u00e0 l\u2019encaissement": {
+                    "account_number": "512"
+                },
+                "Ch\u00e8ques \u00e0 encaisser": {
+                    "account_number": "513"
+                },
+                "Ch\u00e8ques \u00e0 l\u2019encaissement": {
+                    "account_number": "514"
+                },
+                "Cartes de cr\u00e9dit \u00e0 encaisser": {
+                    "account_number": "515"
+                },
+                "Autres valeurs \u00e0 l\u2019encaissement": {
+                    "Warrants": {
+                        "account_number": "5181"
+                    },
+                    "Billets de fonds": {
+                        "account_number": "5182"
+                    },
+                    "Ch\u00e8ques de voyage": {
+                        "account_number": "5185"
+                    },
+                    "Coupons \u00e9chus": {
+                        "account_number": "5186"
+                    },
+                    "Int\u00e9r\u00eats \u00e9chus des obligations": {
+                        "account_number": "5187"
+                    },
+                    "account_number": "518"
+                },
+                "account_number": "51"
+            },
+            "Banques": {
+                "Banques locales": {
+                    "Banques en monnaie nationale": {
+                        "account_type": "Bank",
+                        "account_number": "5211"
+                    },
+                    "Banques en devises": {
+                        "account_type": "Bank",
+                        "account_number": "5215"
+                    },
+                    "account_type": "Bank",
+                    "account_number": "521"
+                },
+                "Banques autres \u00c9tats r\u00e9gion": {
+                    "account_number": "522"
+                },
+                "Banques autres \u00c9tats zone mon\u00e9taire": {
+                    "account_number": "523"
+                },
+                "Banques hors zone mon\u00e9taire": {
+                    "account_number": "524"
+                },
+                "Banques d\u00e9p\u00f4t \u00e0 terme": {
+                    "account_number": "525"
+                },
+                "Banques, int\u00e9r\u00eats courus": {
+                    "Banque, int\u00e9r\u00eats courus, charges \u00e0 payer": {
+                        "account_number": "5261"
+                    },
+                    "Banque, int\u00e9r\u00eats courus, produits \u00e0 recevoir": {
+                        "account_number": "5267"
+                    },
+                    "account_number": "526"
+                },
+                "account_number": "52"
+            },
+            "\u00c9tablissements financiers et assimil\u00e9s": {
+                "Ch\u00e8ques postaux": {
+                    "account_number": "531"
+                },
+                "Tr\u00e9sor": {
+                    "account_number": "532"
+                },
+                "Soci\u00e9t\u00e9s de gestion et d\u2019interm\u00e9diation (SGI)": {
+                    "account_number": "533"
+                },
+                "\u00c9tablissements financiers, int\u00e9r\u00eats courus": {
+                    "account_number": "536"
+                },
+                "Autres organismes financiers": {
+                    "account_number": "538"
+                },
+                "account_number": "53"
+            },
+            "Instruments de tr\u00e9sorerie": {
+                "Options de taux d\u2019int\u00e9r\u00eat": {
+                    "account_number": "541"
+                },
+                "Options de taux de change": {
+                    "account_number": "542"
+                },
+                "Options de taux boursiers": {
+                    "account_number": "543"
+                },
+                "Instruments de march\u00e9s \u00e0 terme": {
+                    "account_number": "544"
+                },
+                "Avoirs d\u2019or et autres m\u00e9taux pr\u00e9cieux": {
+                    "account_number": "545"
+                },
+                "account_number": "54"
+            },
+            "Instruments de monnaie \u00e9lectronique": {
+                "Monnaie \u00e9lectronique carte carburant": {
+                    "account_number": "551"
+                },
+                "Monnaie \u00e9lectronique t\u00e9l\u00e9phone portable": {
+                    "account_number": "552"
+                },
+                "Monnaie \u00e9lectronique carte p\u00e9age": {
+                    "account_number": "553"
+                },
+                "Porte-monnaie \u00e9lectronique": {
+                    "account_number": "554"
+                },
+                "Autres instruments de monnaies \u00e9lectroniques": {
+                    "account_number": "558"
+                },
+                "account_number": "55"
+            },
+            "Banques, cr\u00e9dits de tr\u00e9sorerie et d\u2019escompte": {
+                "Cr\u00e9dits de tr\u00e9sorerie": {
+                    "account_number": "561"
+                },
+                "Escompte de cr\u00e9dits de campagne": {
+                    "account_number": "564"
+                },
+                "Escompte de cr\u00e9dits ordinaires": {
+                    "account_number": "565"
+                },
+                "Banques, cr\u00e9dits de tr\u00e9sorerie, int\u00e9r\u00eats courus": {
+                    "account_number": "566"
+                },
+                "account_number": "56"
+            },
+            "Caisse": {
+                "Caisse si\u00e8ge social": {
+                    "Caisse en monnaie nationale": {
+                        "account_number": "5711"
+                    },
+                    "Caisse en devises": {
+                        "account_number": "5712"
+                    },
+                    "account_number": "571"
+                },
+                "Caisse succursale A": {
+                    "En monnaie nationale": {
+                        "account_number": "5721"
+                    },
+                    "En devises": {
+                        "account_number": "5722"
+                    },
+                    "account_number": "572"
+                },
+                "Caisse succursale B": {
+                    "En monnaie nationale": {
+                        "account_number": "5731"
+                    },
+                    "En devises": {
+                        "account_number": "5732"
+                    },
+                    "account_number": "573"
+                },
+                "account_number": "57"
+            },
+            "R\u00e9gies d\u2019avances, accr\u00e9ditifs et virements internes": {
+                "R\u00e9gies d\u2019avance": {
+                    "account_number": "581"
+                },
+                "Accr\u00e9ditifs": {
+                    "account_number": "582"
+                },
+                "Virements de fonds": {
+                    "account_number": "585"
+                },
+                "Autres virements internes": {
+                    "account_number": "588"
+                },
+                "account_number": "58"
+            },
+            "D\u00e9pr\u00e9ciations et provisions pour risque \u00e0 court terme": {
+                "D\u00e9pr\u00e9ciations des titres de placement": {
+                    "account_number": "590"
+                },
+                "D\u00e9pr\u00e9ciations des titres et valeurs \u00e0 encaisser": {
+                    "account_number": "591"
+                },
+                "D\u00e9pr\u00e9ciations des comptes banques": {
+                    "account_number": "592"
+                },
+                "D\u00e9pr\u00e9ciations des comptes \u00e9tablissements financiers et assimil\u00e9s": {
+                    "account_number": "593"
+                },
+                "D\u00e9pr\u00e9ciations des comptes d\u2019instruments de tr\u00e9sorerie": {
+                    "account_number": "594"
+                },
+                "Provisions pour risque \u00e0 court terme \u00e0 caract\u00e8re financier": {
+                    "account_number": "599"
+                },
+                "account_number": "59"
+            },
+            "root_type": "Asset",
+            "account_number": "5"
+        },
+        "Comptes de charges des activit\u00e9s ordinaires": {
+            "Achats et variations de stocks": {
+                "Achats de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6014"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6015"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6019"
+                    },
+                    "account_number": "601"
+                },
+                "Achats de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "6021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "6022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "6023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "6024"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6025"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6029"
+                    },
+                    "account_number": "602"
+                },
+                "Variations des stocks de biens achet\u00e9s": {
+                    "Variations des stocks de marchandises": {
+                        "account_number": "6031"
+                    },
+                    "Variations des stocks de mati\u00e8res premi\u00e8res et fournitures li\u00e9es": {
+                        "account_number": "6032"
+                    },
+                    "Variations des stocks d\u2019autres approvisionnements": {
+                        "account_number": "6033"
+                    },
+                    "account_number": "603"
+                },
+                "Achats stock\u00e9s de mati\u00e8res et fournitures consommables": {
+                    "Mati\u00e8res consommables": {
+                        "account_number": "6041"
+                    },
+                    "Mati\u00e8res combustibles": {
+                        "account_number": "6042"
+                    },
+                    "Produits d\u2019entretien": {
+                        "account_number": "6043"
+                    },
+                    "Fournitures d\u2019atelier et d\u2019usine": {
+                        "account_number": "6044"
+                    },
+                    "Frais sur achat": {
+                        "account_number": "6045"
+                    },
+                    "Fournitures de magasin": {
+                        "account_number": "6046"
+                    },
+                    "Fournitures de bureau": {
+                        "account_number": "6047"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6049"
+                    },
+                    "account_number": "604"
+                },
+                "Autres achats": {
+                    "Fournitures non stockables Eau": {
+                        "account_number": "6051"
+                    },
+                    "Fournitures non stockables \u00c9lectricit\u00e9": {
+                        "account_number": "6052"
+                    },
+                    "Fournitures non stockables Autres \u00e9nergies": {
+                        "account_number": "6053"
+                    },
+                    "Fournitures d\u2019entretien non stockables": {
+                        "account_number": "6054"
+                    },
+                    "Fournitures de bureau non stockables": {
+                        "account_number": "6055"
+                    },
+                    "Achats de petit mat\u00e9riel et outillage": {
+                        "account_number": "6056"
+                    },
+                    "Achats d\u2019\u00e9tudes et prestations de services": {
+                        "account_number": "6057"
+                    },
+                    "Achats de travaux, mat\u00e9riels et \u00e9quipements": {
+                        "account_number": "6058"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6059"
+                    },
+                    "account_number": "605"
+                },
+                "Achats d\u2019emballages": {
+                    "Emballages perdus": {
+                        "account_number": "6081"
+                    },
+                    "Emballages r\u00e9cup\u00e9rables non identifiables": {
+                        "account_number": "6082"
+                    },
+                    "Emballages \u00e0 usage mixte": {
+                        "account_number": "6083"
+                    },
+                    "Frais sur achats": {
+                        "account_number": "6085"
+                    },
+                    "Rabais, remises et ristournes obtenus (non ventil\u00e9s)": {
+                        "account_number": "6089"
+                    },
+                    "account_number": "608"
+                },
+                "account_number": "60"
+            },
+            "Transports": {
+                "Transports sur ventes": {
+                    "account_number": "612"
+                },
+                "Transports pour le compte de tiers": {
+                    "account_number": "613"
+                },
+                "Transports du personnel": {
+                    "account_number": "614"
+                },
+                "Transports de plis": {
+                    "account_number": "616"
+                },
+                "Autres frais de transport": {
+                    "Voyages et d\u00e9placements": {
+                        "account_number": "6181"
+                    },
+                    "Transports entre \u00e9tablissements ou chantiers": {
+                        "account_number": "6182"
+                    },
+                    "Transports administratifs": {
+                        "account_number": "6183"
+                    },
+                    "account_number": "618"
+                },
+                "account_number": "61"
+            },
+            "Services ext\u00e9rieurs": {
+                "Sous-traitance g\u00e9n\u00e9rale": {
+                    "account_number": "621"
+                },
+                "Locations, charges locatives": {
+                    "Locations de terrains": {
+                        "account_number": "6221"
+                    },
+                    "Locations de b\u00e2timents": {
+                        "account_number": "6222"
+                    },
+                    "Locations de mat\u00e9riels et outillages": {
+                        "account_number": "6223"
+                    },
+                    "Malis sur emballages": {
+                        "account_number": "6224"
+                    },
+                    "Locations d\u2019emballages": {
+                        "account_number": "6225"
+                    },
+                    "Fermages et loyers du foncier": {
+                        "account_number": "6226"
+                    },
+                    "Locations et charges locatives diverses": {
+                        "account_number": "6228"
+                    },
+                    "account_number": "622"
+                },
+                "Redevances de location acquisition": {
+                    "Cr\u00e9dit-bail immobilier": {
+                        "account_number": "6232"
+                    },
+                    "Cr\u00e9dit-bail mobilier": {
+                        "account_number": "6233"
+                    },
+                    "Location-vente": {
+                        "account_number": "6234"
+                    },
+                    "Autres contrats de location acquisition": {
+                        "account_number": "6238"
+                    },
+                    "account_number": "623"
+                },
+                "Entretien, r\u00e9parations, remise en \u00e9tat et maintenance": {
+                    "Entretien et r\u00e9parations des biens immobiliers": {
+                        "account_number": "6241"
+                    },
+                    "Entretien et r\u00e9parations des biens mobiliers": {
+                        "account_number": "6242"
+                    },
+                    "Maintenance": {
+                        "account_number": "6243"
+                    },
+                    "Charges de d\u00e9mant\u00e8lement et remise en \u00e9tat": {
+                        "account_number": "6244"
+                    },
+                    "Autres entretiens et r\u00e9parations": {
+                        "account_number": "6248"
+                    },
+                    "account_number": "624"
+                },
+                "Primes d\u2019assurance": {
+                    "Assurances multirisques": {
+                        "account_number": "6251"
+                    },
+                    "Assurances mat\u00e9riel de transport": {
+                        "account_number": "6252"
+                    },
+                    "Assurances risques d\u2019exploitation": {
+                        "account_number": "6253"
+                    },
+                    "Assurances responsabilit\u00e9 du producteur": {
+                        "account_number": "6254"
+                    },
+                    "Assurances insolvabilit\u00e9 clients": {
+                        "account_number": "6255"
+                    },
+                    "Assurances transport sur ventes": {
+                        "account_number": "6257"
+                    },
+                    "Autres primes d\u2019assurances": {
+                        "account_number": "6258"
+                    },
+                    "account_number": "625"
+                },
+                "\u00c9tudes, recherches et documentation": {
+                    "\u00c9tudes et recherches": {
+                        "account_number": "6261"
+                    },
+                    "Documentation g\u00e9n\u00e9rale": {
+                        "account_number": "6265"
+                    },
+                    "Documentation technique": {
+                        "account_number": "6266"
+                    },
+                    "account_number": "626"
+                },
+                "Publicit\u00e9, publications, relations publiques": {
+                    "Annonces, insertions": {
+                        "account_number": "6271"
+                    },
+                    "Catalogues, imprim\u00e9s publicitaires": {
+                        "account_number": "6272"
+                    },
+                    "\u00c9chantillons": {
+                        "account_number": "6273"
+                    },
+                    "Foires et expositions": {
+                        "account_number": "6274"
+                    },
+                    "Publications": {
+                        "account_number": "6275"
+                    },
+                    "Cadeaux \u00e0 la client\u00e8le": {
+                        "account_number": "6276"
+                    },
+                    "Frais de colloques, s\u00e9minaires, conf\u00e9rences": {
+                        "account_number": "6277"
+                    },
+                    "Autres charges de publicit\u00e9 et relations publiques": {
+                        "account_number": "6278"
+                    },
+                    "account_number": "627"
+                },
+                "Frais de t\u00e9l\u00e9communications": {
+                    "Frais de t\u00e9l\u00e9phone": {
+                        "account_number": "6281"
+                    },
+                    "Frais de t\u00e9lex": {
+                        "account_number": "6282"
+                    },
+                    "Frais de t\u00e9l\u00e9copie": {
+                        "account_number": "6283"
+                    },
+                    "Autres frais de t\u00e9l\u00e9communications": {
+                        "account_number": "6288"
+                    },
+                    "account_number": "628"
+                },
+                "account_number": "62"
+            },
+            "Autres services ext\u00e9rieurs": {
+                "Frais bancaires": {
+                    "Frais sur titres (vente, garde)": {
+                        "account_number": "6311"
+                    },
+                    "Frais sur effets": {
+                        "account_number": "6312"
+                    },
+                    "Location de coffres": {
+                        "account_number": "6313"
+                    },
+                    "Commissions d\u2019affacturage": {
+                        "account_number": "6314"
+                    },
+                    "Commissions sur cartes de cr\u00e9dit": {
+                        "account_number": "6315"
+                    },
+                    "Frais d\u2019\u00e9mission d\u2019emprunts": {
+                        "account_number": "6316"
+                    },
+                    "Frais sur instruments monnaie \u00e9lectronique": {
+                        "account_number": "6317"
+                    },
+                    "Autres frais bancaires": {
+                        "account_number": "6318"
+                    },
+                    "account_number": "631"
+                },
+                "R\u00e9mun\u00e9rations d\u2019interm\u00e9diaires et de conseils": {
+                    "Commissions et courtages sur ventes": {
+                        "account_number": "6322"
+                    },
+                    "Honoraires des professions r\u00e9glement\u00e9es": {
+                        "account_number": "6324"
+                    },
+                    "Frais d\u2019actes et de contentieux": {
+                        "account_number": "6325"
+                    },
+                    "R\u00e9mun\u00e9rations d\u2019affacturage": {
+                        "account_number": "6326"
+                    },
+                    "R\u00e9mun\u00e9rations des autres prestataires de services": {
+                        "account_number": "6327"
+                    },
+                    "Divers frais": {
+                        "account_number": "6328"
+                    },
+                    "account_number": "632"
+                },
+                "Frais de formation du personnel": {
+                    "account_number": "633"
+                },
+                "Redevances pour brevets, licences, logiciels, concessions et droits et valeurs similaires": {
+                    "Redevances pour brevets, licences": {
+                        "account_number": "6342"
+                    },
+                    "Redevances pour logiciels": {
+                        "account_number": "6343"
+                    },
+                    "Redevances pour marques": {
+                        "account_number": "6344"
+                    },
+                    "Redevances pour sites internet": {
+                        "account_number": "6345"
+                    },
+                    "Redevances pour concessions, droits et valeurs similaires": {
+                        "account_number": "6346"
+                    },
+                    "account_number": "634"
+                },
+                "Cotisations": {
+                    "Cotisations": {
+                        "account_number": "6351"
+                    },
+                    "Concours divers": {
+                        "account_number": "6358"
+                    },
+                    "account_number": "635"
+                },
+                "R\u00e9mun\u00e9rations de personnel ext\u00e9rieur \u00e0 l\u2019entit\u00e9": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6371"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6372"
+                    },
+                    "account_number": "637"
+                },
+                "Autres charges externes": {
+                    "Frais de recrutement du personnel": {
+                        "account_number": "6381"
+                    },
+                    "Frais de d\u00e9m\u00e9nagement": {
+                        "account_number": "6382"
+                    },
+                    "R\u00e9ceptions": {
+                        "account_number": "6383"
+                    },
+                    "Missions": {
+                        "account_number": "6384"
+                    },
+                    "Charges de copropri\u00e9t\u00e9": {
+                        "account_number": "6385"
+                    },
+                    "account_number": "638"
+                },
+                "account_number": "63"
+            },
+            "Imp\u00f4ts et taxes": {
+                "Imp\u00f4ts et taxes directs": {
+                    "Imp\u00f4ts fonciers et taxes annexes": {
+                        "account_number": "6411"
+                    },
+                    "Patentes, licences et taxes annexes": {
+                        "account_number": "6412"
+                    },
+                    "Taxes sur appointements et salaires": {
+                        "account_number": "6413"
+                    },
+                    "Taxes d\u2019apprentissage": {
+                        "account_number": "6414"
+                    },
+                    "Formation professionnelle continue": {
+                        "account_number": "6415"
+                    },
+                    "Autres imp\u00f4ts et taxes directs": {
+                        "account_number": "6418"
+                    },
+                    "account_number": "641"
+                },
+                "Imp\u00f4ts et taxes indirects": {
+                    "account_number": "645"
+                },
+                "Droits d\u2019enregistrement": {
+                    "Droits de mutation": {
+                        "account_number": "6461"
+                    },
+                    "Droits de timbre": {
+                        "account_number": "6462"
+                    },
+                    "Taxes sur les v\u00e9hicules de soci\u00e9t\u00e9": {
+                        "account_number": "6463"
+                    },
+                    "Vignettes": {
+                        "account_number": "6464"
+                    },
+                    "Autres droits": {
+                        "account_number": "6468"
+                    },
+                    "account_number": "646"
+                },
+                "P\u00e9nalit\u00e9s, amendes fiscales": {
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts directs": {
+                        "account_number": "6471"
+                    },
+                    "P\u00e9nalit\u00e9s d\u2019assiette, imp\u00f4ts indirects": {
+                        "account_number": "6472"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts directs": {
+                        "account_number": "6473"
+                    },
+                    "P\u00e9nalit\u00e9s de recouvrement, imp\u00f4ts indirects": {
+                        "account_number": "6474"
+                    },
+                    "Autres p\u00e9nalit\u00e9s et amendes fiscales": {
+                        "account_number": "6478"
+                    },
+                    "account_number": "647"
+                },
+                "Autres imp\u00f4ts et taxes": {
+                    "account_number": "648"
+                },
+                "account_number": "64"
+            },
+            "Autres charges": {
+                "Pertes sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "Clients": {
+                        "account_number": "6511"
+                    },
+                    "Autres d\u00e9biteurs": {
+                        "account_number": "6515"
+                    },
+                    "account_number": "651"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de b\u00e9n\u00e9fices (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "6521"
+                    },
+                    "Pertes imput\u00e9es par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "6525"
+                    },
+                    "account_number": "652"
+                },
+                "Valeurs comptables des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "6541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "6542"
+                    },
+                    "account_number": "654"
+                },
+                "Perte de change sur cr\u00e9ances et dettes commerciale": {
+                    "account_number": "656"
+                },
+                "P\u00e9nalit\u00e9s et amendes p\u00e9nales": {
+                    "account_number": "657"
+                },
+                "Charges diverses": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "6581"
+                    },
+                    "Dons": {
+                        "account_number": "6582"
+                    },
+                    "M\u00e9c\u00e9nat": {
+                        "account_number": "6583"
+                    },
+                    "Autres charges diverses": {
+                        "account_number": "6588"
+                    },
+                    "account_number": "658"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "6591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "6593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "6594"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme": {
+                        "account_number": "6598"
+                    },
+                    "account_number": "659"
+                },
+                "account_number": "65"
+            },
+            "Charges de personnel": {
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6611"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6612"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6613"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6614"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6615"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6616"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6617"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6618"
+                    },
+                    "account_number": "661"
+                },
+                "R\u00e9mun\u00e9rations directes vers\u00e9es au personnel non national": {
+                    "Appointements salaires et commissions": {
+                        "account_number": "6621"
+                    },
+                    "Primes et gratifications": {
+                        "account_number": "6622"
+                    },
+                    "Cong\u00e9s pay\u00e9s": {
+                        "account_number": "6623"
+                    },
+                    "Indemnit\u00e9s de pr\u00e9avis, de licenciement et de recherche d\u2019embauche": {
+                        "account_number": "6624"
+                    },
+                    "Indemnit\u00e9s de maladie vers\u00e9es aux travailleurs": {
+                        "account_number": "6625"
+                    },
+                    "Suppl\u00e9ment familial": {
+                        "account_number": "6626"
+                    },
+                    "Avantages en nature": {
+                        "account_number": "6627"
+                    },
+                    "Autres r\u00e9mun\u00e9rations directes": {
+                        "account_number": "6628"
+                    },
+                    "account_number": "662"
+                },
+                "Indemnit\u00e9s forfaitaires vers\u00e9es au personnel": {
+                    "Indemnit\u00e9s de logement": {
+                        "account_number": "6631"
+                    },
+                    "Indemnit\u00e9s de repr\u00e9sentation": {
+                        "account_number": "6632"
+                    },
+                    "Indemnit\u00e9s d\u2019expatriation": {
+                        "account_number": "6633"
+                    },
+                    "Indemnit\u00e9s de transport": {
+                        "account_number": "6634"
+                    },
+                    "Autres indemnit\u00e9s et avantages divers": {
+                        "account_number": "6638"
+                    },
+                    "account_number": "663"
+                },
+                "Charges sociales": {
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel national": {
+                        "account_number": "6641"
+                    },
+                    "Charges sociales sur r\u00e9mun\u00e9ration du personnel non national": {
+                        "account_number": "6642"
+                    },
+                    "account_number": "664"
+                },
+                "R\u00e9mun\u00e9rations et charges sociales de l\u2019exploitant individuel": {
+                    "R\u00e9mun\u00e9ration du travail de l\u2019exploitant": {
+                        "account_number": "6661"
+                    },
+                    "Charges sociales": {
+                        "account_number": "6662"
+                    },
+                    "account_number": "666"
+                },
+                "R\u00e9mun\u00e9ration transf\u00e9r\u00e9e de personnel ext\u00e9rieur": {
+                    "Personnel int\u00e9rimaire": {
+                        "account_number": "6671"
+                    },
+                    "Personnel d\u00e9tach\u00e9 ou pr\u00eat\u00e9 \u00e0 l\u2019entit\u00e9": {
+                        "account_number": "6672"
+                    },
+                    "account_number": "667"
+                },
+                "Autres charges sociales": {
+                    "Versements aux syndicats et comit\u00e9s d\u2019entreprise, d\u2019\u00e9tablissement": {
+                        "account_number": "6681"
+                    },
+                    "Versements aux comit\u00e9s d\u2019hygi\u00e8ne et de s\u00e9curit\u00e9": {
+                        "account_number": "6682"
+                    },
+                    "Versements et contributions aux autres \u0153uvres sociales": {
+                        "account_number": "6683"
+                    },
+                    "M\u00e9decine du travail et pharmacie": {
+                        "account_number": "6684"
+                    },
+                    "Assurances et organismes de sant\u00e9": {
+                        "account_number": "6685"
+                    },
+                    "Assurances retraite et fonds de pension": {
+                        "account_number": "6686"
+                    },
+                    "Majorations et p\u00e9nalit\u00e9s sociales": {
+                        "account_number": "6687"
+                    },
+                    "Charges sociales diverses": {
+                        "account_number": "6688"
+                    },
+                    "account_number": "668"
+                },
+                "account_number": "66"
+            },
+            "Frais financiers et charges assimil\u00e9es": {
+                "Int\u00e9r\u00eats des emprunts": {
+                    "Emprunts obligataires": {
+                        "account_number": "6711"
+                    },
+                    "Emprunts aupr\u00e8s des \u00e9tablissements de cr\u00e9dit": {
+                        "account_number": "6712"
+                    },
+                    "Dettes li\u00e9es \u00e0 des participations": {
+                        "account_number": "6713"
+                    },
+                    "Primes de remboursement des obligations": {
+                        "account_number": "6714"
+                    },
+                    "account_number": "671"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail immobilier": {
+                        "account_number": "6722"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / cr\u00e9dit-bail mobilier": {
+                        "account_number": "6723"
+                    },
+                    "Int\u00e9r\u00eats dans loyers de location acquisition / location-vente": {
+                        "account_number": "6724"
+                    },
+                    "Int\u00e9r\u00eats dans loyers des autres locations acquisition": {
+                        "account_number": "6728"
+                    },
+                    "account_number": "672"
+                },
+                "Escomptes accord\u00e9s": {
+                    "account_number": "673"
+                },
+                "Autres int\u00e9r\u00eats": {
+                    "Avances re\u00e7ues et d\u00e9p\u00f4ts cr\u00e9diteurs": {
+                        "account_number": "6741"
+                    },
+                    "Comptes courants bloqu\u00e9s": {
+                        "account_number": "6742"
+                    },
+                    "Int\u00e9r\u00eats sur obligations cautionn\u00e9es": {
+                        "account_number": "6743"
+                    },
+                    "Int\u00e9r\u00eats sur dettes commerciales": {
+                        "account_number": "6744"
+                    },
+                    "Int\u00e9r\u00eats bancaires et sur op\u00e9rations de financement (escompte...)": {
+                        "account_number": "6745"
+                    },
+                    "Int\u00e9r\u00eats sur dettes diverses": {
+                        "account_number": "6748"
+                    },
+                    "account_number": "674"
+                },
+                "Escomptes des effets de commerce": {
+                    "account_number": "675"
+                },
+                "Pertes de change financi\u00e8res": {
+                    "account_number": "676"
+                },
+                "Pertes sur titres de placement": {
+                    "Pertes sur cessions de titres de placement": {
+                        "account_number": "6771"
+                    },
+                    "Mali provenant d\u2019attribution gratuite d\u2019actions au personnel salari\u00e9 et aux dirigeants": {
+                        "account_number": "6772"
+                    },
+                    "account_number": "677"
+                },
+                "Pertes et charges sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "6781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "6782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "6784"
+                    },
+                    "account_number": "678"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "6791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "6795"
+                    },
+                    "Autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "6798"
+                    },
+                    "account_number": "679"
+                },
+                "account_number": "67"
+            },
+            "Dotations aux amortissements": {
+                "Dotations aux amortissements d\u2019exploitation": {
+                    "Dotations aux amortissements des immobilisations incorporelles": {
+                        "account_number": "6812"
+                    },
+                    "Dotations aux amortissements des immobilisations corporelles": {
+                        "account_number": "6813"
+                    },
+                    "account_number": "681"
+                },
+                "account_number": "68"
+            },
+            "Dotations aux provisions et aux d\u00e9pr\u00e9ciations": {
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6911"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations incorporelles": {
+                        "account_number": "6913"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations corporelles": {
+                        "account_number": "6914"
+                    },
+                    "account_number": "691"
+                },
+                "Dotations aux provisions et aux d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Dotations aux provisions pour risques et charges": {
+                        "account_number": "6971"
+                    },
+                    "Dotations aux d\u00e9pr\u00e9ciations des immobilisations financi\u00e8res": {
+                        "account_number": "6972"
+                    },
+                    "account_number": "697"
+                },
+                "account_number": "69"
+            },
+            "root_type": "Expense",
+            "account_number": "6"
+        },
+        "Comptes de produits des activit\u00e9s ordinaires": {
+            "Ventes": {
+                "Ventes de marchandises": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7011"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7012"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7013"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7014"
+                    },
+                    "Sur internet": {
+                        "account_number": "7015"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7019"
+                    },
+                    "account_number": "701"
+                },
+                "Ventes de produits finis": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7021"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7022"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7023"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7024"
+                    },
+                    "Sur internet": {
+                        "account_number": "7025"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7029"
+                    },
+                    "account_number": "702"
+                },
+                "Ventes de produits interm\u00e9diaires": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7031"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7032"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7033"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7034"
+                    },
+                    "Sur internet": {
+                        "account_number": "7035"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7039"
+                    },
+                    "account_number": "703"
+                },
+                "Ventes de produits r\u00e9siduels": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7041"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7042"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7043"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7044"
+                    },
+                    "Sur internet": {
+                        "account_number": "7045"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7049"
+                    },
+                    "account_number": "704"
+                },
+                "Travaux factur\u00e9s": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7051"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7052"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7053"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7054"
+                    },
+                    "Sur internet": {
+                        "account_number": "7055"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7059"
+                    },
+                    "account_number": "705"
+                },
+                "Services vendus": {
+                    "Dans la R\u00e9gion": {
+                        "account_number": "7061"
+                    },
+                    "Hors R\u00e9gion": {
+                        "account_number": "7062"
+                    },
+                    "Aux entit\u00e9s du groupe dans la R\u00e9gion": {
+                        "account_number": "7063"
+                    },
+                    "Aux entit\u00e9s du groupe hors R\u00e9gion": {
+                        "account_number": "7064"
+                    },
+                    "Sur internet": {
+                        "account_number": "7065"
+                    },
+                    "Rabais, remises, ristournes accord\u00e9s (non ventil\u00e9s)": {
+                        "account_number": "7069"
+                    },
+                    "account_number": "706"
+                },
+                "Produits accessoires": {
+                    "Ports, emballages perdus et autres frais factur\u00e9s": {
+                        "account_number": "7071"
+                    },
+                    "Commissions et courtages": {
+                        "account_number": "7072"
+                    },
+                    "Locations": {
+                        "account_number": "7073"
+                    },
+                    "Bonis sur reprises et cessions d\u2019emballages": {
+                        "account_number": "7074"
+                    },
+                    "Mise \u00e0 disposition de personnel": {
+                        "account_number": "7075"
+                    },
+                    "Redevances pour brevets, logiciels, marques et droits similaires": {
+                        "account_number": "7076"
+                    },
+                    "Services exploit\u00e9s dans l\u2019int\u00e9r\u00eat du personnel": {
+                        "account_number": "7077"
+                    },
+                    "Autres produits accessoires": {
+                        "account_number": "7078"
+                    },
+                    "account_number": "707"
+                },
+                "account_number": "70"
+            },
+            "Subventions d\u2019exploitation": {
+                "Sur produits \u00e0 l\u2019exportation": {
+                    "account_number": "711"
+                },
+                "Sur produits \u00e0 l\u2019importation": {
+                    "account_number": "712"
+                },
+                "Sur produits de p\u00e9r\u00e9quation": {
+                    "account_number": "713"
+                },
+                "Indemnit\u00e9s et subventions d\u2019exploitation (entit\u00e9 agricole)": {
+                    "account_number": "714"
+                },
+                "Autres subventions d\u2019exploitation": {
+                    "Vers\u00e9es par l\u2019\u00c9tat et les collectivit\u00e9s publiques": {
+                        "account_number": "7181"
+                    },
+                    "Vers\u00e9es par les organismes internationaux": {
+                        "account_number": "7182"
+                    },
+                    "Vers\u00e9es par des tiers": {
+                        "account_number": "7183"
+                    },
+                    "account_number": "718"
+                },
+                "account_number": "71"
+            },
+            "Production immobilis\u00e9e": {
+                "Immobilisations incorporelles": {
+                    "account_number": "721"
+                },
+                "Immobilisations corporelles": {
+                    "Immobilisations corporelles (hors actifs biologiques)": {
+                        "account_number": "7221"
+                    },
+                    "Immobilisations corporelles (actifs biologiques)": {
+                        "account_number": "7222"
+                    },
+                    "account_number": "722"
+                },
+                "Production auto-consomm\u00e9e": {
+                    "account_number": "724"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "726"
+                },
+                "account_number": "72"
+            },
+            "Variations des stocks de biens et de services produits": {
+                "Variations des stocks de produits en cours": {
+                    "Produits en cours": {
+                        "account_number": "7341"
+                    },
+                    "Travaux en cours": {
+                        "account_number": "7342"
+                    },
+                    "account_number": "734"
+                },
+                "Variations des en-cours de services": {
+                    "\u00c9tudes en cours": {
+                        "account_number": "7351"
+                    },
+                    "Prestations de services en cours": {
+                        "account_number": "7352"
+                    },
+                    "account_number": "735"
+                },
+                "Variations des stocks de produits finis": {
+                    "account_number": "736"
+                },
+                "Variations des stocks de produits interm\u00e9diaires et r\u00e9siduels": {
+                    "Produits interm\u00e9diaires": {
+                        "account_number": "7371"
+                    },
+                    "Produits r\u00e9siduels": {
+                        "account_number": "7372"
+                    },
+                    "account_number": "737"
+                },
+                "account_number": "73"
+            },
+            "Autres produits": {
+                "Profits sur cr\u00e9ances clients et autres d\u00e9biteurs": {
+                    "account_number": "751"
+                },
+                "Quote-part de r\u00e9sultat sur op\u00e9rations faites en commun": {
+                    "Quote-part transf\u00e9r\u00e9e de pertes (comptabilit\u00e9 du g\u00e9rant)": {
+                        "account_number": "7521"
+                    },
+                    "B\u00e9n\u00e9fices attribu\u00e9s par transfert (comptabilit\u00e9 des associ\u00e9s non g\u00e9rants)": {
+                        "account_number": "7525"
+                    },
+                    "account_number": "752"
+                },
+                "Produits des cessions courantes d\u2019immobilisations": {
+                    "Immobilisations incorporelles": {
+                        "account_number": "7541"
+                    },
+                    "Immobilisations corporelles": {
+                        "account_number": "7542"
+                    },
+                    "account_number": "754"
+                },
+                "Gains de change sur cr\u00e9ances et dettes commerciales": {
+                    "account_number": "756"
+                },
+                "Produits divers": {
+                    "Indemnit\u00e9s de fonction et autres r\u00e9mun\u00e9rations d\u2019administrateurs": {
+                        "account_number": "7581"
+                    },
+                    "Indemnit\u00e9s d\u2019assurances re\u00e7ues": {
+                        "account_number": "7582"
+                    },
+                    "Autres produits divers": {
+                        "account_number": "7588"
+                    },
+                    "account_number": "758"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                    "Sur risques \u00e0 court terme": {
+                        "account_number": "7591"
+                    },
+                    "Sur stocks": {
+                        "account_number": "7593"
+                    },
+                    "Sur cr\u00e9ances": {
+                        "account_number": "7594"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme d\u2019exploitation": {
+                        "account_number": "7598"
+                    },
+                    "account_number": "759"
+                },
+                "account_number": "75"
+            },
+            "Revenus financiers et produits assimil\u00e9s": {
+                "Int\u00e9r\u00eats de pr\u00eats et cr\u00e9ances diverses": {
+                    "Int\u00e9r\u00eats de pr\u00eats": {
+                        "account_number": "7712"
+                    },
+                    "Int\u00e9r\u00eats sur cr\u00e9ances diverses": {
+                        "account_number": "7713"
+                    },
+                    "account_number": "771"
+                },
+                "Revenus de participations et autres titres immobilis\u00e9s": {
+                    "Revenus des titres de participation": {
+                        "account_number": "7721"
+                    },
+                    "Revenus autres titres immobilis\u00e9s": {
+                        "account_number": "7722"
+                    },
+                    "account_number": "772"
+                },
+                "Escomptes obtenus": {
+                    "account_number": "773"
+                },
+                "Revenus de placement": {
+                    "Revenus des obligations": {
+                        "account_number": "7745"
+                    },
+                    "Revenus des titres de placement": {
+                        "account_number": "7746"
+                    },
+                    "account_number": "774"
+                },
+                "Int\u00e9r\u00eats dans loyers de location acquisition": {
+                    "account_number": "775"
+                },
+                "Gains de change financiers": {
+                    "account_number": "776"
+                },
+                "Gains sur cessions de titres de placement": {
+                    "account_number": "777"
+                },
+                "Gains sur risques financiers": {
+                    "Sur rentes viag\u00e8res": {
+                        "account_number": "7781"
+                    },
+                    "Sur op\u00e9rations financi\u00e8res": {
+                        "account_number": "7782"
+                    },
+                    "Sur instruments de tr\u00e9sorerie": {
+                        "account_number": "7784"
+                    },
+                    "account_number": "778"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions \u00e0 court terme financi\u00e8res": {
+                    "Sur risques financiers": {
+                        "account_number": "7791"
+                    },
+                    "Sur titres de placement": {
+                        "account_number": "7795"
+                    },
+                    "Sur autres charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme financi\u00e8res": {
+                        "account_number": "7798"
+                    },
+                    "account_number": "779"
+                },
+                "account_number": "77"
+            },
+            "Transferts de charges": {
+                "Transferts de charges d\u2019exploitation": {
+                    "account_number": "781"
+                },
+                "Transferts de charges financi\u00e8res": {
+                    "account_number": "787"
+                },
+                "account_number": "78"
+            },
+            "Reprises de provisions, de d\u00e9pr\u00e9ciations et autres": {
+                "Reprises de provisions et d\u00e9pr\u00e9ciations d\u2019exploitation": {
+                    "Pour risques et charges": {
+                        "account_number": "7911"
+                    },
+                    "Des immobilisations incorporelles": {
+                        "account_number": "7913"
+                    },
+                    "Des immobilisations corporelles": {
+                        "account_number": "7914"
+                    },
+                    "account_number": "791"
+                },
+                "Reprises de provisions et d\u00e9pr\u00e9ciations financi\u00e8res": {
+                    "Pour risques et charges": {
+                        "account_number": "7971"
+                    },
+                    "Des immobilisations financi\u00e8res": {
+                        "account_number": "7972"
+                    },
+                    "account_number": "797"
+                },
+                "Reprises d\u2019amortissements": {
+                    "account_number": "798"
+                },
+                "Reprises de subventions d\u2019investissement": {
+                    "account_number": "799"
+                },
+                "account_number": "79"
+            },
+            "root_type": "Income",
+            "account_number": "7"
+        },
+        "8-Comptes des autres charges et des autres produits (CHARGES)": {
+            "Valeurs comptables des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "811"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "812"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "816"
+                },
+                "account_number": "81"
+            },
+            "Charges hors activit\u00e9s ordinaires": {
+                "Charges HAO constat\u00e9es": {
+                    "account_number": "831"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de restructuration": {
+                    "account_number": "833"
+                },
+                "Pertes sur cr\u00e9ances HAO": {
+                    "account_number": "834"
+                },
+                "Dons et lib\u00e9ralit\u00e9s accord\u00e9s": {
+                    "account_number": "835"
+                },
+                "Abandons de cr\u00e9ances consentis": {
+                    "account_number": "836"
+                },
+                "Charges li\u00e9es aux op\u00e9rations de liquidation": {
+                    "account_number": "837"
+                },
+                "Charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "839"
+                },
+                "account_number": "83"
+            },
+            "Dotations hors activit\u00e9s ordinaires": {
+                "Dotations aux provisions r\u00e9glement\u00e9es": {
+                    "account_number": "851"
+                },
+                "Dotations aux amortissements HAO": {
+                    "account_number": "852"
+                },
+                "Dotations aux d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "853"
+                },
+                "Dotations aux provisions pour risques et charges HAO": {
+                    "account_number": "854"
+                },
+                "Autres dotations HAO": {
+                    "account_number": "858"
+                },
+                "account_number": "85"
+            },
+            "Participation des travailleurs": {
+                "Participation l\u00e9gale aux b\u00e9n\u00e9fices": {
+                    "account_number": "871"
+                },
+                "Participation contractuelle aux b\u00e9n\u00e9fices": {
+                    "account_number": "874"
+                },
+                "Autres participations": {
+                    "account_number": "878"
+                },
+                "account_number": "87"
+            },
+            "Imp\u00f4ts sur le r\u00e9sultat": {
+                "Imp\u00f4ts sur les b\u00e9n\u00e9fices de l\u2019exercice": {
+                    "Activit\u00e9s exerc\u00e9es dans l\u2019\u00c9tat": {
+                        "account_number": "8911"
+                    },
+                    "Activit\u00e9s exerc\u00e9es dans les autres \u00c9tats de la R\u00e9gion": {
+                        "account_number": "8912"
+                    },
+                    "Activit\u00e9s exerc\u00e9es hors R\u00e9gion": {
+                        "account_number": "8913"
+                    },
+                    "account_number": "891"
+                },
+                "Rappel d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "account_number": "892"
+                },
+                "Imp\u00f4t minimum forfaitaire IMF": {
+                    "account_number": "895"
+                },
+                "D\u00e9gr\u00e8vements et annulations d\u2019imp\u00f4ts sur r\u00e9sultats ant\u00e9rieurs": {
+                    "D\u00e9gr\u00e8vements": {
+                        "account_number": "8991"
+                    },
+                    "Annulations pour pertes r\u00e9troactives": {
+                        "account_number": "8994"
+                    },
+                    "account_number": "899"
+                },
+                "account_number": "89"
+            },
+            "root_type": "Expense"
+        },
+        "8-Comptes des autres charges et des autres produits (PRODUITS)": {
+            "Produits des cessions d\u2019immobilisations": {
+                "Immobilisations incorporelles": {
+                    "account_number": "821"
+                },
+                "Immobilisations corporelles": {
+                    "account_number": "822"
+                },
+                "Immobilisations financi\u00e8res": {
+                    "account_number": "826"
+                },
+                "account_number": "82"
+            },
+            "Produits hors activit\u00e9s ordinaires": {
+                "Produits HAO constat\u00e9s": {
+                    "account_number": "841"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de restructuration": {
+                    "account_number": "843"
+                },
+                "Indemnit\u00e9s et subventions HAO (entit\u00e9 agricole)": {
+                    "account_number": "844"
+                },
+                "Dons et lib\u00e9ralit\u00e9s obtenus": {
+                    "account_number": "845"
+                },
+                "Abandons de cr\u00e9ances obtenus": {
+                    "account_number": "846"
+                },
+                "Produits li\u00e9s aux op\u00e9rations de liquidation": {
+                    "account_number": "847"
+                },
+                "Transferts de charges HAO": {
+                    "account_number": "848"
+                },
+                "Reprises de charges pour d\u00e9pr\u00e9ciations et provisions pour risques \u00e0 court terme HAO": {
+                    "account_number": "849"
+                },
+                "account_number": "84"
+            },
+            "Reprises de charges, provisions et d\u00e9pr\u00e9ciations HAO": {
+                "Reprises de provisions r\u00e9glement\u00e9es": {
+                    "account_number": "861"
+                },
+                "Reprises d\u2019amortissements HAO": {
+                    "account_number": "862"
+                },
+                "Reprises de d\u00e9pr\u00e9ciations HAO": {
+                    "account_number": "863"
+                },
+                "Reprises de provisions pour risques et charges HAO": {
+                    "account_number": "864"
+                },
+                "Autres reprises HAO": {
+                    "account_number": "868"
+                },
+                "account_number": "86"
+            },
+            "Subventions d\u2019\u00e9quilibre": {
+                "\u00c9tat": {
+                    "account_number": "881"
+                },
+                "Collectivit\u00e9s publiques": {
+                    "account_number": "884"
+                },
+                "Groupe": {
+                    "account_number": "886"
+                },
+                "Autres": {
+                    "account_number": "888"
+                },
+                "account_number": "88"
+            },
+            "root_type": "Income"
+        }
+    }
+}


### PR DESCRIPTION
New PR to replace #43999 as per maintainers' request.
-
SYSCOHADA is the accounting system and financial reporting currently adopted by 17 African countries. It provides a standardized framework to enhance transparency and comparability in financial statements for businesses in these regions.

This PR aims at adding this standardized chart of accounts into ERPNext so it is usable by said countries.
If possible, these changes should be backported.

References : 
- https://fr.wikipedia.org/wiki/Plan_comptable_(OHADA)
- https://www.droit-afrique.com/uploads/OHADA-Plan-comptable-2017.pdf


Files added:
-
1. **Generic chart of accounts with code**
`erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable_avec_code.json`

2. **Generic chart of accounts**
`erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_plan_comptable.json`

3. **Helper to generate individual files for all affiliated countries by specifying country name where applicable**
`erpnext/accounts/doctype/account/chart_of_accounts/verified/syscohada_chart_of_accounts.py`

The files generated for each country will look like: **country**_plan_comptable.json or **country**_plan_comptable_avec_code.json

Files deleted :
-
**Unverified chart file for syscohada**
`erpnext/accounts/doctype/account/chart_of_accounts/unverified/syscohada_syscohada_chart_template.json`


Screenshots :
-
Setup Wizard:

![setup_wizard](https://github.com/user-attachments/assets/6ee50a10-b101-4bda-bc55-a7207d5e173a)


Company:

![societe_1](https://github.com/user-attachments/assets/29bee1f6-a10a-4a7e-924f-c51879ce0d6e)

![societe_2](https://github.com/user-attachments/assets/b39498ed-7d1f-4e96-bb2f-9eb65e39f846)

![societe_3](https://github.com/user-attachments/assets/69e8e6c1-eaca-4a41-b33a-b7b3d219240d)


no-docs