### PR TITLE
fix: validate advance amount in company currency

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -789,7 +789,7 @@ class calculate_taxes_and_totals:
 			grand_total = self.doc.base_rounded_total or self.doc.base_grand_total
 
 			invoice_total = flt(
-				grand_total - self.doc.base_write_off_amount, self.doc.precision("grand_total")
+				grand_total - flt(self.doc.base_write_off_amount), self.doc.precision("grand_total")
 			)
 
 			if invoice_total > 0 and self.doc.total_advance > invoice_total:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -786,21 +786,11 @@ class calculate_taxes_and_totals:
 
 			self.doc.total_advance = flt(total_allocated_amount, self.doc.precision("total_advance"))
 
-			grand_total = self.doc.rounded_total or self.doc.grand_total
+			grand_total = self.doc.base_rounded_total or self.doc.base_grand_total
 
-			if self.doc.party_account_currency == self.doc.currency:
-				invoice_total = flt(
-					grand_total - flt(self.doc.write_off_amount), self.doc.precision("grand_total")
-				)
-			else:
-				base_write_off_amount = flt(
-					flt(self.doc.write_off_amount) * self.doc.conversion_rate,
-					self.doc.precision("base_write_off_amount"),
-				)
-				invoice_total = (
-					flt(grand_total * self.doc.conversion_rate, self.doc.precision("grand_total"))
-					- base_write_off_amount
-				)
+			invoice_total = flt(
+				grand_total - self.doc.base_write_off_amount, self.doc.precision("grand_total")
+			)
 
 			if invoice_total > 0 and self.doc.total_advance > invoice_total:
 				frappe.throw(


### PR DESCRIPTION
**Issue:**
Unable to create purchase invoice with the advance amount in foreign currency due to minor precision loss
**ref:** [26967](https://support.frappe.io/helpdesk/tickets/26967)

**Payment:**
![image](https://github.com/user-attachments/assets/9975caf4-5bc8-4c2a-8653-a937ff079502)

**Invoice:**
![image](https://github.com/user-attachments/assets/b6378b52-9a13-44a9-b4a9-916d39017f01)

**Error:**
![image](https://github.com/user-attachments/assets/0b1fd0cf-4198-4cad-8174-df350c89f428)

invoice amount - 80.445
exchange rate - 0.104950000

80.445/0.104950000 = 766.5078608861362

766.5078608861362 * 0.104950000 = 80.445

but since it is being rounded with field precision 766.50 * 0.104950000 = 80.444175

so the condition 80.445 > 80.444175 is passed

**Backport needed for v15**