### PR TITLE
fix: Wrong allocated_amount for sales_team in gross_profit report (backport #43989)

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -768,7 +768,10 @@ class GrossProfitGenerator:
 			"""
 
 		if self.filters.group_by == "Sales Person":
-			sales_person_cols = ", sales.sales_person, sales.allocated_amount, sales.incentives"
+			sales_person_cols = """, sales.sales_person,
+				sales.allocated_percentage * `tabSales Invoice Item`.base_net_amount / 100 as allocated_amount,
+				sales.incentives
+			"""
 			sales_team_table = "left join `tabSales Team` sales on sales.parent = `tabSales Invoice`.name"
 		else:
 			sales_person_cols = ""


### PR DESCRIPTION
Manual backport of #42989 