### PR TITLE
fix: User permissions in financial statements

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -527,7 +527,16 @@ def get_accounting_entries(
 		account_filter_query = get_account_filter_query(root_lft, root_rgt, root_type, gl_entry)
 		query = query.where(ExistsCriterion(account_filter_query))
 
-	entries = query.run(as_dict=True)
+	query = query.get_sql()
+
+	from frappe.desk.reportview import build_match_conditions
+
+	match_conditions = build_match_conditions(doctype)
+
+	if match_conditions:
+		query += "and" + match_conditions
+
+	entries = frappe.db.sql(query, as_dict=True)
 
 	return entries
 

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -527,8 +527,6 @@ def get_accounting_entries(
 		account_filter_query = get_account_filter_query(root_lft, root_rgt, root_type, gl_entry)
 		query = query.where(ExistsCriterion(account_filter_query))
 
-	query = query.get_sql()
-
 	from frappe.desk.reportview import build_match_conditions
 
 	match_conditions = build_match_conditions(doctype)
@@ -536,9 +534,9 @@ def get_accounting_entries(
 	if match_conditions:
 		query += "and" + match_conditions
 
-	entries = frappe.db.sql(query, as_dict=True)
+	query, params = query.walk()
 
-	return entries
+	return frappe.db.sql(query, params, as_dict=True)
 
 
 def get_account_filter_query(root_lft, root_rgt, root_type, gl_entry):


### PR DESCRIPTION
User Permissions are not checked in Financial Statements (Profit And Loss Report, Balance Sheet Report).

Steps to replicate:
- Set user permission for cost center for any user.
- Generate a Report with that user.
- The report will be based on all the cost centres.

![image](https://github.com/user-attachments/assets/10ed8166-ccb7-4506-b902-d65e39990572)




Before:
![image](https://github.com/user-attachments/assets/c4481dc2-d07d-4669-9fce-0263b3751608)

After:
![image](https://github.com/user-attachments/assets/e088eecb-c480-448e-9e78-91e6eb85ff2c)





Frappe.Support Issue: https://support.frappe.io/app/hd-ticket/21597


backport version-15
backport version-14
