### PR TITLE
fix: check difference_posting_date

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -774,10 +774,9 @@ def update_reference_in_payment_entry(
 		)
 	payment_entry.set_amounts()
 
-	args = frappe._dict()
-	if d.difference_posting_date:
-		args.update({"difference_posting_date": d.difference_posting_date})
-	payment_entry.make_exchange_gain_loss_journal(args, dimensions_dict)
+	payment_entry.make_exchange_gain_loss_journal(
+		frappe._dict({"difference_posting_date": d.difference_posting_date}), dimensions_dict
+	)
 
 	if not do_not_save:
 		payment_entry.save(ignore_permissions=True)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -774,9 +774,10 @@ def update_reference_in_payment_entry(
 		)
 	payment_entry.set_amounts()
 
-	payment_entry.make_exchange_gain_loss_journal(
-		frappe._dict({"difference_posting_date": d.difference_posting_date}), dimensions_dict
-	)
+	args = frappe._dict()
+	if d.difference_posting_date:
+		args.update({"difference_posting_date": d.difference_posting_date})
+	payment_entry.make_exchange_gain_loss_journal(args, dimensions_dict)
 
 	if not do_not_save:
 		payment_entry.save(ignore_permissions=True)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1514,7 +1514,9 @@ class AccountsController(TransactionBase):
 
 						je = create_gain_loss_journal(
 							self.company,
-							args.get("difference_posting_date") if args else self.posting_date,
+							args.get("difference_posting_date")
+							if "difference_posting_date" in args and args.get("difference_posting_date")
+							else self.posting_date,
 							self.party_type,
 							self.party,
 							party_account,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1515,7 +1515,9 @@ class AccountsController(TransactionBase):
 						je = create_gain_loss_journal(
 							self.company,
 							args.get("difference_posting_date")
-							if "difference_posting_date" in args and args.get("difference_posting_date")
+							if args
+							and "difference_posting_date" in args
+							and args.get("difference_posting_date")
 							else self.posting_date,
 							self.party_type,
 							self.party,


### PR DESCRIPTION
**Issue:**
Exchange gain/loss journal posting on the current date instead of the invoice date
**ref:** [26926](https://support.frappe.io/helpdesk/tickets/26926)

**Payment Entry:**
![image](https://github.com/user-attachments/assets/91f78125-846d-4feb-81ca-3ac04c03f97b)

**Purchase Invoice:**
![image](https://github.com/user-attachments/assets/adafefb4-bedc-4096-b851-572ee37007de)

**Exchange Journal Before:**
![image](https://github.com/user-attachments/assets/100158ed-ab89-4bda-a203-9168112ac4b0)

**Exchange Journal After:**
![image](https://github.com/user-attachments/assets/17edfc7e-df11-47f7-9341-32ec800a3dcd)


Backport needed v14 &v15
