### PR TITLE
fix: required by date in the reorder material request

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1663,6 +1663,46 @@ class TestStockEntry(IntegrationTestCase):
 			mr.cancel()
 			mr.delete()
 
+	def test_auto_reorder_level_with_lead_time_days(self):
+		from erpnext.stock.reorder_item import reorder_item
+
+		item_doc = make_item(
+			"Test Auto Reorder Item - 002",
+			properties={"stock_uom": "Kg", "purchase_uom": "Nos", "is_stock_item": 1, "lead_time_days": 2},
+			uoms=[{"uom": "Nos", "conversion_factor": 5}],
+		)
+
+		if not frappe.db.exists("Item Reorder", {"parent": item_doc.name}):
+			item_doc.append(
+				"reorder_levels",
+				{
+					"warehouse_reorder_level": 0,
+					"warehouse_reorder_qty": 10,
+					"warehouse": "_Test Warehouse - _TC",
+					"material_request_type": "Purchase",
+				},
+			)
+
+		item_doc.save(ignore_permissions=True)
+
+		frappe.db.set_single_value("Stock Settings", "auto_indent", 1)
+
+		mr_list = reorder_item()
+
+		frappe.db.set_single_value("Stock Settings", "auto_indent", 0)
+		mrs = frappe.get_all(
+			"Material Request Item",
+			fields=["schedule_date"],
+			filters={"item_code": item_doc.name, "uom": "Nos"},
+		)
+
+		for mri in mrs:
+			self.assertEqual(getdate(mri.schedule_date), getdate(add_days(today(), 2)))
+
+		for mr in mr_list:
+			mr.cancel()
+			mr.delete()
+
 	def test_use_serial_and_batch_fields(self):
 		item = make_item(
 			"Test Use Serial and Batch Item SN Item",

--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -98,6 +98,7 @@ def _reorder_item():
 						"description": d.description,
 						"stock_uom": d.stock_uom,
 						"purchase_uom": d.purchase_uom,
+						"lead_time_days": d.lead_time_days,
 					}
 				),
 			)
@@ -129,6 +130,7 @@ def get_items_for_reorder() -> dict[str, list]:
 			item_table.brand,
 			item_table.variant_of,
 			item_table.has_variants,
+			item_table.lead_time_days,
 		)
 		.where(
 			(item_table.disabled == 0)


### PR DESCRIPTION
**Issue**

The lead time days in the item master are not considered when automatically calculating the 'Required By' date in the material request created based on the reorder level.

Lead time days = 25 (in the item master)
Today's date = 04-12-2024
Expected Required By Date = 29-12-2024
Actual Required By Date = 04-12-2024 (Wrong)

<img width="1060" alt="Screenshot 2024-12-04 at 12 27 35 PM" src="https://github.com/user-attachments/assets/97557265-6e02-4896-bbc7-4f5a959132da">


**After Fix**

<img width="1068" alt="Screenshot 2024-12-04 at 12 25 42 PM" src="https://github.com/user-attachments/assets/804eada8-1823-4d85-a842-667682a293f7">
