### PR TITLE
fix: Stock Entry uses incorrect company when generated from Pick List

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -982,6 +982,7 @@ def create_stock_entry(pick_list):
 	stock_entry = frappe.new_doc("Stock Entry")
 	stock_entry.pick_list = pick_list.get("name")
 	stock_entry.purpose = pick_list.get("purpose")
+	stock_entry.company = pick_list.get("company")
 	stock_entry.set_stock_entry_type()
 
 	if pick_list.get("work_order"):


### PR DESCRIPTION
Corrects the problem where the Stock Record associated with the Separation List uses the incorrect company.
The change ensures that the Stock Record uses the company of the original Material Requisition.
Steps to Reproduce
1 Create a Material Requisition of type "Material Transfer" for a specific company code (e.g. "Company2").
2 Create a Picking List from the Requisition.
3 Generate a Stock Entry from the Picking List.
4 Verify that the company code associated with the Stock Entry does not match the company code of the original Requisition ("Company2").
Issue Location
The issue is likely located in the pick_list.py file (lines 865-878) of the "erpnext.stock.doctype.pick_list". module.
Proposed Solution
To fix this issue, it is suggested to change the line stock_entry.company = pick_list.get("company") to get the correct company code from the original Material Requisition.

https://github.com/frappe/erpnext/issues/44678
