### PR TITLE
feat: validate discount date in payment schedule

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2361,6 +2361,7 @@ class AccountsController(TransactionBase):
 			return
 
 		for d in self.get("payment_schedule"):
+			d.validate_from_to_dates("discount_date", "due_date")
 			if self.doctype == "Sales Order" and getdate(d.due_date) < getdate(self.transaction_date):
 				frappe.throw(
 					_("Row {0}: Due Date in the Payment Terms table cannot be before Posting Date").format(


### PR DESCRIPTION
Early payment discount only makes sense if the discount date is earlier than the due date.

![Bildschirmfoto 2024-12-10 um 17 24 35](https://github.com/user-attachments/assets/076b78b5-89c5-4e10-a8ae-57b021e89edf)
