### PR TITLE
fix: only show advance payment entries where "book_advance_payments_in_separate_party_account" is true

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -153,10 +153,7 @@ class PaymentReconciliation(Document):
 		self.add_payment_entries(non_reconciled_payments)
 
 	def get_payment_entries(self):
-		if self.default_advance_account:
-			party_account = [self.receivable_payable_account, self.default_advance_account]
-		else:
-			party_account = [self.receivable_payable_account]
+		party_account = [self.receivable_payable_account]
 
 		order_doctype = "Sales Order" if self.party_type == "Customer" else "Purchase Order"
 		condition = frappe._dict(
@@ -187,6 +184,7 @@ class PaymentReconciliation(Document):
 			self.party,
 			party_account,
 			order_doctype,
+			default_advance_account=self.default_advance_account,
 			against_all_orders=True,
 			limit=self.payment_limit,
 			condition=condition,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2991,7 +2991,7 @@ def get_advance_payment_entries(
 		q = q.select((payment_entry.unallocated_amount).as_("amount"))
 		q = q.where(payment_entry.unallocated_amount > 0)
 
-		unallocated = list(q.run(as_dict=True, debug=True))
+		unallocated = list(q.run(as_dict=True))
 		payment_entries += unallocated
 	return payment_entries
 
@@ -3029,12 +3029,10 @@ def get_common_query(
 	account_condition = payment_entry[field].isin(party_account)
 	if default_advance_account:
 		q = q.where(
-			(
-				account_condition
-				| (
-					(payment_entry[field] == default_advance_account)
-					& (payment_entry.book_advance_payments_in_separate_party_account == 1)
-				)
+			account_condition
+			| (
+				(payment_entry[field] == default_advance_account)
+				& (payment_entry.book_advance_payments_in_separate_party_account == 1)
 			)
 		)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2946,6 +2946,7 @@ def get_advance_payment_entries(
 	party_account,
 	order_doctype,
 	order_list=None,
+	default_advance_account=None,
 	include_unallocated=True,
 	against_all_orders=False,
 	limit=None,
@@ -2959,6 +2960,7 @@ def get_advance_payment_entries(
 			party_type,
 			party,
 			party_account,
+			default_advance_account,
 			limit,
 			condition,
 		)
@@ -2982,13 +2984,14 @@ def get_advance_payment_entries(
 			party_type,
 			party,
 			party_account,
+			default_advance_account,
 			limit,
 			condition,
 		)
 		q = q.select((payment_entry.unallocated_amount).as_("amount"))
 		q = q.where(payment_entry.unallocated_amount > 0)
 
-		unallocated = list(q.run(as_dict=True))
+		unallocated = list(q.run(as_dict=True, debug=True))
 		payment_entries += unallocated
 	return payment_entries
 
@@ -2997,6 +3000,7 @@ def get_common_query(
 	party_type,
 	party,
 	party_account,
+	default_advance_account,
 	limit,
 	condition,
 ):
@@ -3018,14 +3022,24 @@ def get_common_query(
 		.where(payment_entry.docstatus == 1)
 	)
 
-	if payment_type == "Receive":
-		q = q.select((payment_entry.paid_from_account_currency).as_("currency"))
-		q = q.select(payment_entry.paid_from)
-		q = q.where(payment_entry.paid_from.isin(party_account))
+	field = "paid_from" if payment_type == "Receive" else "paid_to"
+
+	q = q.select((payment_entry[f"{field}_account_currency"]).as_("currency"))
+	q = q.select(payment_entry[field])
+	account_condition = payment_entry[field].isin(party_account)
+	if default_advance_account:
+		q = q.where(
+			(
+				account_condition
+				| (
+					(payment_entry[field] == default_advance_account)
+					& (payment_entry.book_advance_payments_in_separate_party_account == 1)
+				)
+			)
+		)
+
 	else:
-		q = q.select((payment_entry.paid_to_account_currency).as_("currency"))
-		q = q.select(payment_entry.paid_to)
-		q = q.where(payment_entry.paid_to.isin(party_account))
+		q = q.where(account_condition)
 
 	if payment_type == "Receive":
 		q = q.select((payment_entry.source_exchange_rate).as_("exchange_rate"))


### PR DESCRIPTION
Issue: Incorrect reconciliation is happening when payment entry is made with the advance account but book_advance_payments_in_separate_party_account was disabled in the Account Settings.

Steps to Replicate:
- Create an Advance Receivable Account.
- Create a Sales Invoice
- Disable "book_advance_payments_in_separate_party_account" in company.
- Create a Payment Entry in the Advance Receivable Account. 
- Enable "book_advance_payments_in_separate_party_account".
- Reconciliation of the payment against the Invoice
- Reconciliation will be successful but outstanding will not be adjusted because the Party Account is different and payment entry is not advance payment entry.



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/24578
