### PR TITLE
fix: 'dict' object has not attribute error

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -690,8 +690,8 @@ def is_within_valid_range(ctx: ItemDetailsCtx, tax) -> bool:
 def get_item_tax_map(*, doc: str | dict | Document, tax_template: str | None = None, as_json=True):
 	doc = parse_json(doc)
 	item_tax_map = {}
-	for t in (t for t in (doc.get("taxes") or []) if not t.set_by_item_tax_template):
-		item_tax_map[t.account_head] = t.rate
+	for t in (t for t in (doc.get("taxes") or []) if not t.get("set_by_item_tax_template")):
+		item_tax_map[t.get("account_head")] = t.get("rate")
 
 	if tax_template:
 		template = frappe.get_cached_doc("Item Tax Template", tax_template)


### PR DESCRIPTION
This commit fixes this kind of error in develop branch: 

![image](https://github.com/user-attachments/assets/016612e6-af1c-4dce-ac17-fd08693873bd)

"doc" in this function is a python dict object, but was being treated like a Frappe dict