### PR TITLE
fix: avg. buying amount for product bundle item with serial and batch no in gross profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -637,6 +637,7 @@ class GrossProfitGenerator:
 				packed_item_row = row.copy()
 				packed_item_row.warehouse = packed_item.warehouse
 				packed_item_row.qty = packed_item.total_qty * -1
+				packed_item_row.serial_and_batch_bundle = packed_item.serial_and_batch_bundle
 				buying_amount += self.get_buying_amount(packed_item_row, packed_item.item_code)
 
 		return flt(buying_amount, self.currency_precision)
@@ -728,6 +729,7 @@ class GrossProfitGenerator:
 					"voucher_no": row.parent,
 					"allow_zero_valuation": True,
 					"company": self.filters.company,
+					"item_code": item_code,
 				}
 			)
 
@@ -996,6 +998,7 @@ class GrossProfitGenerator:
 				"is_return": row.is_return,
 				"cost_center": row.cost_center,
 				"invoice": row.parent,
+				"serial_and_batch_bundle": row.serial_and_batch_bundle,
 			}
 		)
 
@@ -1047,6 +1050,7 @@ class GrossProfitGenerator:
 				pki.rate,
 				(pki.rate * pki.qty).as_("base_amount"),
 				pki.parent_detail_docname,
+				pki.serial_and_batch_bundle,
 			)
 			.where(pki.docstatus == 1)
 		)


### PR DESCRIPTION
Issue: Buying Amount for Product Bundle Items is incorrect.

For Product bundle Items, serial_and_batch_bundle was not set and the item code was also incorrect because it was for the parent item.

Steps to Replicate:
- Create an Item with Serial and batch and one more item.
- Create a Product bundle with the same Items.
- Create a sales invoice without update_stock.
- Create a Delivery Note for sales invoice
- Check buying amount in gross profit report.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/24113

backport version-15-hotfix
backport version-14-hotfix

