### PR TITLE
fix: description overwrite on qty change

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -267,17 +267,20 @@ frappe.ui.form.on("Material Request", {
 			},
 			callback: function (r) {
 				const d = item;
-				const allow_to_change_fields = [
+				let allow_to_change_fields = [
 					"actual_qty",
 					"projected_qty",
 					"min_order_qty",
 					"item_name",
-					"description",
 					"stock_uom",
 					"uom",
 					"conversion_factor",
 					"stock_qty",
 				];
+
+				if (overwrite_warehouse) {
+					allow_to_change_fields.push("description");
+				}
 
 				if (!r.exc) {
 					$.each(r.message, function (key, value) {


### PR DESCRIPTION
Item Description getting changed to default when changing the item's qty in the material request