### PR TITLE
fix: valuation rate for batch in stock reconciliation 

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -207,6 +207,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 					posting_time: frm.doc.posting_time,
 					batch_no: d.batch_no,
 					row: d,
+					company: frm.doc.company,
 				},
 				callback: function (r) {
 					const row = frappe.model.get_doc(cdt, cdn);

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -466,6 +466,7 @@ class StockReconciliation(StockController):
 				batch_no=item.batch_no,
 				inventory_dimensions_dict=inventory_dimensions_dict,
 				row=item,
+				company=self.company,
 			)
 
 			if (
@@ -974,6 +975,7 @@ class StockReconciliation(StockController):
 					self.posting_date,
 					self.posting_time,
 					row=row,
+					company=self.company,
 				)
 
 				current_qty = item_dict.get("qty")
@@ -1308,6 +1310,7 @@ def get_stock_balance_for(
 	with_valuation_rate: bool = True,
 	inventory_dimensions_dict=None,
 	row=None,
+	company=None,
 ):
 	frappe.has_permission("Stock Reconciliation", "write", throw=True)
 
@@ -1366,6 +1369,21 @@ def get_stock_balance_for(
 			)
 			or 0
 		)
+
+		if row.use_serial_batch_fields and row.batch_no:
+			rate = get_incoming_rate(
+				frappe._dict(
+					{
+						"item_code": row.item_code,
+						"warehouse": row.warehouse,
+						"qty": row.qty * -1,
+						"batch_no": row.batch_no,
+						"company": company,
+						"posting_date": posting_date,
+						"posting_time": posting_time,
+					}
+				)
+			)
 
 	return {
 		"qty": qty,


### PR DESCRIPTION
- Inward batch A of item A with 10 qty and 100 rate
- Inward batch B of item A with 10 qty and 200 rate
- Select the batch A and batch B in stock reco in two line item with Use Serial and Batch Fields
- System set the average rate as 150 

Expected Valuation Rate

- For Batch A the rate should be 100
- For Batch B the rate should be 200