### PR TITLE
Consider against_voucher_no when voucher_no is filtered

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -370,8 +370,8 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 			if acc_dict.entries:
 				# opening
 				data.append({"debit_in_transaction_currency": None, "credit_in_transaction_currency": None})
-				if (not filters.group_by and not filters.voucher_no) or (
-					filters.group_by and filters.group_by != "Group by Voucher"
+				if (not filters.get("group_by") and not filters.get("voucher_no")) or (
+					filters.get("group_by") and filters.get("group_by") != "Group by Voucher"
 				):
 					data.append(acc_dict.totals.opening)
 
@@ -382,8 +382,8 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 					data.append(acc_dict.totals.total)
 
 				# closing
-				if (not filters.group_by and not filters.voucher_no) or (
-					filters.group_by and filters.group_by != "Group by Voucher"
+				if (not filters.get("group_by") and not filters.get("voucher_no")) or (
+					filters.get("group_by") and filters.get("group_by") != "Group by Voucher"
 				):
 					data.append(acc_dict.totals.closing)
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -516,6 +516,8 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map, tot
 					gle.get("account"),
 					gle.get("party_type"),
 					gle.get("party"),
+					gle.get("against_voucher_type"),
+					gle.get("against_voucher_no"),
 				]
 
 				if immutable_ledger:

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -378,7 +378,7 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 				data += acc_dict.entries
 
 				# totals
-				if not (not filters.get("group_by") and filters.voucher_no):
+				if filters.get("group_by") or not filters.voucher_no:
 					data.append(acc_dict.totals.total)
 
 				# closing

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -35,9 +35,6 @@ def execute(filters=None):
 	if filters.get("party"):
 		filters.party = frappe.parse_json(filters.get("party"))
 
-	if filters.get("voucher_no") and not filters.get("group_by"):
-		filters.group_by = "Group by Voucher (Consolidated)"
-
 	validate_filters(filters, account_details)
 
 	validate_party(filters)
@@ -373,16 +370,21 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 			if acc_dict.entries:
 				# opening
 				data.append({"debit_in_transaction_currency": None, "credit_in_transaction_currency": None})
-				if filters.get("group_by") != "Group by Voucher":
+				if (not filters.group_by and not filters.voucher_no) or (
+					filters.group_by and filters.group_by != "Group by Voucher"
+				):
 					data.append(acc_dict.totals.opening)
 
 				data += acc_dict.entries
 
 				# totals
-				data.append(acc_dict.totals.total)
+				if not (not filters.get("group_by") and filters.voucher_no):
+					data.append(acc_dict.totals.total)
 
 				# closing
-				if filters.get("group_by") != "Group by Voucher":
+				if (not filters.group_by and not filters.voucher_no) or (
+					filters.group_by and filters.group_by != "Group by Voucher"
+				):
 					data.append(acc_dict.totals.closing)
 
 		data.append({"debit_in_transaction_currency": None, "credit_in_transaction_currency": None})
@@ -516,8 +518,6 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map, tot
 					gle.get("account"),
 					gle.get("party_type"),
 					gle.get("party"),
-					gle.get("against_voucher_type"),
-					gle.get("against_voucher_no"),
 				]
 
 				if immutable_ledger:


### PR DESCRIPTION
**Issue:**
General Ledger does not consider the against voucher type and against voucher when there isn't any grouping
**ref:** [26554](https://support.frappe.io/helpdesk/tickets/26554)

**Solution:**
When there isn't any grouping and the voucher is filtered `Group by Voucher (Consolidated)` is set to `filters.group_by`, so the against_voucher_no is not taken into consideration.
I removed the `Group by Voucher (Consolidated)` assignment and ignored the opening and closing of the voucher


![image](https://github.com/user-attachments/assets/800e29ec-ea48-4647-8eff-02c134581e5a)

**Before:**
![image](https://github.com/user-attachments/assets/417d854b-a89c-4b56-9695-e8c06163130b)

**After:**
![image](https://github.com/user-attachments/assets/e6cb025e-b6d4-47a8-a1df-f2580a9430cb)

**Backport needed for v15**
