### PR TITLE
refactor: drop pytz

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import frappe
 from frappe import _
@@ -1007,13 +1007,13 @@ def now_datetime(user):
 
 
 def convert_utc_to_user_timezone(utc_timestamp, user):
-	from pytz import UnknownTimeZoneError, timezone
+	from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 	user_tz = get_tz(user)
-	utcnow = timezone("UTC").localize(utc_timestamp)
+	utcnow = utc_timestamp.replace(tzinfo=timezone.utc)
 	try:
-		return utcnow.astimezone(timezone(user_tz))
-	except UnknownTimeZoneError:
+		return utcnow.astimezone(ZoneInfo(user_tz))
+	except ZoneInfoNotFoundError:
 		return utcnow
 
 

--- a/erpnext/utilities/doctype/video/video.py
+++ b/erpnext/utilities/doctype/video/video.py
@@ -6,7 +6,6 @@ import re
 from datetime import datetime
 
 import frappe
-import pytz
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
@@ -77,6 +76,8 @@ def get_frequency(value):
 
 
 def update_youtube_data():
+	from zoneinfo import ZoneInfo
+
 	# Called every 30 minutes via hooks
 	video_settings = frappe.get_cached_doc("Video Settings")
 	if not video_settings.enable_youtube_tracking:
@@ -84,7 +85,7 @@ def update_youtube_data():
 
 	frequency = get_frequency(video_settings.frequency)
 	time = datetime.now()
-	timezone = pytz.timezone(get_system_timezone())
+	timezone = ZoneInfo(get_system_timezone())
 	site_time = time.astimezone(timezone)
 
 	if frequency == 30:

--- a/erpnext/www/book_appointment/index.py
+++ b/erpnext/www/book_appointment/index.py
@@ -1,8 +1,8 @@
 import datetime
 import json
+import zoneinfo
 
 import frappe
-import pytz
 from frappe import _
 from frappe.utils.data import get_system_timezone
 
@@ -38,9 +38,7 @@ def get_appointment_settings():
 
 @frappe.whitelist(allow_guest=True)
 def get_timezones():
-	import pytz
-
-	return pytz.all_timezones
+	return zoneinfo.available_timezones()
 
 
 @frappe.whitelist(allow_guest=True)
@@ -125,17 +123,17 @@ def filter_timeslots(date, timeslots):
 
 
 def convert_to_guest_timezone(guest_tz, datetimeobject):
-	guest_tz = pytz.timezone(guest_tz)
-	local_timezone = pytz.timezone(get_system_timezone())
+	guest_tz = zoneinfo.ZoneInfo(guest_tz)
+	local_timezone = zoneinfo.ZoneInfo(get_system_timezone())
 	datetimeobject = local_timezone.localize(datetimeobject)
 	datetimeobject = datetimeobject.astimezone(guest_tz)
 	return datetimeobject
 
 
 def convert_to_system_timezone(guest_tz, datetimeobject):
-	guest_tz = pytz.timezone(guest_tz)
+	guest_tz = zoneinfo.ZoneInfo.timezone(guest_tz)
 	datetimeobject = guest_tz.localize(datetimeobject)
-	system_tz = pytz.timezone(get_system_timezone())
+	system_tz = zoneinfo.ZoneInfo.timezone(get_system_timezone())
 	datetimeobject = datetimeobject.astimezone(system_tz)
 	return datetimeobject
 


### PR DESCRIPTION
Follow up to https://github.com/frappe/frappe/pull/28093 so I can drop the pytz dependency
