### PR TITLE
fix: 'Use Multi-Level BOM' checkbox default value

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -305,15 +305,6 @@ frappe.ui.form.on("BOM", {
 
 		if (!skip_qty_field) {
 			fields.push({
-				fieldtype: "Check",
-				label: __("Use Multi-Level BOM"),
-				fieldname: "use_multi_level_bom",
-				default: 1,
-			});
-		}
-
-		if (!skip_qty_field) {
-			fields.push({
 				fieldtype: "Float",
 				label: __("Qty To Manufacture"),
 				fieldname: "qty",
@@ -338,6 +329,13 @@ frappe.ui.form.on("BOM", {
 
 					cur_dialog.refresh();
 				},
+			});
+
+			fields.push({
+				fieldtype: "Check",
+				label: __("Use Multi-Level BOM"),
+				fieldname: "use_multi_level_bom",
+				default: frm.doc?.__onload.use_multi_level_bom,
 			});
 		}
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -217,6 +217,23 @@ class BOM(WebsiteGenerator):
 
 		return index
 
+	def onload(self):
+		super().onload()
+
+		self.set_onload_for_muulti_level_bom()
+
+	def set_onload_for_muulti_level_bom(self):
+		use_multi_level_bom = frappe.db.get_value(
+			"Property Setter",
+			{"field_name": "use_multi_level_bom", "doc_type": "Work Order", "property": "default"},
+			"value",
+		)
+
+		if use_multi_level_bom is None:
+			use_multi_level_bom = 1
+
+		self.set_onload("use_multi_level_bom", cint(use_multi_level_bom))
+
 	@staticmethod
 	def get_next_version_index(existing_boms: list[str]) -> int:
 		# split by "/" and "-"


### PR DESCRIPTION
Set the default value for the 'Use Multi-Level BOM' field in the BOM based on the default value specified for the 'Use Multi-Level BOM' field in the work order.


<img width="717" alt="image" src="https://github.com/user-attachments/assets/150255f2-3455-433a-9419-e922bc5b7ff4">