### PR TITLE
fix: BOM name issue

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -179,8 +179,13 @@ class BOM(WebsiteGenerator):
 
 		search_key = f"{self.doctype}-{self.item}%"
 		existing_boms = frappe.get_all(
-			"BOM", filters={"name": ("like", search_key), "amended_from": ["is", "not set"]}, pluck="name"
+			"BOM", filters={"name": search_key, "amended_from": ["is", "not set"]}, pluck="name"
 		)
+
+		if not existing_boms:
+			existing_boms = frappe.get_all(
+				"BOM", filters={"name": ("like", search_key), "amended_from": ["is", "not set"]}, pluck="name"
+			)
 
 		if existing_boms:
 			index = self.get_next_version_index(existing_boms)


### PR DESCRIPTION
**Issue**

- Create a Item with name as "AA"
- Create a Item with name as "A"
- Create a BOM for the Item "AA" BOM-AA-001
- Create a new BOM for the Item "AA" BOM-AA-002
- Create a BOM for the Item "A"
- System set the name for the BOM as "BOM-A-003" instead of "BOM-A-001"