### PR TITLE
fix: permissions for marking Quotation as lost

### DIFF
--- a/erpnext/crm/doctype/competitor/competitor.json
+++ b/erpnext/crm/doctype/competitor/competitor.json
@@ -38,7 +38,7 @@
    "table_fieldname": "competitors"
   }
  ],
- "modified": "2024-03-27 13:06:45.911065",
+ "modified": "2024-12-10 08:26:38.496003",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Competitor",
@@ -53,20 +53,25 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "System Manager",
+   "role": "Sales Master Manager",
    "share": 1,
    "write": 1
   },
   {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
    "read": 1,
-   "report": 1,
-   "role": "Sales User",
-   "share": 1,
-   "write": 1
+   "role": "Sales User"
+  },
+  {
+   "read": 1,
+   "role": "Sales Manager"
+  },
+  {
+   "read": 1,
+   "role": "Maintenance Manager"
+  },
+  {
+   "read": 1,
+   "role": "Maintenance User"
   }
  ],
  "quick_entry": 1,

--- a/erpnext/setup/doctype/quotation_lost_reason/quotation_lost_reason.json
+++ b/erpnext/setup/doctype/quotation_lost_reason/quotation_lost_reason.json
@@ -32,7 +32,7 @@
    "table_fieldname": "lost_reasons"
   }
  ],
- "modified": "2024-03-27 13:10:31.419151",
+ "modified": "2024-12-10 08:21:38.280627",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Quotation Lost Reason",
@@ -49,6 +49,22 @@
    "role": "Sales Master Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Sales User"
+  },
+  {
+   "read": 1,
+   "role": "Sales Manager"
+  },
+  {
+   "read": 1,
+   "role": "Maintenance User"
+  },
+  {
+   "read": 1,
+   "role": "Maintenance Manager"
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
When marking a **Quotation** as lost, the user should be able to select a **Lost Reason** and a **Competitor**. I think everybody with write perms on **Quotation** should also be able to mark it as lost. Hence, they need read perms on **Lost Reason** and **Competitor**.