### PR TITLE
feat: Multiselect cc in process statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -244,9 +244,9 @@
   },
   {
    "fieldname": "cc_to",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "CC To",
-   "options": "User"
+   "options": "Process Statement Of Accounts CC"
   },
   {
    "default": "1",
@@ -400,7 +400,7 @@
   }
  ],
  "links": [],
- "modified": "2024-10-18 17:51:39.108481",
+ "modified": "2024-12-11 12:11:13.543134",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -31,6 +31,9 @@ class ProcessStatementOfAccounts(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import (
+			ProcessStatementOfAccountsCC,
+		)
 		from erpnext.accounts.doctype.process_statement_of_accounts_customer.process_statement_of_accounts_customer import (
 			ProcessStatementOfAccountsCustomer,
 		)
@@ -41,7 +44,7 @@ class ProcessStatementOfAccounts(Document):
 		ageing_based_on: DF.Literal["Due Date", "Posting Date"]
 		based_on_payment_terms: DF.Check
 		body: DF.TextEditor | None
-		cc_to: DF.Link | None
+		cc_to: DF.TableMultiSelect[ProcessStatementOfAccountsCC]
 		collection_name: DF.DynamicLink | None
 		company: DF.Link
 		cost_center: DF.TableMultiSelect[PSOACostCenter]
@@ -324,7 +327,7 @@ def get_recipients_and_cc(customer, doc):
 	cc = []
 	if doc.cc_to != "":
 		try:
-			cc = [frappe.get_value("User", doc.cc_to, "email")]
+			cc = [frappe.get_value("User", user.cc, "email") for user in doc.cc_to]
 		except Exception:
 			pass
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.json
@@ -1,0 +1,32 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-11 12:10:04.654593",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "cc"
+ ],
+ "fields": [
+  {
+   "fieldname": "cc",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CC",
+   "options": "User"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-12-11 12:10:39.772598",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Process Statement Of Accounts CC",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ProcessStatementOfAccountsCC(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		cc: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -392,3 +392,4 @@ erpnext.patches.v15_0.migrate_old_item_wise_tax_detail_data_format
 erpnext.patches.v15_0.set_is_exchange_gain_loss_in_payment_entry_deductions
 erpnext.patches.v14_0.update_stock_uom_in_work_order_item
 erpnext.patches.v15_0.enable_allow_existing_serial_no
+erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,10 +1,16 @@
 import frappe
+from frappe import qb
 
 
 def execute():
-	data = frappe.db.sql(
-		"""SELECT name, cc_to FROM `tabProcess Statement Of Accounts` WHERE cc_to IS NOT NULL""", as_dict=True
-	)
+	process_statement_of_accounts = qb.DocType("Process Statement Of Accounts")
+
+	data = (
+		frappe.qb.from_(process_statement_of_accounts)
+		.select(process_statement_of_accounts.name, process_statement_of_accounts.cc_to)
+		.where(process_statement_of_accounts.cc_to.isnotnull())
+	).run(as_dict=True)
+
 	for d in data:
 		doc = frappe.get_doc("Process Statement Of Accounts", d.name)
 		doc.append("cc_to", {"cc": d.cc_to})

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	data = frappe.db.sql(
+		"""SELECT name, cc_to FROM `tabProcess Statement Of Accounts` WHERE cc_to IS NOT NULL""", as_dict=True
+	)
+	for d in data:
+		doc = frappe.get_doc("Process Statement Of Accounts", d.name)
+		doc.append("cc_to", {"cc": d.cc_to})
+		doc.save()

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,9 +1,8 @@
 import frappe
-from frappe import qb
 
 
 def execute():
-	process_statement_of_accounts = qb.DocType("Process Statement Of Accounts")
+	process_statement_of_accounts = frappe.qb.DocType("Process Statement Of Accounts")
 
 	data = (
 		frappe.qb.from_(process_statement_of_accounts)


### PR DESCRIPTION
**Issue:**
Need option to add multiple email in cc: Process Statement of Accounts
**ref:** [25154](https://support.frappe.io/helpdesk/tickets/25154)

**Solution:**
Added multiselect field to have more that one cc in email

**Before:**
![imageedit_2_2933670886](https://github.com/user-attachments/assets/daecd169-689e-4c58-8e34-db1cbbec7e5f)

**After:**
![imageedit_4_9486530008](https://github.com/user-attachments/assets/6485dac2-b3bf-4abb-a67d-cf7407988cd4)

**Backport needed for v15**

`no-docs`