### PR TITLE
fix: remove invalid filter in Account Receivable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -551,9 +551,7 @@ class ReceivablePayableReport:
 			self.append_payment_term(row, d, term)
 
 	def append_payment_term(self, row, d, term):
-		if (
-			self.filters.get("customer") or self.filters.get("supplier")
-		) and d.currency == d.party_account_currency:
+		if d.currency == d.party_account_currency:
 			invoiced = d.payment_amount
 		else:
 			invoiced = d.base_payment_amount


### PR DESCRIPTION
Due to an invalid filter Account Receivable report was not generated correctly.

There is no such filter as `customer` or `supplier` in the Account Receivable/Payable Report. Due to this when the report is based on the payment term template, it was incorrect.


Note:
The fix is required for backward compatibility.
The issue is not replicated locally because both payment_amount and base payment amount is set.




backport version-14
backport version-15


Frappe Support : https://support.frappe.io/app/hd-ticket/22249



