### PR TITLE
fix: Consider against_voucher_type and against_voucher_no as well in …

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -516,6 +516,8 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map, tot
 					gle.get("account"),
 					gle.get("party_type"),
 					gle.get("party"),
+					gle.get("against_voucher_type"),
+					gle.get("against_voucher_no"),
 				]
 
 				if immutable_ledger:


### PR DESCRIPTION
**Issue:**
General Ledger does not consider the against voucher type and against voucher no while grouping the entries
**ref:** [26554](https://support.frappe.io/helpdesk/tickets/26554)

![image](https://github.com/user-attachments/assets/800e29ec-ea48-4647-8eff-02c134581e5a)

**Before:**
![image](https://github.com/user-attachments/assets/43329d54-70b0-4d5d-82d9-e76ff910f5c5)

**After:**
![image](https://github.com/user-attachments/assets/97c74fdd-2d9b-47b3-9c1a-88547181d73a)

**backport needed for v15**