### PR TITLE
fix: update free item qty while adding same item in seperate row

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -651,8 +651,17 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 
 	qty = pricing_rule.free_qty or 1
 	if pricing_rule.is_recursive:
-		transaction_qty = (args.get("qty") if args else doc.total_qty) - pricing_rule.apply_recursion_over
-		if transaction_qty:
+		transaction_qty = sum(
+			[
+				row.qty
+				for row in doc.items
+				if not row.is_free_item
+				and row.item_code == args.item_code
+				and row.pricing_rules == args.pricing_rules
+			]
+		)
+		transaction_qty = transaction_qty - pricing_rule.apply_recursion_over
+		if transaction_qty and transaction_qty > 0:
 			qty = flt(transaction_qty) * qty / pricing_rule.recurse_for
 			if pricing_rule.round_free_qty:
 				qty = (flt(transaction_qty) // pricing_rule.recurse_for) * (pricing_rule.free_qty or 1)


### PR DESCRIPTION
backport of #44493

**Issue:**
Free item qty not updating properly when the same item code is added in a separate row
**ref:** [26495](https://support.frappe.io/helpdesk/tickets/26495)

**Promotional Scheme:**
![Screenshot from 2024-12-04 00-45-59](https://github.com/user-attachments/assets/360928f9-3e71-4645-8adc-59aefe601f6a)

**Before:**
![Screenshot 2024-12-04_00-44-32](https://github.com/user-attachments/assets/9595e3c0-bb25-41df-ac87-1c9e22ebee36)

**After:**
![Screenshot 2024-12-04_00-45-41](https://github.com/user-attachments/assets/3f4db203-c656-42da-b3d8-1e1a887c3baf)
