### PR TITLE
fix: better indicator base amount for Tax Witholding in Journal Entry

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -72,8 +72,8 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 			if net_total_map.get((voucher_type, name)):
 				if voucher_type == "Journal Entry" and tax_amount and rate:
 					# back calcalute total amount from rate and tax_amount
-					if rate:
-						total_amount = grand_total = base_total = tax_amount / (rate / 100)
+					base_total = min(tax_amount / (rate / 100), net_total_map.get((voucher_type, name))[0])
+					total_amount = grand_total = base_total
 				elif voucher_type == "Purchase Invoice":
 					total_amount, grand_total, base_total, bill_no, bill_date = net_total_map.get(
 						(voucher_type, name)
@@ -409,7 +409,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 			"paid_amount_after_tax",
 			"base_paid_amount",
 		],
-		"Journal Entry": ["total_amount"],
+		"Journal Entry": ["total_debit"],
 	}
 
 	entries = frappe.get_all(
@@ -431,7 +431,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 		elif doctype == "Payment Entry":
 			value = [entry.paid_amount, entry.paid_amount_after_tax, entry.base_paid_amount]
 		else:
-			value = [entry.total_amount] * 3
+			value = [entry.total_debit] * 3
 
 		net_total_map[(doctype, entry.name)] = value
 


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/helpdesk/tickets/26923

### Use case

Over deduction of TDS from Journal Entry for an expense booked.

### Issue

Excess amount reported forms part of income of supplier if reported as is.

### Implementation

Base amount for TDS is lower of total JV value or reverse calculation (from tax rate and tax amount being deducted)
This is to based on the assumption that supplier is deducting TDS manually while staying compliant and there is no under deduction.

backport to version-14 and version-15 is expected