### PR TITLE
fix: make projected qty editable after submit

### DIFF
--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -456,6 +456,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "projected_qty",
    "fieldtype": "Float",
    "label": "Projected Qty",
@@ -697,7 +698,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-24 14:18:43.952844",
+ "modified": "2024-12-12 13:49:17.765883",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",


### PR DESCRIPTION
**Issue:**
Unable to set quotation as lost as the projected qty is being updated [here](https://github.com/frappe/erpnext/blob/15c7d26378d195b9ffeee0e6b9efbbb3bc7748a0/erpnext/controllers/selling_controller.py#L24)
**ref:** [26916](https://support.frappe.io/helpdesk/tickets/26916)

![image](https://github.com/user-attachments/assets/ee13ab46-9349-4426-bb6a-7c64c9fe410c)


**Backport needed for v15**