### PR TITLE
fix: missing ctx in API function calls

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -322,7 +322,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 				method: "erpnext.assets.doctype.asset_capitalization.asset_capitalization.get_consumed_stock_item_details",
 				child: row,
 				args: {
-					args: {
+					ctx: {
 						item_code: row.item_code,
 						warehouse: row.warehouse,
 						stock_qty: flt(row.stock_qty),
@@ -350,7 +350,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 				method: "erpnext.assets.doctype.asset_capitalization.asset_capitalization.get_consumed_asset_details",
 				child: row,
 				args: {
-					args: {
+					ctx: {
 						asset: row.asset,
 						doctype: me.frm.doc.doctype,
 						name: me.frm.doc.name,
@@ -377,7 +377,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 				method: "erpnext.assets.doctype.asset_capitalization.asset_capitalization.get_service_item_details",
 				child: row,
 				args: {
-					args: {
+					ctx: {
 						item_code: row.item_code,
 						qty: flt(row.qty),
 						expense_account: row.expense_account,


### PR DESCRIPTION
Related to this https://github.com/frappe/erpnext/pull/44230

<img width="1379" alt="Screenshot 2024-12-01 at 6 02 26 PM" src="https://github.com/user-attachments/assets/23da82f5-cc2b-46bf-98b8-4dc3e9720949">
