### PR TITLE
fix: update discount when pricing rule is changed

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -415,6 +415,8 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 			"parent": args.parent,
 			"parenttype": args.parenttype,
 			"child_docname": args.get("child_docname"),
+			"discount_percentage": 0.0,
+			"discount_amount": 0,
 		}
 	)
 


### PR DESCRIPTION
**Issue:**
Discount not updating when the pricing rule is changed
**ref:** [27103](https://support.frappe.io/helpdesk/tickets/27103)

**Before:**

https://github.com/user-attachments/assets/8733a547-7895-471f-a14f-b65ace1495d9

**After:**

https://github.com/user-attachments/assets/4e7cbada-3f6d-424c-aa78-2a960d25f37d



**Backport needed for v14 and v15**

