### PR TITLE
fix: incorrect stock UOM for BOM raw materials

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -264,6 +264,24 @@ class BOM(WebsiteGenerator):
 		self.update_cost(update_parent=False, from_child_bom=True, update_hour_rate=False, save=False)
 		self.set_process_loss_qty()
 		self.validate_scrap_items()
+		self.set_default_uom()
+
+	def set_default_uom(self):
+		if not self.get("items"):
+			return
+
+		item_wise_uom = frappe._dict(
+			frappe.get_all(
+				"Item",
+				filters={"name": ("in", [item.item_code for item in self.items])},
+				fields=["name", "stock_uom"],
+				as_list=1,
+			)
+		)
+
+		for row in self.get("items"):
+			if row.stock_uom != item_wise_uom.get(row.item_code):
+				row.stock_uom = item_wise_uom.get(row.item_code)
 
 	def get_context(self, context):
 		context.parents = [{"name": "boms", "title": _("All BOMs")}]

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -763,6 +763,26 @@ class TestBOM(IntegrationTestCase):
 		self.assertTrue("_Test RM Item 2 Fixed Asset Item" not in items)
 		self.assertTrue("_Test RM Item 3 Manufacture Item" in items)
 
+	def test_bom_raw_materials_stock_uom(self):
+		rm_item = make_item(
+			properties={"is_stock_item": 1, "valuation_rate": 1000.0, "stock_uom": "Nos"}
+		).name
+		fg_item = make_item(properties={"is_stock_item": 1}).name
+
+		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
+
+		bom = make_bom(item=fg_item, raw_materials=[rm_item], do_not_submit=True)
+		for row in bom.items:
+			self.assertEqual(row.stock_uom, "Nos")
+
+		frappe.db.set_value("Item", rm_item, "stock_uom", "Kg")
+
+		bom.items[0].qty = 2
+		bom.save()
+
+		for row in bom.items:
+			self.assertEqual(row.stock_uom, "Kg")
+
 
 def get_default_bom(item_code="_Test FG Item 2"):
 	return frappe.db.get_value("BOM", {"item": item_code, "is_active": 1, "is_default": 1})


### PR DESCRIPTION
Steps to replicate the issue

- Create the BOM in draft state with raw materials having default UOM as Kg 
- Change the default UOM of raw materials from Kg to Nos
- Now submit the BOM which has been created in the first step
- System submit the BOM with the wrong stock UOM for raw materials