### PR TITLE
fix: pos invoice return reference missing

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -118,11 +118,11 @@ class POSInvoiceMergeLog(Document):
 		sales = [d for d in pos_invoice_docs if d.get("is_return") == 0]
 
 		sales_invoice, credit_note = "", ""
-		if returns:
-			credit_note = self.process_merging_into_credit_note(returns)
-
 		if sales:
 			sales_invoice = self.process_merging_into_sales_invoice(sales)
+
+		if returns:
+			credit_note = self.process_merging_into_credit_note(returns, sales_invoice)
 
 		self.save()  # save consolidated_sales_invoice & consolidated_credit_note ref in merge log
 		self.update_pos_invoices(pos_invoice_docs, sales_invoice, credit_note)
@@ -141,8 +141,13 @@ class POSInvoiceMergeLog(Document):
 
 		sales_invoice.is_consolidated = 1
 		sales_invoice.set_posting_time = 1
-		sales_invoice.posting_date = getdate(self.posting_date)
-		sales_invoice.posting_time = get_time(self.posting_time)
+
+		if not sales_invoice.posting_date:
+			sales_invoice.posting_date = getdate(self.posting_date)
+
+		if not sales_invoice.posting_time:
+			sales_invoice.posting_time = get_time(self.posting_time)
+
 		sales_invoice.save()
 		sales_invoice.submit()
 
@@ -150,11 +155,13 @@ class POSInvoiceMergeLog(Document):
 
 		return sales_invoice.name
 
-	def process_merging_into_credit_note(self, data):
+	def process_merging_into_credit_note(self, data, sales_invoice):
 		credit_note = self.get_new_sales_invoice()
 		credit_note.is_return = 1
 
 		credit_note = self.merge_pos_invoice_into(credit_note, data)
+
+		credit_note.return_against = sales_invoice
 
 		credit_note.is_consolidated = 1
 		credit_note.set_posting_time = 1
@@ -181,6 +188,10 @@ class POSInvoiceMergeLog(Document):
 
 		for doc in data:
 			map_doc(doc, invoice, table_map={"doctype": invoice.doctype})
+
+			if doc.get("posting_date"):
+				invoice.posting_date = getdate(doc.posting_date)
+				invoice.posting_time = get_time(doc.posting_time)
 
 			if doc.redeem_loyalty_points:
 				invoice.loyalty_redemption_account = doc.loyalty_redemption_account
@@ -299,6 +310,8 @@ class POSInvoiceMergeLog(Document):
 		sales_invoice = frappe.new_doc("Sales Invoice")
 		sales_invoice.customer = self.customer
 		sales_invoice.is_pos = 1
+		sales_invoice.posting_date = None
+		sales_invoice.posting_time = None
 
 		return sales_invoice
 


### PR DESCRIPTION
- Create the POS Invoice
- Create the returned POS Invoice
- Create the closing entry

**Issue 1**
- You will notice that the return entry created first and after that the original invoice created

**Issue 2**
- Change the valuation rate using stock reco before the POS Invoice
- System won't update the rate of returned invoice
<img width="1315" alt="Screenshot 2024-12-16 at 5 17 09 PM" src="https://github.com/user-attachments/assets/95374dd8-fcab-4b67-b58e-523fe8305ecc" />


**After Fix**
<img width="1245" alt="Screenshot 2024-12-16 at 10 22 32 PM" src="https://github.com/user-attachments/assets/d42d17fa-b4af-4782-9853-237414560199" />



