### PR TITLE
fix: correct color for draft in list view

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request_list.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request_list.js
@@ -1,7 +1,7 @@
 const INDICATORS = {
 	"Partially Paid": "orange",
 	Cancelled: "red",
-	Draft: "gray",
+	Draft: "red",
 	Failed: "red",
 	Initiated: "green",
 	Paid: "blue",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
@@ -15,7 +15,7 @@ frappe.listview_settings["Sales Invoice"] = {
 	],
 	get_indicator: function (doc) {
 		const status_colors = {
-			Draft: "grey",
+			Draft: "red",
 			Unpaid: "orange",
 			Paid: "green",
 			Return: "gray",

--- a/erpnext/stock/doctype/pick_list/pick_list_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list_list.js
@@ -4,7 +4,7 @@
 frappe.listview_settings["Pick List"] = {
 	get_indicator: function (doc) {
 		const status_colors = {
-			Draft: "grey",
+			Draft: "red",
 			Open: "orange",
 			Completed: "green",
 			Cancelled: "red",

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order_list.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order_list.js
@@ -4,7 +4,7 @@
 frappe.listview_settings["Subcontracting Order"] = {
 	get_indicator: function (doc) {
 		const status_colors = {
-			Draft: "grey",
+			Draft: "red",
 			Open: "orange",
 			"Partially Received": "yellow",
 			Completed: "green",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt_list.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt_list.js
@@ -4,7 +4,7 @@
 frappe.listview_settings["Subcontracting Receipt"] = {
 	get_indicator: function (doc) {
 		const status_colors = {
-			Draft: "grey",
+			Draft: "red",
 			Return: "gray",
 			"Return Issued": "grey",
 			Completed: "green",


### PR DESCRIPTION
The draft colour was set previously but "has_indicator_for_draft" was not set due to which the default colour i.e. red was shown.
So to keep the User experience the same we are not adding the flag but setting the default color in the code.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/22685

ref PR: https://github.com/frappe/erpnext/pull/43449
