### PR TITLE
fix: variant qty while making work order from BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -412,7 +412,7 @@ frappe.ui.form.on("BOM", {
 			dialog.fields_dict.items.df.data.push({
 				item_code: d.item_code,
 				variant_item_code: "",
-				qty: d.qty,
+				qty: (d.qty / frm.doc.quantity) * (dialog.fields_dict.qty.value || 1),
 				source_warehouse: d.source_warehouse,
 				operation: d.operation,
 			});


### PR DESCRIPTION
**Issue**

In the BOM to make 10 Quantity of FG Items required 2 Quantity of raw materials for template items. Now while making the work order system set the FG qty as 1 and raw materials qty as 2 which is wrong.

Expected qty = 2 / 10 = 0.2

<img width="826" alt="Screenshot 2024-12-05 at 3 44 21 PM" src="https://github.com/user-attachments/assets/d6306b8e-8645-4191-9a62-468cd7f194a1">



**After Fix**


<img width="632" alt="Screenshot 2024-12-05 at 3 44 04 PM" src="https://github.com/user-attachments/assets/58064e33-5044-42cc-9eb6-c64794076f57">
