### PR TITLE
fix: allow all dispatch address for drop ship invoice

### DIFF
--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -99,9 +99,12 @@ $.extend(erpnext.queries, {
 	},
 
 	dispatch_address_query: function (doc) {
+		var filters = { link_doctype: "Company", link_name: doc.company || "" };
+		var is_drop_ship = doc.items.some((item) => item.delivered_by_supplier);
+		if (is_drop_ship) filters = {};
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",
-			filters: { link_doctype: "Company", link_name: doc.company || "" },
+			filters: filters,
 		};
 	},
 


### PR DESCRIPTION
In the drop ship invoice dispatch address is the supplier's address.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/26725
