### PR TITLE
fix: set company bank account if default account not set in mode of p…

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1328,6 +1328,24 @@ frappe.ui.form.on("Payment Entry", {
 					if (r.message) {
 						if (!frm.doc.mode_of_payment) {
 							frm.set_value(field, r.message.account);
+						} else {
+							frappe.call({
+								method: "frappe.client.get_value",
+								args: {
+									doctype: "Mode of Payment Account",
+									filters: {
+										parent: frm.doc.mode_of_payment,
+										company: frm.doc.company,
+									},
+									fieldname: "default_account",
+									parent: "Mode of Payment",
+								},
+								callback: function (res) {
+									if (!res.message.default_account) {
+										frm.set_value(field, r.message.account);
+									}
+								},
+							});
 						}
 						frm.set_value("bank", r.message.bank);
 						frm.set_value("bank_account_no", r.message.bank_account_no);


### PR DESCRIPTION
**Issue:**
Company bank account is not set in Account Paid From/To if the mode of payment is selected, but the mode of payment doesn't have a default bank account set.
**ref:** [26506](https://support.frappe.io/helpdesk/tickets/26506)

**Before:**

https://github.com/user-attachments/assets/43b8aec0-a6ce-4543-a3f0-3b993f997cb5


**After:**

https://github.com/user-attachments/assets/e4862d39-c089-4c79-a1ad-6b91593f5e3a


**Backport needed for v14 & v15**
