### PR TITLE
fix: not able to make PO for returned qty from material request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -115,6 +115,14 @@ frappe.ui.form.on("Material Request", {
 
 			if (flt(frm.doc.per_received, precision) < 100) {
 				frm.add_custom_button(__("Stop"), () => frm.events.update_status(frm, "Stopped"));
+
+				if (frm.doc.material_request_type === "Purchase") {
+					frm.add_custom_button(
+						__("Purchase Order"),
+						() => frm.events.make_purchase_order(frm),
+						__("Create")
+					);
+				}
 			}
 
 			if (flt(frm.doc.per_ordered, precision) < 100) {
@@ -153,14 +161,6 @@ frappe.ui.form.on("Material Request", {
 					frm.add_custom_button(
 						__("Material Receipt"),
 						() => frm.events.make_stock_entry(frm),
-						__("Create")
-					);
-				}
-
-				if (frm.doc.material_request_type === "Purchase") {
-					frm.add_custom_button(
-						__("Purchase Order"),
-						() => frm.events.make_purchase_order(frm),
 						__("Create")
 					);
 				}

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -378,7 +378,9 @@ def set_missing_values(source, target_doc):
 
 def update_item(obj, target, source_parent):
 	target.conversion_factor = obj.conversion_factor
-	target.qty = flt(flt(obj.stock_qty) - flt(obj.ordered_qty)) / target.conversion_factor
+
+	qty = obj.received_qty or obj.ordered_qty
+	target.qty = flt(flt(obj.stock_qty) - flt(qty)) / target.conversion_factor
 	target.stock_qty = target.qty * target.conversion_factor
 	if getdate(target.schedule_date) < getdate(nowdate()):
 		target.schedule_date = None
@@ -430,7 +432,9 @@ def make_purchase_order(source_name, target_doc=None, args=None):
 		filtered_items = args.get("filtered_children", [])
 		child_filter = d.name in filtered_items if filtered_items else True
 
-		return d.ordered_qty < d.stock_qty and child_filter
+		qty = d.received_qty or d.ordered_qty
+
+		return qty < d.stock_qty and child_filter
 
 	doclist = get_mapped_doc(
 		"Material Request",


### PR DESCRIPTION
Steps to replicate issue 

- Make material request for 10 qty
- Make PO and PR against it
- Make Purchase Return Entry with quantity as 2
- Now try to make new PO from the material request
- But you won't be able to make a new PO for returned qty 2 from the material request

