### PR TITLE
fix: only show advance payment entries where "book_advance_payments_in_separate_party_account" is true (backport #44545)

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -153,10 +153,7 @@ class PaymentReconciliation(Document):
 		self.add_payment_entries(non_reconciled_payments)
 
 	def get_payment_entries(self):
-		if self.default_advance_account:
-			party_account = [self.receivable_payable_account, self.default_advance_account]
-		else:
-			party_account = [self.receivable_payable_account]
+		party_account = [self.receivable_payable_account]
 
 		order_doctype = "Sales Order" if self.party_type == "Customer" else "Purchase Order"
 		condition = frappe._dict(
@@ -187,6 +184,7 @@ class PaymentReconciliation(Document):
 			self.party,
 			party_account,
 			order_doctype,
+			default_advance_account=self.default_advance_account,
 			against_all_orders=True,
 			limit=self.payment_limit,
 			condition=condition,


### PR DESCRIPTION
Manual backport of https://github.com/frappe/erpnext/pull/44545