### PR TITLE
fix: Multiple Fixes in Gross Profit Report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -636,6 +636,7 @@ class GrossProfitGenerator:
 			if packed_item.get("parent_detail_docname") == row.item_row:
 				packed_item_row = row.copy()
 				packed_item_row.warehouse = packed_item.warehouse
+				packed_item_row.qty = packed_item.total_qty * -1
 				buying_amount += self.get_buying_amount(packed_item_row, packed_item.item_code)
 
 		return flt(buying_amount, self.currency_precision)
@@ -668,7 +669,9 @@ class GrossProfitGenerator:
 		else:
 			my_sle = self.get_stock_ledger_entries(item_code, row.warehouse)
 			if (row.update_stock or row.dn_detail) and my_sle:
-				parenttype, parent = row.parenttype, row.parent
+				parenttype = row.parenttype
+				parent = row.invoice or row.parent
+
 				if row.dn_detail:
 					parenttype, parent = "Delivery Note", row.delivery_note
 
@@ -963,30 +966,33 @@ class GrossProfitGenerator:
 			}
 		)
 
-	def get_bundle_item_row(self, product_bundle, item):
+	def get_bundle_item_row(self, row, item):
 		return frappe._dict(
 			{
-				"parent_invoice": product_bundle.item_code,
-				"indent": product_bundle.indent + 1,
+				"parent_invoice": row.item_code,
+				"parenttype": row.parenttype,
+				"indent": row.indent + 1,
 				"parent": None,
 				"invoice_or_item": item.item_code,
-				"posting_date": product_bundle.posting_date,
-				"posting_time": product_bundle.posting_time,
-				"project": product_bundle.project,
-				"customer": product_bundle.customer,
-				"customer_group": product_bundle.customer_group,
+				"posting_date": row.posting_date,
+				"posting_time": row.posting_time,
+				"project": row.project,
+				"customer": row.customer,
+				"customer_group": row.customer_group,
 				"item_code": item.item_code,
 				"item_name": item.item_name,
 				"description": item.description,
-				"warehouse": product_bundle.warehouse,
+				"warehouse": item.warehouse or row.warehouse,
+				"update_stock": row.update_stock,
 				"item_group": "",
 				"brand": "",
-				"dn_detail": product_bundle.dn_detail,
-				"delivery_note": product_bundle.delivery_note,
+				"dn_detail": row.dn_detail,
+				"delivery_note": row.delivery_note,
 				"qty": item.total_qty * -1,
-				"item_row": None,
-				"is_return": product_bundle.is_return,
-				"cost_center": product_bundle.cost_center,
+				"item_row": row.item_row,
+				"is_return": row.is_return,
+				"cost_center": row.cost_center,
+				"invoice": row.parent,
 			}
 		)
 

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -915,7 +915,7 @@ class GrossProfitGenerator:
 		"""
 
 		grouped = OrderedDict()
-		product_bundels = self.product_bundles.get("Sales Invoice", {})
+		product_bundles = self.product_bundles.get("Sales Invoice", {})
 
 		for row in self.si_list:
 			# initialize list with a header row for each new parent
@@ -926,7 +926,7 @@ class GrossProfitGenerator:
 			)
 
 			# if item is a bundle, add it's components as seperate rows
-			if bundled_items := product_bundels.get(row.parent, {}).get(row.item_code):
+			if bundled_items := product_bundles.get(row.parent, {}).get(row.item_code):
 				for x in bundled_items:
 					bundle_item = self.get_bundle_item_row(row, x)
 					grouped.get(row.parent).append(bundle_item)


### PR DESCRIPTION
### Correct buying amount for a product bundle.
The buying amount was incorrect for the product bundle because it was always set on the basis of the average due to missing keys required for calculating the buying amount from Stock Ledger Entry.

SLE:
![image](https://github.com/user-attachments/assets/054e910f-495c-4586-86fc-816e4eb673ef)


Before:
![image](https://github.com/user-attachments/assets/34b9c539-d864-4581-a52e-872e985b881e)


After:
![image](https://github.com/user-attachments/assets/cd361353-9f48-4882-b38c-0032be59ec46)

### Fixed Data Inconsistency
- Instead of using Product Bundle Details, Packed Item details are used for grouped invoices.
- This helps in consistency and performance

- Performance Fixes
  - Remove frappe.db.get_value for fetching base_net_amount instead of using item query. 


Frappe Support Issue:
https://support.frappe.io/app/hd-ticket/24113
https://support.frappe.io/app/hd-ticket/20809
https://support.frappe.io/app/hd-ticket/23693


Closes:https://github.com/frappe/erpnext/issues/42329, https://github.com/frappe/erpnext/issues/35792, https://github.com/frappe/erpnext/issues/41302

backport version-15
backport version-14
