### PR TITLE
fix: handle zero salvage value case

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -805,10 +805,10 @@ class Asset(AccountsController):
 			):
 				return args.get("rate_of_depreciation")
 
-			if self.flags.increase_in_asset_value_due_to_repair:
-				if not flt(args.get("expected_value_after_useful_life")):
-					return args.get("rate_of_depreciation")
+			if args.get("rate_of_depreciation") and not flt(args.get("expected_value_after_useful_life")):
+				return args.get("rate_of_depreciation")
 
+			if self.flags.increase_in_asset_value_due_to_repair:
 				value = flt(args.get("expected_value_after_useful_life")) / flt(
 					args.get("value_after_depreciation")
 				)

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -806,6 +806,9 @@ class Asset(AccountsController):
 				return args.get("rate_of_depreciation")
 
 			if self.flags.increase_in_asset_value_due_to_repair:
+				if not flt(args.get("expected_value_after_useful_life")):
+					return args.get("rate_of_depreciation")
+
 				value = flt(args.get("expected_value_after_useful_life")) / flt(
 					args.get("value_after_depreciation")
 				)

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -88,7 +88,8 @@
    "depends_on": "eval:doc.depreciation_method == 'Written Down Value'",
    "fieldname": "rate_of_depreciation",
    "fieldtype": "Percent",
-   "label": "Rate of Depreciation (%)"
+   "label": "Rate of Depreciation (%)",
+   "mandatory_depends_on": "eval:doc.depreciation_method == 'Written Down Value'"
   },
   {
    "fieldname": "salvage_value_percentage",
@@ -128,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-29 14:36:54.399034",
+ "modified": "2024-12-13 12:11:03.743209",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
This update resolves a scenario where a zero salvage value incorrectly sets the depreciation rate to 100%. The logic has been adjusted to retain the previous depreciation rate when the salvage value is zero.
Also set the rate of depreciation as a mandatory field when the depreciation method is "Written Down Value".