### PR TITLE
fix: fetch tax withholding category from the voucher

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -244,9 +244,9 @@
   },
   {
    "fieldname": "cc_to",
-   "fieldtype": "Link",
+   "fieldtype": "Table MultiSelect",
    "label": "CC To",
-   "options": "User"
+   "options": "Process Statement Of Accounts CC"
   },
   {
    "default": "1",
@@ -400,7 +400,7 @@
   }
  ],
  "links": [],
- "modified": "2024-10-18 17:51:39.108481",
+ "modified": "2024-12-11 12:11:13.543134",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -31,6 +31,9 @@ class ProcessStatementOfAccounts(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from erpnext.accounts.doctype.process_statement_of_accounts_cc.process_statement_of_accounts_cc import (
+			ProcessStatementOfAccountsCC,
+		)
 		from erpnext.accounts.doctype.process_statement_of_accounts_customer.process_statement_of_accounts_customer import (
 			ProcessStatementOfAccountsCustomer,
 		)
@@ -41,7 +44,7 @@ class ProcessStatementOfAccounts(Document):
 		ageing_based_on: DF.Literal["Due Date", "Posting Date"]
 		based_on_payment_terms: DF.Check
 		body: DF.TextEditor | None
-		cc_to: DF.Link | None
+		cc_to: DF.TableMultiSelect[ProcessStatementOfAccountsCC]
 		collection_name: DF.DynamicLink | None
 		company: DF.Link
 		cost_center: DF.TableMultiSelect[PSOACostCenter]
@@ -324,7 +327,7 @@ def get_recipients_and_cc(customer, doc):
 	cc = []
 	if doc.cc_to != "":
 		try:
-			cc = [frappe.get_value("User", doc.cc_to, "email")]
+			cc = [frappe.get_value("User", user.cc, "email") for user in doc.cc_to]
 		except Exception:
 			pass
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.json
@@ -1,0 +1,32 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-11 12:10:04.654593",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "cc"
+ ],
+ "fields": [
+  {
+   "fieldname": "cc",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "CC",
+   "options": "User"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-12-11 12:10:39.772598",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Process Statement Of Accounts CC",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts_cc/process_statement_of_accounts_cc.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ProcessStatementOfAccountsCC(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		cc: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -539,7 +539,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 	)
 
 	supp_credit_amt = supp_jv_credit_amt
-	supp_credit_amt += inv.tax_withholding_net_total
+	supp_credit_amt += inv.get("tax_withholding_net_total", 0)
 
 	for type in payment_entry_amounts:
 		if type.payment_type == "Pay":
@@ -551,9 +551,9 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
 	if inv.doctype != "Payment Entry":
-		tax_withholding_net_total = inv.base_tax_withholding_net_total
+		tax_withholding_net_total = inv.get("base_tax_withholding_net_total", 0)
 	else:
-		tax_withholding_net_total = inv.tax_withholding_net_total
+		tax_withholding_net_total = inv.get("tax_withholding_net_total", 0)
 
 	if (threshold and tax_withholding_net_total >= threshold) or (
 		cumulative_threshold and (supp_credit_amt + supp_inv_credit_amt) >= cumulative_threshold

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -409,7 +409,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 			"paid_amount_after_tax",
 			"base_paid_amount",
 		],
-		"Journal Entry": ["total_amount"],
+		"Journal Entry": ["total_amount", "tax_withholding_category"],
 	}
 
 	entries = frappe.get_all(

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -72,8 +72,8 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 			if net_total_map.get((voucher_type, name)):
 				if voucher_type == "Journal Entry" and tax_amount and rate:
 					# back calcalute total amount from rate and tax_amount
-					if rate:
-						total_amount = grand_total = base_total = tax_amount / (rate / 100)
+					base_total = min(tax_amount / (rate / 100), net_total_map.get((voucher_type, name))[0])
+					total_amount = grand_total = base_total
 				elif voucher_type == "Purchase Invoice":
 					total_amount, grand_total, base_total, bill_no, bill_date = net_total_map.get(
 						(voucher_type, name)
@@ -409,7 +409,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 			"paid_amount_after_tax",
 			"base_paid_amount",
 		],
-		"Journal Entry": ["total_amount", "tax_withholding_category"],
+		"Journal Entry": ["total_debit", "tax_withholding_category"],
 	}
 
 	entries = frappe.get_all(
@@ -431,7 +431,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 		elif doctype == "Payment Entry":
 			value = [entry.paid_amount, entry.paid_amount_after_tax, entry.base_paid_amount]
 		else:
-			value = [entry.total_amount] * 3
+			value = [entry.total_debit] * 3
 
 		net_total_map[(doctype, entry.name)] = value
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -76,15 +76,12 @@ def validate_return_against(doc):
 def validate_returned_items(doc):
 	valid_items = frappe._dict()
 
-	select_fields = "item_code, qty, stock_qty, rate, parenttype, conversion_factor"
+	select_fields = "item_code, qty, stock_qty, rate, parenttype, conversion_factor, name"
 	if doc.doctype != "Purchase Invoice":
 		select_fields += ",serial_no, batch_no"
 
 	if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"]:
 		select_fields += ",rejected_qty, received_qty"
-
-	if doc.doctype in ["Purchase Receipt", "Purchase Invoice"]:
-		select_fields += ",name"
 
 	for d in frappe.db.sql(
 		f"""select {select_fields} from `tab{doc.doctype} Item` where parent = %s""",
@@ -113,11 +110,13 @@ def validate_returned_items(doc):
 	for d in doc.get("items"):
 		key = d.item_code
 		raise_exception = False
-		if doc.doctype in ["Purchase Receipt", "Purchase Invoice"]:
+		if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Sales Invoice"]:
 			field = frappe.scrub(doc.doctype) + "_item"
 			if d.get(field):
 				key = (d.item_code, d.get(field))
 				raise_exception = True
+		elif doc.doctype == "Delivery Note":
+			key = (d.item_code, d.get("dn_detail"))
 
 		if d.item_code and (flt(d.qty) < 0 or flt(d.get("received_qty")) < 0):
 			if key not in valid_items:
@@ -129,7 +128,7 @@ def validate_returned_items(doc):
 				)
 			else:
 				ref = valid_items.get(key, frappe._dict())
-				validate_quantity(doc, d, ref, valid_items, already_returned_items)
+				validate_quantity(doc, key, d, ref, valid_items, already_returned_items)
 
 				if (
 					ref.rate
@@ -159,7 +158,7 @@ def validate_returned_items(doc):
 		frappe.throw(_("At least one item should be entered with negative quantity in return document"))
 
 
-def validate_quantity(doc, args, ref, valid_items, already_returned_items):
+def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 	fields = ["stock_qty"]
 	if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"]:
 		if not args.get("return_qty_from_rejected_warehouse"):
@@ -167,7 +166,7 @@ def validate_quantity(doc, args, ref, valid_items, already_returned_items):
 		else:
 			fields.extend(["received_qty"])
 
-	already_returned_data = already_returned_items.get(args.item_code) or {}
+	already_returned_data = already_returned_items.get(key) or {}
 
 	company_currency = erpnext.get_company_currency(doc.company)
 	stock_qty_precision = get_field_precision(
@@ -253,15 +252,20 @@ def get_already_returned_items(doc):
 		column += """, sum(abs(child.rejected_qty) * child.conversion_factor) as rejected_qty,
 			sum(abs(child.received_qty) * child.conversion_factor) as received_qty"""
 
+	field = (
+		frappe.scrub(doc.doctype) + "_item"
+		if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Sales Invoice"]
+		else "dn_detail"
+	)
 	data = frappe.db.sql(
 		f"""
-		select {column}
+		select {column}, {field}
 		from
 			`tab{doc.doctype} Item` child, `tab{doc.doctype}` par
 		where
 			child.parent = par.name and par.docstatus = 1
 			and par.is_return = 1 and par.return_against = %s
-		group by item_code
+		group by item_code, {field}
 	""",
 		doc.return_against,
 		as_dict=1,
@@ -271,7 +275,7 @@ def get_already_returned_items(doc):
 
 	for d in data:
 		items.setdefault(
-			d.item_code,
+			(d.item_code, d.get(field)),
 			frappe._dict(
 				{
 					"qty": d.get("qty"),

--- a/erpnext/locale/ar.po
+++ b/erpnext/locale/ar.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Arabic\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "% Completed"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr ""
@@ -856,7 +856,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr "الحساب إلزامي للحصول على إدخالات الدفع"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "لم يتم تعيين الحساب لمخطط لوحة المعلومات {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr "الحساب {0} لا ينتمي للشركة {1}\\n<br>\\nAccount {0} d
 msgid "Account {0} does not exist"
 msgstr "حساب {0} غير موجود"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "الحساب {0} غير موجود"
 
@@ -1747,8 +1747,8 @@ msgstr ""
 msgid "Accounting Entries"
 msgstr "القيود المحاسبة"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "المدخلات الحسابية للأصول"
@@ -2159,8 +2159,8 @@ msgstr "حساب الاستهلاك المتراكم"
 msgid "Accumulated Depreciation Amount"
 msgstr "قيمة الاستهلاك المتراكمة"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "الاستهلاك المتراكم كما في"
 
@@ -2563,7 +2563,7 @@ msgstr "نوع الضريبة الفعلي لا يمكن تضمينه في مع�
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr "إضافة  عرض سعر"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr "مدير"
 msgid "Advance Account"
 msgstr "حساب مقدم"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr "مقابل"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "مقابل الحساب"
 
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "مقابل إيصال"
 
@@ -3556,7 +3556,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "مقابل إيصال  نوع"
@@ -3570,7 +3570,7 @@ msgstr "عمر"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "(العمر (أيام"
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "كل الأصناف المركبة"
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "جميع الإصناف تم نقلها لأمر العمل"
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4107,8 +4107,8 @@ msgstr "السماح بأوامر مبيعات متعددة مقابل طلب ا
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "السماح بالقيم السالبة للمخزون"
 
@@ -4247,6 +4247,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "السماح بقيمة صفر"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4669,7 +4675,7 @@ msgstr "معدل من"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5385,11 +5391,11 @@ msgstr "أثناء تمكين الحقل {0} ، يجب أن تكون قيمة ا
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5401,8 +5407,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "نظرًا لوجود مواد خام كافية ، فإن طلب المواد ليس مطلوبًا للمستودع {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5437,7 +5443,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr "حركة الأصول"
 msgid "Asset Movement Item"
 msgstr "بند حركة الأصول"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "تم إنشاء سجل حركة الأصول {0}\\n<br>\\nAsset Movement record {0} created"
 
@@ -5788,7 +5794,7 @@ msgstr "تحليلات قيمة الأصول"
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "لا يمكن إلغاء الأصل، لانه بالفعل {0}"
 
@@ -5808,7 +5814,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5864,7 +5870,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6034,7 +6040,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "في الصف # {0}: لا يمكن أن يكون معرف التسلسل {1} أقل من معرف تسلسل الصف السابق {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6042,11 +6048,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6665,7 +6671,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr "قائمة مكونات المواد"
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "يجب ألا يكون BOM 1 {0} و BOM 2 {1} متطابقين"
 
@@ -6907,7 +6913,7 @@ msgstr "مطلوب، قائمة مكونات المواد و كمية التصن
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "فاتورة الموارد لا تحتوي على أي صنف مخزون"
@@ -6916,23 +6922,23 @@ msgstr "فاتورة الموارد لا تحتوي على أي صنف مخزو�
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "تكرار BOM: {0} لا يمكن أن يكون تابعًا لـ {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "قائمة المواد {0} لا تنتمي إلى الصنف {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "قائمة مكونات المواد {0} يجب أن تكون نشطة\\n<br>\\nBOM {0} must be active"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "قائمة مكونات المواد {0} يجب أن تكون مسجلة\\n<br>\\nBOM {0} must be submitted"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7002,7 +7008,7 @@ msgstr "الموازنة"
 msgid "Balance (Dr - Cr)"
 msgstr "الرصيد (مدين - دائن)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "الرصيد ({0})"
 
@@ -7651,7 +7657,7 @@ msgstr "حالة انتهاء صلاحية الدفعة الصنف"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,16 +7683,20 @@ msgstr "حالة انتهاء صلاحية الدفعة الصنف"
 msgid "Batch No"
 msgstr "رقم دفعة"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7700,7 +7710,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7803,7 +7813,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr "تاريخ الفاتورة"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr "تمت الفوترة"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr "فوترة AMT"
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "الفواتير الكمية"
@@ -8270,7 +8280,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "يجب تعيين كل من تاريخ بدء الفترة التجريبية وتاريخ انتهاء الفترة التجريبية"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8957,7 +8967,7 @@ msgstr "جداول الحملة"
 msgid "Can be approved by {0}"
 msgstr "يمكن الموافقة عليها بواسطة {0}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8965,7 +8975,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "لا يمكن التصفية على أساس Cashier ، إذا تم تجميعها بواسطة Cashier"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr "لا يمكن التصفية بناءً على ملف تعريف نقط�
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "لا يمكن التصفية بناءً على طريقة الدفع ، إذا تم تجميعها حسب طريقة الدفع"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "لا يمكن الفلتره علي اساس (رقم الأيصال)، إذا تم وضعه في مجموعة على اساس (ايصال)"
 
@@ -8996,15 +9006,15 @@ msgstr "يمكن إجراء دفعة فقط مقابل فاتورة غير مد�
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9264,7 +9274,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "لا يمكن تعطيل أو إلغاء قائمة المواد لانها مترابطة مع قوائم مواد اخرى"
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "لا يمكن حذف الرقم التسلسلي {0}، لانه يتم استخدامها في قيود المخزون"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9302,7 +9312,7 @@ msgstr "لا يمكن ضمان التسليم بواسطة Serial No حيث أن
 msgid "Cannot find Item with this Barcode"
 msgstr "لا يمكن العثور على عنصر بهذا الرمز الشريطي"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9365,11 +9375,11 @@ msgstr "لا يمكن تحديد التخويل على أساس الخصم ل {0
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "لا يمكن تعيين عدة عناصر افتراضية لأي شركة."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "لا يمكن ضبط كمية أقل من الكمية المسلمة"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "لا يمكن تعيين كمية أقل من الكمية المستلمة"
 
@@ -9932,7 +9942,7 @@ msgstr "عرض الشيك"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "تاريخ الصك / السند المرجع"
 
@@ -10204,7 +10214,7 @@ msgstr "وثيقة مغلقة"
 msgid "Closed Documents"
 msgstr "وثائق مغلقة"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10227,7 +10237,7 @@ msgstr "إغلاق (دائن)"
 msgid "Closing (Dr)"
 msgstr "إغلاق (مدين)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "الإغلاق (الافتتاحي + الإجمالي)"
 
@@ -10250,7 +10260,7 @@ msgstr "مبلغ الإغلاق"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "الرصيد الختامي"
 
@@ -10700,7 +10710,7 @@ msgstr "شركات"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr "شركات"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "يجب أن تتطابق عملات الشركة لكلتا الشركتين مع معاملات Inter Inter Company."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "حقل الشركة مطلوب"
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr "نوع المحتوى"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "استمر"
@@ -12301,12 +12311,13 @@ msgstr "كلفة"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr "كلفة"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "التكلفة كما في"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "تكلفة السلع والمواد المسلمة"
@@ -12463,14 +12470,6 @@ msgstr "تكلفة البضاعة المباعة"
 msgid "Cost of Issued Items"
 msgstr "تكلفة المواد المصروفة"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "تكلفة الشراء الجديد"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12479,14 +12478,6 @@ msgstr ""
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "تكلفة البنود التي تم شراؤها"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "تكلفة الأصول الملغاة او المخردة"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "تكلفة الأصول المباعة"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12726,7 +12717,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr ""
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr ""
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "إنشاء نموذج إدخال مخزون الاحتفاظ"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13176,11 +13167,11 @@ msgstr ""
 msgid "Credit"
 msgstr "دائن"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "الائتمان ({0})"
 
@@ -13296,7 +13287,7 @@ msgstr "أشهر الائتمان"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr "العملة ل {0} يجب أن تكون {1} \\n<br>\\nCurrency for {0} 
 msgid "Currency of the Closing Account must be {0}"
 msgstr "عملة الحساب الختامي يجب أن تكون {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "العملة من قائمة الأسعار {0} يجب أن تكون {1} أو {2}"
 
@@ -14045,7 +14036,7 @@ msgstr "رمز العميل"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr "ملاحظات العميل"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "أسم فئة العميل"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14204,7 +14195,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr "منتجات العميل"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "العميل لبو"
 
@@ -14250,7 +14241,7 @@ msgstr "رقم محمول العميل"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr "البيانات المصدرة من Tally والتي تتكون من م
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr "عزيزي مدير النظام،"
 msgid "Debit"
 msgstr "مدين"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "مدين ({0})"
 
@@ -14917,7 +14908,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr "يجب أن تكون قائمة المواد الافتراضية ({0}) 
 msgid "Default BOM for {0} not found"
 msgstr "فاتورة المواد ل {0} غير موجودة\\n<br>\\nDefault BOM for {0} not found"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15958,7 +15949,7 @@ msgstr "لم يتم اعتماد ملاحظه التسليم {0}\\n<br>\\nDelive
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "مذكرات التسليم"
@@ -16157,7 +16148,7 @@ msgstr "إهلاك"
 msgid "Depreciation Amount"
 msgstr "قيمة الإهلاك"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "قيمة الإهلاك خلال الفترة"
 
@@ -16171,7 +16162,7 @@ msgstr "تاريخ الإهلاك"
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "تم إلغاء الإهلاك بسبب التخلص من الأصول"
 
@@ -16232,15 +16223,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "صف الإهلاك {0}: يجب أن تكون القيمة المتوقعة بعد العمر الافتراضي أكبر من أو تساوي {1}"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "صف الإهلاك {0}: لا يمكن أن يكون تاريخ الاستهلاك التالي قبل تاريخ المتاح للاستخدام"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "صف الإهلاك {0}: لا يمكن أن يكون تاريخ الاستهلاك قبل تاريخ الشراء"
 
@@ -16489,7 +16480,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr "حساب الفرق"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "يجب أن يكون حساب الفرق حسابًا لنوع الأصول / الخصوم ، نظرًا لأن إدخال الأسهم هذا هو إدخال فتح"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "حساب الفرق يجب أن يكون حساب الأصول / حساب نوع الالتزام، حيث يعتبر تسوية المخزون بمثابة مدخل افتتاح\\n<br>\\nDifference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 
@@ -17428,7 +17419,7 @@ msgstr "هل تريد حقا  استعادة هذه الأصول المخردة 
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17834,7 +17825,7 @@ msgstr "تاريخ الاستحقاق أو المرجع لا يمكن أن يك�
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr "تم العثور علي مجموعه عناصر مكرره في جدو�
 msgid "Duplicate project has been created"
 msgstr "تم إنشاء مشروع مكرر"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "صف مكرر {0} مع نفس {1}"
 
@@ -18850,7 +18841,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "أدخل المورد"
 
@@ -18929,7 +18920,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19006,7 +18997,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "خطأ"
 
@@ -19574,6 +19565,12 @@ msgstr "النفقات المدرجة في تقييم الأصول"
 msgid "Expenses Included In Valuation"
 msgstr "المصروفات متضمنة في تقييم السعر"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "جلب BOM انفجرت (بما في ذلك المجالس الفرعية)"
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20225,15 +20222,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20454,7 +20451,7 @@ msgstr "الأصول الثابتة"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr "للشراء"
 msgid "For Company"
 msgstr "للشركة"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "للمورد الافتراضي (اختياري)"
 
@@ -20666,7 +20663,7 @@ msgstr "للمورد"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "لمستودع"
@@ -20709,7 +20706,7 @@ msgstr "عن مورد فردي"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20970,7 +20967,7 @@ msgstr "من العملاء"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr "(من تاريخ) لا يمكن أن يكون أكبر (الي التا�
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr "العقد الإضافية التي يمكن أن تنشأ إلا في 
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "مبلغ الدفع المستقبلي"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "الدفع في المستقبل المرجع"
 
@@ -21489,7 +21486,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "GL الدخول"
 
@@ -21783,7 +21780,7 @@ msgstr "الحصول على البنود من"
 msgid "Get Items From Purchase Receipts"
 msgstr "الحصول على أصناف من إيصالات الشراء"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr "عقدة المجموعة"
 msgid "Group Same Items"
 msgstr "تجميع العناصر المتشابهة"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "لا يمكن استخدام مستودعات المجموعة في المعاملات. يرجى تغيير قيمة {0}"
 
@@ -23746,11 +23743,11 @@ msgstr "في سوق الأسهم الكمية"
 msgid "In Transit"
 msgstr "في مرحلة انتقالية"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "مستودع غير صحيح"
 
@@ -24478,8 +24475,8 @@ msgstr "تعليمات"
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "أذونات غير كافية"
 
@@ -24728,7 +24725,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "الباركود غير صالح. لا يوجد عنصر مرفق بهذا الرمز الشريطي."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "طلب فارغ غير صالح للعميل والعنصر المحدد"
 
@@ -24805,7 +24802,7 @@ msgstr "حساب الوالد غير صالح"
 msgid "Invalid Part Number"
 msgstr "رقم الجزء غير صالح"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "وقت نشر غير صالح"
 
@@ -24817,7 +24814,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24825,7 +24822,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24833,9 +24830,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr "كمية غير صحيحة"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24847,7 +24844,7 @@ msgstr "سعر البيع غير صالح"
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "URL غير صالح"
 
@@ -24872,7 +24869,7 @@ msgstr "سبب ضائع غير صالح {0} ، يرجى إنشاء سبب ضائ
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "سلسلة تسمية غير صالحة (. مفقود) لـ {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "مرجع غير صالح {0} {1}"
 
@@ -24896,7 +24893,7 @@ msgstr "غير صالح {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "غير صالح {0} للمعاملات بين الشركات."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "{0} غير صالح : {1}\\n<br>\\nInvalid {0}: {1}"
@@ -24964,7 +24961,7 @@ msgstr "تاريخ الفاتورة"
 msgid "Invoice Discounting"
 msgstr "خصم الفواتير"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "الفاتورة الكبرى المجموع"
 
@@ -25053,9 +25050,9 @@ msgstr "لا يمكن إجراء الفاتورة لمدة صفر ساعة"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "قيمة الفواتير"
 
@@ -25752,7 +25749,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "هناك حاجة لجلب تفاصيل البند."
 
@@ -25804,7 +25801,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr "مادة المصنع"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr "اسم السلعة"
 msgid "Item operation"
 msgstr "عملية الصنف"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26902,7 +26899,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr "العنصر {0} غير موجود\\n<br>\\nItem {0} does not exist"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "الصنف{0} غير موجود في النظام أو انتهت صلاحيته"
 
@@ -26990,7 +26987,7 @@ msgstr "البند {0} الكمية المطلوبة {1} لا يمكن أن تك
 msgid "Item {0}: {1} qty produced. "
 msgstr "العنصر {0}: {1} الكمية المنتجة."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27027,7 +27024,7 @@ msgstr "الحركة التاريخية للمبيعات وفقاً للصنف"
 msgid "Item-wise Sales Register"
 msgstr "سجل حركة مبيعات وفقاً للصنف"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "الصنف: {0} غير موجود في النظام"
 
@@ -27132,7 +27129,7 @@ msgstr "اصناف يمكن طلبه"
 msgid "Items and Pricing"
 msgstr "السلع والتسعيرات"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27341,7 +27338,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "تم إنشاء بطاقة العمل {0}"
 
@@ -28962,11 +28959,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr "نفقات متنوعة"
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30368,7 +30365,7 @@ msgstr "قيم مفقودة مطلوبة"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "قالب بريد إلكتروني مفقود للإرسال. يرجى ضبط واحد في إعدادات التسليم."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30849,7 +30846,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "يجب أن يكون عدد صحيح"
 
@@ -30882,7 +30879,7 @@ msgstr "N / A"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr "غاز طبيعي"
 msgid "Needs Analysis"
 msgstr "تحليل الاحتياجات"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "الكمية السلبية غير مسموح بها\\n<br>\\nnegative Quantity is not allowed"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "معدل التقييم السلبي غير مسموح به\\n<br>\\nNegative Valuation Rate is not allowed"
 
@@ -31102,8 +31099,8 @@ msgstr "صافي القيمة"
 msgid "Net Amount (Company Currency)"
 msgstr "صافي المبلغ  ( بعملة الشركة )"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "صافي قيمة الأصول كما في"
 
@@ -31674,7 +31671,7 @@ msgstr "لم يتم العثور على مورد للمعاملات بين ال�
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31859,15 +31856,15 @@ msgstr ""
 msgid "No record found"
 msgstr "لم يتم العثور على أي سجل"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31915,7 +31912,7 @@ msgstr "غير مطابقة"
 msgid "Non Profit"
 msgstr "غير ربحية"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "البنود غير الأسهم"
 
@@ -31929,7 +31926,7 @@ msgstr ""
 msgid "None"
 msgstr "لا شيء"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "لا يوجد أي من البنود لديها أي تغيير في كمية أو قيمة.\\n<br>\\nNone of the items have any change in quantity or value."
 
@@ -32044,8 +32041,8 @@ msgstr "ليس في الأسهم"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr "غير مسموح به"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "ملاحظات"
@@ -32736,7 +32733,7 @@ msgstr "فتح أوامر العمل"
 msgid "Open a new ticket"
 msgstr "افتح تذكرة جديدة"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "افتتاحي"
@@ -32768,7 +32765,7 @@ msgstr "افتتاحي  (Dr)"
 msgid "Opening Accumulated Depreciation"
 msgstr "الاهلاك التراكمي الافتتاحي"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32782,7 +32779,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr "مبلغ الافتتاح"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "الرصيد الافتتاحي"
 
@@ -32912,7 +32909,7 @@ msgstr "تكاليف التشغيل (عملة الشركة)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "تكلفة التشغيل حسب أمر العمل / BOM"
 
@@ -32942,7 +32939,7 @@ msgstr "تكاليف التشغيل"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr "العمليات"
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "لا يمكن ترك (العمليات) فارغة"
 
@@ -33581,7 +33578,7 @@ msgstr "معلقة"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr "مدفوع"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr "الطرف المعني"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "حساب طرف"
 
@@ -34746,12 +34743,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr "واجب الدفع"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr "جدول الدفع"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr "الأنشطة المعلقة"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "في انتظار المبلغ"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,8 +35850,8 @@ msgstr "المخزون الدائم المطلوب للشركة {0} لمشاهد
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "الشخصية"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36467,7 +36464,7 @@ msgstr "الرجاء إدخال الحساب لمبلغ التغيير\\n<br> \\
 msgid "Please enter Approving Role or Approving User"
 msgstr "الرجاء إدخال صلاحية المخول بالتصديق أو المستخدم المخول بالتصديق"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "يرجى إدخال مركز التكلفة\\n<br>\\nPlease enter Cost Center"
 
@@ -36479,7 +36476,7 @@ msgstr "الرجاء إدخال تاريخ التسليم"
 msgid "Please enter Employee Id of this sales person"
 msgstr "الرجاء إدخال معرف الموظف الخاص بشخص المبيعات هذا"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "الرجاء إدخال حساب النفقات\\n<br>\\nPlease enter Expense Account"
 
@@ -36488,7 +36485,7 @@ msgstr "الرجاء إدخال حساب النفقات\\n<br>\\nPlease enter Ex
 msgid "Please enter Item Code to get Batch Number"
 msgstr "الرجاء إدخال رمز العنصر للحصول على رقم الدفعة\\n<br>\\nPlease enter Item Code to get Batch Number"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "الرجاء إدخال كود البند للحصول على رقم الدفعة"
 
@@ -36782,7 +36779,7 @@ msgstr "الرجاء تجديد تاريخ النشر قبل تحديد المس
 msgid "Please select Posting Date first"
 msgstr "الرجاء تحديد تاريخ النشر أولا\\n<br>\\nPlease select Posting Date first"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "الرجاء اختيار قائمة الأسعار\\n<br>\\nPlease select Price List"
 
@@ -36810,7 +36807,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "يرجى تحديد بوم"
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr "الرجاء اختيار الشركة"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "الرجاء تحديد شركة أولاً."
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr "الرجاء اختيار {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "الرجاء تحديد {0} أولا\\n<br>\\nPlease select {0} first"
@@ -37042,7 +37039,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37167,7 +37164,7 @@ msgstr "يرجى تعيين المرشحات"
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "يرجى تحديد (تكرار) بعد الحفظ"
 
@@ -37197,7 +37194,7 @@ msgstr "يرجى إعداد جدول الحملة في الحملة {0}"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "الرجاء تعيين {0}"
@@ -37230,7 +37227,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "رجاء حدد"
 
@@ -37250,7 +37247,7 @@ msgstr "الرجاء تحديد الشركة للمضى قدما\\n<br>\\nPlease
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "يرجى تحديد هوية الصف صالحة لصف {0} في الجدول {1}"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37258,7 +37255,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "يرجى تحديد خاصية واحدة على الأقل في جدول (الخاصيات)"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "يرجى تحديد الكمية أو التقييم إما قيم أو كليهما"
 
@@ -37438,14 +37435,14 @@ msgstr "نفقات بريدية"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "لم يتم العثور على السعر للعنصر {0} في قائمة الأسعار {1}"
 
@@ -38465,7 +38462,7 @@ msgstr "فشلت العملية"
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38962,9 +38959,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr "المدير الرئيسي للمشتريات"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr "سيتم تحديد كمية المواد الخام بناءً على �
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "الكمية للفاتورة"
@@ -40608,7 +40607,7 @@ msgstr "هدف مراجعة الجودة"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr "هدف مراجعة الجودة"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr "الكمية يجب ألا تكون أكثر من {0}"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "الكمية من البنود التي تم الحصول عليها بعد التصنيع / إعادة التعبئة من الكميات المعطاء من المواد الخام"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "الكمية مطلوبة للبند {0} في الصف {1}\\n<br>\\nQuantity required for Item {0} in row {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr "كمية لجعل"
 msgid "Quantity to Manufacture"
 msgstr "كمية لتصنيع"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "لا يمكن أن تكون الكمية للتصنيع صفراً للتشغيل {0}"
 
@@ -41436,7 +41435,7 @@ msgstr "مستودع المواد الخام"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr "المواد الخام الموردة التكلفة"
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "لا يمكن ترك المواد الخام فارغة."
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr "القبض / حساب الدائنة"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr "وردت في"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr "وردت في"
 msgid "Received Qty"
 msgstr "تلقى الكمية"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "الكمية المستلمة"
 
@@ -42145,7 +42144,7 @@ msgstr "المرجع # {0} بتاريخ {1}"
 msgid "Reference Date"
 msgstr "المرجع تاريخ"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42568,7 +42567,7 @@ msgstr "المتبقية"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "الرصيد المتبقي"
@@ -42621,9 +42620,9 @@ msgstr "كلام"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "العناصر إزالتها مع أي تغيير في كمية أو قيمة."
 
@@ -43124,7 +43123,7 @@ msgstr "الطالب"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr "التوجيه"
 msgid "Routing Name"
 msgstr "اسم التوجيه"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44251,23 +44250,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تحرير فاتورة به بالفعل."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تسليمه بالفعل"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم استلامه بالفعل"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تعيين ترتيب العمل إليه."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تعيينه لأمر شراء العميل."
 
@@ -44275,7 +44274,7 @@ msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تع
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "الصف # {0}: لا يمكن اختيار Warehouse Supplier أثناء توريد المواد الخام إلى المقاول من الباطن"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "الصف # {0}: لا يمكن تعيين &quot;معدل&quot; إذا كان المقدار أكبر من مبلغ الفاتورة للعنصر {1}."
 
@@ -44383,7 +44382,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "الصف # {0}: العنصر {1} ليس عنصرًا تسلسليًا / مُجمَّع. لا يمكن أن يكون له رقم مسلسل / لا دفعة ضده."
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "الصف # {0}: كمية البند {1} لا يمكن أن يكون صفرا"
 
@@ -44469,8 +44468,8 @@ msgstr "الصف # {0}: كمية البند {1} لا يمكن أن يكون صف
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44746,11 +44745,11 @@ msgstr "الصف {0}:  الدفعة المقدمة مقابل الزبائن ي�
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "الصف {0}:المورد المقابل المتقدم يجب أن يكون مدين\\n<br>\\nRow {0}: Advance against Supplier must be debit"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44783,7 +44782,7 @@ msgstr "الصف {0}: مركز التكلفة مطلوب لعنصر {1}"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "صف {0}: لا يمكن ربط قيد دائن مع {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "الصف {0}: العملة للـ BOM #{1} يجب أن يساوي العملة المختارة {2}<br>Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 
@@ -44795,7 +44794,7 @@ msgstr "الصف {0}: لا يمكن ربط قيد مدين مع {1}"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "الصف {0}: لا يمكن أن يكون مستودع التسليم ({1}) ومستودع العميل ({2}) متماثلين"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "الصف {0}: تاريخ بداية الإهلاك مطلوب"
 
@@ -44816,7 +44815,7 @@ msgstr "الصف {0}: أدخل الموقع لعنصر مادة العرض {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "الصف {0}: سعر صرف إلزامي"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "الصف {0}: القيمة المتوقعة بعد أن تكون الحياة المفيدة أقل من إجمالي مبلغ الشراء"
 
@@ -44986,7 +44985,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -44994,7 +44993,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "الصف {0}: عامل تحويل UOM إلزامي\\n<br>\\nRow {0}: UOM Conversion Factor is mandatory"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45023,7 +45022,7 @@ msgstr "الصف {0}: {1} {2} لا يتطابق مع {3}"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "الصف {1}: لا يمكن أن تكون الكمية ({0}) كسرًا. للسماح بذلك ، قم بتعطيل &#39;{2}&#39; في UOM {3}."
 
@@ -45661,7 +45660,7 @@ msgstr "أوامر المبيعات لتقديم"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr "ملخص دفع المبيعات"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr "سجل مبيعات"
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "مبيعات المعاده"
@@ -46032,7 +46031,7 @@ msgstr "تم إدخال نفس الشركة أكثر من مره\\n<br>\\nSame C
 msgid "Same Item"
 msgstr "نفس البند"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46059,7 +46058,7 @@ msgstr "مستودع الاحتفاظ بالعينات"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "حجم العينة"
@@ -46595,7 +46594,7 @@ msgstr "اختيار العناصر"
 msgid "Select Items based on Delivery Date"
 msgstr "حدد العناصر بناءً على تاريخ التسليم"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46699,7 +46698,7 @@ msgstr "حدد أولوية افتراضية."
 msgid "Select a Supplier"
 msgstr "حدد المورد"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "حدد موردًا من الموردين الافتراضيين للعناصر أدناه. عند التحديد ، سيتم إجراء طلب الشراء مقابل العناصر التي تنتمي إلى المورد المحدد فقط."
 
@@ -46745,7 +46744,7 @@ msgstr "حدد دفتر تمويل للعنصر {0} في الصف {1}"
 msgid "Select item group"
 msgstr "حدد مجموعة العناصر"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "حدد عنصر القالب"
 
@@ -46762,7 +46761,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46783,11 +46782,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "حدد رمز عنصر متغير لعنصر النموذج {0}"
 
@@ -47105,7 +47104,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47220,12 +47219,16 @@ msgstr "الرقم المتسلسل {0} لا ينتمي إلى البند {1}\\n
 msgid "Serial No {0} does not exist"
 msgstr "الرقم المتسلسل {0} غير موجود\\n<br>\\nSerial No {0} does not exist"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47265,7 +47268,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "الرقم التسلسلي ودفعات"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47338,11 +47341,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr "تاريخ توقف الخدمة"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "لا يمكن أن يكون تاريخ إيقاف الخدمة بعد تاريخ انتهاء الخدمة"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "لا يمكن أن يكون تاريخ إيقاف الخدمة قبل تاريخ بدء الخدمة"
 
@@ -47790,7 +47793,7 @@ msgstr "تعيين كلمة المرور"
 msgid "Set Posting Date"
 msgstr "حدد تاريخ النشر"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47804,7 +47807,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "عيّن Project وجميع المهام إلى الحالة {0}؟"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "ضبط الكمية"
 
@@ -47899,7 +47902,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47929,15 +47932,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr "حدد هذا إذا كان العميل شركة إدارة عامة."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "تعيين {0} في فئة الأصول {1} أو الشركة {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "قم بتعيين {0} في الشركة {1}"
 
@@ -48004,7 +48007,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr "تأسيس شركة"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48809,15 +48812,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "عذرا ، رمز القسيمة هذا لم يعد صالحًا"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "عذرا ، لقد انتهت صلاحية رمز القسيمة"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "عذرًا ، لم تبدأ صلاحية رمز القسيمة"
 
@@ -48899,7 +48902,7 @@ msgstr "نوع المصدر"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr "تقسيم القضية"
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49444,7 +49447,7 @@ msgstr "حالة"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50794,7 +50797,7 @@ msgstr "إعدادات النجاح"
 msgid "Successful"
 msgstr "ناجح"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "تمت التسوية بنجاح\\n<br>\\nSuccessfully Reconciled"
 
@@ -51006,7 +51009,7 @@ msgstr "الموردة الكمية"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr "تفاصيل المورد"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr "تاريخ فاتورة المورد لا يمكن أن تكون أكب�
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "رقم فاتورة المورد"
@@ -51210,7 +51213,7 @@ msgstr "ملخص دفتر الأستاذ"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr "قالب الشروط والأحكام"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr "الأسهم غير موجودة مع {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53219,11 +53222,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "وقد تم إرساء المهمة كعمل خلفية. في حالة وجود أي مشكلة في المعالجة في الخلفية ، سيقوم النظام بإضافة تعليق حول الخطأ في تسوية المخزون هذا والعودة إلى مرحلة المسودة"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53277,7 +53280,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "هناك صيانة نشطة أو إصلاحات ضد الأصل. يجب عليك إكمالها جميعًا قبل إلغاء الأصل."
 
@@ -53551,7 +53554,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53567,7 +53570,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53770,7 +53773,7 @@ msgstr ""
 msgid "Timer"
 msgstr "مؤقت"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "الموقت تجاوزت الساعات المعطاة."
 
@@ -53972,7 +53975,7 @@ msgstr "إلى العملات"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr "لمستودع"
 msgid "To Warehouse (Optional)"
 msgstr "إلى مستودع (اختياري)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54447,7 +54450,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr ""
 msgid "URL"
 msgstr "رابط الانترنت"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "يمكن أن يكون عنوان URL عبارة عن سلسلة فقط"
 
@@ -56610,7 +56613,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56658,6 +56661,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57072,7 +57081,7 @@ msgstr "معدل التقييم للعنصر {0} ، مطلوب لإجراء إد
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "معدل التقييم إلزامي إذا ادخلت قيمة مبدئية للمخزون\\n<br>\\nValuation Rate is mandatory if Opening Stock entered"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "معدل التقييم مطلوب للبند {0} في الصف {1}"
 
@@ -57082,7 +57091,7 @@ msgstr "معدل التقييم مطلوب للبند {0} في الصف {1}"
 msgid "Valuation and Total"
 msgstr "التقييم والمجموع"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57168,6 +57177,11 @@ msgstr "القيمة أو الكمية"
 msgid "Value Proposition"
 msgstr "موقع ذو قيمة"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "يجب أن تكون قيمة للسمة {0} ضمن مجموعة من {1} إلى {2} في الزيادات من {3} لالبند {4}"
@@ -57175,6 +57189,22 @@ msgstr "يجب أن تكون قيمة للسمة {0} ضمن مجموعة من {1
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr "الحقل البديل"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "عنصر متغير"
 
@@ -57554,11 +57584,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "رقم السند"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57596,7 +57626,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57626,9 +57656,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr "عميل غير مسجل"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr "المستودع إلزامي"
 msgid "Warehouse not found against the account {0}"
 msgstr "لم يتم العثور على المستودع مقابل الحساب {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "لم يتم العثور على المستودع في النظام"
 
@@ -58107,7 +58137,7 @@ msgstr "تحذير لطلب جديد للاقتباسات"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "تحذير"
 
@@ -58127,7 +58157,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "تحذير: {0} أخر # {1} موجود في مدخل المخزن {2}\\n<br>\\nWarning: Another {0} # {1} exists against stock entry {2}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "تحذير : كمية المواد المطلوبة  هي أقل من الحد الأدنى للطلب الكمية"
 
@@ -58660,8 +58690,8 @@ msgstr "لا يمكن إنشاء أمر العمل للسبب التالي:<br> 
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "لا يمكن رفع أمر العمل مقابل قالب العنصر"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "تم عمل الطلب {0}"
 
@@ -59073,7 +59103,7 @@ msgstr "نعم"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "غير مسموح لك بالتحديث وفقًا للشروط المحددة في {} سير العمل."
 
@@ -59138,11 +59168,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59194,7 +59228,7 @@ msgstr "لا يمكنك تقديم الطلب بدون دفع."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "ليس لديك أذونات لـ {} من العناصر في {}."
 
@@ -59346,7 +59380,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59682,7 +59716,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59690,7 +59724,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "{0} القسيمة المستخدمة هي {1}. الكمية المسموح بها مستنفدة"
 
@@ -59750,7 +59784,7 @@ msgstr "{0} يحتوي بالفعل على إجراء الأصل {1}."
 msgid "{0} and {1}"
 msgstr "{0} و {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} و {1} إلزاميان"
@@ -59841,7 +59875,7 @@ msgstr "تم حظر {0} حتى لا تتم متابعة هذه المعاملة"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr "{0} يجب أن يكون سالبة في وثيقة الارجاع"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} لم يتم العثور على العنصر {1}"
 
@@ -59939,7 +59973,7 @@ msgstr "{0} لا يمكن فلترة المدفوعات المدخلة  {1}"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/bs.po
+++ b/erpnext/locale/bs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:15\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:27\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Bosnian\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "% Završena metoda"
 msgid "% Completed"
 msgstr "% Završeno"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% Količina gotovoih stavki"
@@ -904,7 +904,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1109,7 +1109,7 @@ msgstr "Prihvaćena količina na zalihama JM"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1208,7 +1208,7 @@ msgstr "Prema CEFACT/ICG/2010/IC013 ili CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1427,7 +1427,7 @@ msgstr ""
 msgid "Account is not set for the dashboard chart {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgstr ""
 msgid "Account {0} does not exist"
 msgstr "Račun {0} ne postoji"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "Račun {0} ne postoji"
 
@@ -1795,8 +1795,8 @@ msgstr "Filter računovodstvenih dimenzija"
 msgid "Accounting Entries"
 msgstr "Računovodstveni unosi"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Računovodstveni unos za imovinu"
@@ -2207,8 +2207,8 @@ msgstr "Račun akumulirane amortizacije"
 msgid "Accumulated Depreciation Amount"
 msgstr "Iznos akumulirane amortizacije"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "Akumulirana amortizacija na dan"
 
@@ -2611,7 +2611,7 @@ msgstr "Stvarni tip poreza ne može se uključiti u stopu stavke u redu {0}"
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2724,7 +2724,7 @@ msgid "Add Quote"
 msgstr "Dodaj ponudu"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3336,7 +3336,7 @@ msgstr "Administrator"
 msgid "Advance Account"
 msgstr "Avansni račun"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr "Protiv"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr ""
 
@@ -3604,7 +3604,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr ""
@@ -3618,7 +3618,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr ""
 
@@ -3765,7 +3765,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgstr "Sve stavke su već zaprimljene"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Sve stavke su već prenesene za ovaj radni nalog."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Sve stavke u ovom dokumentu već imaju povezanu inspekciju kvaliteta."
 
@@ -4155,8 +4155,8 @@ msgstr "Dozvoli višestruke prodajne narudžbe na osnovu narudžbenice kupca"
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Dozvoli negativnu zalihu"
 
@@ -4295,6 +4295,12 @@ msgstr "Dozvoli nultu vrijednost"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Dozvoli nultu procijenjenu vrijednost"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4717,7 +4723,7 @@ msgstr "Izmijenjeno od"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4856,7 +4862,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5433,11 +5439,11 @@ msgstr ""
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5449,8 +5455,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5485,7 +5491,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5552,7 +5558,7 @@ msgstr "Kapitalizacija imovine Stavka zalihe"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5698,7 +5704,7 @@ msgstr ""
 msgid "Asset Movement Item"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr ""
 
@@ -5836,7 +5842,7 @@ msgstr ""
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr ""
 
@@ -5856,7 +5862,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5912,7 +5918,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6082,7 +6088,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "U redu #{0}: id sekvence {1} ne može biti manji od id-a sekvence prethodnog reda {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6090,11 +6096,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6713,7 +6719,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6726,7 +6732,7 @@ msgstr ""
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr ""
 
@@ -6955,7 +6961,7 @@ msgstr ""
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr ""
@@ -6964,23 +6970,23 @@ msgstr ""
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7050,7 +7056,7 @@ msgstr ""
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr ""
 
@@ -7699,7 +7705,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7725,16 +7731,20 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7748,7 +7758,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7851,7 +7861,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7860,7 +7870,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7874,7 +7884,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7893,8 +7903,8 @@ msgstr ""
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7915,7 +7925,7 @@ msgstr ""
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr ""
@@ -8318,7 +8328,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -9005,7 +9015,7 @@ msgstr ""
 msgid "Can be approved by {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -9013,7 +9023,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -9029,7 +9039,7 @@ msgstr ""
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr ""
 
@@ -9044,15 +9054,15 @@ msgstr ""
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9312,7 +9322,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr ""
 
@@ -9333,7 +9343,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9350,7 +9360,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9413,11 +9423,11 @@ msgstr ""
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -9980,7 +9990,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10252,7 +10262,7 @@ msgstr ""
 msgid "Closed Documents"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10275,7 +10285,7 @@ msgstr ""
 msgid "Closing (Dr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr ""
 
@@ -10298,7 +10308,7 @@ msgstr ""
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr ""
 
@@ -10748,7 +10758,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10795,7 +10805,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11115,7 +11125,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr ""
@@ -11970,7 +11980,7 @@ msgid "Content Type"
 msgstr "Vrsta sadržaja"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Nastavi"
@@ -12349,12 +12359,13 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12362,6 +12373,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12490,11 +12502,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr ""
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr ""
@@ -12511,14 +12518,6 @@ msgstr ""
 msgid "Cost of Issued Items"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr ""
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12526,14 +12525,6 @@ msgstr ""
 
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
 msgstr ""
 
 #: erpnext/config/projects.py:67
@@ -12774,7 +12765,7 @@ msgstr "Cr"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12789,7 +12780,7 @@ msgstr "Cr"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12834,7 +12825,7 @@ msgstr "Cr"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13032,7 +13023,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr ""
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13224,11 +13215,11 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr ""
 
@@ -13344,7 +13335,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13566,12 +13557,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13684,7 +13675,7 @@ msgstr ""
 msgid "Currency of the Closing Account must be {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr ""
 
@@ -14093,7 +14084,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14189,11 +14180,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14233,7 +14224,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14252,7 +14243,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr ""
 
@@ -14298,7 +14289,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14688,7 +14679,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14924,11 +14915,11 @@ msgstr "Poštovani menadžeru sistema,"
 msgid "Debit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr ""
 
@@ -14965,7 +14956,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15175,7 +15166,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -16006,7 +15997,7 @@ msgstr ""
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16205,7 +16196,7 @@ msgstr ""
 msgid "Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr ""
 
@@ -16219,7 +16210,7 @@ msgstr ""
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr ""
 
@@ -16280,15 +16271,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr ""
 
@@ -16537,7 +16528,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16720,7 +16711,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17476,7 +17467,7 @@ msgstr ""
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17882,7 +17873,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18006,7 +17997,7 @@ msgstr ""
 msgid "Duplicate project has been created"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr ""
 
@@ -18898,7 +18889,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr ""
 
@@ -18978,7 +18969,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19055,7 +19046,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Grеška"
 
@@ -19623,6 +19614,12 @@ msgstr ""
 msgid "Expenses Included In Valuation"
 msgstr ""
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "Eksperimentalno"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19961,7 +19958,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr ""
@@ -19977,7 +19974,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20274,15 +20271,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20503,7 +20500,7 @@ msgstr ""
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20654,7 +20651,7 @@ msgstr ""
 msgid "For Company"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr ""
 
@@ -20715,7 +20712,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr ""
@@ -20758,7 +20755,7 @@ msgstr ""
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -21019,7 +21016,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21129,8 +21126,8 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21506,14 +21503,14 @@ msgstr "Dalji čvorovi se mogu kreirati samo pod čvorovima tipa 'Grupa'"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -21538,7 +21535,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr ""
 
@@ -21832,7 +21829,7 @@ msgstr ""
 msgid "Get Items From Purchase Receipts"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22355,7 +22352,7 @@ msgstr "Grupni čvor"
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr ""
 
@@ -23795,11 +23792,11 @@ msgstr ""
 msgid "In Transit"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24269,7 +24266,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr ""
 
@@ -24527,8 +24524,8 @@ msgstr "Instrukcije"
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24777,7 +24774,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -24854,7 +24851,7 @@ msgstr ""
 msgid "Invalid Part Number"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr ""
 
@@ -24866,7 +24863,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24874,7 +24871,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24882,9 +24879,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24896,7 +24893,7 @@ msgstr ""
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "Nevažeći URL"
 
@@ -24921,7 +24918,7 @@ msgstr ""
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr ""
 
@@ -24945,7 +24942,7 @@ msgstr ""
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr ""
@@ -25013,7 +25010,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25102,9 +25099,9 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr ""
 
@@ -25801,7 +25798,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -25853,7 +25850,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26095,7 +26092,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26126,7 +26123,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26553,7 +26550,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26912,7 +26909,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26951,7 +26948,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr ""
 
@@ -27039,7 +27036,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27076,7 +27073,7 @@ msgstr ""
 msgid "Item-wise Sales Register"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr ""
 
@@ -27181,7 +27178,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27390,7 +27387,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr ""
 
@@ -29011,11 +29008,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30359,7 +30356,7 @@ msgstr ""
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30417,7 +30414,7 @@ msgstr "Nedostajuće vrijednosti su obavezne"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30898,7 +30895,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr ""
 
@@ -30931,7 +30928,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31069,11 +31066,11 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31151,8 +31148,8 @@ msgstr ""
 msgid "Net Amount (Company Currency)"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr ""
 
@@ -31723,7 +31720,7 @@ msgstr ""
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31908,15 +31905,15 @@ msgstr ""
 msgid "No record found"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31964,7 +31961,7 @@ msgstr ""
 msgid "Non Profit"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr ""
 
@@ -31978,7 +31975,7 @@ msgstr ""
 msgid "None"
 msgstr "Nijedan"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr ""
 
@@ -32093,8 +32090,8 @@ msgstr ""
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32116,7 +32113,7 @@ msgstr "Nije dozvoljeno"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Napomena"
@@ -32785,7 +32782,7 @@ msgstr ""
 msgid "Open a new ticket"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr ""
@@ -32817,7 +32814,7 @@ msgstr ""
 msgid "Opening Accumulated Depreciation"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32831,7 +32828,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr ""
 
@@ -32961,7 +32958,7 @@ msgstr ""
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr ""
 
@@ -32991,7 +32988,7 @@ msgstr ""
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33117,7 +33114,7 @@ msgstr ""
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr ""
 
@@ -33630,7 +33627,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34185,9 +34182,9 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34636,12 +34633,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34662,7 +34659,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr ""
 
@@ -34795,12 +34792,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34927,7 +34924,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35369,7 +35366,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35607,13 +35604,13 @@ msgstr ""
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr ""
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35902,8 +35899,8 @@ msgstr ""
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "Lična"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36516,7 +36513,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36528,7 +36525,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36537,7 +36534,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -36831,7 +36828,7 @@ msgstr ""
 msgid "Please select Posting Date first"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr ""
 
@@ -36859,7 +36856,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr ""
 
@@ -36868,10 +36865,10 @@ msgid "Please select a Company"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37021,7 +37018,7 @@ msgid "Please select {0}"
 msgstr "Molimo odaberite {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr ""
@@ -37091,7 +37088,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37216,7 +37213,7 @@ msgstr "Molimo postavite filtere"
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37246,7 +37243,7 @@ msgstr ""
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr ""
@@ -37279,7 +37276,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Molimo navedite"
 
@@ -37299,7 +37296,7 @@ msgstr ""
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37307,7 +37304,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37487,14 +37484,14 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37983,7 +37980,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr ""
 
@@ -38514,7 +38511,7 @@ msgstr ""
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -39011,9 +39008,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -39021,6 +39019,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39032,7 +39031,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39651,7 +39650,7 @@ msgstr "Glavni voditelj nabave"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40111,12 +40110,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40224,7 +40223,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40319,7 +40318,7 @@ msgstr ""
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr ""
@@ -40657,7 +40656,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40674,7 +40673,7 @@ msgstr ""
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40795,11 +40794,11 @@ msgstr ""
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40814,7 +40813,7 @@ msgstr ""
 msgid "Quantity to Manufacture"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr ""
 
@@ -41485,7 +41484,7 @@ msgstr ""
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41544,7 +41543,7 @@ msgstr ""
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr ""
 
@@ -41739,7 +41738,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41833,7 +41832,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41844,7 +41843,7 @@ msgstr ""
 msgid "Received Qty"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr ""
 
@@ -42194,7 +42193,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42617,7 +42616,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -42670,9 +42669,9 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42706,7 +42705,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr ""
 
@@ -43173,7 +43172,7 @@ msgstr ""
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44204,11 +44203,11 @@ msgstr "Usmjeravanje"
 msgid "Routing Name"
 msgstr "Naziv usmjeravanja"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "Red #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44300,23 +44299,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
@@ -44324,7 +44323,7 @@ msgstr ""
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr ""
 
@@ -44432,7 +44431,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -44510,7 +44509,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -44518,8 +44517,8 @@ msgstr ""
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44795,11 +44794,11 @@ msgstr ""
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44832,7 +44831,7 @@ msgstr ""
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr ""
 
@@ -44844,7 +44843,7 @@ msgstr ""
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr ""
 
@@ -44865,7 +44864,7 @@ msgstr ""
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr ""
 
@@ -45035,7 +45034,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -45043,7 +45042,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45072,7 +45071,7 @@ msgstr ""
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
@@ -45710,7 +45709,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45808,7 +45807,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45894,7 +45893,7 @@ msgstr ""
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr ""
@@ -46081,7 +46080,7 @@ msgstr ""
 msgid "Same Item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46108,7 +46107,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -46644,7 +46643,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46748,7 +46747,7 @@ msgstr ""
 msgid "Select a Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr ""
 
@@ -46794,7 +46793,7 @@ msgstr ""
 msgid "Select item group"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr ""
 
@@ -46811,7 +46810,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46832,11 +46831,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr ""
 
@@ -47154,7 +47153,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47240,7 +47239,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47269,12 +47268,16 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47314,7 +47317,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47387,11 +47390,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47738,12 +47741,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -47839,7 +47842,7 @@ msgstr "Postavi lozinku"
 msgid "Set Posting Date"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47853,7 +47856,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr ""
 
@@ -47948,7 +47951,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47978,15 +47981,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr ""
 
@@ -48053,7 +48056,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48858,15 +48861,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr ""
 
@@ -48948,7 +48951,7 @@ msgstr ""
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49068,7 +49071,7 @@ msgstr ""
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49493,7 +49496,7 @@ msgstr ""
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49991,7 +49994,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -50000,10 +50003,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50843,7 +50846,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr ""
 
@@ -51055,7 +51058,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51159,9 +51162,9 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51214,7 +51217,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr ""
@@ -51259,7 +51262,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52875,11 +52878,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53255,7 +53258,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53268,11 +53271,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53326,7 +53329,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr ""
 
@@ -53600,7 +53603,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53616,7 +53619,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53819,7 +53822,7 @@ msgstr ""
 msgid "Timer"
 msgstr ""
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr ""
 
@@ -54021,7 +54024,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54320,7 +54323,7 @@ msgstr ""
 msgid "To Warehouse (Optional)"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54395,7 +54398,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54496,7 +54499,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56049,7 +56052,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr ""
 
@@ -56659,7 +56662,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56707,6 +56710,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57121,7 +57130,7 @@ msgstr ""
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -57131,7 +57140,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57217,6 +57226,11 @@ msgstr ""
 msgid "Value Proposition"
 msgstr ""
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr ""
@@ -57224,6 +57238,22 @@ msgstr ""
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57305,7 +57335,7 @@ msgid "Variant Field"
 msgstr ""
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr ""
 
@@ -57603,11 +57633,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57633,7 +57663,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57645,7 +57675,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57675,9 +57705,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57845,7 +57875,7 @@ msgstr ""
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58030,7 +58060,7 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr ""
 
@@ -58156,7 +58186,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr ""
 
@@ -58176,7 +58206,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr ""
 
@@ -58709,8 +58739,8 @@ msgstr ""
 msgid "Work Order cannot be raised against a Item Template"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr ""
 
@@ -59122,7 +59152,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -59187,11 +59217,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59243,7 +59277,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -59395,7 +59429,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59731,7 +59765,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59739,7 +59773,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr ""
 
@@ -59799,7 +59833,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr ""
@@ -59890,7 +59924,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59972,7 +60006,7 @@ msgstr ""
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr ""
 
@@ -59988,7 +60022,7 @@ msgstr ""
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/de.po
+++ b/erpnext/locale/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-12 07:07\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:27\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "Fortschritt berechnen nach"
 msgid "% Completed"
 msgstr "% Abgeschlossen"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% fertige Artikelmenge"
@@ -960,7 +960,7 @@ msgstr "Eine Preisliste ist eine Sammlung von Artikelpreisen, entweder für den 
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "Ein Produkt oder eine Dienstleistung, die gekauft, verkauft oder auf Lager gehalten wird."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "Ein Abstimmungsauftrag {0} wird für dieselben Filter ausgeführt. Kann gerade nicht erneut gestartet werden"
 
@@ -1165,7 +1165,7 @@ msgstr "Angenommene Menge in Lagereinheit"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1264,7 +1264,7 @@ msgstr "Gemäß CEFACT/ICG/2010/IC013 oder CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1483,7 +1483,7 @@ msgstr "Konto ist obligatorisch, um Zahlungseingänge zu erhalten"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "Konto ist nicht für das Dashboard-Diagramm {0} festgelegt."
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "Konto nicht gefunden"
 
@@ -1524,7 +1524,7 @@ msgstr "Konto {0} gehört nicht zu Unternehmen {1}"
 msgid "Account {0} does not exist"
 msgstr "Konto {0} existiert nicht"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "Konto {0} existiert nicht"
 
@@ -1851,8 +1851,8 @@ msgstr "Filter für Buchhaltungsdimensionen"
 msgid "Accounting Entries"
 msgstr "Buchungen"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Buchungseintrag für Vermögenswert"
@@ -2263,8 +2263,8 @@ msgstr "Konto für kumulierte Abschreibung (Wertberichtigung)"
 msgid "Accumulated Depreciation Amount"
 msgstr "Aufgelaufener Abschreibungsbetrag"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "Kumulierte Abschreibungen zum"
 
@@ -2667,7 +2667,7 @@ msgstr "Tatsächliche Steuerart kann nicht im Artikelpreis in Zeile {0} beinhalt
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2780,7 +2780,7 @@ msgid "Add Quote"
 msgstr "Angebot hinzufügen"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "Rohmaterialien hinzufügen"
@@ -3392,7 +3392,7 @@ msgstr "Administrator"
 msgid "Advance Account"
 msgstr "Vorschusskonto"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr "Vorschusskonto: {0} muss entweder in der Rechnungswährung des Kunden: {1} oder in der Standardwährung des Unternehmens: {2} angegeben werden"
 
@@ -3524,7 +3524,7 @@ msgstr "Zu"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "Gegenkonto"
 
@@ -3636,7 +3636,7 @@ msgstr "Gegen Lieferantenrechnung {0}"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "Gegenbeleg"
 
@@ -3660,7 +3660,7 @@ msgstr "Belegnr."
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "Gegen Belegart"
@@ -3674,7 +3674,7 @@ msgstr "Alter"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "Alter (Tage)"
 
@@ -3821,7 +3821,7 @@ msgstr "Alle Aktivitäten"
 msgid "All Activities HTML"
 msgstr "Alle Aktivitäten HTML"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "Alle Stücklisten"
 
@@ -3974,7 +3974,7 @@ msgstr "Alle Artikel sind bereits eingegangen"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Alle Positionen wurden bereits für diesen Arbeitsauftrag übertragen."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Für alle Artikel in diesem Dokument ist bereits eine Qualitätsprüfung verknüpft."
 
@@ -4211,8 +4211,8 @@ msgstr "Erlauben Sie mehrere Aufträge für die Bestellung eines Kunden"
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Negativen Lagerbestand zulassen"
 
@@ -4351,6 +4351,12 @@ msgstr "Null-Bewertung erlauben"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Nullbewertung zulassen"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4773,7 +4779,7 @@ msgstr "Berichtigung von"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4912,7 +4918,7 @@ msgstr "Betrag in Transaktionswährung"
 msgid "Amount in {0}"
 msgstr "Betrag in {0}"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5489,11 +5495,11 @@ msgstr "Wenn das Feld {0} aktiviert ist, sollte der Wert des Feldes {1} größer
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Da es bereits gebuchte Transaktionen für den Artikel {0} gibt, können Sie den Wert von {1} nicht ändern."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "Da es negative Bestände gibt, können Sie {0} nicht aktivieren."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "Da es reservierte Bestände gibt, können Sie {0} nicht deaktivieren."
 
@@ -5505,8 +5511,8 @@ msgstr "Da es genügend Artikel für die Unterbaugruppe gibt, ist ein Arbeitsauf
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "Da genügend Rohstoffe vorhanden sind, ist für Warehouse {0} keine Materialanforderung erforderlich."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "Da {0} aktiviert ist, können Sie {1} nicht aktivieren."
 
@@ -5541,7 +5547,7 @@ msgstr "Montageartikel"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5608,7 +5614,7 @@ msgstr "Lagerartikel für Vermögensgegenstand-Aktivierung"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5754,7 +5760,7 @@ msgstr "Vermögensgegenstand-Bewegung"
 msgid "Asset Movement Item"
 msgstr "Vermögensbewegungsgegenstand"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "Vermögensgegenstand-Bewegung {0} erstellt"
 
@@ -5892,7 +5898,7 @@ msgstr "Sachanlagenwertanalyse"
 msgid "Asset cancelled"
 msgstr "Vermögensgegenstand storniert"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "Vermögenswert kann nicht rückgängig gemacht werden, da es ohnehin schon {0} ist"
 
@@ -5912,7 +5918,7 @@ msgstr "Vermögensgegenstand erstellt"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "Vermögensgegenstand angelegt, nachdem die Vermögensgegenstand-Aktivierung {0} gebucht wurde"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "Vermögensgegenstand, der nach der Abspaltung von Vermögensgegenstand {0} erstellt wurde"
 
@@ -5968,7 +5974,7 @@ msgstr "Vermögensgegenstand gebucht"
 msgid "Asset transferred to Location {0}"
 msgstr "Vermögensgegenstand an Standort {0} übertragen"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "Vermögensgegenstand nach der Abspaltung in Vermögensgegenstand {0} aktualisiert"
 
@@ -6105,7 +6111,7 @@ msgstr "In Zeile #{0}: Die kommissionierte Menge {1} für den Artikel {2} ist gr
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "Es muss mindestens ein Vermögensgegenstand ausgewählt werden."
 
@@ -6138,7 +6144,7 @@ msgstr "Mindestens ein Lager ist obligatorisch"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "In Zeile {0}: Die Sequenz-ID {1} darf nicht kleiner sein als die vorherige Zeilen-Sequenz-ID {2}."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "In Zeile {0}: Chargennummer ist obligatorisch für Artikel {1}"
 
@@ -6146,11 +6152,11 @@ msgstr "In Zeile {0}: Chargennummer ist obligatorisch für Artikel {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "In der Zeile {0}: Menge ist obligatorisch für die Charge {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "In Zeile {0}: Seriennummer ist obligatorisch für Artikel {1}"
 
@@ -6769,7 +6775,7 @@ msgstr "BIN Menge"
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6782,7 +6788,7 @@ msgstr "Stückliste"
 msgid "BOM 1"
 msgstr "Stückliste 1"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "Stückliste 1 {0} und Stückliste 2 {1} sollten nicht identisch sein"
 
@@ -7011,7 +7017,7 @@ msgstr "Stückliste und Fertigungsmenge werden benötigt"
 msgid "BOM and Production"
 msgstr "Stückliste und Produktion"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "Stückliste enthält keine Lagerware"
@@ -7020,23 +7026,23 @@ msgstr "Stückliste enthält keine Lagerware"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "Stücklistenrekursion: {0} darf nicht untergeordnet zu {1} sein"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "Stücklistenrekursion: {1} kann nicht über- oder untergeordnet von {0} sein"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "Stückliste {0} gehört nicht zum Artikel {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "Stückliste {0} muss aktiv sein"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "Stückliste {0} muss gebucht werden"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr "Stückliste {0} für den Artikel {1} nicht gefunden"
 
@@ -7106,7 +7112,7 @@ msgstr "Saldo"
 msgid "Balance (Dr - Cr)"
 msgstr "Saldo (S - H)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "Saldo ({0})"
 
@@ -7755,7 +7761,7 @@ msgstr "Stapelobjekt Ablauf-Status"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7781,17 +7787,21 @@ msgstr "Stapelobjekt Ablauf-Status"
 msgid "Batch No"
 msgstr "Chargennummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr "Chargennummer ist obligatorisch"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "Charge Nr. {0} existiert nicht"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Die Chargennummer {0} ist mit dem Artikel {1} verknüpft, der eine Seriennummer hat. Bitte scannen Sie stattdessen die Seriennummer."
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
 #: erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -7804,7 +7814,7 @@ msgstr "Chargennummer."
 msgid "Batch Nos"
 msgstr "Chargennummern"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "Chargennummern wurden erfolgreich erstellt"
 
@@ -7907,7 +7917,7 @@ msgstr "Die folgenden Abonnementpläne haben eine andere Währung als die Standa
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7916,7 +7926,7 @@ msgstr "Rechnungsdatum"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7930,7 +7940,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7949,8 +7959,8 @@ msgstr "Abgerechnet"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7971,7 +7981,7 @@ msgstr "Abgerechneter Betrag"
 msgid "Billed Items To Be Received"
 msgstr "Zu erhaltende abgerechnete Artikel"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "In Rechnung gestellte Menge"
@@ -8374,7 +8384,7 @@ msgstr "Sowohl das Debitorenkonto: {0} als auch das Vorschusskonto: {1} müssen 
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "Das Startdatum für die Testperiode und das Enddatum für die Testperiode müssen festgelegt werden"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr "Sowohl das {0} Konto: {1} als auch das Vorschusskonto: {2} müssen für das Unternehmen dieselbe Währung haben: {3}"
 
@@ -9061,7 +9071,7 @@ msgstr "Kampagnenpläne"
 msgid "Can be approved by {0}"
 msgstr "Kann von {0} genehmigt werden"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr "Der Arbeitsauftrag kann nicht geschlossen werden, da sich {0} Jobkarten im Status „In Bearbeitung“ befinden."
 
@@ -9069,7 +9079,7 @@ msgstr "Der Arbeitsauftrag kann nicht geschlossen werden, da sich {0} Jobkarten 
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "Kann nicht nach Kassierer filtern, wenn nach Kassierer gruppiert"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr "Kann nicht nach untergeordnetem Konto filtern, wenn nach Konto gruppiert"
 
@@ -9085,7 +9095,7 @@ msgstr "Kann nicht nach POS-Profil filtern, wenn nach POS-Profil gruppiert"
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "Kann nicht nach Zahlungsmethode filtern, wenn nach Zahlungsmethode gruppiert"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "Kann nicht nach Belegnummer filtern, wenn nach Beleg gruppiert"
 
@@ -9100,15 +9110,15 @@ msgstr "Zahlung kann nur zu einem noch nicht abgerechneten Beleg vom Typ {0} ers
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Kann sich nur auf eine Zeile beziehen, wenn die Berechnungsart der Kosten entweder \"auf vorherige Zeilensumme\" oder \"auf vorherigen Zeilenbetrag\" ist"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "Die Bewertungsmethode kann nicht geändert werden, da es Transaktionen gegen einige Artikel gibt, die keine eigene Bewertungsmethode haben"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr "Sie können die chargenweise Bewertung für aktive Chargen nicht deaktivieren."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr "Sie können die chargenweise Bewertung für Artikel mit FIFO-Bewertungsmethode nicht deaktivieren."
 
@@ -9368,7 +9378,7 @@ msgstr "Es kann keine Pickliste für den Auftrag {0} erstellt werden, da dieser 
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr "Es kann nicht auf deaktivierte Konten gebucht werden: {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "Stückliste kann nicht deaktiviert oder storniert werden, weil sie mit anderen Stücklisten verknüpft ist"
 
@@ -9389,7 +9399,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "Die Seriennummer {0} kann nicht gelöscht werden, da sie in Lagertransaktionen verwendet wird"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr "Sie können die chargenweise Bewertung für die FIFO-Bewertungsmethode nicht deaktivieren."
 
@@ -9406,7 +9416,7 @@ msgstr "Die Lieferung per Seriennummer kann nicht sichergestellt werden, da Arti
 msgid "Cannot find Item with this Barcode"
 msgstr "Artikel mit diesem Barcode kann nicht gefunden werden"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Es wurde kein Standardlager für den Artikel {0} gefunden. Bitte legen Sie eines im Artikelstamm oder in den Lagereinstellungen fest."
 
@@ -9469,11 +9479,11 @@ msgstr "Genehmigung kann nicht auf der Basis des Rabattes für {0} festgelegt we
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Es können nicht mehrere Artikelstandards für ein Unternehmen festgelegt werden."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Menge kann nicht kleiner als gelieferte Menge sein"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "Menge kann nicht kleiner als die empfangene Menge eingestellt werden"
 
@@ -10036,7 +10046,7 @@ msgstr "Scheck Breite"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "Scheck-/ Referenzdatum"
 
@@ -10308,7 +10318,7 @@ msgstr "Geschlossenes Dokument"
 msgid "Closed Documents"
 msgstr "Geschlossene Dokumente"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr "Ein geschlossener Arbeitsauftrag kann nicht gestoppt oder erneut geöffnet werden"
 
@@ -10331,7 +10341,7 @@ msgstr "Schlußstand (Haben)"
 msgid "Closing (Dr)"
 msgstr "Schlußstand (Soll)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "Schließen (Eröffnung + Gesamt)"
 
@@ -10354,7 +10364,7 @@ msgstr "Schlussbetrag"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "Schlussbilanz"
 
@@ -10804,7 +10814,7 @@ msgstr "Firmen"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10851,7 +10861,7 @@ msgstr "Firmen"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11171,7 +11181,7 @@ msgstr "Unternehmen und Buchungsdatum sind obligatorisch"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "Firmenwährungen beider Unternehmen sollten für Inter Company-Transaktionen übereinstimmen."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "Firmenfeld ist erforderlich"
@@ -12026,7 +12036,7 @@ msgid "Content Type"
 msgstr "Inhaltstyp"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Fortsetzen"
@@ -12405,12 +12415,13 @@ msgstr "Kosten"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12418,6 +12429,7 @@ msgstr "Kosten"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12546,11 +12558,6 @@ msgstr "Kosten pro Einheit"
 msgid "Cost and Freight"
 msgstr "Kosten und Fracht bis Bestimmungshafen"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "Kosten, wie auf"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "Aufwendungen für gelieferte Artikel"
@@ -12567,14 +12574,6 @@ msgstr "Selbstkosten"
 msgid "Cost of Issued Items"
 msgstr "Aufwendungen für in Umlauf gebrachte Artikel"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "Kosten eines neuen Kaufs"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12583,14 +12582,6 @@ msgstr "Kosten mangelhafter Qualität"
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "Aufwendungen für bezogene Artikel"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "Aufwand für verschrotteten Vermögensgegenstand"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "Kosten des verkauften Vermögensgegenstandes"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12830,7 +12821,7 @@ msgstr "H"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12845,7 +12836,7 @@ msgstr "H"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12890,7 +12881,7 @@ msgstr "H"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13088,7 +13079,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "Legen Sie einen Muster-Retention-Stock-Eintrag an"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "Lagerbewegung erstellen"
 
@@ -13282,11 +13273,11 @@ msgstr "Erstellung von {0} teilweise erfolgreich.\n"
 msgid "Credit"
 msgstr "Haben"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "Haben (Transaktion)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "Guthaben ({0})"
 
@@ -13402,7 +13393,7 @@ msgstr "Kreditmonate"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13624,12 +13615,12 @@ msgstr "Tasse"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13742,7 +13733,7 @@ msgstr "Währung für {0} muss {1} sein"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "Die Währung des Abschlusskontos muss {0} sein"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "Die Währung der Preisliste {0} muss {1} oder {2}"
 
@@ -14151,7 +14142,7 @@ msgstr "Kunden-Nr."
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14247,11 +14238,11 @@ msgstr "Kundenrückmeldung"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14291,7 +14282,7 @@ msgstr "Kundengruppe (Zeile)"
 msgid "Customer Group Name"
 msgstr "Kundengruppenname"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "Kundengruppe: {0} existiert nicht"
 
@@ -14310,7 +14301,7 @@ msgstr "Kunden-Artikel"
 msgid "Customer Items"
 msgstr "Kunden-Artikel"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "Kunden LPO"
 
@@ -14356,7 +14347,7 @@ msgstr "Mobilnummer des Kunden"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14746,7 +14737,7 @@ msgstr "Aus Tally exportierte Daten, die aus dem Kontenplan, Kunden, Lieferanten
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14982,11 +14973,11 @@ msgstr "Sehr geehrter System Manager,"
 msgid "Debit"
 msgstr "Soll"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "Soll (Transaktion)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "Soll ({0})"
 
@@ -15023,7 +15014,7 @@ msgstr "Soll-Betrag in Transaktionswährung"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15233,7 +15224,7 @@ msgstr "Standardstückliste ({0}) muss für diesen Artikel oder dessen Vorlage a
 msgid "Default BOM for {0} not found"
 msgstr "Standardstückliste für {0} nicht gefunden"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Standard Stückliste für Fertigprodukt {0} nicht gefunden"
 
@@ -16064,7 +16055,7 @@ msgstr "Lieferschein {0} ist nicht gebucht"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr "Lieferschein(e) für die Pickliste erstellt"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Lieferscheine"
@@ -16263,7 +16254,7 @@ msgstr "Abschreibung"
 msgid "Depreciation Amount"
 msgstr "Abschreibungsbetrag"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "Abschreibungsbetrag in der Zeit"
 
@@ -16277,7 +16268,7 @@ msgstr "Abschreibungen Datum"
 msgid "Depreciation Details"
 msgstr "Details zur Abschreibung"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "Die Abschreibungen Ausgeschieden aufgrund der Veräußerung von Vermögenswerten"
 
@@ -16338,15 +16329,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "Abschreibungszeile {0}: Der erwartete Wert nach der Nutzungsdauer muss größer oder gleich {1} sein"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "Abschreibungszeile {0}: Das nächste Abschreibungsdatum darf nicht vor dem Zeitpunkt der Einsatzbereitschaft liegen"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "Abschreibungszeile {0}: Das nächste Abschreibungsdatum darf nicht vor dem Kaufdatum liegen"
 
@@ -16595,7 +16586,7 @@ msgstr "Für vollständig abgeschriebene Vermögensgegenstände kann keine Absch
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16778,7 +16769,7 @@ msgstr "Differenzkonto"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "Das Differenzkonto muss ein Konto vom Typ Aktiva / Passiva sein, da es sich bei dieser Bestandsbuchung um eine Eröffnungsbuchung handelt"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Differenzkonto muss ein Vermögens-/Verbindlichkeiten-Konto sein, da dieser Lagerabgleich eine Eröffnungsbuchung ist"
 
@@ -17534,7 +17525,7 @@ msgstr "Wollen Sie diesen entsorgte Vermögenswert wirklich wiederherstellen?"
 msgid "Do you still want to enable negative inventory?"
 msgstr "Möchten Sie dennoch negative Bestände erlauben?"
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr "Möchten Sie die ausgewählten {0} löschen?"
 
@@ -17940,7 +17931,7 @@ msgstr "Fälligkeits-/Stichdatum kann nicht nach {0} liegen"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18064,7 +18055,7 @@ msgstr "Doppelte Artikelgruppe in der Artikelgruppentabelle gefunden"
 msgid "Duplicate project has been created"
 msgstr "Es wurde ein doppeltes Projekt erstellt"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "Dupliziere Zeile {0} mit demselben {1}"
 
@@ -18956,7 +18947,7 @@ msgstr "Manuell eingeben"
 msgid "Enter Serial Nos"
 msgstr "Seriennummern eingeben"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "Lieferant eingeben"
 
@@ -19036,7 +19027,7 @@ msgstr "Geben Sie den Namen der Bank oder des Kreditinstituts ein, bevor Sie buc
 msgid "Enter the opening stock units."
 msgstr "Geben Sie die Anfangsbestandseinheiten ein."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr "Geben Sie die Menge des Artikels ein, der aus dieser Stückliste hergestellt werden soll."
 
@@ -19113,7 +19104,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Fehler"
 
@@ -19684,6 +19675,12 @@ msgstr "Aufwendungen, die in der Vermögensbewertung enthalten sind"
 msgid "Expenses Included In Valuation"
 msgstr "In der Bewertung enthaltene Aufwendungen"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "Experimentell"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -20022,7 +20019,7 @@ msgstr "Zeiterfassung laden"
 msgid "Fetch Value From"
 msgstr "Wert abrufen von"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "Abruf der aufgelösten Stückliste (einschließlich der Unterbaugruppen)"
@@ -20038,7 +20035,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "Wechselkurse werden abgerufen ..."
 
@@ -20335,15 +20332,15 @@ msgstr "Fertigerzeugnisartikel Menge"
 msgid "Finished Good Item Quantity"
 msgstr "Fertigerzeugnisartikel Menge"
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Fertigerzeugnisartikel ist nicht als Dienstleistungsartikel {0} angelegt"
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Menge für Fertigerzeugnis {0} kann nicht Null sein"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Fertigerzeugnis {0} muss ein untervergebener Artikel sein"
 
@@ -20564,7 +20561,7 @@ msgstr "Anlagevermögen"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20715,7 +20712,7 @@ msgstr "Für den Kauf"
 msgid "For Company"
 msgstr "Für Unternehmen"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "Für Standardlieferanten (optional)"
 
@@ -20776,7 +20773,7 @@ msgstr "Für Lieferant"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "Für Lager"
@@ -20819,7 +20816,7 @@ msgstr "Für einzelne Anbieter"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "Für den Artikel {0} muss der Einzelpreis eine positive Zahl sein. Um negative Einzelpreise zuzulassen, aktivieren Sie {1} in {2}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr "Für den Vorgang {0}: Die Menge ({1}) darf nicht größer sein als die ausstehende Menge ({2})"
 
@@ -21080,7 +21077,7 @@ msgstr "Von Kunden"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21190,8 +21187,8 @@ msgstr "Von-Datum kann später liegen als Bis-Datum"
 msgid "From Date is mandatory"
 msgstr "Von-Datum ist obligatorisch"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21567,14 +21564,14 @@ msgstr "Weitere Knoten können nur unter Knoten vom Typ \"Gruppe\" erstellt werd
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Zukünftiger Zahlungsbetrag"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "Zukünftige Zahlung"
 
@@ -21599,7 +21596,7 @@ msgstr "Hauptbuchsaldo"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "Buchung zum Hauptbuch"
 
@@ -21893,7 +21890,7 @@ msgstr "Holen Sie Elemente aus"
 msgid "Get Items From Purchase Receipts"
 msgstr "Artikel vom Eingangsbeleg übernehmen"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22416,7 +22413,7 @@ msgstr "Gruppen-Knoten"
 msgid "Group Same Items"
 msgstr "Gleiche Artikel gruppieren"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "Group Warehouses können nicht für Transaktionen verwendet werden. Bitte ändern Sie den Wert von {0}"
 
@@ -23858,11 +23855,11 @@ msgstr "Anzahl auf Lager"
 msgid "In Transit"
 msgstr "In Lieferung"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24332,7 +24329,7 @@ msgid "Incorrect Type of Transaction"
 msgstr "Falsche Transaktionsart"
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "Falsches Lager"
 
@@ -24590,8 +24587,8 @@ msgstr "Anweisungen"
 msgid "Insufficient Capacity"
 msgstr "Unzureichende Kapazität"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "Nicht ausreichende Berechtigungen"
 
@@ -24840,7 +24837,7 @@ msgstr "Ungültiges Datum für die automatische Wiederholung"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Ungültiger Barcode. Es ist kein Artikel an diesen Barcode angehängt."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Ungültiger Rahmenauftrag für den ausgewählten Kunden und Artikel"
 
@@ -24917,7 +24914,7 @@ msgstr "Ungültiges übergeordnetes Konto"
 msgid "Invalid Part Number"
 msgstr "Ungültige Teilenummer"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "Ungültige Buchungszeit"
 
@@ -24929,7 +24926,7 @@ msgstr "Ungültige primäre Rolle"
 msgid "Invalid Priority"
 msgstr "Ungültige Priorität"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr "Ungültige Prozessverlust-Konfiguration"
 
@@ -24937,7 +24934,7 @@ msgstr "Ungültige Prozessverlust-Konfiguration"
 msgid "Invalid Purchase Invoice"
 msgstr "Ungültige Eingangsrechnung"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "Ungültige Menge"
 
@@ -24945,9 +24942,9 @@ msgstr "Ungültige Menge"
 msgid "Invalid Quantity"
 msgstr "Ungültige Menge"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "Ungültiger Zeitplan"
 
@@ -24959,7 +24956,7 @@ msgstr "Ungültiger Verkaufspreis"
 msgid "Invalid Serial and Batch Bundle"
 msgstr "Ungültiges Serien- und Chargenbündel"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "ungültige URL"
 
@@ -24984,7 +24981,7 @@ msgstr "Ungültiger Grund für verlorene(s) {0}, bitte erstellen Sie einen neuen
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Ungültige Namensreihe (. Fehlt) für {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "Ungültige Referenz {0} {1}"
 
@@ -25008,7 +25005,7 @@ msgstr "Ungültige(r) {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "Ungültige {0} für Inter Company-Transaktion."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "Ungültige(r/s) {0}: {1}"
@@ -25076,7 +25073,7 @@ msgstr "Rechnungsdatum"
 msgid "Invoice Discounting"
 msgstr "Rechnungsrabatt"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "Rechnungssumme"
 
@@ -25165,9 +25162,9 @@ msgstr "Die Rechnung kann nicht für die Null-Rechnungsstunde erstellt werden"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "Rechnungsbetrag"
 
@@ -25864,7 +25861,7 @@ msgstr "Die Ausgabe kann nicht an einen Standort erfolgen. Bitte geben Sie den M
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Es kann bis zu einigen Stunden dauern, bis nach der Zusammenführung von Artikeln genaue Bestandswerte sichtbar sind."
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "Wird gebraucht, um Artikeldetails abzurufen"
 
@@ -25916,7 +25913,7 @@ msgstr "Es ist nicht möglich, die Gebühren gleichmäßig zu verteilen, wenn de
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26158,7 +26155,7 @@ msgstr "Artikel-Warenkorb"
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26189,7 +26186,7 @@ msgstr "Artikel-Warenkorb"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26616,7 +26613,7 @@ msgstr "Artikel Hersteller"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26975,7 +26972,7 @@ msgstr "Artikelname"
 msgid "Item operation"
 msgstr "Artikeloperation"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Die Artikelmenge kann nicht aktualisiert werden, da das Rohmaterial bereits verarbeitet werden."
 
@@ -27014,7 +27011,7 @@ msgstr "Artikel {0} kann nicht mehr als {1} im Rahmenauftrag {2} bestellt werden
 msgid "Item {0} does not exist"
 msgstr "Artikel {0} existiert nicht"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "Artikel {0} ist nicht im System vorhanden oder abgelaufen"
 
@@ -27102,7 +27099,7 @@ msgstr "Artikel {0}: Bestellmenge {1} kann nicht weniger als Mindestbestellmenge
 msgid "Item {0}: {1} qty produced. "
 msgstr "Artikel {0}: {1} produzierte Menge."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "Artikel {0} existiert nicht."
 
@@ -27139,7 +27136,7 @@ msgstr "Artikelbezogene Verkaufshistorie"
 msgid "Item-wise Sales Register"
 msgstr "Artikelbezogene Übersicht der Verkäufe"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "Artikel: {0} ist nicht im System vorhanden"
 
@@ -27244,7 +27241,7 @@ msgstr "Anzufragende Artikel"
 msgid "Items and Pricing"
 msgstr "Artikel und Preise"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27453,7 +27450,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "Jobkarte {0} erstellt"
 
@@ -29075,11 +29072,11 @@ msgstr "Geschäftsleitung"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30423,7 +30420,7 @@ msgstr "Sonstige Aufwendungen"
 msgid "Mismatch"
 msgstr "Keine Übereinstimmung"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr "Fehlt"
 
@@ -30481,7 +30478,7 @@ msgstr "Angaben zu fehlenden Werten erforderlich"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "Fehlende E-Mail-Vorlage für den Versand. Bitte legen Sie einen in den Liefereinstellungen fest."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr "Fehlender Wert"
@@ -30962,7 +30959,7 @@ msgstr "Musik"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "Muss eine ganze Zahl sein"
 
@@ -30995,7 +30992,7 @@ msgstr "Keine Angaben"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31133,11 +31130,11 @@ msgstr "Erdgas"
 msgid "Needs Analysis"
 msgstr "Muss analysiert werden"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "Negative Menge ist nicht erlaubt"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negative Bewertung ist nicht erlaubt"
 
@@ -31215,8 +31212,8 @@ msgstr "Nettobetrag"
 msgid "Net Amount (Company Currency)"
 msgstr "Nettobetrag (Unternehmenswährung)"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "Nettoinventarwert Vermögenswert wie"
 
@@ -31787,7 +31784,7 @@ msgstr "Es wurde kein Lieferant für Transaktionen zwischen Unternehmen gefunden
 msgid "No Tax Withholding data found for the current posting date."
 msgstr "Für das aktuelle Buchungsdatum wurden keine Quellensteuerdaten gefunden."
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr "Keine Bedingungen"
 
@@ -31972,15 +31969,15 @@ msgstr ""
 msgid "No record found"
 msgstr "Kein Datensatz gefunden"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr "Keine Datensätze in der Zuteilungstabelle gefunden"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr "Keine Datensätze in der Tabelle Rechnungen gefunden"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr "Keine Datensätze in der Zahlungstabelle gefunden"
 
@@ -32028,7 +32025,7 @@ msgstr "Nichtkonformität"
 msgid "Non Profit"
 msgstr "Gemeinnützig"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "Artikel ohne Lagerhaltung"
 
@@ -32042,7 +32039,7 @@ msgstr "Nicht-Nullen"
 msgid "None"
 msgstr "Keine"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "Keiner der Artikel hat irgendeine Änderung bei Mengen oder Kosten."
 
@@ -32157,8 +32154,8 @@ msgstr "Nicht lagernd"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32180,7 +32177,7 @@ msgstr "Nicht gestattet"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Anmerkung"
@@ -32849,7 +32846,7 @@ msgstr "Arbeitsaufträge öffnen"
 msgid "Open a new ticket"
 msgstr "Öffnen Sie ein neues Ticket"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "Eröffnung"
@@ -32881,7 +32878,7 @@ msgstr "Anfangsstand (Soll)"
 msgid "Opening Accumulated Depreciation"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32895,7 +32892,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr "Eröffnungsbetrag"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "Anfangsbestand"
 
@@ -33025,7 +33022,7 @@ msgstr "Betriebskosten (Gesellschaft Währung)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr "Betriebskosten pro Stücklistenmenge"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "Betriebskosten gemäß Fertigungsauftrag / Stückliste"
 
@@ -33055,7 +33052,7 @@ msgstr "Betriebskosten"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33181,7 +33178,7 @@ msgstr "Arbeitsvorbereitung"
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "Der Betrieb kann nicht leer sein"
 
@@ -33694,7 +33691,7 @@ msgstr "Ausstehend"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34249,9 +34246,9 @@ msgstr "Bezahlt"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34700,12 +34697,12 @@ msgstr "Teile pro Million"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34726,7 +34723,7 @@ msgstr "Partei"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "Konto der Partei"
 
@@ -34859,12 +34856,12 @@ msgstr "Parteispezifischer Artikel"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34991,7 +34988,7 @@ msgid "Payable"
 msgstr "Zahlbar"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35433,7 +35430,7 @@ msgstr "Zahlungsplan"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35671,13 +35668,13 @@ msgstr "Ausstehende Aktivitäten"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "Ausstehender Betrag"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35966,8 +35963,8 @@ msgstr "Permanente Bestandsaufnahme erforderlich, damit das Unternehmen {0} dies
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "Persönlich"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36580,7 +36577,7 @@ msgstr "Bitte geben Sie Konto für Änderungsbetrag"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Bitte genehmigende Rolle oder genehmigenden Nutzer eingeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "Bitte die Kostenstelle eingeben"
 
@@ -36592,7 +36589,7 @@ msgstr "Bitte geben Sie das Lieferdatum ein"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Bitte die Mitarbeiter-ID dieses Vertriebsmitarbeiters angeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "Bitte das Aufwandskonto angeben"
 
@@ -36601,7 +36598,7 @@ msgstr "Bitte das Aufwandskonto angeben"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Bitte geben Sie Item Code zu Chargennummer erhalten"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "Bitte die Artikelnummer eingeben um die Chargennummer zu erhalten"
 
@@ -36895,7 +36892,7 @@ msgstr "Bitte erst Buchungsdatum und dann die Partei auswählen"
 msgid "Please select Posting Date first"
 msgstr "Bitte zuerst ein Buchungsdatum auswählen"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "Bitte eine Preisliste auswählen"
 
@@ -36923,7 +36920,7 @@ msgstr "Bitte wählen Sie \"Unterauftrag\" anstatt \"Bestellung\" {0}"
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "Bitte Stückliste auwählen"
 
@@ -36932,10 +36929,10 @@ msgid "Please select a Company"
 msgstr "Bitte ein Unternehmen auswählen"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "Bitte wählen Sie zuerst eine Firma aus."
 
@@ -37085,7 +37082,7 @@ msgid "Please select {0}"
 msgstr "Bitte {0} auswählen"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "Bitte zuerst {0} auswählen"
@@ -37155,7 +37152,7 @@ msgstr "Bitte setzen Sie den Steuercode für die öffentliche Verwaltung '%s'"
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37280,7 +37277,7 @@ msgstr "Bitte Filter einstellen"
 msgid "Please set one of the following:"
 msgstr "Bitte stellen Sie eine der folgenden Optionen ein:"
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "Bitte setzen Sie wiederkehrende nach dem Speichern"
 
@@ -37310,7 +37307,7 @@ msgstr "Richten Sie den Kampagnenzeitplan in der Kampagne {0} ein."
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "Bitte {0} setzen"
@@ -37343,7 +37340,7 @@ msgstr "Bitte richten Sie ein Gruppenkonto mit dem Kontotyp - {0} für die Firma
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Bitte angeben"
 
@@ -37363,7 +37360,7 @@ msgstr "Bitte Unternehmen angeben um fortzufahren"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Bitte eine gültige Zeilen-ID für die Zeile {0} in Tabelle {1} angeben"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr "Bitte geben Sie eine {0} an"
 
@@ -37371,7 +37368,7 @@ msgstr "Bitte geben Sie eine {0} an"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Bitte geben Sie mindestens ein Attribut in der Attributtabelle ein"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Bitte entweder die Menge oder den Wertansatz oder beides eingeben"
 
@@ -37551,14 +37548,14 @@ msgstr "Portoaufwendungen"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -38047,7 +38044,7 @@ msgstr "Preis pro Einheit ({0})"
 msgid "Price is not set for the item."
 msgstr "Für den Artikel ist kein Preis festgelegt."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "Preis für Artikel {0} in Preisliste {1} nicht gefunden"
 
@@ -38578,7 +38575,7 @@ msgstr "Prozess fehlgeschlagen"
 msgid "Process Loss"
 msgstr "Prozessverlust"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr "Der Prozentsatz der Prozessverluste kann nicht größer als 100 sein"
 
@@ -39075,9 +39072,10 @@ msgstr "Fortschritt (%)"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -39085,6 +39083,7 @@ msgstr "Fortschritt (%)"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39096,7 +39095,7 @@ msgstr "Fortschritt (%)"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39715,7 +39714,7 @@ msgstr "Einkaufsstammdaten-Manager"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40175,12 +40174,12 @@ msgstr "Für Artikel {0} im Lager {1} ist bereits eine Einlagerungsregel vorhand
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40288,7 +40287,7 @@ msgstr "Menge pro Einheit"
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40383,7 +40382,7 @@ msgstr "Die Menge der Rohstoffe richtet sich nach der Menge des Fertigerzeugniss
 msgid "Qty to Be Consumed"
 msgstr "Zu verbrauchende Menge"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "Menge zu Bill"
@@ -40721,7 +40720,7 @@ msgstr "Qualitätsüberprüfungsziel"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40738,7 +40737,7 @@ msgstr "Qualitätsüberprüfungsziel"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40859,11 +40858,11 @@ msgstr "Menge darf nicht mehr als {0} sein"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "Menge eines Artikels nach der Herstellung/dem Umpacken auf Basis vorgegebener Mengen von Rohmaterial"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "Für Artikel {0} in Zeile {1} benötigte Menge"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40878,7 +40877,7 @@ msgstr "Zu machende Menge"
 msgid "Quantity to Manufacture"
 msgstr "Menge zu fertigen"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "Die herzustellende Menge darf für den Vorgang {0} nicht Null sein."
 
@@ -41549,7 +41548,7 @@ msgstr "Rohstofflager"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41608,7 +41607,7 @@ msgstr "Kosten gelieferter Rohmaterialien"
 msgid "Raw Materials Warehouse"
 msgstr "Rohstofflager"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "Rohmaterial kann nicht leer sein"
 
@@ -41803,7 +41802,7 @@ msgid "Receivable / Payable Account"
 msgstr "Forderungen-/Verbindlichkeiten-Konto"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41897,7 +41896,7 @@ msgstr "Eingegangen am"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41908,7 +41907,7 @@ msgstr "Eingegangen am"
 msgid "Received Qty"
 msgstr "Erhaltene Menge"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "Erhaltene Menge Menge"
 
@@ -42258,7 +42257,7 @@ msgstr "Referenz #{0} vom {1}"
 msgid "Reference Date"
 msgstr "Referenzdatum"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42681,7 +42680,7 @@ msgstr "Verbleibend"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Verbleibendes Saldo"
@@ -42734,9 +42733,9 @@ msgstr "Bemerkung"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42770,7 +42769,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "Artikel wurden ohne Veränderung der Menge oder des Wertes entfernt."
 
@@ -43238,7 +43237,7 @@ msgstr "Anforderer"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44269,11 +44268,11 @@ msgstr ""
 msgid "Routing Name"
 msgstr "Routing-Name"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "Zeile #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "Zeile # {0}:"
 
@@ -44365,23 +44364,23 @@ msgstr "Zeile #{0}: Die Chargennummer {1} ist bereits ausgewählt."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Zeile {0}: Es kann nicht mehr als {1} zu Zahlungsbedingung {2} zugeordnet werden"
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Zeile {0}: Der bereits abgerechnete Artikel {1} kann nicht gelöscht werden."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Zeile {0}: Element {1}, das bereits geliefert wurde, kann nicht gelöscht werden"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Zeile {0}: Element {1}, das bereits empfangen wurde, kann nicht gelöscht werden"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Zeile {0}: Element {1}, dem ein Arbeitsauftrag zugewiesen wurde, kann nicht gelöscht werden."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Zeile {0}: Artikel {1}, der der Bestellung des Kunden zugeordnet ist, kann nicht gelöscht werden."
 
@@ -44389,7 +44388,7 @@ msgstr "Zeile {0}: Artikel {1}, der der Bestellung des Kunden zugeordnet ist, ka
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "Zeile {0}: Supplier Warehouse kann nicht ausgewählt werden, während Rohstoffe an Subunternehmer geliefert werden"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "Zeile {0}: Die Rate kann nicht festgelegt werden, wenn der Betrag für Artikel {1} höher als der Rechnungsbetrag ist."
 
@@ -44497,7 +44496,7 @@ msgstr "Zeile #{0}: Artikel {1} existiert nicht"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Zeile #{0}: Artikel {1} wurde kommissioniert, bitte reservieren Sie den Bestand aus der Pickliste."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Zeile {0}: Element {1} ist kein serialisiertes / gestapeltes Element. Es kann keine Seriennummer / Chargennummer dagegen haben."
 
@@ -44575,7 +44574,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Zeile {0}: Artikelmenge {1} kann nicht Null sein."
 
@@ -44583,8 +44582,8 @@ msgstr "Zeile {0}: Artikelmenge {1} kann nicht Null sein."
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr "Zeile #{0}: Die zu reservierende Menge für den Artikel {1} sollte größer als 0 sein."
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr "Zeile #{0}: Einzelpreis muss gleich sein wie {1}: {2} ({3} / {4})"
 
@@ -44860,11 +44859,11 @@ msgstr "Zeile {0}: Voraus gegen Kunde muss Kredit"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "Zeile {0}: Voraus gegen Lieferant muss belasten werden"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "Zeile {0}: Der zugewiesene Betrag {1} muss kleiner oder gleich dem ausstehenden Rechnungsbetrag {2} sein"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "Zeile {0}: Der zugewiesene Betrag {1} muss kleiner oder gleich dem verbleibenden Zahlungsbetrag {2} sein"
 
@@ -44897,7 +44896,7 @@ msgstr "Zeile {0}: Kostenstelle ist für einen Eintrag {1} erforderlich"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "Zeile {0}: Habenbuchung kann nicht mit ein(em) {1} verknüpft werden"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "Zeile {0}: Währung der Stückliste # {1} sollte der gewählten Währung entsprechen {2}"
 
@@ -44909,7 +44908,7 @@ msgstr "Zeile {0}: Sollbuchung kann nicht mit ein(em) {1} verknüpft werden"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Zeile {0}: Lieferlager ({1}) und Kundenlager ({2}) können nicht identisch sein"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "Zeile {0}: Das Abschreibungsstartdatum ist erforderlich"
 
@@ -44930,7 +44929,7 @@ msgstr "Zeile {0}: Geben Sie einen Ort für den Vermögenswert {1} ein."
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Zeile {0}: Wechselkurs ist erforderlich"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "Zeile {0}: Erwarteter Wert nach Nutzungsdauer muss kleiner als Brutto Kaufbetrag sein"
 
@@ -45100,7 +45099,7 @@ msgstr "Zeile {0}: Das {3}-Konto {1} gehört nicht zum Unternehmen {2}"
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -45108,7 +45107,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "Zeile {0}: Umrechnungsfaktor für Maßeinheit ist zwingend erforderlich"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45137,7 +45136,7 @@ msgstr "Zeile {0}: {1} {2} stimmt nicht mit {3} überein"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr "Zeile {0}: {2} Artikel {1} existiert nicht in {2} {3}"
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Zeile {1}: Menge ({0}) darf kein Bruch sein. Deaktivieren Sie dazu &#39;{2}&#39; in UOM {3}."
 
@@ -45775,7 +45774,7 @@ msgstr "Auszuliefernde Aufträge"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45873,7 +45872,7 @@ msgstr "Zusammenfassung der Verkaufszahlung"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45959,7 +45958,7 @@ msgstr "Übersicht über den Umsatz"
 msgid "Sales Representative"
 msgstr "Vertriebsmitarbeiter:in"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "Retoure"
@@ -46146,7 +46145,7 @@ msgstr "Das selbe Unternehmen wurde mehrfach angegeben"
 msgid "Same Item"
 msgstr "Gleicher Artikel"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr "Dieselbe Artikel- und Lagerkombination wurde bereits eingegeben."
 
@@ -46173,7 +46172,7 @@ msgstr "Beispiel Retention Warehouse"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Stichprobenumfang"
@@ -46709,7 +46708,7 @@ msgstr "Gegenstände auswählen"
 msgid "Select Items based on Delivery Date"
 msgstr "Wählen Sie die Positionen nach dem Lieferdatum aus"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr "Artikel für die Qualitätsprüfung auswählen"
 
@@ -46813,7 +46812,7 @@ msgstr "Wählen Sie eine Standardpriorität."
 msgid "Select a Supplier"
 msgstr "Wählen Sie einen Lieferanten aus"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "Wählen Sie einen Lieferanten aus den Standardlieferanten der folgenden Artikel aus. Bei der Auswahl erfolgt eine Bestellung nur für Artikel, die dem ausgewählten Lieferanten gehören."
 
@@ -46859,7 +46858,7 @@ msgstr "Wählen Sie das Finanzbuch für das Element {0} in Zeile {1} aus."
 msgid "Select item group"
 msgstr "Artikelgruppe auswählen"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "Vorlagenelement auswählen"
 
@@ -46876,7 +46875,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr "Wählen Sie den Artikel, der hergestellt werden soll."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "Wählen Sie den Artikel, der hergestellt werden soll. Der Name des Artikels, die ME, das Unternehmen und die Währung werden automatisch abgerufen."
 
@@ -46897,11 +46896,11 @@ msgstr "Wählen Sie das Datum"
 msgid "Select the date and your timezone"
 msgstr "Wählen Sie das Datum und Ihre Zeitzone"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr "Wählen Sie die Rohstoffe (Artikel) aus, die zur Herstellung des Artikels benötigt werden"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "Wählen Sie den Variantenartikelcode für den Vorlagenartikel {0} aus"
 
@@ -47220,7 +47219,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47306,7 +47305,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr "Serien- und Chargennummer für Fertigerzeugnis"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr "Seriennummer ist obligatorisch"
 
@@ -47335,13 +47334,17 @@ msgstr "Seriennummer {0} gehört nicht zu Artikel {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Seriennummer {0} existiert nicht"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr "Seriennummer {0} existiert nicht"
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
 msgstr "Die Seriennummer {0} ist bereits hinzugefügt"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
 msgid "Serial No {0} is under maintenance contract upto {1}"
@@ -47380,7 +47383,7 @@ msgstr "Seriennummern stimmen nicht überein"
 msgid "Serial Nos and Batches"
 msgstr "Seriennummern und Chargen"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr "Seriennummern wurden erfolgreich erstellt"
 
@@ -47453,11 +47456,11 @@ msgstr "Seriennummer und Charge"
 msgid "Serial and Batch Bundle"
 msgstr "Serien- und Chargenbündel"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr "Serien- und Chargenbündel erstellt"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr "Serien- und Chargenbündel aktualisiert"
 
@@ -47804,12 +47807,12 @@ msgid "Service Stop Date"
 msgstr "Service-Stopp-Datum"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Das Service-Stopp-Datum kann nicht nach dem Service-Enddatum liegen"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Das Servicestoppdatum darf nicht vor dem Servicestartdatum liegen"
 
@@ -47905,7 +47908,7 @@ msgstr "Passwort festlegen"
 msgid "Set Posting Date"
 msgstr "Buchungsdatum festlegen"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47919,7 +47922,7 @@ msgstr "Projektstatus festlegen"
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "Projekt und alle Aufgaben auf Status {0} setzen?"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "Anzahl festlegen"
 
@@ -48014,7 +48017,7 @@ msgstr "Legen Sie das Standardkonto {0} für \"Artikel ohne Lagerhaltung\" fest"
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -48044,15 +48047,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr "Stellen Sie dies ein, wenn der Kunde ein Unternehmen der öffentlichen Verwaltung ist."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr "Legen Sie {0} in die Vermögensgegenstand-Kategorie {1} für das Unternehmen {2} fest"
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "Stellen Sie {0} in der Anlagenkategorie {1} oder im Unternehmen {2} ein"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "{0} in Firma {1} festlegen"
 
@@ -48119,7 +48122,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr "Firma gründen"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr "Die Einstellung {} ist erforderlich"
@@ -48926,15 +48929,15 @@ msgstr "Verkauft von"
 msgid "Something went wrong please try again"
 msgstr "Etwas ist schief gelaufen, bitte versuchen Sie es erneut"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "Dieser Gutscheincode ist leider nicht mehr gültig"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "Die Gültigkeit dieses Gutscheincodes ist leider abgelaufen"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "Die Gültigkeit dieses Gutscheincodes wurde leider noch nicht gestartet"
 
@@ -49016,7 +49019,7 @@ msgstr "Quelle Typ"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49136,7 +49139,7 @@ msgstr "Split-Problem"
 msgid "Split Qty"
 msgstr "Abgespaltene Menge"
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49561,7 +49564,7 @@ msgstr "Bundesland"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -50059,7 +50062,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -50068,10 +50071,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr "Bestandsreservierung"
 
@@ -50911,7 +50914,7 @@ msgstr "Erfolgseinstellungen"
 msgid "Successful"
 msgstr "Erfolgreich"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "Erfolgreich abgestimmt"
 
@@ -51123,7 +51126,7 @@ msgstr "Gelieferte Anzahl"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51227,9 +51230,9 @@ msgstr "Lieferantendetails"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51282,7 +51285,7 @@ msgstr "Lieferant Rechnungsdatum kann nicht größer sein als Datum der Veröffe
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "Lieferantenrechnungsnr."
@@ -51327,7 +51330,7 @@ msgstr "Lieferanten-Ledger-Zusammenfassung"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52944,11 +52947,11 @@ msgstr "Vorlage für Allgemeine Geschäftsbedingungen"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53324,7 +53327,7 @@ msgstr "Die Freigaben existieren nicht mit der {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53337,11 +53340,11 @@ msgstr "Die Synchronisierung wurde im Hintergrund gestartet. Bitte überprüfen 
 msgid "The task has been enqueued as a background job."
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt. Falls bei der Verarbeitung im Hintergrund Probleme auftreten, fügt das System einen Kommentar zum Fehler in dieser Bestandsabstimmung hinzu und kehrt zum Entwurfsstadium zurück"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt. Falls bei der Verarbeitung im Hintergrund ein Problem auftritt, fügt das System einen Kommentar über den Fehler bei dieser Bestandsabstimmung hinzu und kehrt zur Stufe Gebucht zurück"
 
@@ -53395,7 +53398,7 @@ msgstr "{0} {1} erfolgreich erstellt"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "Es gibt aktive Wartungs- oder Reparaturarbeiten am Vermögenswert. Sie müssen alle Schritte ausführen, bevor Sie das Asset stornieren können."
 
@@ -53669,7 +53672,7 @@ msgstr "Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} verschr
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr "Dieser Zeitplan wurde erstellt, als der Vermögensgegenstand {0} über die Ausgangsrechnung {1} verkauft wurde."
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr "Dieser Zeitplan wurde erstellt, als Vermögensgegenstand {0} aktualisiert wurde, nachdem er in einen neuen Vermögensgegenstand {1} aufgeteilt wurde."
 
@@ -53685,7 +53688,7 @@ msgstr "Dieser Zeitplan wurde erstellt, als die Vermögenswertanpassung {1} von 
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr "Dieser Zeitplan wurde erstellt, als die Schichten des Vermögensgegenstandes {0} durch die Vermögensgegenstand -Schichtzuordung {1} angepasst wurden."
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr "Dieser Zeitplan wurde erstellt, als der neue Vermögensgegenstand {0} von dem Vermögensgegenstand {1} abgespalten wurde."
 
@@ -53888,7 +53891,7 @@ msgstr "Zeitleiste"
 msgid "Timer"
 msgstr "Timer"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "Timer hat die angegebenen Stunden überschritten."
 
@@ -54090,7 +54093,7 @@ msgstr "In Währung"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54389,7 +54392,7 @@ msgstr "An Lager"
 msgid "To Warehouse (Optional)"
 msgstr "Eingangslager (Optional)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54464,7 +54467,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54565,7 +54568,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56118,7 +56121,7 @@ msgstr "UPC-A"
 msgid "URL"
 msgstr "URL"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "URL kann nur eine Zeichenfolge sein"
 
@@ -56728,7 +56731,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56776,6 +56779,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57190,7 +57199,7 @@ msgstr "Der Bewertungssatz für den Posten {0} ist erforderlich, um Buchhaltungs
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Bewertungskurs ist obligatorisch, wenn Öffnung Stock eingegeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Bewertungssatz für Position {0} in Zeile {1} erforderlich"
 
@@ -57200,7 +57209,7 @@ msgstr "Bewertungssatz für Position {0} in Zeile {1} erforderlich"
 msgid "Valuation and Total"
 msgstr "Bewertung und Summe"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Die Bewertungsrate für von Kunden beigestellte Artikel wurde auf Null gesetzt."
 
@@ -57286,6 +57295,11 @@ msgstr "Wert oder Menge"
 msgid "Value Proposition"
 msgstr "Wertversprechen"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "Wert für das Attribut {0} muss im Bereich von {1} bis {2} in den Schritten von {3} für Artikel {4}"
@@ -57294,6 +57308,22 @@ msgstr "Wert für das Attribut {0} muss im Bereich von {1} bis {2} in den Schrit
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
 msgstr "Warenwert"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
+msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
 msgid "Value of goods cannot be 0"
@@ -57374,7 +57404,7 @@ msgid "Variant Field"
 msgstr "Variantenfeld"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "Variantenartikel"
 
@@ -57672,11 +57702,11 @@ msgstr "Beleg"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57702,7 +57732,7 @@ msgstr "Beleg"
 msgid "Voucher No"
 msgstr "Belegnr."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr "Beleg Nr. ist obligatorisch"
 
@@ -57714,7 +57744,7 @@ msgstr "Beleg Menge"
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr "Beleg Untertyp"
 
@@ -57744,9 +57774,9 @@ msgstr "Beleg Untertyp"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57914,7 +57944,7 @@ msgstr "Laufkundschaft"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58099,7 +58129,7 @@ msgstr "Lager ist erforderlich"
 msgid "Warehouse not found against the account {0}"
 msgstr "Lager für Konto {0} nicht gefunden"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "Lager im System nicht gefunden"
 
@@ -58225,7 +58255,7 @@ msgstr "Warnung für neue Angebotsanfrage"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "Warnung"
 
@@ -58245,7 +58275,7 @@ msgstr "Warnung!"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "Achtung: Zu Lagerbuchung {2} gibt es eine andere Gegenbuchung {0} # {1}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "Achtung : Materialanfragemenge ist geringer als die Mindestbestellmenge"
 
@@ -58778,8 +58808,8 @@ msgstr "Arbeitsauftrag kann aus folgenden Gründen nicht erstellt werden:<br> {0
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "Arbeitsauftrag kann nicht gegen eine Artikelbeschreibungsvorlage ausgelöst werden"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "Arbeitsauftrag wurde {0}"
 
@@ -59191,7 +59221,7 @@ msgstr "Ja"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Sie dürfen nicht gemäß den im {} Workflow festgelegten Bedingungen aktualisieren."
 
@@ -59256,11 +59286,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Sie können keine Änderungen an der Jobkarte vornehmen, da der Arbeitsauftrag geschlossen ist."
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59312,7 +59346,7 @@ msgstr "Sie können die Bestellung nicht ohne Zahlung buchen."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Sie haben keine Berechtigungen für {} Elemente in einem {}."
 
@@ -59464,7 +59498,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr "als Prozentsatz der fertigen Artikelmenge"
 
@@ -59800,7 +59834,7 @@ msgstr "{0} <b>{1}</b> hat Vermögensgegenstände gebucht. Entfernen Sie Artikel
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} Konto für Kunde {1} nicht gefunden."
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59808,7 +59842,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "Verwendeter {0} -Coupon ist {1}. Zulässige Menge ist erschöpft"
 
@@ -59868,7 +59902,7 @@ msgstr "{0} hat bereits eine übergeordnete Prozedur {1}."
 msgid "{0} and {1}"
 msgstr "{0} und {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} und {1} sind obligatorisch"
@@ -59959,7 +59993,7 @@ msgstr "{0} ist blockiert, daher kann diese Transaktion nicht fortgesetzt werden
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -60041,7 +60075,7 @@ msgstr "{0} muss im Retourenschein negativ sein"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} für Artikel {1} nicht gefunden"
 
@@ -60057,7 +60091,7 @@ msgstr "{0} Zahlungsbuchungen können nicht nach {1} gefiltert werden"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr "Menge {0} des Artikels {1} wird im Lager {2} mit einer Kapazität von {3} empfangen."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/eo.po
+++ b/erpnext/locale/eo.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:15\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:27\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Esperanto\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "crwdns132104:0crwdne132104:0"
 msgid "% Completed"
 msgstr "crwdns132106:0crwdne132106:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "crwdns62438:0crwdne62438:0"
@@ -856,7 +856,7 @@ msgstr "crwdns111574:0crwdne111574:0"
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "crwdns111576:0crwdne111576:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "crwdns62656:0{0}crwdne62656:0"
 
@@ -1061,7 +1061,7 @@ msgstr "crwdns132228:0crwdne132228:0"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr "crwdns132236:0crwdne132236:0"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr "crwdns62950:0crwdne62950:0"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "crwdns62952:0{0}crwdne62952:0"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "crwdns62954:0crwdne62954:0"
 
@@ -1420,7 +1420,7 @@ msgstr "crwdns62970:0{0}crwdnd62970:0{1}crwdne62970:0"
 msgid "Account {0} does not exist"
 msgstr "crwdns62972:0{0}crwdne62972:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "crwdns62974:0{0}crwdne62974:0"
 
@@ -1747,8 +1747,8 @@ msgstr "crwdns132270:0crwdne132270:0"
 msgid "Accounting Entries"
 msgstr "crwdns132272:0crwdne132272:0"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "crwdns63168:0crwdne63168:0"
@@ -2159,8 +2159,8 @@ msgstr "crwdns132290:0crwdne132290:0"
 msgid "Accumulated Depreciation Amount"
 msgstr "crwdns63274:0crwdne63274:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "crwdns63278:0crwdne63278:0"
 
@@ -2563,7 +2563,7 @@ msgstr "crwdns63454:0{0}crwdne63454:0"
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr "crwdns132354:0crwdne132354:0"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "crwdns132356:0crwdne132356:0"
@@ -3288,7 +3288,7 @@ msgstr "crwdns63820:0crwdne63820:0"
 msgid "Advance Account"
 msgstr "crwdns132422:0crwdne132422:0"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr "crwdns132426:0{0}crwdnd132426:0{1}crwdnd132426:0{2}crwdne132426:0"
 
@@ -3420,7 +3420,7 @@ msgstr "crwdns111606:0crwdne111606:0"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "crwdns63874:0crwdne63874:0"
 
@@ -3532,7 +3532,7 @@ msgstr "crwdns148756:0{0}crwdne148756:0"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "crwdns63928:0crwdne63928:0"
 
@@ -3556,7 +3556,7 @@ msgstr "crwdns63932:0crwdne63932:0"
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "crwdns63936:0crwdne63936:0"
@@ -3570,7 +3570,7 @@ msgstr "crwdns63942:0crwdne63942:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "crwdns63944:0crwdne63944:0"
 
@@ -3717,7 +3717,7 @@ msgstr "crwdns132482:0crwdne132482:0"
 msgid "All Activities HTML"
 msgstr "crwdns132484:0crwdne132484:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "crwdns64004:0crwdne64004:0"
 
@@ -3870,7 +3870,7 @@ msgstr "crwdns112194:0crwdne112194:0"
 msgid "All items have already been transferred for this Work Order."
 msgstr "crwdns64040:0crwdne64040:0"
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "crwdns64042:0crwdne64042:0"
 
@@ -4107,8 +4107,8 @@ msgstr "crwdns132534:0crwdne132534:0"
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "crwdns132536:0crwdne132536:0"
 
@@ -4247,6 +4247,12 @@ msgstr "crwdns132574:0crwdne132574:0"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "crwdns132576:0crwdne132576:0"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr "crwdns151932:0crwdne151932:0"
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4669,7 +4675,7 @@ msgstr "crwdns132600:0crwdne132600:0"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr "crwdns148856:0crwdne148856:0"
 msgid "Amount in {0}"
 msgstr "crwdns148598:0{0}crwdne148598:0"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr "crwdns151890:0crwdne151890:0"
@@ -5385,11 +5391,11 @@ msgstr "crwdns64802:0{0}crwdnd64802:0{1}crwdne64802:0"
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "crwdns64804:0{0}crwdnd64804:0{1}crwdne64804:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "crwdns64806:0{0}crwdne64806:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "crwdns64808:0{0}crwdne64808:0"
 
@@ -5401,8 +5407,8 @@ msgstr "crwdns111624:0{0}crwdne111624:0"
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "crwdns64810:0{0}crwdne64810:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "crwdns64812:0{0}crwdnd64812:0{1}crwdne64812:0"
 
@@ -5437,7 +5443,7 @@ msgstr "crwdns132704:0crwdne132704:0"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr "crwdns64862:0crwdne64862:0"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr "crwdns64936:0crwdne64936:0"
 msgid "Asset Movement Item"
 msgstr "crwdns64940:0crwdne64940:0"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "crwdns64942:0{0}crwdne64942:0"
 
@@ -5788,7 +5794,7 @@ msgstr "crwdns65006:0crwdne65006:0"
 msgid "Asset cancelled"
 msgstr "crwdns65008:0crwdne65008:0"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "crwdns65010:0{0}crwdne65010:0"
 
@@ -5808,7 +5814,7 @@ msgstr "crwdns65014:0crwdne65014:0"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "crwdns65016:0{0}crwdne65016:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "crwdns65018:0{0}crwdne65018:0"
 
@@ -5864,7 +5870,7 @@ msgstr "crwdns65042:0crwdne65042:0"
 msgid "Asset transferred to Location {0}"
 msgstr "crwdns65044:0{0}crwdne65044:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "crwdns65046:0{0}crwdne65046:0"
 
@@ -6001,7 +6007,7 @@ msgstr "crwdns142818:0#{0}crwdnd142818:0{1}crwdnd142818:0{2}crwdnd142818:0{3}crw
 msgid "At least one account with exchange gain or loss is required"
 msgstr "crwdns151596:0crwdne151596:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "crwdns104530:0crwdne104530:0"
 
@@ -6034,7 +6040,7 @@ msgstr "crwdns104538:0crwdne104538:0"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "crwdns65110:0#{0}crwdnd65110:0{1}crwdnd65110:0{2}crwdne65110:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "crwdns65112:0{0}crwdnd65112:0{1}crwdne65112:0"
 
@@ -6042,11 +6048,11 @@ msgstr "crwdns65112:0{0}crwdnd65112:0{1}crwdne65112:0"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "crwdns132736:0{0}crwdnd132736:0{1}crwdne132736:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "crwdns127452:0{0}crwdnd127452:0{1}crwdne127452:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "crwdns65114:0{0}crwdnd65114:0{1}crwdne65114:0"
 
@@ -6665,7 +6671,7 @@ msgstr "crwdns132856:0crwdne132856:0"
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr "crwdns65358:0crwdne65358:0"
 msgid "BOM 1"
 msgstr "crwdns65380:0crwdne65380:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "crwdns65382:0{0}crwdnd65382:0{1}crwdne65382:0"
 
@@ -6907,7 +6913,7 @@ msgstr "crwdns65484:0crwdne65484:0"
 msgid "BOM and Production"
 msgstr "crwdns148764:0crwdne148764:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "crwdns65486:0crwdne65486:0"
@@ -6916,23 +6922,23 @@ msgstr "crwdns65486:0crwdne65486:0"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "crwdns65488:0{0}crwdnd65488:0{1}crwdne65488:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "crwdns65490:0{1}crwdnd65490:0{0}crwdne65490:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "crwdns65492:0{0}crwdnd65492:0{1}crwdne65492:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "crwdns65494:0{0}crwdne65494:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "crwdns65496:0{0}crwdne65496:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr "crwdns132870:0{0}crwdnd132870:0{1}crwdne132870:0"
 
@@ -7002,7 +7008,7 @@ msgstr "crwdns65516:0crwdne65516:0"
 msgid "Balance (Dr - Cr)"
 msgstr "crwdns65518:0crwdne65518:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "crwdns65520:0{0}crwdne65520:0"
 
@@ -7651,7 +7657,7 @@ msgstr "crwdns65808:0crwdne65808:0"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,17 +7683,21 @@ msgstr "crwdns65808:0crwdne65808:0"
 msgid "Batch No"
 msgstr "crwdns65810:0crwdne65810:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr "crwdns65852:0crwdne65852:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "crwdns104540:0{0}crwdne104540:0"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "crwdns65854:0{0}crwdnd65854:0{1}crwdne65854:0"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+msgstr "crwdns151934:0{0}crwdnd151934:0{1}crwdnd151934:0{2}crwdnd151934:0{1}crwdnd151934:0{2}crwdne151934:0"
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
 #: erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -7700,7 +7710,7 @@ msgstr "crwdns132966:0crwdne132966:0"
 msgid "Batch Nos"
 msgstr "crwdns65858:0crwdne65858:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "crwdns65860:0crwdne65860:0"
 
@@ -7803,7 +7813,7 @@ msgstr "crwdns104542:0{0}crwdne104542:0"
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr "crwdns65900:0crwdne65900:0"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr "crwdns132986:0crwdne132986:0"
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr "crwdns65918:0crwdne65918:0"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr "crwdns132988:0crwdne132988:0"
 msgid "Billed Items To Be Received"
 msgstr "crwdns65932:0crwdne65932:0"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "crwdns65934:0crwdne65934:0"
@@ -8270,7 +8280,7 @@ msgstr "crwdns133060:0{0}crwdnd133060:0{1}crwdnd133060:0{2}crwdne133060:0"
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "crwdns66112:0crwdne66112:0"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr "crwdns133062:0{0}crwdnd133062:0{1}crwdnd133062:0{2}crwdnd133062:0{3}crwdne133062:0"
 
@@ -8957,7 +8967,7 @@ msgstr "crwdns133124:0crwdne133124:0"
 msgid "Can be approved by {0}"
 msgstr "crwdns66390:0{0}crwdne66390:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr "crwdns66392:0{0}crwdne66392:0"
 
@@ -8965,7 +8975,7 @@ msgstr "crwdns66392:0{0}crwdne66392:0"
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "crwdns66394:0crwdne66394:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr "crwdns66396:0crwdne66396:0"
 
@@ -8981,7 +8991,7 @@ msgstr "crwdns66400:0crwdne66400:0"
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "crwdns66402:0crwdne66402:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "crwdns66404:0crwdne66404:0"
 
@@ -8996,15 +9006,15 @@ msgstr "crwdns66406:0{0}crwdne66406:0"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "crwdns66408:0crwdne66408:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "crwdns66410:0crwdne66410:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr "crwdns142820:0crwdne142820:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr "crwdns142822:0crwdne142822:0"
 
@@ -9264,7 +9274,7 @@ msgstr "crwdns66574:0{0}crwdne66574:0"
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr "crwdns66576:0{0}crwdne66576:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "crwdns66578:0crwdne66578:0"
 
@@ -9285,7 +9295,7 @@ msgstr "crwdns151892:0crwdne151892:0"
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "crwdns66584:0{0}crwdne66584:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr "crwdns142824:0crwdne142824:0"
 
@@ -9302,7 +9312,7 @@ msgstr "crwdns66586:0{0}crwdne66586:0"
 msgid "Cannot find Item with this Barcode"
 msgstr "crwdns66588:0crwdne66588:0"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "crwdns143360:0{0}crwdne143360:0"
 
@@ -9365,11 +9375,11 @@ msgstr "crwdns66612:0{0}crwdne66612:0"
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "crwdns66614:0crwdne66614:0"
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "crwdns66616:0crwdne66616:0"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "crwdns66618:0crwdne66618:0"
 
@@ -9932,7 +9942,7 @@ msgstr "crwdns133228:0crwdne133228:0"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "crwdns66844:0crwdne66844:0"
 
@@ -10204,7 +10214,7 @@ msgstr "crwdns66960:0crwdne66960:0"
 msgid "Closed Documents"
 msgstr "crwdns133254:0crwdne133254:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr "crwdns66964:0crwdne66964:0"
 
@@ -10227,7 +10237,7 @@ msgstr "crwdns66970:0crwdne66970:0"
 msgid "Closing (Dr)"
 msgstr "crwdns66972:0crwdne66972:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "crwdns66974:0crwdne66974:0"
 
@@ -10250,7 +10260,7 @@ msgstr "crwdns133260:0crwdne133260:0"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "crwdns66982:0crwdne66982:0"
 
@@ -10700,7 +10710,7 @@ msgstr "crwdns133292:0crwdne133292:0"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr "crwdns133292:0crwdne133292:0"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr "crwdns67420:0crwdne67420:0"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "crwdns67422:0crwdne67422:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "crwdns67424:0crwdne67424:0"
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr "crwdns133428:0crwdne133428:0"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "crwdns67902:0crwdne67902:0"
@@ -12301,12 +12311,13 @@ msgstr "crwdns133466:0crwdne133466:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr "crwdns133466:0crwdne133466:0"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr "crwdns133474:0crwdne133474:0"
 msgid "Cost and Freight"
 msgstr "crwdns143386:0crwdne143386:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "crwdns68190:0crwdne68190:0"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "crwdns68192:0crwdne68192:0"
@@ -12463,14 +12470,6 @@ msgstr "crwdns68194:0crwdne68194:0"
 msgid "Cost of Issued Items"
 msgstr "crwdns68198:0crwdne68198:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr "crwdns149082:0crwdne149082:0"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "crwdns68200:0crwdne68200:0"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12479,14 +12478,6 @@ msgstr "crwdns68202:0crwdne68202:0"
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "crwdns68204:0crwdne68204:0"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "crwdns68206:0crwdne68206:0"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "crwdns68208:0crwdne68208:0"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12726,7 +12717,7 @@ msgstr "crwdns68298:0crwdne68298:0"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr "crwdns68298:0crwdne68298:0"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr "crwdns68298:0crwdne68298:0"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "crwdns68380:0crwdne68380:0"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "crwdns68382:0crwdne68382:0"
 
@@ -13176,11 +13167,11 @@ msgstr "crwdns68496:0{0}crwdne68496:0"
 msgid "Credit"
 msgstr "crwdns68498:0crwdne68498:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "crwdns68504:0crwdne68504:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "crwdns68506:0{0}crwdne68506:0"
 
@@ -13296,7 +13287,7 @@ msgstr "crwdns133536:0crwdne133536:0"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr "crwdns112294:0crwdne112294:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr "crwdns68710:0{0}crwdnd68710:0{1}crwdne68710:0"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "crwdns68712:0{0}crwdne68712:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "crwdns68714:0{0}crwdnd68714:0{1}crwdnd68714:0{2}crwdne68714:0"
 
@@ -14045,7 +14036,7 @@ msgstr "crwdns133616:0crwdne133616:0"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr "crwdns133624:0crwdne133624:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr "crwdns68980:0crwdne68980:0"
 msgid "Customer Group Name"
 msgstr "crwdns133626:0crwdne133626:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "crwdns68984:0{0}crwdne68984:0"
 
@@ -14204,7 +14195,7 @@ msgstr "crwdns68988:0crwdne68988:0"
 msgid "Customer Items"
 msgstr "crwdns133630:0crwdne133630:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "crwdns68992:0crwdne68992:0"
 
@@ -14250,7 +14241,7 @@ msgstr "crwdns133632:0crwdne133632:0"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr "crwdns133674:0crwdne133674:0"
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr "crwdns69314:0crwdne69314:0"
 msgid "Debit"
 msgstr "crwdns69316:0crwdne69316:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "crwdns69322:0crwdne69322:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "crwdns69324:0{0}crwdne69324:0"
 
@@ -14917,7 +14908,7 @@ msgstr "crwdns133722:0crwdne133722:0"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr "crwdns69414:0{0}crwdne69414:0"
 msgid "Default BOM for {0} not found"
 msgstr "crwdns69416:0{0}crwdne69416:0"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr "crwdns69418:0{0}crwdne69418:0"
 
@@ -15958,7 +15949,7 @@ msgstr "crwdns69776:0{0}crwdne69776:0"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr "crwdns69778:0crwdne69778:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "crwdns69780:0crwdne69780:0"
@@ -16157,7 +16148,7 @@ msgstr "crwdns69866:0crwdne69866:0"
 msgid "Depreciation Amount"
 msgstr "crwdns69872:0crwdne69872:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "crwdns69876:0crwdne69876:0"
 
@@ -16171,7 +16162,7 @@ msgstr "crwdns69878:0crwdne69878:0"
 msgid "Depreciation Details"
 msgstr "crwdns133952:0crwdne133952:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "crwdns69882:0crwdne69882:0"
 
@@ -16232,15 +16223,15 @@ msgstr "crwdns142940:0crwdne142940:0"
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr "crwdns142942:0{0}crwdne142942:0"
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "crwdns69910:0{0}crwdnd69910:0{1}crwdne69910:0"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "crwdns69912:0{0}crwdne69912:0"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "crwdns69914:0{0}crwdne69914:0"
 
@@ -16489,7 +16480,7 @@ msgstr "crwdns69926:0crwdne69926:0"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr "crwdns70148:0crwdne70148:0"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "crwdns70158:0crwdne70158:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "crwdns70160:0crwdne70160:0"
 
@@ -17428,7 +17419,7 @@ msgstr "crwdns70506:0crwdne70506:0"
 msgid "Do you still want to enable negative inventory?"
 msgstr "crwdns134078:0crwdne134078:0"
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr "crwdns111702:0{0}crwdne111702:0"
 
@@ -17834,7 +17825,7 @@ msgstr "crwdns70712:0{0}crwdne70712:0"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr "crwdns70788:0crwdne70788:0"
 msgid "Duplicate project has been created"
 msgstr "crwdns70790:0crwdne70790:0"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "crwdns70792:0{0}crwdnd70792:0{1}crwdne70792:0"
 
@@ -18850,7 +18841,7 @@ msgstr "crwdns149088:0crwdne149088:0"
 msgid "Enter Serial Nos"
 msgstr "crwdns104560:0crwdne104560:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "crwdns71174:0crwdne71174:0"
 
@@ -18929,7 +18920,7 @@ msgstr "crwdns104568:0crwdne104568:0"
 msgid "Enter the opening stock units."
 msgstr "crwdns71208:0crwdne71208:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr "crwdns71210:0crwdne71210:0"
 
@@ -19006,7 +18997,7 @@ msgstr "crwdns112322:0crwdne112322:0"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "crwdns71236:0crwdne71236:0"
 
@@ -19574,6 +19565,12 @@ msgstr "crwdns71508:0crwdne71508:0"
 msgid "Expenses Included In Valuation"
 msgstr "crwdns71512:0crwdne71512:0"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "crwdns151936:0crwdne151936:0"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr "crwdns71682:0crwdne71682:0"
 msgid "Fetch Value From"
 msgstr "crwdns134356:0crwdne134356:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "crwdns71686:0crwdne71686:0"
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr "crwdns151676:0crwdne151676:0"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "crwdns71690:0crwdne71690:0"
 
@@ -20225,15 +20222,15 @@ msgstr "crwdns71814:0crwdne71814:0"
 msgid "Finished Good Item Quantity"
 msgstr "crwdns134404:0crwdne134404:0"
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "crwdns71818:0{0}crwdne71818:0"
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "crwdns71820:0{0}crwdne71820:0"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "crwdns71822:0{0}crwdne71822:0"
 
@@ -20454,7 +20451,7 @@ msgstr "crwdns71904:0crwdne71904:0"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr "crwdns134458:0crwdne134458:0"
 msgid "For Company"
 msgstr "crwdns134460:0crwdne134460:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "crwdns71954:0crwdne71954:0"
 
@@ -20666,7 +20663,7 @@ msgstr "crwdns71970:0crwdne71970:0"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "crwdns71972:0crwdne71972:0"
@@ -20709,7 +20706,7 @@ msgstr "crwdns134476:0crwdne134476:0"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "crwdns71992:0{0}crwdnd71992:0{1}crwdnd71992:0{2}crwdne71992:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr "crwdns104578:0{0}crwdnd104578:0{1}crwdnd104578:0{2}crwdne104578:0"
 
@@ -20970,7 +20967,7 @@ msgstr "crwdns134514:0crwdne134514:0"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr "crwdns72130:0crwdne72130:0"
 msgid "From Date is mandatory"
 msgstr "crwdns143442:0crwdne143442:0"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr "crwdns72304:0crwdne72304:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "crwdns72306:0crwdne72306:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "crwdns72308:0crwdne72308:0"
 
@@ -21489,7 +21486,7 @@ msgstr "crwdns72314:0crwdne72314:0"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "crwdns72316:0crwdne72316:0"
 
@@ -21783,7 +21780,7 @@ msgstr "crwdns72408:0crwdne72408:0"
 msgid "Get Items From Purchase Receipts"
 msgstr "crwdns134630:0crwdne134630:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr "crwdns72628:0crwdne72628:0"
 msgid "Group Same Items"
 msgstr "crwdns134692:0crwdne134692:0"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "crwdns72632:0{0}crwdne72632:0"
 
@@ -23746,11 +23743,11 @@ msgstr "crwdns73252:0crwdne73252:0"
 msgid "In Transit"
 msgstr "crwdns73254:0crwdne73254:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr "crwdns73260:0crwdne73260:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr "crwdns73262:0crwdne73262:0"
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr "crwdns73472:0crwdne73472:0"
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "crwdns73474:0crwdne73474:0"
 
@@ -24478,8 +24475,8 @@ msgstr "crwdns134984:0crwdne134984:0"
 msgid "Insufficient Capacity"
 msgstr "crwdns73606:0crwdne73606:0"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "crwdns73608:0crwdne73608:0"
 
@@ -24728,7 +24725,7 @@ msgstr "crwdns73716:0crwdne73716:0"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "crwdns73718:0crwdne73718:0"
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "crwdns73720:0crwdne73720:0"
 
@@ -24805,7 +24802,7 @@ msgstr "crwdns73750:0crwdne73750:0"
 msgid "Invalid Part Number"
 msgstr "crwdns73752:0crwdne73752:0"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "crwdns73754:0crwdne73754:0"
 
@@ -24817,7 +24814,7 @@ msgstr "crwdns73756:0crwdne73756:0"
 msgid "Invalid Priority"
 msgstr "crwdns73758:0crwdne73758:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr "crwdns73760:0crwdne73760:0"
 
@@ -24825,7 +24822,7 @@ msgstr "crwdns73760:0crwdne73760:0"
 msgid "Invalid Purchase Invoice"
 msgstr "crwdns73762:0crwdne73762:0"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "crwdns73764:0crwdne73764:0"
 
@@ -24833,9 +24830,9 @@ msgstr "crwdns73764:0crwdne73764:0"
 msgid "Invalid Quantity"
 msgstr "crwdns73766:0crwdne73766:0"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "crwdns73768:0crwdne73768:0"
 
@@ -24847,7 +24844,7 @@ msgstr "crwdns73770:0crwdne73770:0"
 msgid "Invalid Serial and Batch Bundle"
 msgstr "crwdns127484:0crwdne127484:0"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "crwdns73772:0crwdne73772:0"
 
@@ -24872,7 +24869,7 @@ msgstr "crwdns73780:0{0}crwdne73780:0"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "crwdns73782:0{0}crwdne73782:0"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "crwdns73784:0{0}crwdnd73784:0{1}crwdne73784:0"
 
@@ -24896,7 +24893,7 @@ msgstr "crwdns73790:0{0}crwdne73790:0"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "crwdns73792:0{0}crwdne73792:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "crwdns73794:0{0}crwdnd73794:0{1}crwdne73794:0"
@@ -24964,7 +24961,7 @@ msgstr "crwdns135034:0crwdne135034:0"
 msgid "Invoice Discounting"
 msgstr "crwdns73820:0crwdne73820:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "crwdns73824:0crwdne73824:0"
 
@@ -25053,9 +25050,9 @@ msgstr "crwdns73868:0crwdne73868:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "crwdns73870:0crwdne73870:0"
 
@@ -25752,7 +25749,7 @@ msgstr "crwdns74218:0{0}crwdne74218:0"
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "crwdns74220:0crwdne74220:0"
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "crwdns74222:0crwdne74222:0"
 
@@ -25804,7 +25801,7 @@ msgstr "crwdns74224:0crwdne74224:0"
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr "crwdns111786:0crwdne111786:0"
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr "crwdns111786:0crwdne111786:0"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr "crwdns74534:0crwdne74534:0"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr "crwdns74804:0crwdne74804:0"
 msgid "Item operation"
 msgstr "crwdns135230:0crwdne135230:0"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "crwdns74808:0crwdne74808:0"
 
@@ -26902,7 +26899,7 @@ msgstr "crwdns74820:0{0}crwdnd74820:0{1}crwdnd74820:0{2}crwdne74820:0"
 msgid "Item {0} does not exist"
 msgstr "crwdns74822:0{0}crwdne74822:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "crwdns74824:0{0}crwdne74824:0"
 
@@ -26990,7 +26987,7 @@ msgstr "crwdns74862:0{0}crwdnd74862:0{1}crwdnd74862:0{2}crwdne74862:0"
 msgid "Item {0}: {1} qty produced. "
 msgstr "crwdns74864:0{0}crwdnd74864:0{1}crwdne74864:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "crwdns74866:0crwdne74866:0"
 
@@ -27027,7 +27024,7 @@ msgstr "crwdns74876:0crwdne74876:0"
 msgid "Item-wise Sales Register"
 msgstr "crwdns74878:0crwdne74878:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "crwdns74880:0{0}crwdne74880:0"
 
@@ -27132,7 +27129,7 @@ msgstr "crwdns74940:0crwdne74940:0"
 msgid "Items and Pricing"
 msgstr "crwdns74942:0crwdne74942:0"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "crwdns74944:0{0}crwdne74944:0"
 
@@ -27341,7 +27338,7 @@ msgstr "crwdns142956:0crwdne142956:0"
 msgid "Job Worker Warehouse"
 msgstr "crwdns142958:0crwdne142958:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "crwdns75012:0{0}crwdne75012:0"
 
@@ -28962,11 +28959,11 @@ msgstr "crwdns143466:0crwdne143466:0"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr "crwdns76346:0crwdne76346:0"
 msgid "Mismatch"
 msgstr "crwdns76348:0crwdne76348:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr "crwdns76350:0crwdne76350:0"
 
@@ -30368,7 +30365,7 @@ msgstr "crwdns76370:0crwdne76370:0"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "crwdns76374:0crwdne76374:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr "crwdns76376:0crwdne76376:0"
@@ -30849,7 +30846,7 @@ msgstr "crwdns143476:0crwdne143476:0"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "crwdns76644:0crwdne76644:0"
 
@@ -30882,7 +30879,7 @@ msgstr "crwdns135626:0crwdne135626:0"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr "crwdns135642:0crwdne135642:0"
 msgid "Needs Analysis"
 msgstr "crwdns76732:0crwdne76732:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "crwdns76734:0crwdne76734:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "crwdns76736:0crwdne76736:0"
 
@@ -31102,8 +31099,8 @@ msgstr "crwdns135644:0crwdne135644:0"
 msgid "Net Amount (Company Currency)"
 msgstr "crwdns135646:0crwdne135646:0"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "crwdns76778:0crwdne76778:0"
 
@@ -31674,7 +31671,7 @@ msgstr "crwdns77056:0{0}crwdne77056:0"
 msgid "No Tax Withholding data found for the current posting date."
 msgstr "crwdns77058:0crwdne77058:0"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr "crwdns77060:0crwdne77060:0"
 
@@ -31859,15 +31856,15 @@ msgstr "crwdns151908:0crwdne151908:0"
 msgid "No record found"
 msgstr "crwdns77138:0crwdne77138:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr "crwdns77140:0crwdne77140:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr "crwdns77142:0crwdne77142:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr "crwdns77144:0crwdne77144:0"
 
@@ -31915,7 +31912,7 @@ msgstr "crwdns77162:0crwdne77162:0"
 msgid "Non Profit"
 msgstr "crwdns77168:0crwdne77168:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "crwdns77170:0crwdne77170:0"
 
@@ -31929,7 +31926,7 @@ msgstr "crwdns135710:0crwdne135710:0"
 msgid "None"
 msgstr "crwdns135712:0crwdne135712:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "crwdns77174:0crwdne77174:0"
 
@@ -32044,8 +32041,8 @@ msgstr "crwdns77214:0crwdne77214:0"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr "crwdns77216:0crwdne77216:0"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "crwdns77218:0crwdne77218:0"
@@ -32736,7 +32733,7 @@ msgstr "crwdns77532:0crwdne77532:0"
 msgid "Open a new ticket"
 msgstr "crwdns77534:0crwdne77534:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "crwdns77536:0crwdne77536:0"
@@ -32768,7 +32765,7 @@ msgstr "crwdns77542:0crwdne77542:0"
 msgid "Opening Accumulated Depreciation"
 msgstr "crwdns77544:0crwdne77544:0"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr "crwdns77550:0{0}crwdne77550:0"
 
@@ -32782,7 +32779,7 @@ msgstr "crwdns77550:0{0}crwdne77550:0"
 msgid "Opening Amount"
 msgstr "crwdns135826:0crwdne135826:0"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "crwdns77556:0crwdne77556:0"
 
@@ -32912,7 +32909,7 @@ msgstr "crwdns135838:0crwdne135838:0"
 msgid "Operating Cost Per BOM Quantity"
 msgstr "crwdns135840:0crwdne135840:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "crwdns77608:0crwdne77608:0"
 
@@ -32942,7 +32939,7 @@ msgstr "crwdns135844:0crwdne135844:0"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr "crwdns77670:0crwdne77670:0"
 msgid "Operations Routing"
 msgstr "crwdns149098:0crwdne149098:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "crwdns77678:0crwdne77678:0"
 
@@ -33581,7 +33578,7 @@ msgstr "crwdns135910:0crwdne135910:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr "crwdns78204:0crwdne78204:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr "crwdns112550:0crwdne112550:0"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr "crwdns78408:0crwdne78408:0"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "crwdns78442:0crwdne78442:0"
 
@@ -34746,12 +34743,12 @@ msgstr "crwdns78486:0crwdne78486:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr "crwdns78570:0crwdne78570:0"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr "crwdns78746:0crwdne78746:0"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr "crwdns78884:0crwdne78884:0"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "crwdns78886:0crwdne78886:0"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,8 +35850,8 @@ msgstr "crwdns79004:0{0}crwdne79004:0"
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "crwdns136188:0crwdne136188:0"
+msgid "Personal Details"
+msgstr "crwdns151938:0crwdne151938:0"
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36467,7 +36464,7 @@ msgstr "crwdns79280:0crwdne79280:0"
 msgid "Please enter Approving Role or Approving User"
 msgstr "crwdns79282:0crwdne79282:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "crwdns79284:0crwdne79284:0"
 
@@ -36479,7 +36476,7 @@ msgstr "crwdns79286:0crwdne79286:0"
 msgid "Please enter Employee Id of this sales person"
 msgstr "crwdns79288:0crwdne79288:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "crwdns79290:0crwdne79290:0"
 
@@ -36488,7 +36485,7 @@ msgstr "crwdns79290:0crwdne79290:0"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "crwdns79292:0crwdne79292:0"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "crwdns79294:0crwdne79294:0"
 
@@ -36782,7 +36779,7 @@ msgstr "crwdns79426:0crwdne79426:0"
 msgid "Please select Posting Date first"
 msgstr "crwdns79428:0crwdne79428:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "crwdns79430:0crwdne79430:0"
 
@@ -36810,7 +36807,7 @@ msgstr "crwdns79440:0{0}crwdne79440:0"
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "crwdns79442:0{0}crwdne79442:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "crwdns79444:0crwdne79444:0"
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr "crwdns79446:0crwdne79446:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "crwdns79448:0crwdne79448:0"
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr "crwdns79508:0{0}crwdne79508:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "crwdns79510:0{0}crwdne79510:0"
@@ -37042,7 +37039,7 @@ msgstr "crwdns79532:0%scrwdne79532:0"
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr "crwdns79534:0crwdne79534:0"
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr "crwdns136260:0crwdne136260:0"
 
@@ -37167,7 +37164,7 @@ msgstr "crwdns79588:0crwdne79588:0"
 msgid "Please set one of the following:"
 msgstr "crwdns79590:0crwdne79590:0"
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "crwdns79592:0crwdne79592:0"
 
@@ -37197,7 +37194,7 @@ msgstr "crwdns79604:0{0}crwdne79604:0"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "crwdns79606:0{0}crwdne79606:0"
@@ -37230,7 +37227,7 @@ msgstr "crwdns111904:0{0}crwdnd111904:0{1}crwdne111904:0"
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "crwdns79616:0crwdne79616:0"
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "crwdns79618:0crwdne79618:0"
 
@@ -37250,7 +37247,7 @@ msgstr "crwdns79622:0crwdne79622:0"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "crwdns79624:0{0}crwdnd79624:0{1}crwdne79624:0"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr "crwdns79626:0{0}crwdne79626:0"
 
@@ -37258,7 +37255,7 @@ msgstr "crwdns79626:0{0}crwdne79626:0"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "crwdns79628:0crwdne79628:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "crwdns79630:0crwdne79630:0"
 
@@ -37438,14 +37435,14 @@ msgstr "crwdns79678:0crwdne79678:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr "crwdns79964:0{0}crwdne79964:0"
 msgid "Price is not set for the item."
 msgstr "crwdns79966:0crwdne79966:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "crwdns79968:0{0}crwdnd79968:0{1}crwdne79968:0"
 
@@ -38465,7 +38462,7 @@ msgstr "crwdns80268:0crwdne80268:0"
 msgid "Process Loss"
 msgstr "crwdns136368:0crwdne136368:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr "crwdns80274:0crwdne80274:0"
 
@@ -38962,9 +38959,10 @@ msgstr "crwdns80480:0crwdne80480:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr "crwdns80480:0crwdne80480:0"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr "crwdns80480:0crwdne80480:0"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr "crwdns80810:0crwdne80810:0"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr "crwdns81040:0{0}crwdnd81040:0{1}crwdne81040:0"
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr "crwdns81106:0crwdne81106:0"
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr "crwdns136474:0crwdne136474:0"
 msgid "Qty to Be Consumed"
 msgstr "crwdns136476:0crwdne136476:0"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "crwdns81156:0crwdne81156:0"
@@ -40608,7 +40607,7 @@ msgstr "crwdns81312:0crwdne81312:0"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr "crwdns81312:0crwdne81312:0"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr "crwdns81398:0{0}crwdne81398:0"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "crwdns136506:0crwdne136506:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "crwdns81402:0{0}crwdnd81402:0{1}crwdne81402:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr "crwdns81406:0crwdne81406:0"
 msgid "Quantity to Manufacture"
 msgstr "crwdns81408:0crwdne81408:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "crwdns81410:0{0}crwdne81410:0"
 
@@ -41436,7 +41435,7 @@ msgstr "crwdns81766:0crwdne81766:0"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr "crwdns136588:0crwdne136588:0"
 msgid "Raw Materials Warehouse"
 msgstr "crwdns136590:0crwdne136590:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "crwdns81796:0crwdne81796:0"
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr "crwdns136632:0crwdne136632:0"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr "crwdns81912:0crwdne81912:0"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr "crwdns81912:0crwdne81912:0"
 msgid "Received Qty"
 msgstr "crwdns81914:0crwdne81914:0"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "crwdns81928:0crwdne81928:0"
 
@@ -42145,7 +42144,7 @@ msgstr "crwdns82078:0#{0}crwdnd82078:0{1}crwdne82078:0"
 msgid "Reference Date"
 msgstr "crwdns82080:0crwdne82080:0"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr "crwdns82084:0crwdne82084:0"
 
@@ -42568,7 +42567,7 @@ msgstr "crwdns82288:0crwdne82288:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "crwdns82290:0crwdne82290:0"
@@ -42621,9 +42620,9 @@ msgstr "crwdns82292:0crwdne82292:0"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr "crwdns136752:0crwdne136752:0"
 msgid "Remove item if charges is not applicable to that item"
 msgstr "crwdns111940:0crwdne111940:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "crwdns82338:0crwdne82338:0"
 
@@ -43124,7 +43123,7 @@ msgstr "crwdns82534:0crwdne82534:0"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr "crwdns83024:0crwdne83024:0"
 msgid "Routing Name"
 msgstr "crwdns136952:0crwdne136952:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "crwdns83032:0crwdne83032:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "crwdns83034:0{0}crwdne83034:0"
 
@@ -44251,23 +44250,23 @@ msgstr "crwdns83070:0#{0}crwdnd83070:0{1}crwdne83070:0"
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "crwdns83072:0#{0}crwdnd83072:0{1}crwdnd83072:0{2}crwdne83072:0"
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "crwdns83074:0#{0}crwdnd83074:0{1}crwdne83074:0"
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "crwdns83076:0#{0}crwdnd83076:0{1}crwdne83076:0"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "crwdns83078:0#{0}crwdnd83078:0{1}crwdne83078:0"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "crwdns83080:0#{0}crwdnd83080:0{1}crwdne83080:0"
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "crwdns83082:0#{0}crwdnd83082:0{1}crwdne83082:0"
 
@@ -44275,7 +44274,7 @@ msgstr "crwdns83082:0#{0}crwdnd83082:0{1}crwdne83082:0"
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "crwdns83084:0#{0}crwdne83084:0"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "crwdns83086:0#{0}crwdnd83086:0{1}crwdne83086:0"
 
@@ -44383,7 +44382,7 @@ msgstr "crwdns83134:0#{0}crwdnd83134:0{1}crwdne83134:0"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "crwdns83136:0#{0}crwdnd83136:0{1}crwdne83136:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "crwdns83138:0#{0}crwdnd83138:0{1}crwdne83138:0"
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "crwdns151836:0#{0}crwdnd151836:0{1}crwdnd151836:0{2}crwdne151836:0"
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "crwdns83172:0#{0}crwdnd83172:0{1}crwdne83172:0"
 
@@ -44469,8 +44468,8 @@ msgstr "crwdns83172:0#{0}crwdnd83172:0{1}crwdne83172:0"
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr "crwdns83174:0#{0}crwdnd83174:0{1}crwdne83174:0"
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr "crwdns83176:0#{0}crwdnd83176:0{1}crwdnd83176:0{2}crwdnd83176:0{3}crwdnd83176:0{4}crwdne83176:0"
 
@@ -44746,11 +44745,11 @@ msgstr "crwdns83302:0{0}crwdne83302:0"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "crwdns83304:0{0}crwdne83304:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "crwdns83306:0{0}crwdnd83306:0{1}crwdnd83306:0{2}crwdne83306:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "crwdns83308:0{0}crwdnd83308:0{1}crwdnd83308:0{2}crwdne83308:0"
 
@@ -44783,7 +44782,7 @@ msgstr "crwdns83318:0{0}crwdnd83318:0{1}crwdne83318:0"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "crwdns83320:0{0}crwdnd83320:0{1}crwdne83320:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "crwdns83322:0{0}crwdnd83322:0#{1}crwdnd83322:0{2}crwdne83322:0"
 
@@ -44795,7 +44794,7 @@ msgstr "crwdns83324:0{0}crwdnd83324:0{1}crwdne83324:0"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "crwdns83326:0{0}crwdnd83326:0{1}crwdnd83326:0{2}crwdne83326:0"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "crwdns83328:0{0}crwdne83328:0"
 
@@ -44816,7 +44815,7 @@ msgstr "crwdns83334:0{0}crwdnd83334:0{1}crwdne83334:0"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "crwdns83336:0{0}crwdne83336:0"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "crwdns83338:0{0}crwdne83338:0"
 
@@ -44986,7 +44985,7 @@ msgstr "crwdns149102:0{0}crwdnd149102:0{3}crwdnd149102:0{1}crwdnd149102:0{2}crwd
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr "crwdns83416:0{0}crwdnd83416:0{1}crwdnd83416:0{2}crwdne83416:0"
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr "crwdns136956:0{0}crwdne136956:0"
 
@@ -44994,7 +44993,7 @@ msgstr "crwdns136956:0{0}crwdne136956:0"
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "crwdns83420:0{0}crwdne83420:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "crwdns151454:0{0}crwdnd151454:0{1}crwdne151454:0"
@@ -45023,7 +45022,7 @@ msgstr "crwdns83430:0{0}crwdnd83430:0{1}crwdnd83430:0{2}crwdnd83430:0{3}crwdne83
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr "crwdns111978:0{0}crwdnd111978:0{2}crwdnd111978:0{1}crwdnd111978:0{2}crwdnd111978:0{3}crwdne111978:0"
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "crwdns83434:0{1}crwdnd83434:0{0}crwdnd83434:0{2}crwdnd83434:0{3}crwdne83434:0"
 
@@ -45661,7 +45660,7 @@ msgstr "crwdns137000:0crwdne137000:0"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr "crwdns83756:0crwdne83756:0"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr "crwdns83788:0crwdne83788:0"
 msgid "Sales Representative"
 msgstr "crwdns143522:0crwdne143522:0"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "crwdns83790:0crwdne83790:0"
@@ -46032,7 +46031,7 @@ msgstr "crwdns83866:0crwdne83866:0"
 msgid "Same Item"
 msgstr "crwdns137018:0crwdne137018:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr "crwdns83872:0crwdne83872:0"
 
@@ -46059,7 +46058,7 @@ msgstr "crwdns137022:0crwdne137022:0"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "crwdns83884:0crwdne83884:0"
@@ -46595,7 +46594,7 @@ msgstr "crwdns84128:0crwdne84128:0"
 msgid "Select Items based on Delivery Date"
 msgstr "crwdns84130:0crwdne84130:0"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr "crwdns84132:0crwdne84132:0"
 
@@ -46699,7 +46698,7 @@ msgstr "crwdns84172:0crwdne84172:0"
 msgid "Select a Supplier"
 msgstr "crwdns84174:0crwdne84174:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "crwdns84176:0crwdne84176:0"
 
@@ -46745,7 +46744,7 @@ msgstr "crwdns84192:0{0}crwdnd84192:0{1}crwdne84192:0"
 msgid "Select item group"
 msgstr "crwdns84194:0crwdne84194:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "crwdns84196:0crwdne84196:0"
 
@@ -46762,7 +46761,7 @@ msgstr "crwdns84200:0crwdne84200:0"
 msgid "Select the Item to be manufactured."
 msgstr "crwdns84202:0crwdne84202:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "crwdns84204:0crwdne84204:0"
 
@@ -46783,11 +46782,11 @@ msgstr "crwdns148834:0crwdne148834:0"
 msgid "Select the date and your timezone"
 msgstr "crwdns84210:0crwdne84210:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr "crwdns84212:0crwdne84212:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "crwdns84214:0{0}crwdne84214:0"
 
@@ -47105,7 +47104,7 @@ msgstr "crwdns84330:0crwdne84330:0"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr "crwdns137146:0crwdne137146:0"
 msgid "Serial No and Batch for Finished Good"
 msgstr "crwdns137148:0crwdne137148:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr "crwdns84400:0crwdne84400:0"
 
@@ -47220,13 +47219,17 @@ msgstr "crwdns84410:0{0}crwdnd84410:0{1}crwdne84410:0"
 msgid "Serial No {0} does not exist"
 msgstr "crwdns84412:0{0}crwdne84412:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr "crwdns104656:0{0}crwdne104656:0"
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
 msgstr "crwdns84416:0{0}crwdne84416:0"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+msgstr "crwdns151940:0{0}crwdnd151940:0{1}crwdnd151940:0{2}crwdnd151940:0{1}crwdnd151940:0{2}crwdne151940:0"
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
 msgid "Serial No {0} is under maintenance contract upto {1}"
@@ -47265,7 +47268,7 @@ msgstr "crwdns84430:0crwdne84430:0"
 msgid "Serial Nos and Batches"
 msgstr "crwdns137150:0crwdne137150:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr "crwdns84434:0crwdne84434:0"
 
@@ -47338,11 +47341,11 @@ msgstr "crwdns137154:0crwdne137154:0"
 msgid "Serial and Batch Bundle"
 msgstr "crwdns84444:0crwdne84444:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr "crwdns84476:0crwdne84476:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr "crwdns84478:0crwdne84478:0"
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr "crwdns137202:0crwdne137202:0"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "crwdns84684:0crwdne84684:0"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "crwdns84686:0crwdne84686:0"
 
@@ -47790,7 +47793,7 @@ msgstr "crwdns111998:0crwdne111998:0"
 msgid "Set Posting Date"
 msgstr "crwdns137226:0crwdne137226:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr "crwdns84724:0crwdne84724:0"
 
@@ -47804,7 +47807,7 @@ msgstr "crwdns84726:0crwdne84726:0"
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "crwdns84728:0{0}crwdne84728:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "crwdns84730:0crwdne84730:0"
 
@@ -47899,7 +47902,7 @@ msgstr "crwdns84770:0{0}crwdne84770:0"
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr "crwdns137236:0crwdne137236:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr "crwdns84774:0crwdne84774:0"
 
@@ -47929,15 +47932,15 @@ msgstr "crwdns137242:0crwdne137242:0"
 msgid "Set this if the customer is a Public Administration company."
 msgstr "crwdns84784:0crwdne84784:0"
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr "crwdns84788:0{0}crwdnd84788:0{1}crwdnd84788:0{2}crwdne84788:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "crwdns84790:0{0}crwdnd84790:0{1}crwdnd84790:0{2}crwdne84790:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "crwdns84792:0{0}crwdnd84792:0{1}crwdne84792:0"
 
@@ -48004,7 +48007,7 @@ msgstr "crwdns137258:0crwdne137258:0"
 msgid "Setting up company"
 msgstr "crwdns84818:0crwdne84818:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr "crwdns84820:0crwdne84820:0"
@@ -48809,15 +48812,15 @@ msgstr "crwdns112008:0crwdne112008:0"
 msgid "Something went wrong please try again"
 msgstr "crwdns85154:0crwdne85154:0"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "crwdns85156:0crwdne85156:0"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "crwdns85158:0crwdne85158:0"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "crwdns85160:0crwdne85160:0"
 
@@ -48899,7 +48902,7 @@ msgstr "crwdns137392:0crwdne137392:0"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr "crwdns85254:0crwdne85254:0"
 msgid "Split Qty"
 msgstr "crwdns85256:0crwdne85256:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr "crwdns85258:0crwdne85258:0"
 
@@ -49444,7 +49447,7 @@ msgstr "crwdns85358:0crwdne85358:0"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr "crwdns85662:0crwdne85662:0"
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr "crwdns85662:0crwdne85662:0"
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr "crwdns85664:0crwdne85664:0"
 
@@ -50794,7 +50797,7 @@ msgstr "crwdns137522:0crwdne137522:0"
 msgid "Successful"
 msgstr "crwdns137524:0crwdne137524:0"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "crwdns86058:0crwdne86058:0"
 
@@ -51006,7 +51009,7 @@ msgstr "crwdns86128:0crwdne86128:0"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr "crwdns137544:0crwdne137544:0"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr "crwdns86262:0crwdne86262:0"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "crwdns86264:0crwdne86264:0"
@@ -51210,7 +51213,7 @@ msgstr "crwdns86278:0crwdne86278:0"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr "crwdns143208:0crwdne143208:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr "crwdns87176:0{0}crwdne87176:0"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "crwdns143554:0{0}crwdnd143554:0{1}crwdnd143554:0{2}crwdnd143554:0{3}crwdnd143554:0{4}crwdnd143554:0{5}crwdne143554:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "crwdns87178:0{0}crwdnd87178:0{1}crwdne87178:0"
 
@@ -53219,11 +53222,11 @@ msgstr "crwdns87180:0{0}crwdne87180:0"
 msgid "The task has been enqueued as a background job."
 msgstr "crwdns104668:0crwdne104668:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "crwdns87186:0crwdne87186:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "crwdns87188:0crwdne87188:0"
 
@@ -53277,7 +53280,7 @@ msgstr "crwdns104670:0{0}crwdnd104670:0{1}crwdne104670:0"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr "crwdns87210:0{0}crwdnd87210:0{1}crwdnd87210:0{2}crwdne87210:0"
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "crwdns87212:0crwdne87212:0"
 
@@ -53551,7 +53554,7 @@ msgstr "crwdns87342:0{0}crwdne87342:0"
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr "crwdns87344:0{0}crwdnd87344:0{1}crwdne87344:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr "crwdns87346:0{0}crwdnd87346:0{1}crwdne87346:0"
 
@@ -53567,7 +53570,7 @@ msgstr "crwdns87350:0{0}crwdnd87350:0{1}crwdne87350:0"
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr "crwdns87352:0{0}crwdnd87352:0{1}crwdne87352:0"
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr "crwdns87354:0{0}crwdnd87354:0{1}crwdne87354:0"
 
@@ -53770,7 +53773,7 @@ msgstr "crwdns137798:0crwdne137798:0"
 msgid "Timer"
 msgstr "crwdns87448:0crwdne87448:0"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "crwdns87450:0crwdne87450:0"
 
@@ -53972,7 +53975,7 @@ msgstr "crwdns137802:0crwdne137802:0"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr "crwdns87698:0crwdne87698:0"
 msgid "To Warehouse (Optional)"
 msgstr "crwdns137832:0crwdne137832:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr "crwdns87702:0crwdne87702:0"
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr "crwdns87736:0crwdne87736:0"
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr "crwdns87738:0crwdne87738:0"
@@ -54447,7 +54450,7 @@ msgstr "crwdns112648:0crwdne112648:0"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr "crwdns138030:0crwdne138030:0"
 msgid "URL"
 msgstr "crwdns138032:0crwdne138032:0"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "crwdns88560:0crwdne88560:0"
 
@@ -56610,7 +56613,7 @@ msgstr "crwdns138130:0crwdne138130:0"
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56659,6 +56662,12 @@ msgstr "crwdns138134:0crwdne138134:0"
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
 msgstr "crwdns138136:0crwdne138136:0"
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
+msgstr "crwdns151942:0crwdne151942:0"
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
 #. 'Purchase Invoice'
@@ -57072,7 +57081,7 @@ msgstr "crwdns89024:0{0}crwdnd89024:0{1}crwdnd89024:0{2}crwdne89024:0"
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "crwdns89026:0crwdne89026:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "crwdns89028:0{0}crwdnd89028:0{1}crwdne89028:0"
 
@@ -57082,7 +57091,7 @@ msgstr "crwdns89028:0{0}crwdnd89028:0{1}crwdne89028:0"
 msgid "Valuation and Total"
 msgstr "crwdns138192:0crwdne138192:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "crwdns89032:0crwdne89032:0"
 
@@ -57168,6 +57177,11 @@ msgstr "crwdns89064:0crwdne89064:0"
 msgid "Value Proposition"
 msgstr "crwdns89066:0crwdne89066:0"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr "crwdns151944:0crwdne151944:0"
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "crwdns89068:0{0}crwdnd89068:0{1}crwdnd89068:0{2}crwdnd89068:0{3}crwdnd89068:0{4}crwdne89068:0"
@@ -57176,6 +57190,22 @@ msgstr "crwdns89068:0{0}crwdnd89068:0{1}crwdnd89068:0{2}crwdnd89068:0{3}crwdnd89
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
 msgstr "crwdns138198:0crwdne138198:0"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr "crwdns151946:0crwdne151946:0"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr "crwdns151948:0crwdne151948:0"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr "crwdns151950:0crwdne151950:0"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
+msgstr "crwdns151952:0crwdne151952:0"
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
 msgid "Value of goods cannot be 0"
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr "crwdns89102:0crwdne89102:0"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "crwdns89104:0crwdne89104:0"
 
@@ -57554,11 +57584,11 @@ msgstr "crwdns138236:0crwdne138236:0"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr "crwdns138236:0crwdne138236:0"
 msgid "Voucher No"
 msgstr "crwdns89206:0crwdne89206:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr "crwdns127524:0crwdne127524:0"
 
@@ -57596,7 +57626,7 @@ msgstr "crwdns89226:0crwdne89226:0"
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr "crwdns89230:0crwdne89230:0"
 
@@ -57626,9 +57656,9 @@ msgstr "crwdns89230:0crwdne89230:0"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr "crwdns143564:0crwdne143564:0"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr "crwdns89400:0crwdne89400:0"
 msgid "Warehouse not found against the account {0}"
 msgstr "crwdns89402:0{0}crwdne89402:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "crwdns89404:0crwdne89404:0"
 
@@ -58107,7 +58137,7 @@ msgstr "crwdns138270:0crwdne138270:0"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "crwdns89458:0crwdne89458:0"
 
@@ -58127,7 +58157,7 @@ msgstr "crwdns89462:0crwdne89462:0"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "crwdns89464:0{0}crwdnd89464:0{1}crwdnd89464:0{2}crwdne89464:0"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "crwdns89466:0crwdne89466:0"
 
@@ -58660,8 +58690,8 @@ msgstr "crwdns89722:0{0}crwdne89722:0"
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "crwdns89724:0crwdne89724:0"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "crwdns89726:0{0}crwdne89726:0"
 
@@ -59073,7 +59103,7 @@ msgstr "crwdns138380:0crwdne138380:0"
 msgid "You are importing data for the code list:"
 msgstr "crwdns151712:0crwdne151712:0"
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "crwdns89926:0crwdne89926:0"
 
@@ -59138,11 +59168,15 @@ msgstr "crwdns89956:0crwdne89956:0"
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "crwdns89960:0crwdne89960:0"
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr "crwdns151954:0{0}crwdnd151954:0{1}crwdnd151954:0{2}crwdnd151954:0{3}crwdne151954:0"
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr "crwdns89962:0crwdne89962:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr "crwdns89964:0crwdne89964:0"
 
@@ -59194,7 +59228,7 @@ msgstr "crwdns89986:0crwdne89986:0"
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "crwdns151146:0{0}crwdnd151146:0{1}crwdnd151146:0{2}crwdne151146:0"
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "crwdns89988:0crwdne89988:0"
 
@@ -59346,7 +59380,7 @@ msgstr "crwdns151716:0crwdne151716:0"
 msgid "as Title"
 msgstr "crwdns151718:0crwdne151718:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr "crwdns90052:0crwdne90052:0"
 
@@ -59682,7 +59716,7 @@ msgstr "crwdns90206:0{0}crwdnd90206:0{1}crwdnd90206:0{2}crwdne90206:0"
 msgid "{0} Account not found against Customer {1}."
 msgstr "crwdns90208:0{0}crwdnd90208:0{1}crwdne90208:0"
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr "crwdns138432:0{0}crwdnd138432:0{1}crwdnd138432:0{2}crwdnd138432:0{3}crwdnd138432:0{4}crwdne138432:0"
 
@@ -59690,7 +59724,7 @@ msgstr "crwdns138432:0{0}crwdnd138432:0{1}crwdnd138432:0{2}crwdnd138432:0{3}crwd
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr "crwdns90210:0{0}crwdnd90210:0{1}crwdnd90210:0{2}crwdnd90210:0{3}crwdnd90210:0{4}crwdnd90210:0{5}crwdnd90210:0{6}crwdne90210:0"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "crwdns90212:0{0}crwdnd90212:0{1}crwdne90212:0"
 
@@ -59750,7 +59784,7 @@ msgstr "crwdns90238:0{0}crwdnd90238:0{1}crwdne90238:0"
 msgid "{0} and {1}"
 msgstr "crwdns90240:0{0}crwdnd90240:0{1}crwdne90240:0"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "crwdns90242:0{0}crwdnd90242:0{1}crwdne90242:0"
@@ -59841,7 +59875,7 @@ msgstr "crwdns90274:0{0}crwdne90274:0"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr "crwdns90308:0{0}crwdne90308:0"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr "crwdns112674:0{0}crwdnd112674:0{1}crwdne112674:0"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "crwdns90312:0{0}crwdnd90312:0{1}crwdne90312:0"
 
@@ -59939,7 +59973,7 @@ msgstr "crwdns90316:0{0}crwdnd90316:0{1}crwdne90316:0"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr "crwdns90318:0{0}crwdnd90318:0{1}crwdnd90318:0{2}crwdnd90318:0{3}crwdne90318:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "crwdns90320:0{0}crwdnd90320:0{1}crwdnd90320:0{2}crwdnd90320:0{3}crwdne90320:0"
 

--- a/erpnext/locale/es.po
+++ b/erpnext/locale/es.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "% Método completo"
 msgid "% Completed"
 msgstr "% Completado"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% Cantidad de Artículos Terminados"
@@ -960,7 +960,7 @@ msgstr "Una lista de precios es una colección de Precios de Productos, ya sea d
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "Un Producto o Servicio que se compra, vende o mantiene en stock."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "Se está ejecutando un trabajo de reconciliación {0} para los mismos filtros. No se puede reconciliar ahora."
 
@@ -1079,7 +1079,7 @@ msgstr "Abamperio"
 #. Label of the abbr (Data) field in DocType 'Company'
 #: erpnext/setup/doctype/company/company.json
 msgid "Abbr"
-msgstr "Abreviatura"
+msgstr "Abrev."
 
 #. Label of the abbr (Data) field in DocType 'Item Attribute Value'
 #: erpnext/stock/doctype/item_attribute_value/item_attribute_value.json
@@ -1165,7 +1165,7 @@ msgstr "Cantidad Aceptada en UdM de Stock"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1264,7 +1264,7 @@ msgstr "Según CEFACT/ICG/2010/IC013 o CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1369,7 +1369,7 @@ msgstr "Detalles de la Cuenta"
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
 msgid "Account Head"
-msgstr "Encabezado de cuenta"
+msgstr "Encabezado de Cuenta"
 
 #. Label of the account_manager (Link) field in DocType 'Customer'
 #: erpnext/selling/doctype/customer/customer.json
@@ -1483,7 +1483,7 @@ msgstr "La cuenta es obligatoria para obtener entradas de pago"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "La cuenta no está configurada para el cuadro de mandos {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "Cuenta no encontrada"
 
@@ -1524,7 +1524,7 @@ msgstr "La cuenta {0} no pertenece a la compañía {1}"
 msgid "Account {0} does not exist"
 msgstr "Cuenta {0} no existe"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "La cuenta {0} no existe"
 
@@ -1851,8 +1851,8 @@ msgstr "Filtro de dimensiones contables"
 msgid "Accounting Entries"
 msgstr "Asientos contables"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Entrada Contable para Activos"
@@ -2263,8 +2263,8 @@ msgstr "Cuenta de depreciación acumulada"
 msgid "Accumulated Depreciation Amount"
 msgstr "Depreciación acumulada Importe"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "La depreciación acumulada como en"
 
@@ -2667,7 +2667,7 @@ msgstr "El tipo de impuesto real no puede incluirse en la tarifa del artículo e
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2780,7 +2780,7 @@ msgid "Add Quote"
 msgstr "Añadir Cita"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "Agregar Materias Primas"
@@ -2970,7 +2970,7 @@ msgstr "Costes adicionales"
 #. Label of the additional_data (Code) field in DocType 'Common Code'
 #: erpnext/edi/doctype/common_code/common_code.json
 msgid "Additional Data"
-msgstr ""
+msgstr "Datos Adicionales"
 
 #. Label of the additional_details (Section Break) field in DocType 'Vehicle'
 #: erpnext/setup/doctype/vehicle/vehicle.json
@@ -3392,7 +3392,7 @@ msgstr "Administrador"
 msgid "Advance Account"
 msgstr "Cuenta de anticipo"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr "La cuenta de anticipo: {0} debe estar en la moneda de facturación del cliente: {1} o en la moneda predeterminada de la empresa: {2}"
 
@@ -3524,7 +3524,7 @@ msgstr "Contra"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "Contra la cuenta"
 
@@ -3636,7 +3636,7 @@ msgstr "Contra factura del proveedor {0}"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "Contra comprobante"
 
@@ -3660,7 +3660,7 @@ msgstr "Contra el Número de Comprobante"
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "Tipo de comprobante"
@@ -3674,7 +3674,7 @@ msgstr "Edad"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "Edad (Días)"
 
@@ -3821,7 +3821,7 @@ msgstr "Todas las Actividades"
 msgid "All Activities HTML"
 msgstr "Todas las actividades HTML"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "Todas las listas de materiales"
 
@@ -3974,7 +3974,7 @@ msgstr "Ya se han recibido todos los artículos"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Todos los artículos ya han sido transferidos para esta Orden de Trabajo."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Todos los artículos de este documento ya tienen una Inspección de Calidad vinculada."
 
@@ -4211,8 +4211,8 @@ msgstr "Permitir múltiples órdenes de venta contra la orden de compra de un cl
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Permitir Inventario Negativo"
 
@@ -4351,6 +4351,12 @@ msgstr "Permitir Tarifa Cero"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Permitir tasa de valoración cero"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4773,7 +4779,7 @@ msgstr "Modificado desde"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4912,10 +4918,10 @@ msgstr "Importe en la moneda de la transacción"
 msgid "Amount in {0}"
 msgstr "Importe en {0}"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
-msgstr ""
+msgstr "Importe a Facturar"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1278
 msgid "Amount {0} {1} against {2} {3}"
@@ -5188,7 +5194,7 @@ msgstr "Reglas de almacenamiento aplicadas."
 #. Label of the applies_to (Table) field in DocType 'Common Code'
 #: erpnext/edi/doctype/common_code/common_code.json
 msgid "Applies To"
-msgstr ""
+msgstr "Se aplica a"
 
 #. Label of the apply_discount_on (Select) field in DocType 'POS Invoice'
 #. Label of the apply_discount_on (Select) field in DocType 'Purchase Invoice'
@@ -5489,11 +5495,11 @@ msgstr "Como el campo {0} está habilitado, el valor del campo {1} debe ser supe
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Como ya existen transacciones validadas contra el artículo {0}, no puede cambiar el valor de {1}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "Como hay existencias negativas, no puede habilitar {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "No puedes desactivarlo porque hay stock reservado {0}."
 
@@ -5505,8 +5511,8 @@ msgstr "Dado que hay suficientes artículos de sub ensamblaje, no se requiere un
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "Como hay suficientes materias primas, la Solicitud de material no es necesaria para Almacén {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "Como {0} está habilitado, no puedes habilitar {1}."
 
@@ -5541,7 +5547,7 @@ msgstr "Artículos de montaje"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5608,7 +5614,7 @@ msgstr "Capitalización de Activo Articulo de Stock"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5754,7 +5760,7 @@ msgstr "Movimiento de Activo"
 msgid "Asset Movement Item"
 msgstr "Elemento de movimiento de activos"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "Movimiento de activo {0} creado"
 
@@ -5892,7 +5898,7 @@ msgstr "Análisis de valor de activos"
 msgid "Asset cancelled"
 msgstr "Activo cancelado"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "Activo no se puede cancelar, como ya es {0}"
 
@@ -5912,7 +5918,7 @@ msgstr "Activo creado"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "El Activo creado fue validado después del la Capitalización de Activos {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "Activo creado después de ser separado del Activo {0}"
 
@@ -5968,7 +5974,7 @@ msgstr "Activo validado"
 msgid "Asset transferred to Location {0}"
 msgstr "Activo transferido a la ubicación {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "Activo actualizado tras ser dividido en Activo {0}"
 
@@ -6105,7 +6111,7 @@ msgstr "En la fila #{0}: La cantidad seleccionada {1} para el artículo {2} es m
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "Al menos un activo tiene que ser seleccionado."
 
@@ -6138,7 +6144,7 @@ msgstr "Es obligatorio tener al menos un almacén"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "En la fila n.º {0}: el ID de secuencia {1} no puede ser menor que el ID de secuencia de fila anterior {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "En la fila {0}: el Núm. de Lote es obligatorio para el Producto {1}"
 
@@ -6146,11 +6152,11 @@ msgstr "En la fila {0}: el Núm. de Lote es obligatorio para el Producto {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "En la fila {0}: No se puede establecer el nº de fila padre para el artículo {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "En la fila {0}: La cant. es obligatoria para el lote {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "En la fila {0}: el Núm. Serial es obligatorio para el Producto {1}"
 
@@ -6769,7 +6775,7 @@ msgstr "Cant. BIN"
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6782,7 +6788,7 @@ msgstr "LdM"
 msgid "BOM 1"
 msgstr "LdM 1"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "BOM 1 {0} y BOM 2 {1} no deben ser iguales"
 
@@ -7011,7 +7017,7 @@ msgstr "Se requiere la lista de materiales (LdM) y cantidad a manufacturar."
 msgid "BOM and Production"
 msgstr "Lista de materiales y producción"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "BOM no contiene ningún artículo de stock"
@@ -7020,23 +7026,23 @@ msgstr "BOM no contiene ningún artículo de stock"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "Recursión de la lista de materiales: {0} no puede ser secundario de {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "Recursión de la LdM: {1} no puede ser principal o secundaria de {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "La lista de materiales (LdM) {0} no pertenece al producto {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "La lista de materiales (LdM) {0} debe estar activa"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "La lista de materiales (LdM) {0} debe ser validada"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7106,7 +7112,7 @@ msgstr "Balance"
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "Balance ({0})"
 
@@ -7755,7 +7761,7 @@ msgstr "Estado de Caducidad de Lote de Productos"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7781,16 +7787,20 @@ msgstr "Estado de Caducidad de Lote de Productos"
 msgid "Batch No"
 msgstr "Lote Nro."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "Lote núm. {0} no existe"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7804,7 +7814,7 @@ msgstr "Nº de Lote"
 msgid "Batch Nos"
 msgstr "Números de Lote"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "Los Núm. de Lote se crearon correctamente"
 
@@ -7907,7 +7917,7 @@ msgstr "Los siguientes planes de suscripción tienen una moneda diferente a la m
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7916,7 +7926,7 @@ msgstr "Fecha de factura"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7930,7 +7940,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7949,8 +7959,8 @@ msgstr "Facturado"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7971,7 +7981,7 @@ msgstr "Monto facturado"
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "Cantidad facturada"
@@ -8374,7 +8384,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "Se deben configurar tanto la fecha de inicio del Período de Prueba como la fecha de finalización del Período de Prueba"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -9061,7 +9071,7 @@ msgstr "Horarios de campaña"
 msgid "Can be approved by {0}"
 msgstr "Puede ser aprobado por {0}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -9069,7 +9079,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "No se puede filtrar según el cajero, si está agrupado por cajero"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -9085,7 +9095,7 @@ msgstr "No se puede filtrar según el perfil de POS, si está agrupado por perfi
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "No se puede filtrar según el método de pago, si está agrupado por método de pago"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "No se puede filtrar en función al 'No. de comprobante', si esta agrupado por el nombre"
 
@@ -9100,15 +9110,15 @@ msgstr "Sólo se puede crear el pago contra {0} impagado"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Puede referirse a la línea, sólo si el tipo de importe es 'previo al importe' o 'previo al total'"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "No se puede cambiar el método de valoración, ya que hay transacciones contra algunos artículos que no tienen su propio método de valoración"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr "No se puede deshabilitar la valoración por lotes para lotes activos."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9368,7 +9378,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "No se puede desactivar o cancelar la 'Lista de Materiales (LdM)' si esta vinculada con otras"
 
@@ -9389,7 +9399,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "No se puede eliminar el No. de serie {0}, ya que esta siendo utilizado en transacciones de stock"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9406,7 +9416,7 @@ msgstr "No se puede garantizar la entrega por número de serie ya que el artícu
 msgid "Cannot find Item with this Barcode"
 msgstr "No se puede encontrar el artículo con este código de barras"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9469,11 +9479,11 @@ msgstr "No se puede establecer la autorización sobre la base de descuento para 
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "No se pueden establecer varios valores predeterminados de artículos para una empresa."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "No se puede establecer una cantidad menor que la cantidad entregada"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "No se puede establecer una cantidad menor que la cantidad recibida"
 
@@ -10036,7 +10046,7 @@ msgstr "Ancho Cheque"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "Cheque / Fecha de referencia"
 
@@ -10308,7 +10318,7 @@ msgstr "Documento Cerrado"
 msgid "Closed Documents"
 msgstr "Documentos Cerrados"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10331,7 +10341,7 @@ msgstr "Cierre (Cred)"
 msgid "Closing (Dr)"
 msgstr "Cierre (Deb)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "Cierre (Apertura + Total)"
 
@@ -10354,7 +10364,7 @@ msgstr "Monto de cierre"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "Balance de cierre"
 
@@ -10804,7 +10814,7 @@ msgstr "Compañías"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10851,7 +10861,7 @@ msgstr "Compañías"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11171,7 +11181,7 @@ msgstr "La Empresa y la Fecha de Publicación son obligatorias"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "Las monedas de la empresa de ambas compañías deben coincidir para las Transacciones entre empresas."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "Campo de la empresa es obligatorio"
@@ -12026,7 +12036,7 @@ msgid "Content Type"
 msgstr "Tipo de contenido"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Continuar"
@@ -12405,12 +12415,13 @@ msgstr "Costo"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12418,6 +12429,7 @@ msgstr "Costo"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12546,11 +12558,6 @@ msgstr "Coste por unidad"
 msgid "Cost and Freight"
 msgstr "Coste y flete"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "Computar como"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "Costo de productos entregados"
@@ -12567,14 +12574,6 @@ msgstr "Costo sobre ventas"
 msgid "Cost of Issued Items"
 msgstr "Costo de productos entregados"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "Costo de Compra de Nueva"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12583,14 +12582,6 @@ msgstr ""
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "Costo de productos comprados"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "Costo del Activo Desechado"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "Costo del activo vendido"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12830,7 +12821,7 @@ msgstr "Cr"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12845,7 +12836,7 @@ msgstr "Cr"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12890,7 +12881,7 @@ msgstr "Cr"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13088,7 +13079,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "Crear entrada de stock de retención de muestra"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "Crear entrada de stock"
 
@@ -13280,11 +13271,11 @@ msgstr ""
 msgid "Credit"
 msgstr "Haber"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "Crédito (Transacción)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "Crédito ({0})"
 
@@ -13400,7 +13391,7 @@ msgstr "Meses de Crédito"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13622,12 +13613,12 @@ msgstr "Taza"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13740,7 +13731,7 @@ msgstr "Moneda para {0} debe ser {1}"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "La divisa / moneda de la cuenta de cierre debe ser {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "La moneda de la lista de precios {0} debe ser {1} o {2}"
 
@@ -14149,7 +14140,7 @@ msgstr "Código de Cliente"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14245,11 +14236,11 @@ msgstr "Comentarios de cliente"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14289,7 +14280,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "Nombre de la categoría de cliente"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "Grupo de Clientes: {0} no existe"
 
@@ -14308,7 +14299,7 @@ msgstr "Artículo del cliente"
 msgid "Customer Items"
 msgstr "Partidas de deudores"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "Cliente LPO"
 
@@ -14354,7 +14345,7 @@ msgstr "Numero de móvil de cliente"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14744,7 +14735,7 @@ msgstr "Datos exportados de Tally que consisten en el plan de cuentas, clientes,
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14980,11 +14971,11 @@ msgstr "Estimado administrador del sistema,"
 msgid "Debit"
 msgstr "Debe"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "Débito (Transacción)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "Débito ({0})"
 
@@ -15021,7 +15012,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15231,7 +15222,7 @@ msgstr "La lista de materiales (LdM) por defecto ({0}) debe estar activa para es
 msgid "Default BOM for {0} not found"
 msgstr "BOM por defecto para {0} no encontrado"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -16062,7 +16053,7 @@ msgstr "La nota de entrega {0} no se ha validado"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Notas de entrega"
@@ -16261,7 +16252,7 @@ msgstr "DEPRECIACIONES"
 msgid "Depreciation Amount"
 msgstr "Monto de la depreciación"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "Monto de la depreciación durante el período"
 
@@ -16275,7 +16266,7 @@ msgstr "Fecha de depreciación"
 msgid "Depreciation Details"
 msgstr "Detalles de la depreciación"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "Depreciación Eliminada debido a la venta de activos"
 
@@ -16336,15 +16327,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "Fila de Depreciación {0}: el valor esperado después de la vida útil debe ser mayor o igual que {1}"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "Fila de depreciación {0}: la siguiente fecha de depreciación no puede ser anterior Fecha disponible para usar"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "Fila de depreciación {0}: la siguiente fecha de depreciación no puede ser anterior a la fecha de compra"
 
@@ -16593,7 +16584,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16776,7 +16767,7 @@ msgstr "Cuenta para la Diferencia"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "La cuenta de diferencia debe ser una cuenta de tipo activo / pasivo, ya que esta entrada de stock es una entrada de apertura"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Una cuenta distinta debe ser del tipo Activo / Pasivo, ya que la reconciliación del stock es una entrada de apertura"
 
@@ -17532,7 +17523,7 @@ msgstr "¿Realmente desea restaurar este activo desechado?"
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17938,7 +17929,7 @@ msgstr "Vencimiento / Fecha de referencia no puede ser posterior a {0}"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18062,7 +18053,7 @@ msgstr "Se encontró grupo de artículos duplicado  en la table de grupo de art�
 msgid "Duplicate project has been created"
 msgstr "Se ha creado un proyecto duplicado"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "Línea {0} duplicada con igual {1}"
 
@@ -18954,7 +18945,7 @@ msgstr "Introducir manualmente"
 msgid "Enter Serial Nos"
 msgstr "Introduzca los números de serie"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "Introducir Proveedor"
 
@@ -19033,7 +19024,7 @@ msgstr "Introduzca el nombre del banco o de la entidad de crédito antes de vali
 msgid "Enter the opening stock units."
 msgstr "Introduzca las unidades de existencias iniciales."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19110,7 +19101,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Error"
 
@@ -19678,6 +19669,12 @@ msgstr "Gastos incluidos en la valoración de activos"
 msgid "Expenses Included In Valuation"
 msgstr "GASTOS DE VALORACIÓN"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "Experimental"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -20016,7 +20013,7 @@ msgstr "Obtener Hoja de Tiempo"
 msgid "Fetch Value From"
 msgstr "Obtener valor de"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "Buscar lista de materiales (LdM) incluyendo subconjuntos"
@@ -20032,7 +20029,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "Obteniendo tipos de cambio..."
 
@@ -20329,15 +20326,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Producto terminado {0} La cantidad no puede ser cero"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20558,7 +20555,7 @@ msgstr "Activo fijo"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20709,7 +20706,7 @@ msgstr "Por Comprar"
 msgid "For Company"
 msgstr "Para la empresa"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "Para el proveedor predeterminado (opcional)"
 
@@ -20770,7 +20767,7 @@ msgstr "De proveedor"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "Para el almacén"
@@ -20813,7 +20810,7 @@ msgstr "Por proveedor individual"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "Para el producto {0}, el precio debe ser un número positivo. Para permitir precios negativos, habilite {1} en {2}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr "Para la operación {0}: la cantidad ({1}) no puede ser mayor que la cantidad pendiente ({2})"
 
@@ -21074,7 +21071,7 @@ msgstr "Desde cliente"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21184,8 +21181,8 @@ msgstr "La fecha 'Desde' no puede ser mayor que la fecha 'Hasta'"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21561,14 +21558,14 @@ msgstr "Sólo se pueden crear más nodos bajo nodos de tipo 'Grupo'"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Monto de pago futuro"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "Ref. De pago futuro"
 
@@ -21593,7 +21590,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "Entrada GL"
 
@@ -21887,7 +21884,7 @@ msgstr "Obtener artículos de"
 msgid "Get Items From Purchase Receipts"
 msgstr "Obtener productos desde recibo de compra"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22410,7 +22407,7 @@ msgstr "Agrupar por nota"
 msgid "Group Same Items"
 msgstr "Agrupar mismos artículos"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "Los Almacenes de grupo no se pueden usar en transacciones. Cambie el valor de {0}"
 
@@ -23850,11 +23847,11 @@ msgstr "En Cantidad de Stock"
 msgid "In Transit"
 msgstr "En Transito"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr "Almacén en Tránsito"
 
@@ -24324,7 +24321,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "Almacén incorrecto"
 
@@ -24582,8 +24579,8 @@ msgstr "Instrucciones"
 msgid "Insufficient Capacity"
 msgstr "Capacidad Insuficiente"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "Permisos Insuficientes"
 
@@ -24832,7 +24829,7 @@ msgstr "Fecha de repetición automática inválida"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Código de barras inválido. No hay ningún elemento adjunto a este código de barras."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Pedido de manta inválido para el cliente y el artículo seleccionado"
 
@@ -24909,7 +24906,7 @@ msgstr "Cuenta principal no válida"
 msgid "Invalid Part Number"
 msgstr "Número de pieza no válido"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "Tiempo de publicación no válido"
 
@@ -24921,7 +24918,7 @@ msgstr "Función principal no válida"
 msgid "Invalid Priority"
 msgstr "Prioridad inválida"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24929,7 +24926,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr "Factura de Compra no válida"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "Cant. inválida"
 
@@ -24937,9 +24934,9 @@ msgstr "Cant. inválida"
 msgid "Invalid Quantity"
 msgstr "Cantidad inválida"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "Programación no válida"
 
@@ -24951,7 +24948,7 @@ msgstr "Precio de venta no válido"
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "URL invalida"
 
@@ -24976,7 +24973,7 @@ msgstr "Motivo perdido no válido {0}, cree un nuevo motivo perdido"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Serie de nombres no válida (falta.) Para {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "Referencia inválida {0} {1}"
 
@@ -25000,7 +24997,7 @@ msgstr "Inválido {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "No válido {0} para la transacción entre empresas."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "No válido {0}: {1}"
@@ -25068,7 +25065,7 @@ msgstr "Fecha de factura"
 msgid "Invoice Discounting"
 msgstr "Descuento de facturas"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "Factura Gran Total"
 
@@ -25157,9 +25154,9 @@ msgstr "No se puede facturar por cero horas de facturación"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "Cantidad facturada"
 
@@ -25856,7 +25853,7 @@ msgstr "La emisión no puede realizarse a una ubicación. Por favor, introduzca 
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "Se necesita a buscar Detalles del artículo."
 
@@ -25908,7 +25905,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26150,7 +26147,7 @@ msgstr "Carrito de Productos"
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26181,7 +26178,7 @@ msgstr "Carrito de Productos"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26608,7 +26605,7 @@ msgstr "Fabricante del artículo"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26967,7 +26964,7 @@ msgstr "Nombre del producto"
 msgid "Item operation"
 msgstr "Operación del artículo"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27006,7 +27003,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr "El elemento {0} no existe"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "El elemento {0} no existe en el sistema o ha expirado"
 
@@ -27094,7 +27091,7 @@ msgstr "El producto {0}: Con la cantidad ordenada {1} no puede ser menor que el 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Elemento {0}: {1} cantidad producida."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "Producto {0} no existe."
 
@@ -27131,7 +27128,7 @@ msgstr "Detalle de las Ventas"
 msgid "Item-wise Sales Register"
 msgstr "Detalle de Ventas"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "El producto: {0} no existe en el sistema"
 
@@ -27236,7 +27233,7 @@ msgstr "Solicitud de Productos"
 msgid "Items and Pricing"
 msgstr "Productos y Precios"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27445,7 +27442,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "Tarjeta de trabajo {0} creada"
 
@@ -29066,11 +29063,11 @@ msgstr "Director General"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30414,7 +30411,7 @@ msgstr "Gastos varios"
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30472,7 +30469,7 @@ msgstr "Valores faltantes requeridos"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "Falta la plantilla de correo electrónico para el envío. Por favor, establezca uno en la configuración de entrega."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30953,7 +30950,7 @@ msgstr "Música"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "Debe ser un número entero"
 
@@ -30986,7 +30983,7 @@ msgstr "N/D"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31124,11 +31121,11 @@ msgstr "Gas natural"
 msgid "Needs Analysis"
 msgstr "Necesita Anáisis"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "No se permiten cantidades negativas"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "La valoración negativa no está permitida"
 
@@ -31206,8 +31203,8 @@ msgstr "Importe Neto"
 msgid "Net Amount (Company Currency)"
 msgstr "Importe neto (Divisa de la empresa)"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "Valor neto de activos como en"
 
@@ -31778,7 +31775,7 @@ msgstr "No se encontró ningún proveedor para transacciones entre empresas que 
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31963,15 +31960,15 @@ msgstr ""
 msgid "No record found"
 msgstr "No se han encontraron registros"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -32019,7 +32016,7 @@ msgstr "No conformidad"
 msgid "Non Profit"
 msgstr "Sin fines de lucro"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "Artículos sin stock"
 
@@ -32033,7 +32030,7 @@ msgstr ""
 msgid "None"
 msgstr "Ninguna"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "Ninguno de los productos tiene cambios en el valor o en la existencias."
 
@@ -32148,8 +32145,8 @@ msgstr "No disponible en stock"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32171,7 +32168,7 @@ msgstr "No permitido"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Nota"
@@ -32840,7 +32837,7 @@ msgstr "Abrir Órdenes de Trabajo"
 msgid "Open a new ticket"
 msgstr "Abra un nuevo ticket"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "Apertura"
@@ -32872,7 +32869,7 @@ msgstr "Apertura (Deb)"
 msgid "Opening Accumulated Depreciation"
 msgstr "Apertura de la depreciación acumulada"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr "La depreciación acumulada de apertura debe ser menor o igual a {0}."
 
@@ -32886,7 +32883,7 @@ msgstr "La depreciación acumulada de apertura debe ser menor o igual a {0}."
 msgid "Opening Amount"
 msgstr "Importe de apertura"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "Saldo de apertura"
 
@@ -33016,7 +33013,7 @@ msgstr "Costo de funcionamiento (Divisa de la Compañia)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "Costo operativo según la orden de trabajo / BOM"
 
@@ -33046,7 +33043,7 @@ msgstr "Costos operativos"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33172,7 +33169,7 @@ msgstr "Operaciones"
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "Las operaciones no pueden dejarse en blanco"
 
@@ -33685,7 +33682,7 @@ msgstr "Excepcional"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34240,9 +34237,9 @@ msgstr "Pagado"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34691,12 +34688,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34717,7 +34714,7 @@ msgstr "Tercero"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "Cuenta asignada"
 
@@ -34850,12 +34847,12 @@ msgstr "Producto específico de la Parte"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34982,7 +34979,7 @@ msgid "Payable"
 msgstr "Pagadero"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35424,7 +35421,7 @@ msgstr "Calendario de Pago"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35662,13 +35659,13 @@ msgstr "Actividades pendientes"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "Monto pendiente"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35957,8 +35954,8 @@ msgstr "Se requiere un inventario perpetuo para que la empresa {0} vea este info
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "Personal"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36571,7 +36568,7 @@ msgstr "Por favor, introduzca la cuenta para el importe de cambio"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Por favor, introduzca 'Función para aprobar' o 'Usuario de aprobación'---"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "Por favor, introduzca el centro de costos"
 
@@ -36583,7 +36580,7 @@ msgstr "Por favor, introduzca la Fecha de Entrega"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Por favor, Introduzca ID de empleado para este vendedor"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "Introduzca la cuenta de gastos"
 
@@ -36592,7 +36589,7 @@ msgstr "Introduzca la cuenta de gastos"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Por favor, introduzca el código de artículo para obtener el número de lote"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "Introduzca el código de artículo para obtener el número de lote"
 
@@ -36886,7 +36883,7 @@ msgstr "Por favor, seleccione fecha de publicación antes de seleccionar la Part
 msgid "Please select Posting Date first"
 msgstr "Por favor, seleccione fecha de publicación primero"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "Por favor, seleccione la lista de precios"
 
@@ -36914,7 +36911,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "Seleccione una Lista de Materiales"
 
@@ -36923,10 +36920,10 @@ msgid "Please select a Company"
 msgstr "Por favor, seleccione la compañía"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "Primero seleccione una empresa."
 
@@ -37076,7 +37073,7 @@ msgid "Please select {0}"
 msgstr "Por favor, seleccione {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "Por favor, seleccione primero {0}"
@@ -37146,7 +37143,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37271,7 +37268,7 @@ msgstr "Por favor, defina los filtros"
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "Por favor configura recurrente después de guardar"
 
@@ -37301,7 +37298,7 @@ msgstr "Configure la programación de la campaña en la campaña {0}"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "Por favor, configure {0}"
@@ -37334,7 +37331,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Por favor, especifique"
 
@@ -37354,7 +37351,7 @@ msgstr "Por favor, especifique la compañía para continuar"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Por favor, especifique un ID de fila válida para la línea {0} en la tabla {1}"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37362,7 +37359,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Por favor, especifique al menos un atributo en la tabla"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Por favor indique la Cantidad o el Tipo de Valoración, o ambos"
 
@@ -37542,14 +37539,14 @@ msgstr "Gastos postales"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -38038,7 +38035,7 @@ msgstr "Precio por Unidad ({0})"
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "Precio no encontrado para el artículo {0} en la lista de precios {1}"
 
@@ -38569,7 +38566,7 @@ msgstr "Proceso fallido"
 msgid "Process Loss"
 msgstr "Pérdida por Proceso"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -39066,9 +39063,10 @@ msgstr "Progreso (%)"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -39076,6 +39074,7 @@ msgstr "Progreso (%)"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39087,7 +39086,7 @@ msgstr "Progreso (%)"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39483,7 +39482,7 @@ msgstr "Fecha de Publicación"
 #. Label of the publisher (Data) field in DocType 'Code List'
 #: erpnext/edi/doctype/code_list/code_list.json
 msgid "Publisher"
-msgstr ""
+msgstr "Publicador"
 
 #. Label of the publisher_id (Data) field in DocType 'Code List'
 #: erpnext/edi/doctype/code_list/code_list.json
@@ -39706,7 +39705,7 @@ msgstr "Director de compras"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40166,12 +40165,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40279,7 +40278,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40374,7 +40373,7 @@ msgstr "La cantidad de materias primas se decidirá en función de la cantidad d
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "Cantidad a facturar"
@@ -40712,7 +40711,7 @@ msgstr "Objetivo de revisión de calidad"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40729,7 +40728,7 @@ msgstr "Objetivo de revisión de calidad"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40850,11 +40849,11 @@ msgstr "La cantidad no debe ser más de {0}"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "Cantidad del producto obtenido después de la fabricación / empaquetado desde las cantidades determinadas de materia prima"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "Cantidad requerida para el producto {0} en la línea {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40869,7 +40868,7 @@ msgstr "Cantidad para Hacer"
 msgid "Quantity to Manufacture"
 msgstr "Cantidad a fabricar"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "La cantidad a fabricar no puede ser cero para la operación {0}"
 
@@ -41540,7 +41539,7 @@ msgstr "Almacén de materia prima"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41599,7 +41598,7 @@ msgstr "Costo materias primas suministradas"
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "'Materias primas' no puede estar en blanco."
 
@@ -41794,7 +41793,7 @@ msgid "Receivable / Payable Account"
 msgstr "Cuenta por Cobrar / Pagar"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41888,7 +41887,7 @@ msgstr "Recibida el"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41899,7 +41898,7 @@ msgstr "Recibida el"
 msgid "Received Qty"
 msgstr "Cant. Recibida"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "Cantidad recibida Cantidad"
 
@@ -42249,7 +42248,7 @@ msgstr "Referencia #{0} con fecha {1}"
 msgid "Reference Date"
 msgstr "Fecha de referencia"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42672,7 +42671,7 @@ msgstr "Restante"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Balance restante"
@@ -42725,9 +42724,9 @@ msgstr "Observación"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42761,7 +42760,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "Elementos eliminados que no han sido afectados en cantidad y valor"
 
@@ -43228,7 +43227,7 @@ msgstr "Solicitante"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44259,11 +44258,11 @@ msgstr "Enrutamiento"
 msgid "Routing Name"
 msgstr "Nombre de Enrutamiento"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "Fila #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "Fila # {0}:"
 
@@ -44355,23 +44354,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se ha facturado."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se entregó"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se ha recibido"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Fila # {0}: No se puede eliminar el elemento {1} que tiene una orden de trabajo asignada."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Fila # {0}: No se puede eliminar el artículo {1} que se asigna a la orden de compra del cliente."
 
@@ -44379,7 +44378,7 @@ msgstr "Fila # {0}: No se puede eliminar el artículo {1} que se asigna a la ord
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "Fila # {0}: No se puede seleccionar el Almacén del proveedor mientras se suministran materias primas al subcontratista"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "Fila # {0}: no se puede establecer el precio si el monto es mayor que el importe facturado para el elemento {1}."
 
@@ -44487,7 +44486,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Fila # {0}: el artículo {1} no es un artículo serializado / en lote. No puede tener un No de serie / No de lote en su contra."
 
@@ -44554,18 +44553,18 @@ msgstr ""
 
 #: erpnext/controllers/stock_controller.py:1014
 msgid "Row #{0}: Quality Inspection is required for Item {1}"
-msgstr ""
+msgstr "Fila #{0}: Se requiere inspección de calidad para el artículo {1}"
 
 #: erpnext/controllers/stock_controller.py:1029
 msgid "Row #{0}: Quality Inspection {1} is not submitted for the item: {2}"
-msgstr ""
+msgstr "Fila #{0}: La inspección de calidad {1} no se ha validado para el artículo: {2}"
 
 #: erpnext/controllers/stock_controller.py:1044
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
-msgstr ""
+msgstr "Fila #{0}: La inspección de calidad {1} fue rechazada para el artículo {2}"
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Fila # {0}: La cantidad del artículo {1} no puede ser cero."
 
@@ -44573,8 +44572,8 @@ msgstr "Fila # {0}: La cantidad del artículo {1} no puede ser cero."
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44853,11 +44852,11 @@ msgstr "Fila {0}: Avance contra el Cliente debe ser de crédito"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "Fila {0}: Avance contra el Proveedor debe ser debito"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "Fila {0}: El importe asignado {1} debe ser menor o igual al importe pendiente de la factura {2}"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "Fila {0}: El importe asignado {1} debe ser menor o igual al importe de pago restante {2}"
 
@@ -44890,7 +44889,7 @@ msgstr "Fila {0}: Centro de Costos es necesario para un elemento {1}"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "Línea {0}: La entrada de crédito no puede vincularse con {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "Fila {0}: Divisa de la lista de materiales # {1} debe ser igual a la moneda seleccionada {2}"
 
@@ -44902,7 +44901,7 @@ msgstr "Línea {0}: La entrada de débito no puede vincularse con {1}"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Fila {0}: el almacén de entrega ({1}) y el almacén del cliente ({2}) no pueden ser iguales"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "Fila {0}: se requiere la Fecha de Inicio de Depreciación"
 
@@ -44923,7 +44922,7 @@ msgstr "Fila {0}: ingrese la ubicación para el artículo del activo {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Fila {0}: Tipo de cambio es obligatorio"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "Fila {0}: valor esperado después de la vida útil debe ser menor que el importe de compra bruta"
 
@@ -45093,7 +45092,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr "Fila {0}: El número total de amortizaciones no puede ser menor o igual al número inicial de amortizaciones contabilizadas"
 
@@ -45101,7 +45100,7 @@ msgstr "Fila {0}: El número total de amortizaciones no puede ser menor o igual 
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "Línea {0}: El factor de conversión de (UdM) es obligatorio"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45130,7 +45129,7 @@ msgstr "Línea {0}: {1} {2} no coincide con {3}"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr "Fila {0}: {2} El elemento {1} no existe en {2} {3}"
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Fila {1}: la cantidad ({0}) no puede ser una fracción. Para permitir esto, deshabilite &#39;{2}&#39; en UOM {3}."
 
@@ -45768,7 +45767,7 @@ msgstr "Órdenes de Ventas para Enviar"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45866,7 +45865,7 @@ msgstr "Resumen de Pago de Ventas"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45888,7 +45887,7 @@ msgstr "Persona de ventas"
 
 #: erpnext/controllers/selling_controller.py:204
 msgid "Sales Person <b>{0}</b> is disabled."
-msgstr ""
+msgstr "Vendedor <b>{0}</b> está desactivado."
 
 #. Name of a report
 #: erpnext/selling/report/sales_person_commission_summary/sales_person_commission_summary.json
@@ -45952,7 +45951,7 @@ msgstr "Registro de ventas"
 msgid "Sales Representative"
 msgstr "Representante de Ventas"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "Devoluciones de ventas"
@@ -46139,7 +46138,7 @@ msgstr "La misma Compañia es ingresada mas de una vez"
 msgid "Same Item"
 msgstr "Mismo articulo"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46166,7 +46165,7 @@ msgstr "Almacenamiento de Muestras de Retención"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Tamaño de muestra"
@@ -46702,7 +46701,7 @@ msgstr "Seleccionar articulos"
 msgid "Select Items based on Delivery Date"
 msgstr "Seleccionar Elementos según la Fecha de Entrega"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46806,7 +46805,7 @@ msgstr "Seleccione una prioridad predeterminada."
 msgid "Select a Supplier"
 msgstr "Seleccione un proveedor"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "Seleccione un proveedor de los proveedores predeterminados de los artículos a continuación. En la selección, se realizará una orden de compra contra los artículos que pertenecen al proveedor seleccionado únicamente."
 
@@ -46852,7 +46851,7 @@ msgstr "Seleccione el libro de finanzas para el artículo {0} en la fila {1}"
 msgid "Select item group"
 msgstr "Seleccionar grupo de artículos"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "Seleccionar elemento de plantilla"
 
@@ -46869,7 +46868,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "Seleccione el artículo a fabricar. El nombre del artículo, la UdM, la empresa y la moneda se obtendrán automáticamente."
 
@@ -46890,11 +46889,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "Seleccione el código de artículo de variante para el artículo de plantilla {0}"
 
@@ -47212,7 +47211,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47298,7 +47297,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47327,12 +47326,16 @@ msgstr "Número de serie {0} no pertenece al producto {1}"
 msgid "Serial No {0} does not exist"
 msgstr "El número de serie {0} no existe"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47372,7 +47375,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "Números de serie y lotes"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47445,11 +47448,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47796,12 +47799,12 @@ msgid "Service Stop Date"
 msgstr "Fecha de Finalización del Servicio"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "La Fecha de Detención del Servicio no puede ser posterior a la Fecha de Finalización del Servicio"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "La Fecha de Detención del Servicio no puede ser anterior a la Decha de Inicio del Servicio"
 
@@ -47897,7 +47900,7 @@ msgstr "Establecer Contraseña"
 msgid "Set Posting Date"
 msgstr "Establecer fecha de publicación"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47911,7 +47914,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "¿Establecer el proyecto y todas las tareas en el estado {0}?"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "Establecer cantidad"
 
@@ -48006,7 +48009,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -48036,15 +48039,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr "Establezca esto si el cliente es una empresa de Administración Pública."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "Establezca {0} en la categoría de activos {1} o en la empresa {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "Establecer {0} en la empresa {1}"
 
@@ -48111,7 +48114,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr "Creando compañía"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48916,15 +48919,15 @@ msgstr "Vendido por"
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "Lo sentimos, este código de cupón ya no es válido"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "Lo sentimos, la validez de este código de cupón ha expirado"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "Lo sentimos, la validez de este código de cupón no ha comenzado"
 
@@ -49006,7 +49009,7 @@ msgstr "Tipo de Fuente"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49126,7 +49129,7 @@ msgstr "Problema de División"
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49551,7 +49554,7 @@ msgstr "Estado"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -50049,7 +50052,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -50058,10 +50061,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50901,7 +50904,7 @@ msgstr "Configuraciones exitosas"
 msgid "Successful"
 msgstr "Exitoso"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "Reconciliado exitosamente"
 
@@ -51113,7 +51116,7 @@ msgstr "Cant. Suministrada"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51217,9 +51220,9 @@ msgstr "Detalles del proveedor"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51272,7 +51275,7 @@ msgstr "Fecha de Factura de Proveedor no puede ser mayor que la fecha de publica
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "Factura de proveedor No."
@@ -51317,7 +51320,7 @@ msgstr "Resumen del Libro Mayor de Proveedores"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52933,11 +52936,11 @@ msgstr "Plantillas de términos y condiciones"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53313,7 +53316,7 @@ msgstr "Las acciones no existen con el {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53326,11 +53329,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr "La tarea se ha puesto en cola como trabajo en segundo plano."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "La tarea se ha puesto en cola como un trabajo en segundo plano. En caso de que haya algún problema con el procesamiento en segundo plano, el sistema agregará un comentario sobre el error en esta Reconciliación de inventario y volverá a la etapa Borrador"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53384,7 +53387,7 @@ msgstr "El {0} {1} creado exitosamente"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "Hay mantenimiento activo o reparaciones contra el activo. Debes completarlos todos antes de cancelar el activo."
 
@@ -53658,7 +53661,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53674,7 +53677,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53877,7 +53880,7 @@ msgstr "Línea de tiempo"
 msgid "Timer"
 msgstr "Temporizador"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "El Temporizador excedió las horas dadas."
 
@@ -54079,7 +54082,7 @@ msgstr "A moneda"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54378,7 +54381,7 @@ msgstr "Para Almacén"
 msgid "To Warehouse (Optional)"
 msgstr "Para almacenes (Opcional)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54453,7 +54456,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54554,7 +54557,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56107,7 +56110,7 @@ msgstr "UPC-A"
 msgid "URL"
 msgstr "URL"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "La URL solo puede ser una cadena"
 
@@ -56717,7 +56720,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56765,6 +56768,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57179,7 +57188,7 @@ msgstr "Tasa de valoración para el artículo {0}, se requiere para realizar asi
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Rango de Valoración es obligatorio si se ha ingresado una Apertura de Almacén"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Tasa de valoración requerida para el artículo {0} en la fila {1}"
 
@@ -57189,7 +57198,7 @@ msgstr "Tasa de valoración requerida para el artículo {0} en la fila {1}"
 msgid "Valuation and Total"
 msgstr "Valuación y Total"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57275,6 +57284,11 @@ msgstr "Valor o cantidad"
 msgid "Value Proposition"
 msgstr "Propuesta de valor"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "Valor del atributo {0} debe estar dentro del rango de {1} a {2} en los incrementos de {3} para el artículo {4}"
@@ -57282,6 +57296,22 @@ msgstr "Valor del atributo {0} debe estar dentro del rango de {1} a {2} en los i
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57363,7 +57393,7 @@ msgid "Variant Field"
 msgstr "Campo de Variante"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "Elemento variante"
 
@@ -57661,11 +57691,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57691,7 +57721,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "Comprobante No."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57703,7 +57733,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57733,9 +57763,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57903,7 +57933,7 @@ msgstr "Entrar"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58088,7 +58118,7 @@ msgstr "Almacén es Obligatorio"
 msgid "Warehouse not found against the account {0}"
 msgstr "Almacén no encontrado en la cuenta {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "El almacén no se encuentra en el sistema"
 
@@ -58214,7 +58244,7 @@ msgstr "Avisar de nuevas Solicitudes de Presupuesto"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "Advertencia"
 
@@ -58234,7 +58264,7 @@ msgstr "¡Advertencia!"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "Advertencia: Existe otra {0} # {1} para la entrada de inventario {2}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "Advertencia: La requisición de materiales es menor que la orden mínima establecida"
 
@@ -58767,8 +58797,8 @@ msgstr "No se puede crear una orden de trabajo por el siguiente motivo:<br> {0}"
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "La Órden de Trabajo no puede levantarse contra una Plantilla de Artículo"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "La orden de trabajo ha sido {0}"
 
@@ -59180,7 +59210,7 @@ msgstr "Si"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "No se le permite actualizar según las condiciones establecidas en {} Flujo de trabajo."
 
@@ -59245,11 +59275,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59301,7 +59335,7 @@ msgstr "No puede validar el pedido sin pago."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "No tienes permisos para {} elementos en un {}."
 
@@ -59453,7 +59487,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59789,7 +59823,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59797,7 +59831,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "Los cupones {0} utilizados son {1}. La cantidad permitida se agota"
 
@@ -59857,7 +59891,7 @@ msgstr "{0} ya tiene un Procedimiento principal {1}."
 msgid "{0} and {1}"
 msgstr "{0} y {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} y {1} son obligatorios"
@@ -59948,7 +59982,7 @@ msgstr "{0} está bloqueado por lo que esta transacción no puede continuar"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -60030,7 +60064,7 @@ msgstr "{0} debe ser negativo en el documento de devolución"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} no encontrado para el Artículo {1}"
 
@@ -60046,7 +60080,7 @@ msgstr "{0} entradas de pago no pueden ser filtradas por {1}"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/fa.po
+++ b/erpnext/locale/fa.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-15 07:24\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:27\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "روش ٪ تکمیل"
 msgid "% Completed"
 msgstr "% تکمیل شده"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% مقدار آیتم تمام شده"
@@ -868,7 +868,7 @@ msgstr "لیست قیمت مجموعه ای از قیمت های آیتم‌ها
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "محصول یا خدماتی که خریداری، فروخته یا در انبار نگهداری می شود."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "یک کار تطبیق {0} برای همین فیلترها در حال اجرا است. الان نمیشه تطبیق کرد"
 
@@ -1073,7 +1073,7 @@ msgstr "مقدار پذیرفته شده در انبار UOM"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1172,7 +1172,7 @@ msgstr "طبق CEFACT/ICG/2010/IC013 یا CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1391,7 +1391,7 @@ msgstr "حساب برای دریافت ثبت پرداخت ها اجباری ا�
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "حساب برای نمودار داشبورد {0} تنظیم نشده است"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "حساب پیدا نشد"
 
@@ -1432,7 +1432,7 @@ msgstr "حساب {0} متعلق به شرکت {1} نیست"
 msgid "Account {0} does not exist"
 msgstr "حساب {0} وجود ندارد"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "حساب {0} وجود ندارد"
 
@@ -1759,8 +1759,8 @@ msgstr "فیلتر ابعاد حسابداری"
 msgid "Accounting Entries"
 msgstr "ثبت‌های حسابداری"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "ثبت حسابداری برای دارایی"
@@ -2171,8 +2171,8 @@ msgstr "حساب استهلاک انباشته"
 msgid "Accumulated Depreciation Amount"
 msgstr "مبلغ استهلاک انباشته"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "استهلاک انباشته به عنوان"
 
@@ -2575,7 +2575,7 @@ msgstr "مالیات نوع واقعی را نمی توان در نرخ آیتم
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2688,7 +2688,7 @@ msgid "Add Quote"
 msgstr "افزودن نقل قول"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "افزودن مواد خام"
@@ -3300,7 +3300,7 @@ msgstr "مدیر"
 msgid "Advance Account"
 msgstr "پیش حساب"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3432,7 +3432,7 @@ msgstr "در برابر"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "در مقابل حساب"
 
@@ -3544,7 +3544,7 @@ msgstr "در مقابل فاکتور تامین کننده {0}"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "در مقابل کوپن"
 
@@ -3568,7 +3568,7 @@ msgstr "در مقابل کوپن شماره"
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "در مقابل نوع کوپن"
@@ -3582,7 +3582,7 @@ msgstr "سن"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "سن (بر حسب روز)"
 
@@ -3729,7 +3729,7 @@ msgstr "تمام فعالیت ها"
 msgid "All Activities HTML"
 msgstr "تمام فعالیت ها HTML"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "همه BOM ها"
 
@@ -3882,7 +3882,7 @@ msgstr "همه آیتم‌ها قبلاً دریافت شده است"
 msgid "All items have already been transferred for this Work Order."
 msgstr "همه آیتم‌ها قبلاً برای این دستور کار منتقل شده اند."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "همه آیتم‌ها در این سند قبلاً دارای یک بازرسی کیفیت مرتبط هستند."
 
@@ -4119,8 +4119,8 @@ msgstr "سفارش‌های فروش چندگانه را در مقابل سفا�
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "موجودی منفی مجاز است"
 
@@ -4259,6 +4259,12 @@ msgstr "اجازه نرخ صفر"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "نرخ ارزش گذاری صفر مجاز است"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4681,7 +4687,7 @@ msgstr "اصلاح شده از"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4820,7 +4826,7 @@ msgstr "مبلغ به ارز تراکنش"
 msgid "Amount in {0}"
 msgstr "مبلغ در {0}"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5397,11 +5403,11 @@ msgstr "از آنجایی که فیلد {0} فعال است، مقدار فیل�
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "از آنجایی که تراکنش‌های ارسالی موجود در مقابل آیتم {0} وجود دارد، نمی‌توانید مقدار {1} را تغییر دهید."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "از آنجایی که موجودی منفی وجود دارد، نمی توانید {0} را فعال کنید."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "از آنجایی که موجودی رزرو شده وجود دارد، نمی توانید {0} را غیرفعال کنید."
 
@@ -5413,8 +5419,8 @@ msgstr "از آنجایی که آیتم‌های زیر مونتاژ کافی و
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "از آنجایی که مواد اولیه کافی وجود دارد، درخواست مواد برای انبار {0} لازم نیست."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "از آنجایی که {0} فعال است، نمی توانید {1} را فعال کنید."
 
@@ -5449,7 +5455,7 @@ msgstr "آیتم‌های مونتاژ"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5516,7 +5522,7 @@ msgstr "آیتم موجودی سرمایه گذاری دارایی"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5662,7 +5668,7 @@ msgstr "جابجایی دارایی"
 msgid "Asset Movement Item"
 msgstr "آیتم جابجایی دارایی"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "رکورد جابجایی دارایی {0} ایجاد شد"
 
@@ -5800,7 +5806,7 @@ msgstr "تجزیه و تحلیل ارزش دارایی"
 msgid "Asset cancelled"
 msgstr "دارایی لغو شد"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "دارایی را نمی توان لغو کرد، زیرا قبلاً {0} است"
 
@@ -5820,7 +5826,7 @@ msgstr "دارایی ایجاد شد"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "دارایی ایجاد شده پس از ارسال با حروف بزرگ دارایی {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "دارایی پس از جدا شدن از دارایی {0} ایجاد شد"
 
@@ -5876,7 +5882,7 @@ msgstr "دارایی ارسال شد"
 msgid "Asset transferred to Location {0}"
 msgstr "دارایی به مکان {0} منتقل شد"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "دارایی پس از تقسیم به دارایی {0} به روز شد"
 
@@ -6013,7 +6019,7 @@ msgstr "در ردیف #{0}: مقدار انتخاب شده {1} برای آیتم
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "حداقل یک دارایی باید انتخاب شود."
 
@@ -6046,7 +6052,7 @@ msgstr "حداقل یک انبار اجباری است"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "در ردیف #{0}: شناسه دنباله {1} نمی تواند کمتر از شناسه دنباله ردیف قبلی {2} باشد."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "در ردیف {0}: شماره دسته برای مورد {1} اجباری است"
 
@@ -6054,11 +6060,11 @@ msgstr "در ردیف {0}: شماره دسته برای مورد {1} اجبار�
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "در ردیف {0}: ردیف والد برای آیتم {1} قابل تنظیم نیست"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "در ردیف {0}: مقدار برای دسته {1} اجباری است"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "در ردیف {0}: شماره سریال برای آیتم {1} اجباری است"
 
@@ -6677,7 +6683,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6690,7 +6696,7 @@ msgstr "BOM"
 msgid "BOM 1"
 msgstr "BOM 1"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "BOM 1 {0} و BOM 2 {1} نباید یکسان باشند"
 
@@ -6919,7 +6925,7 @@ msgstr "BOM و مقدار تولید مورد نیاز است"
 msgid "BOM and Production"
 msgstr "BOM و تولید"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "BOM شامل هیچ آیتم موجودی نیست"
@@ -6928,23 +6934,23 @@ msgstr "BOM شامل هیچ آیتم موجودی نیست"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "بازگشت BOM: {0} نمی تواند فرزند {1} باشد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "بازگشت BOM: {1} نمی تواند والد یا فرزند {0} باشد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "BOM {0} به آیتم {1} تعلق ندارد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "BOM {0} باید فعال باشد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "BOM {0} باید ارسال شود"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr "BOM {0} برای آیتم {1} یافت نشد"
 
@@ -7014,7 +7020,7 @@ msgstr "تراز"
 msgid "Balance (Dr - Cr)"
 msgstr "تراز (Dr - Cr)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "تراز ({0})"
 
@@ -7663,7 +7669,7 @@ msgstr "وضعیت انقضای آیتم دسته"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7689,17 +7695,21 @@ msgstr "وضعیت انقضای آیتم دسته"
 msgid "Batch No"
 msgstr "شماره دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr "شماره دسته اجباری است"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "شماره دسته {0} وجود ندارد"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "شماره دسته {0} با آیتم {1} که دارای شماره سریال است پیوند داده شده است. لطفاً شماره سریال را اسکن کنید."
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
 #: erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -7712,7 +7722,7 @@ msgstr "شماره دسته"
 msgid "Batch Nos"
 msgstr "شماره های دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "شماره های دسته با موفقیت ایجاد شد"
 
@@ -7815,7 +7825,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7824,7 +7834,7 @@ msgstr "تاریخ قبض"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7838,7 +7848,7 @@ msgstr "صورتحساب مقدار رد شده در فاکتور خرید"
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7857,8 +7867,8 @@ msgstr "صورتحساب شد"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7879,7 +7889,7 @@ msgstr "مبلغ پرداختی"
 msgid "Billed Items To Be Received"
 msgstr "آیتم‌های صورتحساب شده برای دریافت"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "مقدار صورتحساب شده"
@@ -8282,7 +8292,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "هم تاریخ شروع دوره آزمایشی و هم تاریخ پایان دوره آزمایشی باید تنظیم شوند"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8802,7 +8812,7 @@ msgstr "جزئیات تماس"
 #. Description of the 'Duration' (Duration) field in DocType 'Call Log'
 #: erpnext/telephony/doctype/call_log/call_log.json
 msgid "Call Duration in seconds"
-msgstr "مدت زمان تماس در ثانیه"
+msgstr "مدت زمان تماس بر حسب ثانیه"
 
 #: erpnext/public/js/call_popup/call_popup.js:48
 msgid "Call Ended"
@@ -8969,7 +8979,7 @@ msgstr "برنامه های کمپین"
 msgid "Can be approved by {0}"
 msgstr "قابل تایید توسط {0}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr "نمی توان دستور کار را بست. از آنجایی که کارت کارهای {0} در حالت کار در حال انجام هستند."
 
@@ -8977,7 +8987,7 @@ msgstr "نمی توان دستور کار را بست. از آنجایی که ک
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "در صورت گروه بندی بر اساس صندوقدار، نمی توان بر اساس صندوقدار فیلتر کرد"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr "اگر براساس حساب گروه‌بندی شود، نمی‌توان بر اساس حساب فرزند فیلتر کرد"
 
@@ -8993,7 +9003,7 @@ msgstr "اگر براساس نمایه POS گروه بندی شود، نمی ت�
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "اگر بر اساس روش پرداخت گروه بندی شود، نمی توان بر اساس روش پرداخت فیلتر کرد"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "اگر بر اساس کوپن گروه بندی شود، نمی توان بر اساس شماره کوپن فیلتر کرد"
 
@@ -9008,15 +9018,15 @@ msgstr "فقط می‌توانید با {0} پرداخت نشده انجام د�
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "فقط در صورتی می‌توان ردیف را ارجاع داد که نوع شارژ «بر مبلغ ردیف قبلی» یا «مجموع ردیف قبلی» باشد"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "نمی توان روش ارزش گذاری را تغییر داد، زیرا معاملاتی در برابر برخی اقلام وجود دارد که روش ارزش گذاری خاص خود را ندارند."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9276,7 +9286,7 @@ msgstr "نمی‌توان فهرست انتخابی برای سفارش فروش
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr "نمی توان ورودی های حسابداری را در برابر حساب های غیرفعال ایجاد کرد: {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "نمی توان BOM را غیرفعال یا لغو کرد زیرا با BOM های دیگر مرتبط است"
 
@@ -9297,7 +9307,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "نمی توان شماره سریال {0} را حذف کرد، زیرا در معاملات موجودی استفاده می شود"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9314,7 +9324,7 @@ msgstr "نمی توان از تحویل با شماره سریال اطمینا�
 msgid "Cannot find Item with this Barcode"
 msgstr "نمی توان موردی را با این بارکد پیدا کرد"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9377,11 +9387,11 @@ msgstr "نمی توان مجوز را بر اساس تخفیف برای {0} تن
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "نمی توان چندین مورد پیش فرض را برای یک شرکت تنظیم کرد."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "نمی توان مقدار کمتر از مقدار تحویلی را تنظیم کرد"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "نمی توان مقدار کمتر از مقدار دریافتی را تنظیم کرد"
 
@@ -9944,7 +9954,7 @@ msgstr "عرض چک"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "تاریخ چک / مرجع"
 
@@ -10216,7 +10226,7 @@ msgstr "سند بسته"
 msgid "Closed Documents"
 msgstr "اسناد بسته"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr "دستور کار بسته را نمی توان متوقف کرد یا دوباره باز کرد"
 
@@ -10239,7 +10249,7 @@ msgstr "اختتامیه (بستانکاری)"
 msgid "Closing (Dr)"
 msgstr "اختتامیه (بدهی)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "اختتامیه (افتتاحیه + کل)"
 
@@ -10262,7 +10272,7 @@ msgstr "مبلغ اختتامیه"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "تراز پایانی"
 
@@ -10712,7 +10722,7 @@ msgstr "شرکت ها"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10759,7 +10769,7 @@ msgstr "شرکت ها"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11079,7 +11089,7 @@ msgstr "شرکت و تاریخ ارسال الزامی است"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "ارزهای شرکت هر دو شرکت باید برای معاملات بین شرکتی مطابقت داشته باشد."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "فیلد شرکت الزامی است"
@@ -11934,7 +11944,7 @@ msgid "Content Type"
 msgstr "نوع محتوا"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "ادامه هید"
@@ -12313,12 +12323,13 @@ msgstr "هزینه"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12326,6 +12337,7 @@ msgstr "هزینه"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12454,11 +12466,6 @@ msgstr "هزینه هر واحد"
 msgid "Cost and Freight"
 msgstr "هزینه و حمل‌ونقل"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "هزینه مانند قبل"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "هزینه آیتم‌های تحویل شده"
@@ -12475,14 +12482,6 @@ msgstr "هزینه کالاهای فروخته شده"
 msgid "Cost of Issued Items"
 msgstr "هزینه آیتم‌های حواله شده"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "هزینه خرید جدید"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12491,14 +12490,6 @@ msgstr "گزارش هزینه کیفیت پایین"
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "هزینه آیتم‌های خریداری شده"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "هزینه دارایی اسقاط شده"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "بهای تمام شده دارایی فروخته شده"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12738,7 +12729,7 @@ msgstr "بستانکاری"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12753,7 +12744,7 @@ msgstr "بستانکاری"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12798,7 +12789,7 @@ msgstr "بستانکاری"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12996,7 +12987,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "ایجاد ثبت نمونه ذخیره موجودی"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "ایجاد ثبت موجودی"
 
@@ -13188,11 +13179,11 @@ msgstr ""
 msgid "Credit"
 msgstr "اعتبار"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "اعتبار (تراکنش)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "اعتبار ({0})"
 
@@ -13308,7 +13299,7 @@ msgstr "ماه های اعتباری"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13530,12 +13521,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13648,7 +13639,7 @@ msgstr "واحد پول برای {0} باید {1} باشد"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "واحد پول حساب بسته شده باید {0} باشد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "واحد پول فهرست قیمت {0} باید {1} یا {2} باشد"
 
@@ -14057,7 +14048,7 @@ msgstr "کد مشتری"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14153,11 +14144,11 @@ msgstr "بازخورد مشتری"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14197,7 +14188,7 @@ msgstr "مورد گروه مشتری"
 msgid "Customer Group Name"
 msgstr "نام گروه مشتری"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "گروه مشتری: {0} وجود ندارد"
 
@@ -14216,7 +14207,7 @@ msgstr "مورد مشتری"
 msgid "Customer Items"
 msgstr "آیتم‌های مشتری"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "LPO مشتری"
 
@@ -14262,7 +14253,7 @@ msgstr "شماره موبایل مشتری"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14652,7 +14643,7 @@ msgstr "داده های صادر شده از Tally که شامل نمودار ح
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14742,7 +14733,7 @@ msgstr "تاریخ صدور"
 #. Label of the date_of_joining (Date) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
 msgid "Date of Joining"
-msgstr "تاریخ عضویت"
+msgstr "تاریخ پیوستن"
 
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:265
 msgid "Date of Transaction"
@@ -14750,7 +14741,7 @@ msgstr "تاریخ تراکنش"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:25
 msgid "Date: {0} to {1}"
-msgstr ""
+msgstr "تاریخ: {0} تا {1}"
 
 #. Label of the dates_section (Section Break) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
@@ -14888,11 +14879,11 @@ msgstr "مدیر محترم سیستم"
 msgid "Debit"
 msgstr "بدهی"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "بدهی (تراکنش)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "بدهی ({0})"
 
@@ -14929,7 +14920,7 @@ msgstr "مبلغ بدهی به ارز تراکنش"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15139,7 +15130,7 @@ msgstr "BOM پیش‌فرض ({0}) باید برای این مورد یا الگ�
 msgid "Default BOM for {0} not found"
 msgstr "BOM پیش‌فرض برای {0} یافت نشد"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr "BOM پیش فرض برای آیتم کالای تمام شده {0} یافت نشد"
 
@@ -15970,7 +15961,7 @@ msgstr "یادداشت تحویل {0} ارسال نشده است"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr "یادداشت(های) تحویل برای لیست انتخاب ایجاد شده است"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "یادداشت های تحویل"
@@ -16169,7 +16160,7 @@ msgstr "استهلاک"
 msgid "Depreciation Amount"
 msgstr "مبلغ استهلاک"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "مبلغ استهلاک در طول دوره"
 
@@ -16183,7 +16174,7 @@ msgstr "تاریخ استهلاک"
 msgid "Depreciation Details"
 msgstr "جزئیات استهلاک"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "استهلاک به دلیل واگذاری دارایی ها حذف می شود"
 
@@ -16244,15 +16235,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "ردیف استهلاک {0}: مقدار مورد انتظار پس از عمر مفید باید بزرگتر یا مساوی با {1} باشد."
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "ردیف استهلاک {0}: تاریخ استهلاک بعدی نمی تواند قبل از تاریخ موجود برای استفاده باشد"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "ردیف استهلاک {0}: تاریخ استهلاک بعدی نمی تواند قبل از تاریخ خرید باشد"
 
@@ -16501,7 +16492,7 @@ msgstr "استهلاک برای دارایی های کاملا مستهلک شد
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16684,7 +16675,7 @@ msgstr "حساب تفاوت"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "حساب تفاوت باید یک حساب از نوع دارایی/بدهی باشد، زیرا این ثبت موجودی یک ثبت افتتاحیه است"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "حساب مابه التفاوت باید یک حساب از نوع دارایی/بدهی باشد، زیرا این تطبیق موجودی یک ثبت افتتاحیه است."
 
@@ -17440,7 +17431,7 @@ msgstr "آیا واقعاً می خواهید این دارایی از بین ر
 msgid "Do you still want to enable negative inventory?"
 msgstr "آیا همچنان می خواهید موجودی منفی را فعال کنید؟"
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr "آیا می خواهید {0} انتخاب شده را پاک کنید؟"
 
@@ -17846,7 +17837,7 @@ msgstr "سررسید / تاریخ مرجع نمی تواند بعد از {0} ب�
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17970,7 +17961,7 @@ msgstr "گروه آیتم تکراری در جدول گروه آیتم یافت 
 msgid "Duplicate project has been created"
 msgstr "پروژه تکراری ایجاد شده است"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "تکرار ردیف {0} با همان {1}"
 
@@ -18862,7 +18853,7 @@ msgstr "ورود دستی"
 msgid "Enter Serial Nos"
 msgstr "شماره های سریال را وارد کنید"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "تامین کننده را وارد کنید"
 
@@ -18941,7 +18932,7 @@ msgstr "قبل از ارسال نام بانک یا موسسه وام دهنده
 msgid "Enter the opening stock units."
 msgstr "واحدهای موجودی افتتاحی را وارد کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr "مقدار آیتمی را که از این صورتحساب مواد تولید می شود وارد کنید."
 
@@ -19018,7 +19009,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "خطا"
 
@@ -19265,7 +19256,7 @@ msgstr "مبلغ سود/زیان مبادله از طریق {0} رزرو شده 
 #: erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
 msgid "Exchange Rate"
-msgstr "قیمت ارز"
+msgstr "نرخ تبدیل"
 
 #. Name of a DocType
 #. Option for the 'Entry Type' (Select) field in DocType 'Journal Entry'
@@ -19340,7 +19331,7 @@ msgstr "لوازم معاف"
 
 #: erpnext/setup/setup_wizard/data/marketing_source.txt:5
 msgid "Exhibition"
-msgstr ""
+msgstr "نمایشگاه"
 
 #. Option for the 'Create Chart Of Accounts Based On' (Select) field in DocType
 #. 'Company'
@@ -19585,6 +19576,12 @@ msgstr "هزینه‌های شامل در ارزیابی دارایی"
 #: erpnext/accounts/report/account_balance/account_balance.js:51
 msgid "Expenses Included In Valuation"
 msgstr "هزینه‌های شامل در ارزیابی"
+
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "آزمایشی"
 
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
@@ -19924,7 +19921,7 @@ msgstr "واکشی جدول زمانی"
 msgid "Fetch Value From"
 msgstr "واکشی مقدار از"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "واکشی BOM گسترده شده (شامل زیر مونتاژ ها)"
@@ -19940,13 +19937,13 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "واکشی نرخ ارز ..."
 
 #: erpnext/manufacturing/page/bom_comparison_tool/bom_comparison_tool.js:72
 msgid "Fetching..."
-msgstr ""
+msgstr "در حال دریافت..."
 
 #. Label of the field (Select) field in DocType 'POS Search Fields'
 #: erpnext/accounts/doctype/pos_search_fields/pos_search_fields.json
@@ -20237,15 +20234,15 @@ msgstr "تعداد آیتم کالای تمام شده"
 msgid "Finished Good Item Quantity"
 msgstr "تعداد آیتم کالای تمام شده"
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "آیتم کالای تمام شده برای آیتم سرویس مشخص نشده است {0}"
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "مقدار آیتم کالای تمام شده {0} تعداد نمی تواند صفر باشد"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "آیتم کالای تمام شده {0} باید یک آیتم قرارداد فرعی باشد"
 
@@ -20466,7 +20463,7 @@ msgstr "دارایی ثابت"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20617,7 +20614,7 @@ msgstr "برای خرید"
 msgid "For Company"
 msgstr "برای شرکت"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "برای تامین کننده پیش فرض (اختیاری)"
 
@@ -20678,7 +20675,7 @@ msgstr "برای تامین کننده"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "برای انبار"
@@ -20721,7 +20718,7 @@ msgstr "برای تامین کننده فردی"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "برای مورد {0}، نرخ باید یک عدد مثبت باشد. برای مجاز کردن نرخ‌های منفی، {1} را در {2} فعال کنید"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20982,7 +20979,7 @@ msgstr "از مشتری"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21092,8 +21089,8 @@ msgstr "From Date نمی تواند بزرگتر از To Date باشد"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21469,14 +21466,14 @@ msgstr "گره های بیشتر را فقط می توان تحت گره های 
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "مبلغ پرداخت آینده"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "مرجع پرداخت آینده"
 
@@ -21501,7 +21498,7 @@ msgstr "تراز دفتر کل"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "ثبت در دفتر کل"
 
@@ -21795,7 +21792,7 @@ msgstr "دریافت آیتم‌ها از"
 msgid "Get Items From Purchase Receipts"
 msgstr "دریافت آیتم‌ها از رسید خرید"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22318,7 +22315,7 @@ msgstr "گره گروه"
 msgid "Group Same Items"
 msgstr "گروه بندی آیتم‌های مشابه"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "انبارهای گروهی را نمی توان در معاملات استفاده کرد. لطفا مقدار {0} را تغییر دهید"
 
@@ -22902,7 +22899,7 @@ msgstr "شناسه"
 #. Label of the ip_address (Data) field in DocType 'Contract'
 #: erpnext/crm/doctype/contract/contract.json
 msgid "IP Address"
-msgstr "آدرس آی پی"
+msgstr "آدرس IP"
 
 #. Name of a report
 #: erpnext/regional/report/irs_1099/irs_1099.json
@@ -23758,11 +23755,11 @@ msgstr "موجودی تعداد"
 msgid "In Transit"
 msgstr "در حمل و نقل"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr "در انتقال ترانزیت"
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr "در انبار ترانزیت"
 
@@ -24232,7 +24229,7 @@ msgid "Incorrect Type of Transaction"
 msgstr "نوع تراکنش نادرست"
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "انبار نادرست"
 
@@ -24490,8 +24487,8 @@ msgstr "دستورالعمل ها"
 msgid "Insufficient Capacity"
 msgstr "ظرفیت ناکافی"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "مجوزهای ناکافی"
 
@@ -24740,7 +24737,7 @@ msgstr "تاریخ تکرار خودکار نامعتبر است"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "بارکد نامعتبر هیچ موردی به این بارکد متصل نیست."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "سفارش کلی نامعتبر برای مشتری و آیتم انتخاب شده"
 
@@ -24817,7 +24814,7 @@ msgstr "حساب والد نامعتبر"
 msgid "Invalid Part Number"
 msgstr "شماره قطعه نامعتبر است"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "زمان ارسال نامعتبر است"
 
@@ -24829,7 +24826,7 @@ msgstr "نقش اصلی نامعتبر است"
 msgid "Invalid Priority"
 msgstr "اولویت نامعتبر است"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr "پیکربندی هدررفت فرآیند نامعتبر است"
 
@@ -24837,7 +24834,7 @@ msgstr "پیکربندی هدررفت فرآیند نامعتبر است"
 msgid "Invalid Purchase Invoice"
 msgstr "فاکتور خرید نامعتبر"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "تعداد نامعتبر است"
 
@@ -24845,9 +24842,9 @@ msgstr "تعداد نامعتبر است"
 msgid "Invalid Quantity"
 msgstr "مقدار نامعتبر"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "زمانبندی نامعتبر است"
 
@@ -24859,7 +24856,7 @@ msgstr "قیمت فروش نامعتبر"
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "URL نامعتبر است"
 
@@ -24884,7 +24881,7 @@ msgstr "دلیل از دست رفتن نامعتبر {0}، لطفاً یک دل�
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "سری نام‌گذاری نامعتبر (. از دست رفته) برای {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "مرجع نامعتبر {0} {1}"
 
@@ -24908,7 +24905,7 @@ msgstr "{0} نامعتبر است"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "{0} برای تراکنش بین شرکتی نامعتبر است."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "نامعتبر {0}: {1}"
@@ -24976,7 +24973,7 @@ msgstr "تاریخ فاکتور"
 msgid "Invoice Discounting"
 msgstr "تخفیف فاکتور"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "فاکتور گرند توتال"
 
@@ -25065,9 +25062,9 @@ msgstr "برای ساعت صورتحساب صفر نمی توان فاکتور �
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "مبلغ فاکتور"
 
@@ -25612,7 +25609,7 @@ msgstr "قرارداد فرعی است"
 #. Label of the is_system_generated (Check) field in DocType 'Journal Entry'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
 msgid "Is System Generated"
-msgstr "سیستم تولید شده است"
+msgstr "تولید شده توسط سیستم است"
 
 #. Label of the is_tax_withholding_account (Check) field in DocType 'Purchase
 #. Taxes and Charges'
@@ -25764,7 +25761,7 @@ msgstr "صدور را نمی توان به یک مکان انجام داد. لط
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "ممکن است چند ساعت طول بکشد تا ارزش موجودی دقیق پس از ادغام اقلام قابل مشاهده باشد."
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "برای واکشی جزئیات آیتم نیاز است."
 
@@ -25816,7 +25813,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26058,7 +26055,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26089,7 +26086,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26516,7 +26513,7 @@ msgstr "تولید کننده آیتم"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26875,7 +26872,7 @@ msgstr "نام آیتم"
 msgid "Item operation"
 msgstr "عملیات آیتم"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "تعداد مورد را نمی توان به روز کرد زیرا مواد خام قبلاً پردازش شده است."
 
@@ -26914,7 +26911,7 @@ msgstr "مورد {0} را نمی توان بیش از {1} در مقابل سفا
 msgid "Item {0} does not exist"
 msgstr "آیتم {0} وجود ندارد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "مورد {0} در سیستم وجود ندارد یا منقضی شده است"
 
@@ -27002,7 +26999,7 @@ msgstr "مورد {0}: تعداد سفارش‌شده {1} نمی‌تواند ک�
 msgid "Item {0}: {1} qty produced. "
 msgstr "آیتم {0}: مقدار {1} تولید شده است. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "مورد {} وجود ندارد."
 
@@ -27039,7 +27036,7 @@ msgstr "تاریخچه فروش بر حسب آیتم"
 msgid "Item-wise Sales Register"
 msgstr "ثبت فروش بر حسب آیتم"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "مورد: {0} در سیستم وجود ندارد"
 
@@ -27144,7 +27141,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr "آیتم‌ها و قیمت"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "موارد را نمی توان به روز کرد زیرا سفارش قرارداد فرعی در برابر سفارش خرید {0} ایجاد شده است."
 
@@ -27353,7 +27350,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "کارت کار {0} ایجاد شد"
 
@@ -28974,11 +28971,11 @@ msgstr "مدیر عامل"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30322,7 +30319,7 @@ msgstr "هزینه های متفرقه"
 msgid "Mismatch"
 msgstr "عدم تطابق"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr "جا افتاده"
 
@@ -30380,7 +30377,7 @@ msgstr "مقادیر از دست رفته الزامی است"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "الگوی ایمیل برای ارسال وجود ندارد. لطفاً یکی را در تنظیمات تحویل تنظیم کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr "مقدار از دست رفته"
@@ -30861,7 +30858,7 @@ msgstr "موسیقی"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "باید عدد کامل باشد"
 
@@ -30894,7 +30891,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31032,11 +31029,11 @@ msgstr "گاز طبیعی"
 msgid "Needs Analysis"
 msgstr "نیاز به تحلیل دارد"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "مقدار منفی مجاز نیست"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "نرخ ارزش گذاری منفی مجاز نیست"
 
@@ -31114,8 +31111,8 @@ msgstr "مبلغ خالص"
 msgid "Net Amount (Company Currency)"
 msgstr "مبلغ خالص (ارز شرکت)"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "ارزش خالص دارایی به عنوان"
 
@@ -31686,7 +31683,7 @@ msgstr "هیچ تامین کننده ای برای Inter Company Transactions ی
 msgid "No Tax Withholding data found for the current posting date."
 msgstr "هیچ داده کسر مالیات برای تاریخ ارسال فعلی یافت نشد."
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr "بدون شرایط"
 
@@ -31871,15 +31868,15 @@ msgstr ""
 msgid "No record found"
 msgstr "هیچ رکوردی پیدا نشد"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr "هیچ رکوردی در جدول تخصیص یافت نشد"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr "هیچ رکوردی در جدول فاکتورها یافت نشد"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr "هیچ رکوردی در جدول پرداخت ها یافت نشد"
 
@@ -31927,7 +31924,7 @@ msgstr "عدم انطباق"
 msgid "Non Profit"
 msgstr "غیر انتفاعی"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "آیتم‌های غیر موجودی"
 
@@ -31941,7 +31938,7 @@ msgstr "غیر صفرها"
 msgid "None"
 msgstr "هیچ کدام"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "هیچ یک از آیتم‌ها هیچ تغییری در مقدار یا ارزش ندارند."
 
@@ -32056,8 +32053,8 @@ msgstr "موجود نیست"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32079,7 +32076,7 @@ msgstr "غیر مجاز"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "یادداشت"
@@ -32748,7 +32745,7 @@ msgstr "باز کردن سفارش‌های کاری"
 msgid "Open a new ticket"
 msgstr "یک بلیط جدید باز کنید"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "افتتاح"
@@ -32780,7 +32777,7 @@ msgstr "افتتاحیه (بدهی)"
 msgid "Opening Accumulated Depreciation"
 msgstr "گشایش استهلاک انباشته"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr "استهلاک انباشته افتتاحیه باید کمتر یا مساوی با {0} باشد."
 
@@ -32794,7 +32791,7 @@ msgstr "استهلاک انباشته افتتاحیه باید کمتر یا م
 msgid "Opening Amount"
 msgstr "مبلغ افتتاحیه"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "تراز افتتاحیه"
 
@@ -32924,7 +32921,7 @@ msgstr "هزینه عملیاتی (ارز شرکت)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr "هزینه عملیاتی به ازای هر مقدار BOM"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "هزینه عملیاتی بر اساس دستور کار / BOM"
 
@@ -32954,7 +32951,7 @@ msgstr "هزینه های عملیاتی"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33080,7 +33077,7 @@ msgstr "عملیات"
 msgid "Operations Routing"
 msgstr "مسیریابی عملیات"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "عملیات را نمی توان خالی گذاشت"
 
@@ -33593,7 +33590,7 @@ msgstr "معوق"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34148,9 +34145,9 @@ msgstr "پرداخت شده"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34599,12 +34596,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34625,7 +34622,7 @@ msgstr "طرف"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "حساب طرف"
 
@@ -34758,12 +34755,12 @@ msgstr "مورد خاص طرف"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34890,7 +34887,7 @@ msgid "Payable"
 msgstr "پرداختنی"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35332,7 +35329,7 @@ msgstr "برنامه زمانی پرداخت"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35570,13 +35567,13 @@ msgstr "فعالیت های معلق"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "مبلغ معلق"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35865,8 +35862,8 @@ msgstr "موجودی دائمی برای شرکت {0} برای مشاهده ای
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "شخصی"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36479,7 +36476,7 @@ msgstr "لطفاً حساب را برای تغییر مبلغ وارد کنید"
 msgid "Please enter Approving Role or Approving User"
 msgstr "لطفاً نقش تأیید یا تأیید کاربر را وارد کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "لطفا مرکز هزینه را وارد کنید"
 
@@ -36491,7 +36488,7 @@ msgstr "لطفا تاریخ تحویل را وارد کنید"
 msgid "Please enter Employee Id of this sales person"
 msgstr "لطفا شناسه کارمند این فروشنده را وارد کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "لطفا حساب هزینه را وارد کنید"
 
@@ -36500,7 +36497,7 @@ msgstr "لطفا حساب هزینه را وارد کنید"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "لطفا کد مورد را برای دریافت شماره دسته وارد کنید"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "لطفا کد مورد را برای دریافت شماره دسته وارد کنید"
 
@@ -36794,7 +36791,7 @@ msgstr "لطفاً قبل از انتخاب طرف، تاریخ ارسال را 
 msgid "Please select Posting Date first"
 msgstr "لطفا ابتدا تاریخ ارسال را انتخاب کنید"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "لطفا لیست قیمت را انتخاب کنید"
 
@@ -36822,7 +36819,7 @@ msgstr "لطفاً به جای سفارش خرید، سفارش قرارداد �
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "لطفاً حساب سود / زیان تحقق نیافته را انتخاب کنید یا حساب سود / زیان پیش فرض را برای شرکت اضافه کنید {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "لطفا یک BOM را انتخاب کنید"
 
@@ -36831,10 +36828,10 @@ msgid "Please select a Company"
 msgstr "لطفا یک شرکت را انتخاب کنید"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "لطفا ابتدا یک شرکت را انتخاب کنید."
 
@@ -36984,7 +36981,7 @@ msgid "Please select {0}"
 msgstr "لطفاً {0} را انتخاب کنید"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "لطفاً ابتدا {0} را انتخاب کنید"
@@ -37054,7 +37051,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr "لطفاً حساب دارایی ثابت را در {} در مقابل {} تنظیم کنید."
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37179,7 +37176,7 @@ msgstr "لطفا فیلترها را تنظیم کنید"
 msgid "Please set one of the following:"
 msgstr "لطفا یکی از موارد زیر را تنظیم کنید:"
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "لطفاً پس از ذخیره، تکرار شونده را تنظیم کنید"
 
@@ -37209,7 +37206,7 @@ msgstr "لطفاً برنامه کمپین را در کمپین {0} تنظیم �
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "لطفاً {0} را تنظیم کنید"
@@ -37242,7 +37239,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "لطفاً این ایمیل را با تیم پشتیبانی خود به اشتراک بگذارید تا آنها بتوانند مشکل را پیدا کرده و برطرف کنند."
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "لطفا مشخص کنید"
 
@@ -37262,7 +37259,7 @@ msgstr "لطفاً شرکت را برای ادامه مشخص کنید"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "لطفاً یک شناسه ردیف معتبر برای ردیف {0} در جدول {1} مشخص کنید"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr "لطفاً یک {0} را مشخص کنید"
 
@@ -37270,7 +37267,7 @@ msgstr "لطفاً یک {0} را مشخص کنید"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "لطفا حداقل یک ویژگی را در جدول Attributes مشخص کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "لطفاً مقدار یا نرخ ارزش گذاری یا هر دو را مشخص کنید"
 
@@ -37450,14 +37447,14 @@ msgstr "هزینه های پستی"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37946,7 +37943,7 @@ msgstr "قیمت هر واحد ({0})"
 msgid "Price is not set for the item."
 msgstr "قیمت برای آیتم تعیین نشده است."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "قیمت مورد {0} در لیست قیمت {1} یافت نشد"
 
@@ -38477,7 +38474,7 @@ msgstr "فرآیند ناموفق بود"
 msgid "Process Loss"
 msgstr "هدررفت فرآیند"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr "درصد هدررفت فرآیند نمی تواند بیشتر از 100 باشد"
 
@@ -38974,9 +38971,10 @@ msgstr "پیشرفت (%)"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38984,6 +38982,7 @@ msgstr "پیشرفت (%)"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38995,7 +38994,7 @@ msgstr "پیشرفت (%)"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39614,7 +39613,7 @@ msgstr "مدیر ارشد خرید"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -39994,7 +39993,7 @@ msgstr "خرید"
 #: erpnext/buying/doctype/supplier_scorecard_scoring_standing/supplier_scorecard_scoring_standing.json
 #: erpnext/buying/doctype/supplier_scorecard_standing/supplier_scorecard_standing.json
 msgid "Purple"
-msgstr "رنگ بنفش"
+msgstr "بنفش"
 
 #. Label of the purpose (Select) field in DocType 'Asset Movement'
 #. Label of the material_request_type (Select) field in DocType 'Material
@@ -40074,12 +40073,12 @@ msgstr "قانون Putaway از قبل برای مورد {0} در انبار {1}
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40187,7 +40186,7 @@ msgstr "تعداد در هر واحد"
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40282,7 +40281,7 @@ msgstr "تعداد مواد خام بر اساس تعداد کالاهای نه�
 msgid "Qty to Be Consumed"
 msgstr "مقدار قابل مصرف"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "مقدار برای صورتحساب"
@@ -40620,7 +40619,7 @@ msgstr "هدف بررسی کیفیت"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40637,7 +40636,7 @@ msgstr "هدف بررسی کیفیت"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40758,11 +40757,11 @@ msgstr "مقدار نباید بیشتر از {0} باشد"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "مقدار آیتم به دست آمده پس از تولید / بسته بندی مجدد از مقادیر معین مواد اولیه"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "مقدار مورد نیاز برای مورد {0} در ردیف {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40777,7 +40776,7 @@ msgstr "مقدار برای ساخت"
 msgid "Quantity to Manufacture"
 msgstr "مقدار برای تولید"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "مقدار برای تولید نمی تواند برای عملیات صفر باشد {0}"
 
@@ -41448,7 +41447,7 @@ msgstr "انبار مواد اولیه"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41507,7 +41506,7 @@ msgstr "هزینه تامین مواد اولیه"
 msgid "Raw Materials Warehouse"
 msgstr "انبار مواد اولیه"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "مواد خام نمی تواند خالی باشد."
 
@@ -41702,7 +41701,7 @@ msgid "Receivable / Payable Account"
 msgstr "حساب دریافتنی / پرداختنی"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41796,7 +41795,7 @@ msgstr "دریافت شد"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41807,7 +41806,7 @@ msgstr "دریافت شد"
 msgid "Received Qty"
 msgstr "تعداد دریافت شده"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "مبلغ مقدار دریافتی"
 
@@ -42157,7 +42156,7 @@ msgstr "مرجع #{0} به تاریخ {1}"
 msgid "Reference Date"
 msgstr "تاریخ مرجع"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr "تاریخ مرجع برای تخفیف پرداخت زودهنگام"
 
@@ -42580,7 +42579,7 @@ msgstr "باقی مانده است"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "موجودی باقی مانده"
@@ -42633,9 +42632,9 @@ msgstr "ملاحظات"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42669,7 +42668,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "آیتم‌های حذف شده بدون تغییر در مقدار یا ارزش."
 
@@ -43136,7 +43135,7 @@ msgstr "درخواست کننده"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44167,11 +44166,11 @@ msgstr "مسیریابی"
 msgid "Routing Name"
 msgstr "نام مسیریابی"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "ردیف #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "ردیف شماره {0}:"
 
@@ -44263,23 +44262,23 @@ msgstr "ردیف #{0}: شماره دسته {1} قبلاً انتخاب شده ا
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "ردیف #{0}: نمی توان بیش از {1} را در مقابل مدت پرداخت {2} تخصیص داد"
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که قبلاً صورتحساب شده است حذف کرد."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "ردیف #{0}: نمی توان مورد {1} را که قبلاً تحویل داده شده حذف کرد"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "ردیف #{0}: نمی توان مورد {1} را که قبلاً دریافت کرده است حذف کرد"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "ردیف #{0}: نمی توان مورد {1} را که دستور کار به آن اختصاص داده است حذف کرد."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "ردیف #{0}: نمی توان مورد {1} را که به سفارش خرید مشتری اختصاص داده است حذف کرد."
 
@@ -44287,7 +44286,7 @@ msgstr "ردیف #{0}: نمی توان مورد {1} را که به سفارش خ
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "ردیف #{0}: هنگام تامین مواد خام به پیمانکار فرعی، نمی توان انبار تامین کننده را انتخاب کرد"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "ردیف #{0}: اگر مبلغ بیشتر از مبلغ صورتحساب مورد {1} باشد، نمی‌توان نرخ را تنظیم کرد."
 
@@ -44395,7 +44394,7 @@ msgstr "ردیف #{0}: مورد {1} وجود ندارد"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "ردیف #{0}: مورد {1} انتخاب شده است، لطفاً موجودی را از فهرست انتخاب رزرو کنید."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "ردیف #{0}: آیتم {1} یک آیتم سریال/دسته‌ای نیست. نمی تواند یک شماره سریال / شماره دسته در مقابل آن داشته باشد."
 
@@ -44473,7 +44472,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "ردیف #{0}: مقدار آیتم {1} نمی تواند صفر باشد."
 
@@ -44481,8 +44480,8 @@ msgstr "ردیف #{0}: مقدار آیتم {1} نمی تواند صفر باشد
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr "ردیف #{0}: مقدار قابل رزرو برای مورد {1} باید بیشتر از 0 باشد."
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr "ردیف #{0}: نرخ باید مانند {1} باشد: {2} ({3} / {4})"
 
@@ -44758,11 +44757,11 @@ msgstr "ردیف {0}: پیش پرداخت در برابر مشتری باید ا
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "ردیف {0}: پیش پرداخت در مقابل تامین کننده باید بدهکار باشد"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "ردیف {0}: مبلغ تخصیص یافته {1} باید کمتر یا برابر با مبلغ معوق فاکتور {2} باشد."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "ردیف {0}: مبلغ تخصیص یافته {1} باید کمتر یا مساوی با مبلغ پرداخت باقی مانده باشد {2}"
 
@@ -44795,7 +44794,7 @@ msgstr "ردیف {0}: مرکز هزینه برای یک مورد {1} لازم ا
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "ردیف {0}: ثبت اعتبار را نمی توان با {1} پیوند داد"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "ردیف {0}: واحد پول BOM #{1} باید برابر با ارز انتخابی {2} باشد."
 
@@ -44807,7 +44806,7 @@ msgstr "ردیف {0}: ورودی بدهی را نمی توان با یک {1} پ�
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "ردیف {0}: انبار تحویل ({1}) و انبار مشتری ({2}) نمی توانند یکسان باشند"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "ردیف {0}: تاریخ شروع استهلاک الزامی است"
 
@@ -44828,7 +44827,7 @@ msgstr "ردیف {0}: مکان مورد دارایی را وارد کنید {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "ردیف {0}: نرخ ارز اجباری است"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "ردیف {0}: ارزش مورد انتظار پس از عمر مفید باید کمتر از مبلغ ناخالص خرید باشد"
 
@@ -44998,7 +44997,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr "ردیف {0}: برای تنظیم تناوب {1}، تفاوت بین تاریخ و تاریخ باید بزرگتر یا مساوی با {2} باشد."
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -45006,7 +45005,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "ردیف {0}: ضریب تبدیل UOM اجباری است"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45035,7 +45034,7 @@ msgstr "ردیف {0}: {1} {2} با {3} مطابقت ندارد"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "ردیف {1}: مقدار ({0}) نمی تواند کسری باشد. برای اجازه دادن به این کار، \"{2}\" را در UOM {3} غیرفعال کنید."
 
@@ -45673,7 +45672,7 @@ msgstr "سفارش‌های فروش برای تحویل"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45771,7 +45770,7 @@ msgstr "خلاصه پرداخت فروش"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45857,7 +45856,7 @@ msgstr "ثبت نام فروش"
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "بازگشت فروش"
@@ -46044,7 +46043,7 @@ msgstr "همان شرکت بیش از یک بار وارد می شود"
 msgid "Same Item"
 msgstr "آیتم مشابه"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr "همان کالا و ترکیب انبار قبلا وارد شده است."
 
@@ -46071,7 +46070,7 @@ msgstr "انبار نگهداری نمونه"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "اندازه‌ی نمونه"
@@ -46607,7 +46606,7 @@ msgstr "موارد را انتخاب کنید"
 msgid "Select Items based on Delivery Date"
 msgstr "آیتم‌ها را بر اساس تاریخ تحویل انتخاب کنید"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr "موارد را برای بازرسی کیفیت انتخاب کنید"
 
@@ -46711,7 +46710,7 @@ msgstr "یک اولویت پیش فرض را انتخاب کنید."
 msgid "Select a Supplier"
 msgstr "یک تامین کننده انتخاب کنید"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "یک تامین کننده از تامین کنندگان پیش فرض موارد زیر انتخاب کنید. در صورت انتخاب، یک سفارش خرید فقط در برابر اقلام متعلق به تامین کننده منتخب انجام می شود."
 
@@ -46757,7 +46756,7 @@ msgstr "کتاب مالی را برای مورد {0} در ردیف {1} انتخ�
 msgid "Select item group"
 msgstr "انتخاب گروه آیتم"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "انتخاب آیتم الگو"
 
@@ -46774,7 +46773,7 @@ msgstr "ایستگاه کاری پیش‌فرض را که در آن عملیات
 msgid "Select the Item to be manufactured."
 msgstr "موردی را که باید تولید شود انتخاب کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "موردی را که باید تولید شود انتخاب کنید. نام مورد، UoM، شرکت و ارز به طور خودکار واکشی می شود."
 
@@ -46795,11 +46794,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr "تاریخ و منطقه زمانی خود را انتخاب کنید"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr "مواد خام (آیتم‌ها) مورد نیاز برای تولید آیتم را انتخاب کنید"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "کد آیتم گونه را برای آیتم الگو انتخاب کنید {0}"
 
@@ -47117,7 +47116,7 @@ msgstr "شماره های سریال / دسته ای"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47203,7 +47202,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr "شماره سریال و دسته ای برای Finished Good"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr "شماره سریال اجباری است"
 
@@ -47232,13 +47231,17 @@ msgstr "شماره سریال {0} به آیتم {1} تعلق ندارد"
 msgid "Serial No {0} does not exist"
 msgstr "شماره سریال {0} وجود ندارد"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr "شماره سریال {0} وجود ندارد"
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
 msgstr "شماره سریال {0} قبلاً اضافه شده است"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
 msgid "Serial No {0} is under maintenance contract upto {1}"
@@ -47277,7 +47280,7 @@ msgstr "عدم تطابق شماره های سریال"
 msgid "Serial Nos and Batches"
 msgstr "شماره های سریال و دسته ها"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr "شماره های سریال با موفقیت ایجاد شد"
 
@@ -47350,11 +47353,11 @@ msgstr "سریال و دسته"
 msgid "Serial and Batch Bundle"
 msgstr "باندل سریال و دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr "باندل سریال و دسته ایجاد شد"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr "باندل سریال و دسته به روز شد"
 
@@ -47701,12 +47704,12 @@ msgid "Service Stop Date"
 msgstr "تاریخ توقف خدمات"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "تاریخ توقف سرویس نمی تواند بعد از تاریخ پایان سرویس باشد"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "تاریخ توقف سرویس نمی تواند قبل از تاریخ شروع سرویس باشد"
 
@@ -47802,7 +47805,7 @@ msgstr "تنظیم رمز عبور"
 msgid "Set Posting Date"
 msgstr "تاریخ ارسال را تنظیم کنید"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr "تنظیم مقدار آیتم هدررفت فرآیند"
 
@@ -47816,7 +47819,7 @@ msgstr "تنظیم وضعیت پروژه"
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "پروژه و همه تسک‌ها روی وضعیت {0} تنظیم شود؟"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "تنظیم مقدار"
 
@@ -47911,7 +47914,7 @@ msgstr "تنظیم حساب پیش‌فرض {0} را برای آیتم‌های 
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr "نام فیلدی را که می‌خواهید داده‌ها را از فرم والد دریافت کنید، تنظیم کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr "تنظیم مقدار آیتم هدررفت فرآیند:"
 
@@ -47941,15 +47944,15 @@ msgstr "وضعیت را به صورت دستی تنظیم کنید."
 msgid "Set this if the customer is a Public Administration company."
 msgstr "اگر مشتری یک شرکت مدیریت دولتی است، این را تنظیم کنید."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr "تنظیم {0} در دسته دارایی {1} برای شرکت {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "تنظیم {0} در دسته دارایی {1} یا شرکت {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "تنظیم {0} در شرکت {1}"
 
@@ -48016,7 +48019,7 @@ msgstr "تنظیم حساب به عنوان حساب شرکت برای تسوی�
 msgid "Setting up company"
 msgstr "راه‌اندازی شرکت"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr "تنظیم {} مورد نیاز است"
@@ -48821,15 +48824,15 @@ msgstr "فروخته شده توسط"
 msgid "Something went wrong please try again"
 msgstr "اشتباهی رخ داده لطفا دوباره تلاش کنید"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "با عرض پوزش، این کد تخفیف دیگر معتبر نیست"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "با عرض پوزش، اعتبار این کد تخفیف منقضی شده است"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "با عرض پوزش، اعتبار این کد تخفیف شروع نشده است"
 
@@ -48911,7 +48914,7 @@ msgstr "نوع منبع"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49031,7 +49034,7 @@ msgstr "تقسیم مشکل"
 msgid "Split Qty"
 msgstr "تقسیم تعداد"
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr "مقدار تقسیم نمی‌تواند بیشتر یا مساوی تعداد دارایی باشد"
 
@@ -49456,7 +49459,7 @@ msgstr "حالت"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49954,7 +49957,7 @@ msgstr "تنظیمات ارسال مجدد موجودی"
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49963,10 +49966,10 @@ msgstr "تنظیمات ارسال مجدد موجودی"
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr "رزرو موجودی"
 
@@ -50806,7 +50809,7 @@ msgstr "تنظیمات موفقیت"
 msgid "Successful"
 msgstr "موفقیت آمیز"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "با موفقیت تطبیق کرد"
 
@@ -51018,7 +51021,7 @@ msgstr "مقدار عرضه شده"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51122,9 +51125,9 @@ msgstr "جزئیات تامین کننده"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51177,7 +51180,7 @@ msgstr "تاریخ فاکتور تامین کننده نمی تواند بیشت
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "شماره فاکتور تامین کننده"
@@ -51222,7 +51225,7 @@ msgstr "خلاصه دفتر کل تامین کننده"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52838,11 +52841,11 @@ msgstr "الگوی شرایط و ضوابط"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53218,7 +53221,7 @@ msgstr "اشتراک‌گذاری‌ها با {0} وجود ندارند"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "موجودی برای اقلام و انبارهای زیر رزرو شده است، همان را در {0} تطبیق موجودی لغو کنید: <br /><br /> {1}"
 
@@ -53231,11 +53234,11 @@ msgstr "همگام سازی در پس زمینه شروع شده است، لطف
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "تسک به عنوان یک کار پس زمینه در نوبت قرار گرفته است. در صورت وجود هرگونه مشکل در پردازش در پس‌زمینه، سیستم نظری در مورد خطا در این تطبیق موجودی اضافه می‌کند و به مرحله پیش‌نویس باز می‌گردد."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "تسک به عنوان یک کار پس زمینه در نوبت قرار گرفته است. در صورت وجود هرگونه مشکل در پردازش در پس‌زمینه، سیستم نظری در مورد خطا در این تطبیق موجودی اضافه می‌کند و به مرحله ارسال باز می‌گردد."
 
@@ -53289,7 +53292,7 @@ msgstr "{0} {1} با موفقیت ایجاد شد"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr "{0} {1} برای محاسبه هزینه ارزیابی کالای نهایی {2} استفاده می‌شود."
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "تعمیر و نگهداری یا تعمیرات فعال در برابر دارایی وجود دارد. قبل از لغو دارایی، باید همه آنها را تکمیل کنید."
 
@@ -53563,7 +53566,7 @@ msgstr "این برنامه زمانی ایجاد شد که دارایی {0} ل�
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr "این برنامه زمانی ایجاد شد که دارایی {0} از طریق فاکتور فروش {1} فروخته شد."
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr "این برنامه زمانی ایجاد شد که دارایی {0} پس از تقسیم به دارایی جدید {1} به روز شد."
 
@@ -53579,7 +53582,7 @@ msgstr "این برنامه زمانی ایجاد شد که تعدیل ارزش 
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr "این برنامه زمانی ایجاد شد که تغییرات دارایی {0} از طریق تخصیص تغییر دارایی {1} تنظیم شد."
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr "این برنامه زمانی ایجاد شد که دارایی جدید {0} از دارایی {1} جدا شد."
 
@@ -53782,7 +53785,7 @@ msgstr "جدول زمانی"
 msgid "Timer"
 msgstr "تایمر"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "تایمر از ساعت های داده شده بیشتر شد."
 
@@ -53984,7 +53987,7 @@ msgstr "به ارز"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54283,7 +54286,7 @@ msgstr "به انبار"
 msgid "To Warehouse (Optional)"
 msgstr "به انبار (اختیاری)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr "برای افزودن عملیات، کادر \"با عملیات\" را علامت بزنید."
 
@@ -54358,7 +54361,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr "برای استفاده از یک کتاب مالی متفاوت، لطفاً علامت «شامل دارایی‌های پیش‌فرض FB» را بردارید."
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr "برای استفاده از یک کتاب مالی متفاوت، لطفاً علامت «شامل ورودی‌های پیش‌فرض FB» را بردارید."
@@ -54459,7 +54462,7 @@ msgstr "Torr"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56012,7 +56015,7 @@ msgstr "UPC-A"
 msgid "URL"
 msgstr "URL"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "URL فقط می تواند یک رشته باشد"
 
@@ -56622,7 +56625,7 @@ msgstr "از ارسال مجدد بر اساس آیتم استفاده کنید"
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56671,6 +56674,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
 msgstr "از فیلدهای شماره سریال / دسته استفاده کنید"
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
+msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
 #. 'Purchase Invoice'
@@ -57084,7 +57093,7 @@ msgstr "نرخ ارزش گذاری برای آیتم {0}، برای انجام �
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "در صورت ثبت موجودی افتتاحیه، نرخ ارزش گذاری الزامی است"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "نرخ ارزش گذاری مورد نیاز برای مورد {0} در ردیف {1}"
 
@@ -57094,7 +57103,7 @@ msgstr "نرخ ارزش گذاری مورد نیاز برای مورد {0} در 
 msgid "Valuation and Total"
 msgstr "ارزش گذاری و کل"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "نرخ ارزش گذاری برای آیتم‌های ارائه شده توسط مشتری صفر تعیین شده است."
 
@@ -57180,6 +57189,11 @@ msgstr "مقدار یا مقدار"
 msgid "Value Proposition"
 msgstr "گزاره ارزش"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "مقدار ویژگی {0} باید در محدوده {1} تا {2} با افزایش {3} برای آیتم{4} باشد"
@@ -57188,6 +57202,22 @@ msgstr "مقدار ویژگی {0} باید در محدوده {1} تا {2} با �
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
 msgstr "ارزش کالاها"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
+msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
 msgid "Value of goods cannot be 0"
@@ -57268,7 +57298,7 @@ msgid "Variant Field"
 msgstr "فیلد گونه"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "آیتم گونه"
 
@@ -57566,11 +57596,11 @@ msgstr "نام کوپن"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57596,7 +57626,7 @@ msgstr "نام کوپن"
 msgid "Voucher No"
 msgstr "شماره کوپن"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57608,7 +57638,7 @@ msgstr "مقدار کوپن"
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr "زیرنوع کوپن"
 
@@ -57638,9 +57668,9 @@ msgstr "زیرنوع کوپن"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57808,7 +57838,7 @@ msgstr "مراجعه حضوری"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57993,7 +58023,7 @@ msgstr "انبار اجباری است"
 msgid "Warehouse not found against the account {0}"
 msgstr "انبار در برابر حساب {0} پیدا نشد"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "انباری در سیستم یافت نشد"
 
@@ -58119,7 +58149,7 @@ msgstr "هشدار برای درخواست جدید برای پیش فاکتور
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "هشدار"
 
@@ -58139,7 +58169,7 @@ msgstr "هشدار!"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "هشدار: یک {0} # {1} دیگر در برابر ثبت موجودی {2} وجود دارد"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "هشدار: تعداد مواد درخواستی کمتر از حداقل تعداد سفارش است"
 
@@ -58672,8 +58702,8 @@ msgstr "دستور کار به دلایل زیر ایجاد نمی شود: <br> 
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "دستور کار را نمی توان در برابر یک الگوی آیتم مطرح کرد"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "دستور کار {0} بوده است"
 
@@ -59033,7 +59063,7 @@ msgstr "سالانه"
 #: erpnext/buying/doctype/supplier_scorecard_scoring_standing/supplier_scorecard_scoring_standing.json
 #: erpnext/buying/doctype/supplier_scorecard_standing/supplier_scorecard_standing.json
 msgid "Yellow"
-msgstr "رنگ زرد"
+msgstr "زرد"
 
 #. Option for the 'Frozen' (Select) field in DocType 'Account'
 #. Option for the 'Is Opening' (Select) field in DocType 'GL Entry'
@@ -59085,7 +59115,7 @@ msgstr "بله"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "شما مجاز به به روز رسانی طبق شرایط تنظیم شده در {} گردش کار نیستید."
 
@@ -59150,11 +59180,15 @@ msgstr "می توانید آن را به عنوان نام ماشین یا نو�
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "از آنجایی که دستور کار بسته شده است، نمی توانید هیچ تغییری در کارت کار ایجاد کنید."
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr "نمی‌توانید امتیازهای وفاداری را که ارزش بیشتری از مجموع گرد شده دارند، پس‌خرید کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr "اگر BOM در برابر هر موردی ذکر شده باشد، نمی توانید نرخ را تغییر دهید."
 
@@ -59206,7 +59240,7 @@ msgstr "شما نمی توانید سفارش را بدون پرداخت ارس�
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "شما مجوز {} مورد در {} را ندارید."
 
@@ -59358,7 +59392,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr "به عنوان درصدی از مقدار کالای تمام شده"
 
@@ -59694,7 +59728,7 @@ msgstr "{0} <b>{1}</b> دارایی‌ها را ارسال کرده است. بر
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} حساب در مقابل مشتری پیدا نشد {1}."
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59702,7 +59736,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr "{0} بودجه برای حساب {1} در برابر {2} {3} {4} است. {5} از {6} بیشتر است"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "{0} کوپن استفاده شده {1} است. مقدار مجاز تمام شده است"
 
@@ -59762,7 +59796,7 @@ msgstr "{0} در حال حاضر یک روش والدین {1} دارد."
 msgid "{0} and {1}"
 msgstr "{0} و {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} و {1} اجباری هستند"
@@ -59853,7 +59887,7 @@ msgstr "{0} مسدود شده است بنابراین این تراکنش نمی
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59935,7 +59969,7 @@ msgstr "{0} باید در سند برگشتی منفی باشد"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr "{0} مجاز به معامله با {1} نیست. لطفاً شرکت را تغییر دهید یا شرکت را در بخش \"مجاز برای معامله با\" در رکورد مشتری اضافه کنید."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} برای آیتم {1} یافت نشد"
 
@@ -59951,7 +59985,7 @@ msgstr "{0} ورودی های پرداخت را نمی توان با {1} فیل�
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr "{0} تعداد مورد {1} در انبار {2} با ظرفیت {3} در حال دریافت است."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} واحد برای مورد {1} در انبار {2} رزرو شده است، لطفاً همان را در {3} تطبیق موجودی لغو کنید."
 

--- a/erpnext/locale/fr.po
+++ b/erpnext/locale/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: French\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "% Méthode Complète"
 msgid "% Completed"
 msgstr "% complété"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr ""
@@ -877,7 +877,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr "Quantité acceptée en UOM de Stock"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1181,7 +1181,7 @@ msgstr "Selon CEFACT/ICG/2010/IC013 ou CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1400,7 +1400,7 @@ msgstr "Le compte est obligatoire pour obtenir les entrées de paiement"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "Le compte n'est pas défini pour le graphique du tableau de bord {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1441,7 +1441,7 @@ msgstr "Le compte {0} n'appartient pas à la société {1}"
 msgid "Account {0} does not exist"
 msgstr "Compte {0} n'existe pas"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "Le compte {0} n'existe pas"
 
@@ -1768,8 +1768,8 @@ msgstr "Filtre de dimensions comptables"
 msgid "Accounting Entries"
 msgstr "Écritures Comptables"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Ecriture comptable pour l'actif"
@@ -2180,8 +2180,8 @@ msgstr "Compte d'Amortissement Cumulé"
 msgid "Accumulated Depreciation Amount"
 msgstr "Montant d'Amortissement Cumulé"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "Amortissement Cumulé depuis"
 
@@ -2584,7 +2584,7 @@ msgstr "Le type de taxe réel ne peut pas être inclus dans le prix de l'Article
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2697,7 +2697,7 @@ msgid "Add Quote"
 msgstr "Ajouter une proposition"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3309,7 +3309,7 @@ msgstr "Administrateur"
 msgid "Advance Account"
 msgstr "Compte d'avances"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3441,7 +3441,7 @@ msgstr "Contre"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "Contrepartie"
 
@@ -3553,7 +3553,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "Pour le Bon"
 
@@ -3577,7 +3577,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "Pour le Type de Bon"
@@ -3591,7 +3591,7 @@ msgstr "Âge"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "Age (jours)"
 
@@ -3738,7 +3738,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "Toutes les nomenclatures"
 
@@ -3891,7 +3891,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "Tous les articles ont déjà été transférés pour cet ordre de fabrication."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4128,8 +4128,8 @@ msgstr "Autoriser plusieurs commandes client par rapport à la commande d'achat 
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Autoriser un Stock Négatif"
 
@@ -4268,6 +4268,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Autoriser un Taux de Valorisation Égal à Zéro"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4690,7 +4696,7 @@ msgstr "Modifié Depuis"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4829,7 +4835,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5406,11 +5412,11 @@ msgstr "Lorsque le champ {0} est activé, la valeur du champ {1} doit être sup�
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5422,8 +5428,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "Comme il y a suffisamment de matières premières, la demande de matériel n'est pas requise pour l'entrepôt {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5458,7 +5464,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5525,7 +5531,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5671,7 +5677,7 @@ msgstr "Mouvement d'Actif"
 msgid "Asset Movement Item"
 msgstr "Élément de mouvement d'actif"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "Registre de Mouvement de l'Actif {0} créé"
 
@@ -5809,7 +5815,7 @@ msgstr "Analyse de la valeur des actifs"
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "L'actif ne peut être annulé, car il est déjà {0}"
 
@@ -5829,7 +5835,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5885,7 +5891,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6022,7 +6028,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6055,7 +6061,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "À la ligne n ° {0}: l'ID de séquence {1} ne peut pas être inférieur à l'ID de séquence de ligne précédent {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6063,11 +6069,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6686,7 +6692,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6699,7 +6705,7 @@ msgstr "Nomenclature"
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "La nomenclature 1 {0} et la nomenclature 2 {1} ne doivent pas être identiques"
 
@@ -6928,7 +6934,7 @@ msgstr "Nomenclature et quantité de production sont nécessaires"
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "Nomenclature ne contient aucun article en stock"
@@ -6937,23 +6943,23 @@ msgstr "Nomenclature ne contient aucun article en stock"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "Récursion de nomenclature: {0} ne peut pas être enfant de {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "Nomenclature {0} n’appartient pas à l'article {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "Nomenclature {0} doit être active"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "Nomenclature {0} doit être soumise"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7023,7 +7029,7 @@ msgstr "Solde"
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "Solde ({0})"
 
@@ -7672,7 +7678,7 @@ msgstr "Statut d'Expiration d'Article du Lot"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7698,16 +7704,20 @@ msgstr "Statut d'Expiration d'Article du Lot"
 msgid "Batch No"
 msgstr "N° du Lot"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7721,7 +7731,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7824,7 +7834,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7833,7 +7843,7 @@ msgstr "Date de la Facture"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7847,7 +7857,7 @@ msgstr "Facturation de la quantité rejetée dans la facture d'achat"
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7866,8 +7876,8 @@ msgstr "Facturé"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7888,7 +7898,7 @@ msgstr "Mnt Facturé"
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "Quantité facturée"
@@ -8291,7 +8301,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "La date de début de la période d'essai et la date de fin de la période d'essai doivent être définies"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8978,7 +8988,7 @@ msgstr "Horaires de campagne"
 msgid "Can be approved by {0}"
 msgstr "Peut être approuvé par {0}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8986,7 +8996,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "Impossible de filtrer en fonction du caissier, s'il est regroupé par caissier"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -9002,7 +9012,7 @@ msgstr "Impossible de filtrer en fonction du profil de point de vente, s'il est 
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "Impossible de filtrer en fonction du mode de paiement, s'il est regroupé par mode de paiement"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "Impossible de filtrer sur la base du N° de Coupon, si les lignes sont regroupées par Coupon"
 
@@ -9017,15 +9027,15 @@ msgstr "Le paiement n'est possible qu'avec les {0} non facturés"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Peut se référer à ligne seulement si le type de charge est 'Montant de la ligne précedente' ou 'Total des lignes précedente'"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "Désactivation ou annulation de la nomenclature impossible car elle est liée avec d'autres nomenclatures"
 
@@ -9306,7 +9316,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "Impossible de supprimer les N° de série {0}, s'ils sont dans les mouvements de stock"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9323,7 +9333,7 @@ msgstr "Impossible de garantir la livraison par numéro de série car l'article 
 msgid "Cannot find Item with this Barcode"
 msgstr "Impossible de trouver l'article avec ce code-barres"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9386,11 +9396,11 @@ msgstr "Impossible de définir l'autorisation sur la base des Prix Réduits pour
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Impossible de définir plusieurs valeurs par défaut pour une entreprise."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Impossible de définir une quantité inférieure à la quantité livrée"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "Impossible de définir une quantité inférieure à la quantité reçue"
 
@@ -9953,7 +9963,7 @@ msgstr "Largeur du Chèque"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "Chèque/Date de Référence"
 
@@ -10225,7 +10235,7 @@ msgstr "Document fermé"
 msgid "Closed Documents"
 msgstr "Documents fermés"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10248,7 +10258,7 @@ msgstr "Fermeture (Cr)"
 msgid "Closing (Dr)"
 msgstr "Fermeture (Dr)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "Fermeture (ouverture + total)"
 
@@ -10271,7 +10281,7 @@ msgstr "Montant de clôture"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "Solde de clôture"
 
@@ -10721,7 +10731,7 @@ msgstr "Sociétés"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10768,7 +10778,7 @@ msgstr "Sociétés"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11088,7 +11098,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "Les devises des deux sociétés doivent correspondre pour les transactions inter-sociétés."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "Le champ de l'entreprise est obligatoire"
@@ -11943,7 +11953,7 @@ msgid "Content Type"
 msgstr "Type de Contenu"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Continuer"
@@ -12322,12 +12332,13 @@ msgstr "Coût"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12335,6 +12346,7 @@ msgstr "Coût"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12463,11 +12475,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "Coût à partir de"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "Coût des articles livrés"
@@ -12484,14 +12491,6 @@ msgstr "Coût des marchandises vendues"
 msgid "Cost of Issued Items"
 msgstr "Coût des Marchandises Vendues"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "Coût du Nouvel Achat"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12500,14 +12499,6 @@ msgstr ""
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "Coût des articles achetés"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "Coût des Immobilisations Mises au Rebut"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "Coût des Immobilisations Vendus"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12747,7 +12738,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12762,7 +12753,7 @@ msgstr ""
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12807,7 +12798,7 @@ msgstr ""
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13005,7 +12996,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "Créer un échantillon de stock de rétention"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13197,11 +13188,11 @@ msgstr ""
 msgid "Credit"
 msgstr "Crédit"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "Crédit ({0})"
 
@@ -13317,7 +13308,7 @@ msgstr "Mois de crédit"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13539,12 +13530,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13657,7 +13648,7 @@ msgstr "Devise pour {0} doit être {1}"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "La devise du Compte Cloturé doit être {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "La devise de la liste de prix {0} doit être {1} ou {2}"
 
@@ -14066,7 +14057,7 @@ msgstr "Code Client"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14162,11 +14153,11 @@ msgstr "Retour d'Expérience Client"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14206,7 +14197,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "Nom du Groupe Client"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14225,7 +14216,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr "Articles du clients"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "Commande client locale"
 
@@ -14271,7 +14262,7 @@ msgstr "N° de Portable du Client"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14661,7 +14652,7 @@ msgstr "Données exportées à partir de Tally comprenant le plan comptable, les
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14897,11 +14888,11 @@ msgstr "Cher Administrateur Système ,"
 msgid "Debit"
 msgstr "Débit"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "Débit ({0})"
 
@@ -14938,7 +14929,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15148,7 +15139,7 @@ msgstr "Nomenclature par défaut ({0}) doit être actif pour ce produit ou son m
 msgid "Default BOM for {0} not found"
 msgstr "Nomenclature par défaut {0} introuvable"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15979,7 +15970,7 @@ msgstr "Bon de Livraison {0} n'est pas soumis"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Bons de livraison"
@@ -16178,7 +16169,7 @@ msgstr "Amortissement"
 msgid "Depreciation Amount"
 msgstr "Montant d'Amortissement"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "Montant d'Amortissement au cours de la période"
 
@@ -16192,7 +16183,7 @@ msgstr "Date d’Amortissement"
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "Amortissement Eliminé en raison de cessions d'actifs"
 
@@ -16253,15 +16244,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "Ligne d'amortissement {0}: la valeur attendue après la durée de vie utile doit être supérieure ou égale à {1}"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "Ligne d'amortissement {0}: La date d'amortissement suivante ne peut pas être antérieure à la date de mise en service"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "Ligne d'amortissement {0}: la date d'amortissement suivante ne peut pas être antérieure à la date d'achat"
 
@@ -16510,7 +16501,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16693,7 +16684,7 @@ msgstr "Compte d’Écart"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "Le compte d'écart doit être un compte de type actif / passif, car cette entrée de stock est une entrée d'ouverture."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Le Compte d’Écart doit être un compte de type Actif / Passif, puisque cette Réconciliation de Stock est une écriture d'à-nouveau"
 
@@ -17449,7 +17440,7 @@ msgstr "Voulez-vous vraiment restaurer cet actif mis au rebut ?"
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17855,7 +17846,7 @@ msgstr "Date d’échéance / de référence ne peut pas être après le {0}"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17979,7 +17970,7 @@ msgstr "Groupe d’articles en double trouvé dans la table des groupes d'articl
 msgid "Duplicate project has been created"
 msgstr "Un projet en double a été créé"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "Ligne {0} en double avec le même {1}"
 
@@ -18871,7 +18862,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "Entrez le fournisseur"
 
@@ -18950,7 +18941,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19027,7 +19018,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Erreur"
 
@@ -19595,6 +19586,12 @@ msgstr "Dépenses incluses dans l'évaluation de l'actif"
 msgid "Expenses Included In Valuation"
 msgstr "Charges Incluses dans la Valorisation"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19933,7 +19930,7 @@ msgstr "Récuprer les temps saisis"
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "Récupérer la nomenclature éclatée (y compris les sous-ensembles)"
@@ -19949,7 +19946,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20246,15 +20243,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20475,7 +20472,7 @@ msgstr "Actif Immobilisé"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20626,7 +20623,7 @@ msgstr "A l'achat"
 msgid "For Company"
 msgstr "Pour la Société"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "Pour le fournisseur par défaut (facultatif)"
 
@@ -20687,7 +20684,7 @@ msgstr "Pour Fournisseur"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "Pour l’Entrepôt"
@@ -20730,7 +20727,7 @@ msgstr "Pour un fournisseur individuel"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20991,7 +20988,7 @@ msgstr "Du Client"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21101,8 +21098,8 @@ msgstr "La Date Initiale ne peut pas être postérieure à la Date Finale"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21478,14 +21475,14 @@ msgstr "D'autres nœuds peuvent être créés uniquement sous les nœuds de type
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Montant du paiement futur"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "Paiement futur Ref"
 
@@ -21510,7 +21507,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "Écriture GL"
 
@@ -21804,7 +21801,7 @@ msgstr "Obtenir les articles de"
 msgid "Get Items From Purchase Receipts"
 msgstr "Obtenir des Articles à partir des Reçus d'Achat"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22327,7 +22324,7 @@ msgstr "Niveau parent"
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "Les entrepôts de groupe ne peuvent pas être utilisés dans les transactions. Veuillez modifier la valeur de {0}"
 
@@ -23767,11 +23764,11 @@ msgstr "Qté En Stock"
 msgid "In Transit"
 msgstr "En transit"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24241,7 +24238,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "Entrepôt incorrect"
 
@@ -24499,8 +24496,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "Permissions insuffisantes"
 
@@ -24749,7 +24746,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Code à barres invalide. Il n'y a pas d'article attaché à ce code à barres."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Commande avec limites non valide pour le client et l'article sélectionnés"
 
@@ -24826,7 +24823,7 @@ msgstr "Compte parent non valide"
 msgid "Invalid Part Number"
 msgstr "Numéro de pièce non valide"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "Heure de publication non valide"
 
@@ -24838,7 +24835,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24846,7 +24843,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24854,9 +24851,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr "Quantité invalide"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24868,7 +24865,7 @@ msgstr "Prix de vente invalide"
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "URL invalide"
 
@@ -24893,7 +24890,7 @@ msgstr "Motif perdu non valide {0}, veuillez créer un nouveau motif perdu"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Masque de numérotation non valide (. Manquante) pour {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "Référence invalide {0} {1}"
 
@@ -24917,7 +24914,7 @@ msgstr "Invalide {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "{0} non valide pour la transaction inter-société."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "Invalide {0} : {1}"
@@ -24985,7 +24982,7 @@ msgstr "Date de la Facture"
 msgid "Invoice Discounting"
 msgstr "Rabais de facture"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "Total général de la facture"
 
@@ -25074,9 +25071,9 @@ msgstr "La facture ne peut pas être faite pour une heure facturée à zéro"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "Montant facturé"
 
@@ -25773,7 +25770,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "Nécessaire pour aller chercher les Détails de l'Article."
 
@@ -25825,7 +25822,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26067,7 +26064,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26098,7 +26095,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26525,7 +26522,7 @@ msgstr "Fabricant d'Article"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26884,7 +26881,7 @@ msgstr "Libellé de l'article"
 msgid "Item operation"
 msgstr "Opération de l'article"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26923,7 +26920,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr "Article {0} n'existe pas"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "L'article {0} n'existe pas dans le système ou a expiré"
 
@@ -27011,7 +27008,7 @@ msgstr "L'article {0} : Qté commandée {1} ne peut pas être inférieure à la 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Article {0}: {1} quantité produite."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27048,7 +27045,7 @@ msgstr "Historique des Ventes par Article"
 msgid "Item-wise Sales Register"
 msgstr "Registre des Ventes par Article"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "Article : {0} n'existe pas dans le système"
 
@@ -27153,7 +27150,7 @@ msgstr "Articles À Demander"
 msgid "Items and Pricing"
 msgstr "Articles et prix"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27362,7 +27359,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "Job card {0} créée"
 
@@ -28983,11 +28980,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30331,7 +30328,7 @@ msgstr "Charges Diverses"
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30389,7 +30386,7 @@ msgstr "Valeurs Manquantes Requises"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "Modèle de courrier électronique manquant pour l'envoi. Veuillez en définir un dans les paramètres de livraison."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30870,7 +30867,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "Doit être un Nombre Entier"
 
@@ -30903,7 +30900,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31041,11 +31038,11 @@ msgstr "Gaz Naturel"
 msgid "Needs Analysis"
 msgstr "Analyse des besoins"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "Quantité Négative n'est pas autorisée"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Taux de Valorisation Négatif n'est pas autorisé"
 
@@ -31123,8 +31120,8 @@ msgstr "Montant Net"
 msgid "Net Amount (Company Currency)"
 msgstr "Montant Net (Devise Société)"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "Valeur Nette des Actifs au"
 
@@ -31695,7 +31692,7 @@ msgstr "Aucun fournisseur trouvé pour les transactions intersociétés qui repr
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31880,15 +31877,15 @@ msgstr ""
 msgid "No record found"
 msgstr "Aucun Enregistrement Trouvé"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31936,7 +31933,7 @@ msgstr "Non-conformité"
 msgid "Non Profit"
 msgstr "À But Non Lucratif"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "Articles hors stock"
 
@@ -31950,7 +31947,7 @@ msgstr ""
 msgid "None"
 msgstr "Aucun"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "Aucun des Articles n’a de changement en quantité ou en valeur."
 
@@ -32065,8 +32062,8 @@ msgstr "En rupture"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32088,7 +32085,7 @@ msgstr "Pas permis"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32757,7 +32754,7 @@ msgstr "Ordres de travail ouverts"
 msgid "Open a new ticket"
 msgstr "Ouvrir un nouveau ticket"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "Ouverture"
@@ -32789,7 +32786,7 @@ msgstr "Ouverture (Dr)"
 msgid "Opening Accumulated Depreciation"
 msgstr "Amortissement Cumulé d'Ouverture"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32803,7 +32800,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr "Montant d'ouverture"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "Solde d'ouverture"
 
@@ -32933,7 +32930,7 @@ msgstr "Coût d'Exploitation (Devise Société)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "Coût d'exploitation selon l'ordre de fabrication / nomenclature"
 
@@ -32963,7 +32960,7 @@ msgstr "Coûts d'Exploitation"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33089,7 +33086,7 @@ msgstr "Opérations"
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "Les opérations ne peuvent pas être laissées vides"
 
@@ -33602,7 +33599,7 @@ msgstr "Solde"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34157,9 +34154,9 @@ msgstr "Payé"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34608,12 +34605,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34634,7 +34631,7 @@ msgstr "Tiers"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "Compte de Tiers"
 
@@ -34767,12 +34764,12 @@ msgstr "Restriction d'article disponible"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34899,7 +34896,7 @@ msgid "Payable"
 msgstr "Créditeur"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35341,7 +35338,7 @@ msgstr "Calendrier de paiement"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35579,13 +35576,13 @@ msgstr "Activités en attente"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "Montant en attente"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35874,8 +35871,8 @@ msgstr "Inventaire permanent requis pour que la société {0} puisse consulter c
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "Personnel"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36488,7 +36485,7 @@ msgstr "Veuillez entrez un Compte pour le Montant de Change"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Veuillez entrer un Rôle Approbateur ou un Rôle Utilisateur"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "Veuillez entrer un Centre de Coûts"
 
@@ -36500,7 +36497,7 @@ msgstr "Entrez la Date de Livraison"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Veuillez entrer l’ID Employé de ce commercial"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "Veuillez entrer un Compte de Charges"
 
@@ -36509,7 +36506,7 @@ msgstr "Veuillez entrer un Compte de Charges"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Veuillez entrer le Code d'Article pour obtenir le Numéro de Lot"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "Veuillez entrer le Code d'Article pour obtenir n° de lot"
 
@@ -36803,7 +36800,7 @@ msgstr "Veuillez sélectionner la Date de Comptabilisation avant de sélectionne
 msgid "Please select Posting Date first"
 msgstr "Veuillez d’abord sélectionner la Date de Comptabilisation"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "Veuillez sélectionner une Liste de Prix"
 
@@ -36831,7 +36828,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "Veuillez sélectionner une nomenclature"
 
@@ -36840,10 +36837,10 @@ msgid "Please select a Company"
 msgstr "Veuillez sélectionner une Société"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "Veuillez d'abord sélectionner une entreprise."
 
@@ -36993,7 +36990,7 @@ msgid "Please select {0}"
 msgstr "Veuillez sélectionner {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "Veuillez d’abord sélectionner {0}"
@@ -37063,7 +37060,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37188,7 +37185,7 @@ msgstr "Veuillez définir des filtres"
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "Veuillez définir la récurrence après avoir sauvegardé"
 
@@ -37218,7 +37215,7 @@ msgstr "Configurez le calendrier de la campagne dans la campagne {0}."
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "Veuillez définir {0}"
@@ -37251,7 +37248,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Veuillez spécifier"
 
@@ -37271,7 +37268,7 @@ msgstr "Veuillez spécifier la Société pour continuer"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Veuillez spécifier un N° de Ligne valide pour la ligne {0} de la table {1}"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37279,7 +37276,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Veuillez spécifier au moins un attribut dans la table Attributs"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Veuillez spécifier la Quantité, le Taux de Valorisation ou les deux"
 
@@ -37459,14 +37456,14 @@ msgstr "Frais postaux"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37955,7 +37952,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "Prix non trouvé pour l'article {0} dans la liste de prix {1}"
 
@@ -38486,7 +38483,7 @@ msgstr "Échec du processus"
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38983,9 +38980,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38993,6 +38991,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39004,7 +39003,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39623,7 +39622,7 @@ msgstr "Responsable des Données d’Achats"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40083,12 +40082,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40196,7 +40195,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40291,7 +40290,7 @@ msgstr "La quantité de matières premières sera déterminée en fonction de la
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "Qté à facturer"
@@ -40629,7 +40628,7 @@ msgstr "Objectif de revue de qualité"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40646,7 +40645,7 @@ msgstr "Objectif de revue de qualité"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40767,11 +40766,11 @@ msgstr "Quantité ne doit pas être plus de {0}"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "Quantité d'article obtenue après production / reconditionnement des quantités données de matières premières"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "Quantité requise pour l'Article {0} à la ligne {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40786,7 +40785,7 @@ msgstr "Quantité à faire"
 msgid "Quantity to Manufacture"
 msgstr "Quantité à fabriquer"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "La quantité à fabriquer ne peut pas être nulle pour l'opération {0}"
 
@@ -41457,7 +41456,7 @@ msgstr "Entrepôt de matières premières"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41516,7 +41515,7 @@ msgstr "Coût des Matières Premières Fournies"
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "Matières Premières ne peuvent pas être vides."
 
@@ -41711,7 +41710,7 @@ msgid "Receivable / Payable Account"
 msgstr "Compte Débiteur / Créditeur"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41805,7 +41804,7 @@ msgstr "Reçu le"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41816,7 +41815,7 @@ msgstr "Reçu le"
 msgid "Received Qty"
 msgstr "Qté Reçue"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "Quantité reçue Quantité"
 
@@ -42166,7 +42165,7 @@ msgstr "Référence #{0} datée du {1}"
 msgid "Reference Date"
 msgstr "Date de Référence"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42589,7 +42588,7 @@ msgstr "Restant"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Solde restant"
@@ -42642,9 +42641,9 @@ msgstr "Remarque"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42678,7 +42677,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "Les articles avec aucune modification de quantité ou de valeur ont étés retirés."
 
@@ -43145,7 +43144,7 @@ msgstr "Demandeur"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44176,11 +44175,11 @@ msgstr "Routage"
 msgid "Routing Name"
 msgstr "Nom d'acheminement"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44272,23 +44271,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été facturé."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été livré"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été reçu"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} auquel un bon de travail est affecté."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Ligne # {0}: impossible de supprimer l'article {1} affecté à la commande d'achat du client."
 
@@ -44296,7 +44295,7 @@ msgstr "Ligne # {0}: impossible de supprimer l'article {1} affecté à la comman
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "Ligne # {0}: Impossible de sélectionner l'entrepôt fournisseur lors de la fourniture de matières premières au sous-traitant"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "Ligne n ° {0}: impossible de définir le prix si le montant est supérieur au montant facturé pour l'élément {1}."
 
@@ -44404,7 +44403,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Ligne # {0}: l'article {1} n'est pas un article sérialisé / en lot. Il ne peut pas avoir de numéro de série / de lot contre lui."
 
@@ -44482,7 +44481,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Ligne n° {0}: La quantité de l'article {1} ne peut être nulle"
 
@@ -44490,8 +44489,8 @@ msgstr "Ligne n° {0}: La quantité de l'article {1} ne peut être nulle"
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44767,11 +44766,11 @@ msgstr "Ligne {0} : L’Avance du Client doit être un crédit"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "Ligne {0} : L’Avance du Fournisseur doit être un débit"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44804,7 +44803,7 @@ msgstr "Ligne {0}: le Centre de Coûts est requis pour un article {1}"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "Ligne {0} : L’Écriture de crédit ne peut pas être liée à un {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "Ligne {0} : La devise de la nomenclature #{1} doit être égale à la devise sélectionnée {2}"
 
@@ -44816,7 +44815,7 @@ msgstr "Ligne {0} : L’Écriture de Débit ne peut pas être lié à un {1}"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Ligne {0}: l'entrepôt de livraison ({1}) et l'entrepôt client ({2}) ne peuvent pas être identiques"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "Ligne {0}: la date de début de l'amortissement est obligatoire"
 
@@ -44837,7 +44836,7 @@ msgstr "Ligne {0}: entrez la localisation de l'actif {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Ligne {0} : Le Taux de Change est obligatoire"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "Ligne {0}: la valeur attendue après la durée de vie utile doit être inférieure au montant brut de l'achat"
 
@@ -45007,7 +45006,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -45015,7 +45014,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "Ligne {0} : Facteur de Conversion nomenclature est obligatoire"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45044,7 +45043,7 @@ msgstr "Ligne {0} : {1} {2} ne correspond pas à {3}"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Ligne {1}: la quantité ({0}) ne peut pas être une fraction. Pour autoriser cela, désactivez «{2}» dans UdM {3}."
 
@@ -45682,7 +45681,7 @@ msgstr "Commandes de vente à livrer"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45780,7 +45779,7 @@ msgstr "Résumé du paiement des ventes"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45866,7 +45865,7 @@ msgstr "Registre des Ventes"
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "Retour de Ventes"
@@ -46053,7 +46052,7 @@ msgstr "La même Société a été entrée plus d'une fois"
 msgid "Same Item"
 msgstr "Même article"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46080,7 +46079,7 @@ msgstr "Entrepôt de stockage des échantillons"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Taille de l'Échantillon"
@@ -46616,7 +46615,7 @@ msgstr "Sélectionner des éléments"
 msgid "Select Items based on Delivery Date"
 msgstr "Sélectionnez les articles en fonction de la Date de Livraison"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46720,7 +46719,7 @@ msgstr "Sélectionnez une priorité par défaut."
 msgid "Select a Supplier"
 msgstr "Sélectionnez un fournisseur"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "Sélectionnez un fournisseur parmi les fournisseurs par défaut des articles ci-dessous. Lors de la sélection, une commande d'achat sera effectué contre des articles appartenant uniquement au fournisseur sélectionné."
 
@@ -46766,7 +46765,7 @@ msgstr "Sélectionnez le livre de financement pour l'élément {0} à la ligne {
 msgid "Select item group"
 msgstr "Sélectionnez un groupe d'articles"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "Sélectionnez l'élément de modèle"
 
@@ -46783,7 +46782,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46804,11 +46803,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "Sélectionnez le code d'article de variante pour l'article de modèle {0}"
 
@@ -47126,7 +47125,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47212,7 +47211,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47241,12 +47240,16 @@ msgstr "N° de Série {0} n'appartient pas à l'Article {1}"
 msgid "Serial No {0} does not exist"
 msgstr "N° de Série {0} n’existe pas"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47286,7 +47289,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "N° de Série et Lots"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47359,11 +47362,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47710,12 +47713,12 @@ msgid "Service Stop Date"
 msgstr "Date d'arrêt du service"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "La date d'arrêt du service ne peut pas être postérieure à la date de fin du service"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "La date d'arrêt du service ne peut pas être antérieure à la date de début du service"
 
@@ -47811,7 +47814,7 @@ msgstr "Définir mot de passe"
 msgid "Set Posting Date"
 msgstr "Définir la date de publication"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47825,7 +47828,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "Définir le projet et toutes les tâches sur le statut {0}?"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "Définir Quantité"
 
@@ -47920,7 +47923,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47950,15 +47953,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr "Définissez cette option si le client est une société d'administration publique."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "Définissez {0} dans la catégorie d'actifs {1} ou la société {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "Définissez {0} dans l'entreprise {1}"
 
@@ -48025,7 +48028,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr "Création d'entreprise"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48830,15 +48833,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "Désolé, ce code promo n'est plus valide"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "Désolé, la validité de ce code promo a expiré"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "Désolé, la validité de ce code promo n'a pas commencé"
 
@@ -48920,7 +48923,7 @@ msgstr "Type de source"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49040,7 +49043,7 @@ msgstr "Diviser le ticket"
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49465,7 +49468,7 @@ msgstr "Etat"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49963,7 +49966,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49972,10 +49975,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50815,7 +50818,7 @@ msgstr "Paramètres de réussite"
 msgid "Successful"
 msgstr "Réussi"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "Réconcilié avec succès"
 
@@ -51027,7 +51030,7 @@ msgstr "Qté Fournie"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51131,9 +51134,9 @@ msgstr "Détails du Fournisseur"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51186,7 +51189,7 @@ msgstr "Fournisseur Date de la Facture du Fournisseur ne peut pas être postéri
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "N° de Facture du Fournisseur"
@@ -51231,7 +51234,7 @@ msgstr "Récapitulatif du grand livre des fournisseurs"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52847,11 +52850,11 @@ msgstr "Modèle des Termes et Conditions"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53227,7 +53230,7 @@ msgstr "Les actions n'existent pas pour {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53240,11 +53243,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "La tâche a été mise en file d'attente en tant que tâche en arrière-plan. En cas de problème de traitement en arrière-plan, le système ajoute un commentaire concernant l'erreur sur ce rapprochement des stocks et revient au stade de brouillon."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53298,7 +53301,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "Il y a une maintenance active ou des réparations sur l'actif. Vous devez les compléter tous avant d'annuler l'élément."
 
@@ -53572,7 +53575,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53588,7 +53591,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53791,7 +53794,7 @@ msgstr ""
 msgid "Timer"
 msgstr "Minuteur"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "La minuterie a dépassé les heures configurées."
 
@@ -53993,7 +53996,7 @@ msgstr "Devise Finale"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54292,7 +54295,7 @@ msgstr "À l'Entrepôt"
 msgid "To Warehouse (Optional)"
 msgstr "À l'Entrepôt (Facultatif)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54367,7 +54370,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54468,7 +54471,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56021,7 +56024,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "L'URL ne peut être qu'une chaîne"
 
@@ -56631,7 +56634,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56679,6 +56682,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57093,7 +57102,7 @@ msgstr "Le taux de valorisation de l'article {0} est requis pour effectuer des �
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Le Taux de Valorisation est obligatoire si un Stock Initial est entré"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Taux de valorisation requis pour le poste {0} à la ligne {1}"
 
@@ -57103,7 +57112,7 @@ msgstr "Taux de valorisation requis pour le poste {0} à la ligne {1}"
 msgid "Valuation and Total"
 msgstr "Valorisation et Total"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57189,6 +57198,11 @@ msgstr "Valeur ou Qté"
 msgid "Value Proposition"
 msgstr "Proposition de valeur"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "Valeur pour l'attribut {0} doit être dans la gamme de {1} à {2} dans les incréments de {3} pour le poste {4}"
@@ -57196,6 +57210,22 @@ msgstr "Valeur pour l'attribut {0} doit être dans la gamme de {1} à {2} dans l
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57277,7 +57307,7 @@ msgid "Variant Field"
 msgstr "Champ de Variante"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "Élément de variante"
 
@@ -57575,11 +57605,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57605,7 +57635,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "N° de Référence"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57617,7 +57647,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57647,9 +57677,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57817,7 +57847,7 @@ msgstr "Spontané"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58002,7 +58032,7 @@ msgstr "L'entrepôt est obligatoire"
 msgid "Warehouse not found against the account {0}"
 msgstr "Entrepôt introuvable sur le compte {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "L'entrepôt n'a pas été trouvé dans le système"
 
@@ -58128,7 +58158,7 @@ msgstr "Avertir lors d'une nouvelle Demande de Devis"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "Avertissement"
 
@@ -58148,7 +58178,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "Attention : Un autre {0} {1} # existe pour l'écriture de stock {2}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "Attention : La Quantité de Matériel Commandé est inférieure à la Qté Minimum de Commande"
 
@@ -58681,8 +58711,8 @@ msgstr "L'ordre de fabrication ne peut pas être créé pour la raison suivante:
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "Un ordre de fabrication ne peut pas être créé pour un modèle d'article"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "L'ordre de fabrication a été {0}"
 
@@ -59094,7 +59124,7 @@ msgstr "Oui"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Vous n'êtes pas autorisé à effectuer la mise à jour selon les conditions définies dans {} Workflow."
 
@@ -59159,11 +59189,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59215,7 +59249,7 @@ msgstr "Vous ne pouvez pas valider la commande sans paiement."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Vous ne disposez pas des autorisations nécessaires pour {} éléments dans un {}."
 
@@ -59367,7 +59401,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59703,7 +59737,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59711,7 +59745,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "Le {0} coupon utilisé est {1}. La quantité autorisée est épuisée"
 
@@ -59771,7 +59805,7 @@ msgstr "{0} a déjà une procédure parent {1}."
 msgid "{0} and {1}"
 msgstr "{0} et {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} et {1} sont obligatoires"
@@ -59862,7 +59896,7 @@ msgstr "{0} est bloqué donc cette transaction ne peut pas continuer"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59944,7 +59978,7 @@ msgstr "{0} doit être négatif dans le document de retour"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} introuvable pour l'élément {1}"
 
@@ -59960,7 +59994,7 @@ msgstr "{0} écritures de paiement ne peuvent pas être filtrées par {1}"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/hu.po
+++ b/erpnext/locale/hu.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Hungarian\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "% Completed"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr ""
@@ -856,7 +856,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Account is not set for the dashboard chart {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Account {0} does not exist"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr ""
 
@@ -1747,8 +1747,8 @@ msgstr ""
 msgid "Accounting Entries"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr ""
@@ -2159,8 +2159,8 @@ msgstr ""
 msgid "Accumulated Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr ""
 
@@ -2563,7 +2563,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr ""
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr ""
 msgid "Advance Account"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr ""
 
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr ""
 
@@ -3556,7 +3556,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr ""
@@ -3570,7 +3570,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4107,8 +4107,8 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr ""
 
@@ -4246,6 +4246,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
+msgstr ""
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
 msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
@@ -4669,7 +4675,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5385,11 +5391,11 @@ msgstr ""
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5401,8 +5407,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5437,7 +5443,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr ""
 msgid "Asset Movement Item"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr ""
 
@@ -5788,7 +5794,7 @@ msgstr ""
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr ""
 
@@ -5808,7 +5814,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5864,7 +5870,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6034,7 +6040,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6042,11 +6048,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6665,7 +6671,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr ""
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr ""
 
@@ -6907,7 +6913,7 @@ msgstr ""
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr ""
@@ -6916,23 +6922,23 @@ msgstr ""
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7002,7 +7008,7 @@ msgstr ""
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr ""
 
@@ -7651,7 +7657,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,16 +7683,20 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7700,7 +7710,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7803,7 +7813,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr ""
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr ""
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr ""
@@ -8270,7 +8280,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8957,7 +8967,7 @@ msgstr ""
 msgid "Can be approved by {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8965,7 +8975,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr ""
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr ""
 
@@ -8996,15 +9006,15 @@ msgstr ""
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9264,7 +9274,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr ""
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9302,7 +9312,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9365,11 +9375,11 @@ msgstr ""
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -9932,7 +9942,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10204,7 +10214,7 @@ msgstr ""
 msgid "Closed Documents"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10227,7 +10237,7 @@ msgstr ""
 msgid "Closing (Dr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr ""
 
@@ -10250,7 +10260,7 @@ msgstr ""
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr ""
 
@@ -10700,7 +10710,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr ""
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr ""
@@ -12301,12 +12311,13 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr ""
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr ""
@@ -12463,14 +12470,6 @@ msgstr ""
 msgid "Cost of Issued Items"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr ""
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12478,14 +12477,6 @@ msgstr ""
 
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
 msgstr ""
 
 #: erpnext/config/projects.py:67
@@ -12726,7 +12717,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr ""
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr ""
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr ""
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13176,11 +13167,11 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr ""
 
@@ -13296,7 +13287,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr ""
 msgid "Currency of the Closing Account must be {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr ""
 
@@ -14045,7 +14036,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14204,7 +14195,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr ""
 
@@ -14250,7 +14241,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr ""
 msgid "Debit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr ""
 
@@ -14917,7 +14908,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15958,7 +15949,7 @@ msgstr ""
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16157,7 +16148,7 @@ msgstr ""
 msgid "Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr ""
 
@@ -16171,7 +16162,7 @@ msgstr ""
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr ""
 
@@ -16232,15 +16223,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr ""
 
@@ -16489,7 +16480,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17428,7 +17419,7 @@ msgstr ""
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17834,7 +17825,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr ""
 msgid "Duplicate project has been created"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr ""
 
@@ -18850,7 +18841,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr ""
 
@@ -18929,7 +18920,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19006,7 +18997,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr ""
 
@@ -19574,6 +19565,12 @@ msgstr ""
 msgid "Expenses Included In Valuation"
 msgstr ""
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr ""
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20225,15 +20222,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20454,7 +20451,7 @@ msgstr ""
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr ""
 msgid "For Company"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr ""
 
@@ -20666,7 +20663,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr ""
@@ -20709,7 +20706,7 @@ msgstr ""
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20970,7 +20967,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -21489,7 +21486,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr ""
 
@@ -21783,7 +21780,7 @@ msgstr ""
 msgid "Get Items From Purchase Receipts"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr ""
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr ""
 
@@ -23746,11 +23743,11 @@ msgstr ""
 msgid "In Transit"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr ""
 
@@ -24478,8 +24475,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24728,7 +24725,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -24805,7 +24802,7 @@ msgstr ""
 msgid "Invalid Part Number"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr ""
 
@@ -24817,7 +24814,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24825,7 +24822,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24833,9 +24830,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24847,7 +24844,7 @@ msgstr ""
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr ""
 
@@ -24872,7 +24869,7 @@ msgstr ""
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr ""
 
@@ -24896,7 +24893,7 @@ msgstr ""
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr ""
@@ -24964,7 +24961,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25053,9 +25050,9 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr ""
 
@@ -25752,7 +25749,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -25804,7 +25801,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26902,7 +26899,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr ""
 
@@ -26990,7 +26987,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27027,7 +27024,7 @@ msgstr ""
 msgid "Item-wise Sales Register"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr ""
 
@@ -27132,7 +27129,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27341,7 +27338,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr ""
 
@@ -28962,11 +28959,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr ""
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30368,7 +30365,7 @@ msgstr ""
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30849,7 +30846,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr ""
 
@@ -30882,7 +30879,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31102,8 +31099,8 @@ msgstr ""
 msgid "Net Amount (Company Currency)"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr ""
 
@@ -31674,7 +31671,7 @@ msgstr ""
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31859,15 +31856,15 @@ msgstr ""
 msgid "No record found"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31915,7 +31912,7 @@ msgstr ""
 msgid "Non Profit"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr ""
 
@@ -31929,7 +31926,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr ""
 
@@ -32044,8 +32041,8 @@ msgstr ""
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32736,7 +32733,7 @@ msgstr ""
 msgid "Open a new ticket"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr ""
@@ -32768,7 +32765,7 @@ msgstr ""
 msgid "Opening Accumulated Depreciation"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32782,7 +32779,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr ""
 
@@ -32912,7 +32909,7 @@ msgstr ""
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr ""
 
@@ -32942,7 +32939,7 @@ msgstr ""
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr ""
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr ""
 
@@ -33581,7 +33578,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr ""
 
@@ -34746,12 +34743,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr ""
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr ""
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,7 +35850,7 @@ msgstr ""
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
+msgid "Personal Details"
 msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
@@ -36467,7 +36464,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36479,7 +36476,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36488,7 +36485,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -36782,7 +36779,7 @@ msgstr ""
 msgid "Please select Posting Date first"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr ""
 
@@ -36810,7 +36807,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr ""
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr ""
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr ""
@@ -37042,7 +37039,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37167,7 +37164,7 @@ msgstr ""
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37197,7 +37194,7 @@ msgstr ""
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr ""
@@ -37230,7 +37227,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr ""
 
@@ -37250,7 +37247,7 @@ msgstr ""
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37258,7 +37255,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37438,14 +37435,14 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr ""
 
@@ -38465,7 +38462,7 @@ msgstr ""
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38962,9 +38959,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr ""
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr ""
@@ -40608,7 +40607,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr ""
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr ""
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr ""
 msgid "Quantity to Manufacture"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr ""
 
@@ -41436,7 +41435,7 @@ msgstr ""
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr ""
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr ""
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr ""
 msgid "Received Qty"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr ""
 
@@ -42145,7 +42144,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42568,7 +42567,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -42621,9 +42620,9 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr ""
 
@@ -43124,7 +43123,7 @@ msgstr ""
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44251,23 +44250,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
@@ -44275,7 +44274,7 @@ msgstr ""
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr ""
 
@@ -44383,7 +44382,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -44469,8 +44468,8 @@ msgstr ""
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44746,11 +44745,11 @@ msgstr ""
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44783,7 +44782,7 @@ msgstr ""
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr ""
 
@@ -44795,7 +44794,7 @@ msgstr ""
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr ""
 
@@ -44816,7 +44815,7 @@ msgstr ""
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr ""
 
@@ -44986,7 +44985,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -44994,7 +44993,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45023,7 +45022,7 @@ msgstr ""
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
@@ -45661,7 +45660,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr ""
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr ""
@@ -46032,7 +46031,7 @@ msgstr ""
 msgid "Same Item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46059,7 +46058,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -46595,7 +46594,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46699,7 +46698,7 @@ msgstr ""
 msgid "Select a Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr ""
 
@@ -46745,7 +46744,7 @@ msgstr ""
 msgid "Select item group"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr ""
 
@@ -46762,7 +46761,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46783,11 +46782,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr ""
 
@@ -47105,7 +47104,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47220,12 +47219,16 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47265,7 +47268,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47338,11 +47341,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -47790,7 +47793,7 @@ msgstr ""
 msgid "Set Posting Date"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47804,7 +47807,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr ""
 
@@ -47899,7 +47902,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47929,15 +47932,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr ""
 
@@ -48004,7 +48007,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48809,15 +48812,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr ""
 
@@ -48899,7 +48902,7 @@ msgstr ""
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr ""
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49444,7 +49447,7 @@ msgstr ""
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50794,7 +50797,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr ""
 
@@ -51006,7 +51009,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr ""
@@ -51210,7 +51213,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53219,11 +53222,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53277,7 +53280,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr ""
 
@@ -53551,7 +53554,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53567,7 +53570,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53770,7 +53773,7 @@ msgstr ""
 msgid "Timer"
 msgstr ""
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr ""
 
@@ -53972,7 +53975,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr ""
 msgid "To Warehouse (Optional)"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54447,7 +54450,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr ""
 
@@ -56610,7 +56613,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56658,6 +56661,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57072,7 +57081,7 @@ msgstr ""
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -57082,7 +57091,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57168,6 +57177,11 @@ msgstr ""
 msgid "Value Proposition"
 msgstr ""
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr ""
@@ -57175,6 +57189,22 @@ msgstr ""
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr ""
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr ""
 
@@ -57554,11 +57584,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57596,7 +57626,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57626,9 +57656,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr ""
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr ""
 
@@ -58107,7 +58137,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr ""
 
@@ -58127,7 +58157,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr ""
 
@@ -58660,8 +58690,8 @@ msgstr ""
 msgid "Work Order cannot be raised against a Item Template"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr ""
 
@@ -59073,7 +59103,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -59138,11 +59168,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59194,7 +59228,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -59346,7 +59380,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59682,7 +59716,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59690,7 +59724,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr ""
 
@@ -59750,7 +59784,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr ""
@@ -59841,7 +59875,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr ""
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr ""
 
@@ -59939,7 +59973,7 @@ msgstr ""
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/pl.po
+++ b/erpnext/locale/pl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Polish\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "% Completed"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr ""
@@ -856,7 +856,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Account is not set for the dashboard chart {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Account {0} does not exist"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr ""
 
@@ -1747,8 +1747,8 @@ msgstr ""
 msgid "Accounting Entries"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr ""
@@ -2159,8 +2159,8 @@ msgstr ""
 msgid "Accumulated Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr ""
 
@@ -2563,7 +2563,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr ""
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr ""
 msgid "Advance Account"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr ""
 
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr ""
 
@@ -3556,7 +3556,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr ""
@@ -3570,7 +3570,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4107,8 +4107,8 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr ""
 
@@ -4246,6 +4246,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
+msgstr ""
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
 msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
@@ -4669,7 +4675,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5385,11 +5391,11 @@ msgstr ""
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5401,8 +5407,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5437,7 +5443,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr ""
 msgid "Asset Movement Item"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr ""
 
@@ -5788,7 +5794,7 @@ msgstr ""
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr ""
 
@@ -5808,7 +5814,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5864,7 +5870,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6034,7 +6040,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6042,11 +6048,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6665,7 +6671,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr ""
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr ""
 
@@ -6907,7 +6913,7 @@ msgstr ""
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr ""
@@ -6916,23 +6922,23 @@ msgstr ""
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7002,7 +7008,7 @@ msgstr ""
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr ""
 
@@ -7651,7 +7657,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,16 +7683,20 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7700,7 +7710,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7803,7 +7813,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr ""
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr ""
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr ""
@@ -8270,7 +8280,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8957,7 +8967,7 @@ msgstr ""
 msgid "Can be approved by {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8965,7 +8975,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr ""
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr ""
 
@@ -8996,15 +9006,15 @@ msgstr ""
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9264,7 +9274,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr ""
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9302,7 +9312,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9365,11 +9375,11 @@ msgstr ""
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -9932,7 +9942,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10204,7 +10214,7 @@ msgstr ""
 msgid "Closed Documents"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10227,7 +10237,7 @@ msgstr ""
 msgid "Closing (Dr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr ""
 
@@ -10250,7 +10260,7 @@ msgstr ""
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr ""
 
@@ -10700,7 +10710,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr ""
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr ""
@@ -12301,12 +12311,13 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr ""
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr ""
@@ -12463,14 +12470,6 @@ msgstr ""
 msgid "Cost of Issued Items"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr ""
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12478,14 +12477,6 @@ msgstr ""
 
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
 msgstr ""
 
 #: erpnext/config/projects.py:67
@@ -12726,7 +12717,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr ""
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr ""
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr ""
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13176,11 +13167,11 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr ""
 
@@ -13296,7 +13287,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr ""
 msgid "Currency of the Closing Account must be {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr ""
 
@@ -14045,7 +14036,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14204,7 +14195,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr ""
 
@@ -14250,7 +14241,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr ""
 msgid "Debit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr ""
 
@@ -14917,7 +14908,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15958,7 +15949,7 @@ msgstr ""
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16157,7 +16148,7 @@ msgstr ""
 msgid "Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr ""
 
@@ -16171,7 +16162,7 @@ msgstr ""
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr ""
 
@@ -16232,15 +16223,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr ""
 
@@ -16489,7 +16480,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17428,7 +17419,7 @@ msgstr ""
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17834,7 +17825,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr ""
 msgid "Duplicate project has been created"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr ""
 
@@ -18850,7 +18841,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr ""
 
@@ -18929,7 +18920,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19006,7 +18997,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr ""
 
@@ -19574,6 +19565,12 @@ msgstr ""
 msgid "Expenses Included In Valuation"
 msgstr ""
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr ""
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20225,15 +20222,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20454,7 +20451,7 @@ msgstr ""
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr ""
 msgid "For Company"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr ""
 
@@ -20666,7 +20663,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr ""
@@ -20709,7 +20706,7 @@ msgstr ""
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20970,7 +20967,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -21489,7 +21486,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr ""
 
@@ -21783,7 +21780,7 @@ msgstr ""
 msgid "Get Items From Purchase Receipts"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr ""
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr ""
 
@@ -23746,11 +23743,11 @@ msgstr ""
 msgid "In Transit"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr ""
 
@@ -24478,8 +24475,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24728,7 +24725,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -24805,7 +24802,7 @@ msgstr ""
 msgid "Invalid Part Number"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr ""
 
@@ -24817,7 +24814,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24825,7 +24822,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24833,9 +24830,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24847,7 +24844,7 @@ msgstr ""
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr ""
 
@@ -24872,7 +24869,7 @@ msgstr ""
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr ""
 
@@ -24896,7 +24893,7 @@ msgstr ""
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr ""
@@ -24964,7 +24961,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25053,9 +25050,9 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr ""
 
@@ -25752,7 +25749,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -25804,7 +25801,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26902,7 +26899,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr ""
 
@@ -26990,7 +26987,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27027,7 +27024,7 @@ msgstr ""
 msgid "Item-wise Sales Register"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr ""
 
@@ -27132,7 +27129,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27341,7 +27338,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr ""
 
@@ -28962,11 +28959,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr ""
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30368,7 +30365,7 @@ msgstr ""
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30849,7 +30846,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr ""
 
@@ -30882,7 +30879,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31102,8 +31099,8 @@ msgstr ""
 msgid "Net Amount (Company Currency)"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr ""
 
@@ -31674,7 +31671,7 @@ msgstr ""
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31859,15 +31856,15 @@ msgstr ""
 msgid "No record found"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31915,7 +31912,7 @@ msgstr ""
 msgid "Non Profit"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr ""
 
@@ -31929,7 +31926,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr ""
 
@@ -32044,8 +32041,8 @@ msgstr ""
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32736,7 +32733,7 @@ msgstr ""
 msgid "Open a new ticket"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr ""
@@ -32768,7 +32765,7 @@ msgstr ""
 msgid "Opening Accumulated Depreciation"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32782,7 +32779,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr ""
 
@@ -32912,7 +32909,7 @@ msgstr ""
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr ""
 
@@ -32942,7 +32939,7 @@ msgstr ""
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr ""
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr ""
 
@@ -33581,7 +33578,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr ""
 
@@ -34746,12 +34743,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr ""
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr ""
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,7 +35850,7 @@ msgstr ""
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
+msgid "Personal Details"
 msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
@@ -36467,7 +36464,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36479,7 +36476,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36488,7 +36485,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -36782,7 +36779,7 @@ msgstr ""
 msgid "Please select Posting Date first"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr ""
 
@@ -36810,7 +36807,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr ""
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr ""
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr ""
@@ -37042,7 +37039,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37167,7 +37164,7 @@ msgstr ""
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37197,7 +37194,7 @@ msgstr ""
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr ""
@@ -37230,7 +37227,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr ""
 
@@ -37250,7 +37247,7 @@ msgstr ""
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37258,7 +37255,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37438,14 +37435,14 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr ""
 
@@ -38465,7 +38462,7 @@ msgstr ""
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38962,9 +38959,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr ""
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr ""
@@ -40608,7 +40607,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr ""
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr ""
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr ""
 msgid "Quantity to Manufacture"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr ""
 
@@ -41436,7 +41435,7 @@ msgstr ""
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr ""
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr ""
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr ""
 msgid "Received Qty"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr ""
 
@@ -42145,7 +42144,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42568,7 +42567,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -42621,9 +42620,9 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr ""
 
@@ -43124,7 +43123,7 @@ msgstr ""
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44251,23 +44250,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
@@ -44275,7 +44274,7 @@ msgstr ""
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr ""
 
@@ -44383,7 +44382,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -44469,8 +44468,8 @@ msgstr ""
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44746,11 +44745,11 @@ msgstr ""
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44783,7 +44782,7 @@ msgstr ""
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr ""
 
@@ -44795,7 +44794,7 @@ msgstr ""
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr ""
 
@@ -44816,7 +44815,7 @@ msgstr ""
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr ""
 
@@ -44986,7 +44985,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -44994,7 +44993,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45023,7 +45022,7 @@ msgstr ""
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
@@ -45661,7 +45660,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr ""
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr ""
@@ -46032,7 +46031,7 @@ msgstr ""
 msgid "Same Item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46059,7 +46058,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -46595,7 +46594,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46699,7 +46698,7 @@ msgstr ""
 msgid "Select a Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr ""
 
@@ -46745,7 +46744,7 @@ msgstr ""
 msgid "Select item group"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr ""
 
@@ -46762,7 +46761,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46783,11 +46782,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr ""
 
@@ -47105,7 +47104,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47220,12 +47219,16 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47265,7 +47268,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47338,11 +47341,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -47790,7 +47793,7 @@ msgstr ""
 msgid "Set Posting Date"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47804,7 +47807,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr ""
 
@@ -47899,7 +47902,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47929,15 +47932,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr ""
 
@@ -48004,7 +48007,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48809,15 +48812,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr ""
 
@@ -48899,7 +48902,7 @@ msgstr ""
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr ""
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49444,7 +49447,7 @@ msgstr ""
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50794,7 +50797,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr ""
 
@@ -51006,7 +51009,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr ""
@@ -51210,7 +51213,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53219,11 +53222,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53277,7 +53280,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr ""
 
@@ -53551,7 +53554,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53567,7 +53570,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53770,7 +53773,7 @@ msgstr ""
 msgid "Timer"
 msgstr ""
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr ""
 
@@ -53972,7 +53975,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr ""
 msgid "To Warehouse (Optional)"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54447,7 +54450,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr ""
 
@@ -56610,7 +56613,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56658,6 +56661,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57072,7 +57081,7 @@ msgstr ""
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -57082,7 +57091,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57168,6 +57177,11 @@ msgstr ""
 msgid "Value Proposition"
 msgstr ""
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr ""
@@ -57175,6 +57189,22 @@ msgstr ""
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr ""
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr ""
 
@@ -57554,11 +57584,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57596,7 +57626,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57626,9 +57656,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr ""
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr ""
 
@@ -58107,7 +58137,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr ""
 
@@ -58127,7 +58157,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr ""
 
@@ -58660,8 +58690,8 @@ msgstr ""
 msgid "Work Order cannot be raised against a Item Template"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr ""
 
@@ -59073,7 +59103,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -59138,11 +59168,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59194,7 +59228,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -59346,7 +59380,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59682,7 +59716,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59690,7 +59724,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr ""
 
@@ -59750,7 +59784,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr ""
@@ -59841,7 +59875,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr ""
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr ""
 
@@ -59939,7 +59973,7 @@ msgstr ""
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/ru.po
+++ b/erpnext/locale/ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "% Completed"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr ""
@@ -856,7 +856,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "Account is not set for the dashboard chart {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Account {0} does not exist"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr ""
 
@@ -1747,8 +1747,8 @@ msgstr ""
 msgid "Accounting Entries"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr ""
@@ -2159,8 +2159,8 @@ msgstr ""
 msgid "Accumulated Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr ""
 
@@ -2563,7 +2563,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr ""
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr ""
 msgid "Advance Account"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr ""
 
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr ""
 
@@ -3556,7 +3556,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr ""
@@ -3570,7 +3570,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4107,8 +4107,8 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr ""
 
@@ -4246,6 +4246,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
+msgstr ""
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
 msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
@@ -4669,7 +4675,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5385,11 +5391,11 @@ msgstr ""
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5401,8 +5407,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5437,7 +5443,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr ""
 msgid "Asset Movement Item"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr ""
 
@@ -5788,7 +5794,7 @@ msgstr ""
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr ""
 
@@ -5808,7 +5814,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5864,7 +5870,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6034,7 +6040,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6042,11 +6048,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6665,7 +6671,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr ""
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr ""
 
@@ -6907,7 +6913,7 @@ msgstr ""
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr ""
@@ -6916,23 +6922,23 @@ msgstr ""
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7002,7 +7008,7 @@ msgstr ""
 msgid "Balance (Dr - Cr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr ""
 
@@ -7651,7 +7657,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,16 +7683,20 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7700,7 +7710,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7803,7 +7813,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr ""
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr ""
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr ""
@@ -8270,7 +8280,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8957,7 +8967,7 @@ msgstr ""
 msgid "Can be approved by {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8965,7 +8975,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr ""
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr ""
 
@@ -8996,15 +9006,15 @@ msgstr ""
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9264,7 +9274,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr ""
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9302,7 +9312,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9365,11 +9375,11 @@ msgstr ""
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -9932,7 +9942,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10204,7 +10214,7 @@ msgstr ""
 msgid "Closed Documents"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10227,7 +10237,7 @@ msgstr ""
 msgid "Closing (Dr)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr ""
 
@@ -10250,7 +10260,7 @@ msgstr ""
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr ""
 
@@ -10700,7 +10710,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr ""
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr ""
@@ -12301,12 +12311,13 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr ""
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr ""
@@ -12463,14 +12470,6 @@ msgstr ""
 msgid "Cost of Issued Items"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr ""
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12478,14 +12477,6 @@ msgstr ""
 
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
 msgstr ""
 
 #: erpnext/config/projects.py:67
@@ -12726,7 +12717,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr ""
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr ""
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr ""
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13176,11 +13167,11 @@ msgstr ""
 msgid "Credit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr ""
 
@@ -13296,7 +13287,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr ""
 msgid "Currency of the Closing Account must be {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr ""
 
@@ -14045,7 +14036,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14204,7 +14195,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr ""
 
@@ -14250,7 +14241,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr ""
 msgid "Debit"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr ""
 
@@ -14917,7 +14908,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15958,7 +15949,7 @@ msgstr ""
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16157,7 +16148,7 @@ msgstr ""
 msgid "Depreciation Amount"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr ""
 
@@ -16171,7 +16162,7 @@ msgstr ""
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr ""
 
@@ -16232,15 +16223,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr ""
 
@@ -16489,7 +16480,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17428,7 +17419,7 @@ msgstr ""
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17834,7 +17825,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr ""
 msgid "Duplicate project has been created"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr ""
 
@@ -18850,7 +18841,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr ""
 
@@ -18929,7 +18920,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19006,7 +18997,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr ""
 
@@ -19574,6 +19565,12 @@ msgstr ""
 msgid "Expenses Included In Valuation"
 msgstr ""
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr ""
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20225,15 +20222,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20454,7 +20451,7 @@ msgstr ""
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr ""
 msgid "For Company"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr ""
 
@@ -20666,7 +20663,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr ""
@@ -20709,7 +20706,7 @@ msgstr ""
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20970,7 +20967,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -21489,7 +21486,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr ""
 
@@ -21783,7 +21780,7 @@ msgstr ""
 msgid "Get Items From Purchase Receipts"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr ""
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr ""
 
@@ -23746,11 +23743,11 @@ msgstr ""
 msgid "In Transit"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr ""
 
@@ -24478,8 +24475,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24728,7 +24725,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -24805,7 +24802,7 @@ msgstr ""
 msgid "Invalid Part Number"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr ""
 
@@ -24817,7 +24814,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24825,7 +24822,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24833,9 +24830,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24847,7 +24844,7 @@ msgstr ""
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr ""
 
@@ -24872,7 +24869,7 @@ msgstr ""
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr ""
 
@@ -24896,7 +24893,7 @@ msgstr ""
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr ""
@@ -24964,7 +24961,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25053,9 +25050,9 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr ""
 
@@ -25752,7 +25749,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -25804,7 +25801,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26902,7 +26899,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr ""
 
@@ -26990,7 +26987,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27027,7 +27024,7 @@ msgstr ""
 msgid "Item-wise Sales Register"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr ""
 
@@ -27132,7 +27129,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27341,7 +27338,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr ""
 
@@ -28962,11 +28959,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr ""
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30368,7 +30365,7 @@ msgstr ""
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30849,7 +30846,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr ""
 
@@ -30882,7 +30879,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31102,8 +31099,8 @@ msgstr ""
 msgid "Net Amount (Company Currency)"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr ""
 
@@ -31674,7 +31671,7 @@ msgstr ""
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31859,15 +31856,15 @@ msgstr ""
 msgid "No record found"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31915,7 +31912,7 @@ msgstr ""
 msgid "Non Profit"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr ""
 
@@ -31929,7 +31926,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr ""
 
@@ -32044,8 +32041,8 @@ msgstr ""
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32736,7 +32733,7 @@ msgstr ""
 msgid "Open a new ticket"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr ""
@@ -32768,7 +32765,7 @@ msgstr ""
 msgid "Opening Accumulated Depreciation"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32782,7 +32779,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr ""
 
@@ -32912,7 +32909,7 @@ msgstr ""
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr ""
 
@@ -32942,7 +32939,7 @@ msgstr ""
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr ""
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr ""
 
@@ -33581,7 +33578,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr ""
 
@@ -34746,12 +34743,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr ""
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr ""
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,7 +35850,7 @@ msgstr ""
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
+msgid "Personal Details"
 msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
@@ -36467,7 +36464,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36479,7 +36476,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36488,7 +36485,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -36782,7 +36779,7 @@ msgstr ""
 msgid "Please select Posting Date first"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr ""
 
@@ -36810,7 +36807,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr ""
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr ""
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr ""
@@ -37042,7 +37039,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37167,7 +37164,7 @@ msgstr ""
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37197,7 +37194,7 @@ msgstr ""
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr ""
@@ -37230,7 +37227,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr ""
 
@@ -37250,7 +37247,7 @@ msgstr ""
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37258,7 +37255,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37438,14 +37435,14 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr ""
 
@@ -38465,7 +38462,7 @@ msgstr ""
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38962,9 +38959,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr ""
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr ""
@@ -40608,7 +40607,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr ""
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr ""
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr ""
 msgid "Quantity to Manufacture"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr ""
 
@@ -41436,7 +41435,7 @@ msgstr ""
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr ""
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr ""
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr ""
 msgid "Received Qty"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr ""
 
@@ -42145,7 +42144,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42568,7 +42567,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -42621,9 +42620,9 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr ""
 
@@ -43124,7 +43123,7 @@ msgstr ""
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44251,23 +44250,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
@@ -44275,7 +44274,7 @@ msgstr ""
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr ""
 
@@ -44383,7 +44382,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -44469,8 +44468,8 @@ msgstr ""
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44746,11 +44745,11 @@ msgstr ""
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44783,7 +44782,7 @@ msgstr ""
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr ""
 
@@ -44795,7 +44794,7 @@ msgstr ""
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr ""
 
@@ -44816,7 +44815,7 @@ msgstr ""
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr ""
 
@@ -44986,7 +44985,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -44994,7 +44993,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45023,7 +45022,7 @@ msgstr ""
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
@@ -45661,7 +45660,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr ""
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr ""
@@ -46032,7 +46031,7 @@ msgstr ""
 msgid "Same Item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46059,7 +46058,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -46595,7 +46594,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46699,7 +46698,7 @@ msgstr ""
 msgid "Select a Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr ""
 
@@ -46745,7 +46744,7 @@ msgstr ""
 msgid "Select item group"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr ""
 
@@ -46762,7 +46761,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46783,11 +46782,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr ""
 
@@ -47105,7 +47104,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47220,12 +47219,16 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47265,7 +47268,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47338,11 +47341,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -47790,7 +47793,7 @@ msgstr ""
 msgid "Set Posting Date"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47804,7 +47807,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr ""
 
@@ -47899,7 +47902,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47929,15 +47932,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr ""
 
@@ -48004,7 +48007,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48809,15 +48812,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr ""
 
@@ -48899,7 +48902,7 @@ msgstr ""
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr ""
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49444,7 +49447,7 @@ msgstr ""
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50794,7 +50797,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr ""
 
@@ -51006,7 +51009,7 @@ msgstr ""
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr ""
@@ -51210,7 +51213,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53219,11 +53222,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53277,7 +53280,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr ""
 
@@ -53551,7 +53554,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53567,7 +53570,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53770,7 +53773,7 @@ msgstr ""
 msgid "Timer"
 msgstr ""
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr ""
 
@@ -53972,7 +53975,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr ""
 msgid "To Warehouse (Optional)"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54447,7 +54450,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr ""
 
@@ -56610,7 +56613,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56658,6 +56661,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57072,7 +57081,7 @@ msgstr ""
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -57082,7 +57091,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57168,6 +57177,11 @@ msgstr ""
 msgid "Value Proposition"
 msgstr ""
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr ""
@@ -57175,6 +57189,22 @@ msgstr ""
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr ""
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr ""
 
@@ -57554,11 +57584,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57596,7 +57626,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57626,9 +57656,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr ""
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr ""
 
@@ -58107,7 +58137,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr ""
 
@@ -58127,7 +58157,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr ""
 
@@ -58660,8 +58690,8 @@ msgstr ""
 msgid "Work Order cannot be raised against a Item Template"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr ""
 
@@ -59073,7 +59103,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -59138,11 +59168,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59194,7 +59228,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -59346,7 +59380,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59682,7 +59716,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59690,7 +59724,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr ""
 
@@ -59750,7 +59784,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr ""
@@ -59841,7 +59875,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr ""
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr ""
 
@@ -59939,7 +59973,7 @@ msgstr ""
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/locale/sv.po
+++ b/erpnext/locale/sv.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-14 07:24\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "% Klar Sätt"
 msgid "% Completed"
 msgstr "% Klar"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% Färdig Artikel Kvantitet"
@@ -960,7 +960,7 @@ msgstr "Prislista är samling av artikel priser som antingen säljs, köpes elle
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "Artikel eller Service som köpes, säljes eller finns på lager."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "Avstämning jobb {0} körs för samma filter. Kan inte stämma av nu"
 
@@ -1165,7 +1165,7 @@ msgstr "Godkänd Kvantitet (per Lager Enhet)"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1264,7 +1264,7 @@ msgstr "Enligt CEFACT/ICG/2010/IC013 eller CEFACT/ICG/2010/IC010"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1483,7 +1483,7 @@ msgstr "Konto erfordras att hämta Betalning Poster"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "Konto är inte angiven för Översikt Panel Diagram {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "Konto ej funnen"
 
@@ -1524,7 +1524,7 @@ msgstr "Konto {0} tillhör inte Bolag {1}"
 msgid "Account {0} does not exist"
 msgstr "Konto {0} finns inte"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "Konto {0} finns inte"
 
@@ -1851,8 +1851,8 @@ msgstr "Bokföring Dimension Filter"
 msgid "Accounting Entries"
 msgstr "Bokföring Poster"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Bokföring Post för Tillgång"
@@ -2263,8 +2263,8 @@ msgstr "Ackumulerad Avskrivning Konto"
 msgid "Accumulated Depreciation Amount"
 msgstr "Ackumulerad Avskrivning Belopp"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "Ackumulerad Avskrivning per "
 
@@ -2667,7 +2667,7 @@ msgstr "Detta Moms/Avgift kan inte inkluderas i Artikel Pris på rad {0}"
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2780,7 +2780,7 @@ msgid "Add Quote"
 msgstr "Lägg till Offert"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "Lägg till Råmaterial"
@@ -3392,7 +3392,7 @@ msgstr "Administratör"
 msgid "Advance Account"
 msgstr "Förskott Konto"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr "Förskott Konto: {0} måste vara antingen i kundens fakturering valuta: {1} eller bolag standard valuta: {2}"
 
@@ -3524,7 +3524,7 @@ msgstr "Mot "
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "Mot Konto"
 
@@ -3636,7 +3636,7 @@ msgstr "Mot Leverantör Faktura {0}"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "Mot Verifikat"
 
@@ -3660,7 +3660,7 @@ msgstr "Mot Verifikat Nummer"
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "Mot Verifikat Typ"
@@ -3674,7 +3674,7 @@ msgstr "Ålder"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "Ålder (Dagar)"
 
@@ -3821,7 +3821,7 @@ msgstr "Alla Aktivitet"
 msgid "All Activities HTML"
 msgstr "Alla Aktivitet HTML"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "Alla Stycklistor"
 
@@ -3974,7 +3974,7 @@ msgstr "Alla Artiklar är redan mottagna"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Alla Artikel har redan överförts för denna Arbetsorder."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Alla Artiklar i detta dokument har redan länkad Kvalitet Kontroll."
 
@@ -4211,8 +4211,8 @@ msgstr "Tillåt flera Försäljning Order mot Kund Inköp Order"
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Tillåt Negativ Lager"
 
@@ -4351,6 +4351,12 @@ msgstr "Tillåt Noll Pris"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Tillåt Noll Värderingssats"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr "Tillåt att befintligt serienummer produceras/tas emot igen"
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4773,7 +4779,7 @@ msgstr "Ändrad Från"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4912,7 +4918,7 @@ msgstr "Belopp i transaktion valuta"
 msgid "Amount in {0}"
 msgstr "Belopp i {0}"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr "Belopp att Fakturera"
@@ -5489,11 +5495,11 @@ msgstr "Eftersom fält {0} är aktiverad ska värdet för fält {1} vara mer än
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Eftersom det finns befintliga godkäAda transaktioner mot artikel {0} kan man inte ändra värdet på {1}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "Eftersom det finns negativ lager kan du inte aktivera {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "Eftersom det finns reserverat lager kan du inte inaktivera {0}."
 
@@ -5505,8 +5511,8 @@ msgstr "Eftersom det finns tillräckligt med Underenhet Artiklar erfordras inte 
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "Eftersom det finns tillräckligt med Råmaterial erfordras inte Material Begäran för Lager {0}."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "Eftersom {0} är aktiverad kan du inte aktivera {1}."
 
@@ -5541,7 +5547,7 @@ msgstr "Montering Artiklar"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5608,7 +5614,7 @@ msgstr "Tillgång Bokning Lager Post"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5754,7 +5760,7 @@ msgstr "Tillgång Förändring"
 msgid "Asset Movement Item"
 msgstr "Tillgång Förändring Artikel"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "Tillgång Förändring Post {0} skapad"
 
@@ -5892,17 +5898,17 @@ msgstr "Tillgång Värde Analys"
 msgid "Asset cancelled"
 msgstr "Tillgång Annullerad"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "Tillgång kan inte annulleras, eftersom det redan är {0}"
 
 #: erpnext/assets/doctype/asset/depreciation.py:507
 msgid "Asset cannot be scrapped before the last depreciation entry."
-msgstr "Tillgång kan inte skrivas av före senaste avskrivning post."
+msgstr "Tillgång kan inte skrotas före senaste avskrivning post."
 
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:698
 msgid "Asset capitalized after Asset Capitalization {0} was submitted"
-msgstr "Tillgång kapitaliserad efter att Tillgång Kapitalisering {0} godkändes "
+msgstr "Tillgång aktiverad efter att Tillgång Aktivering {0} godkändes"
 
 #: erpnext/assets/doctype/asset/asset.py:197
 msgid "Asset created"
@@ -5912,13 +5918,13 @@ msgstr "Tillgång Skapad"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "Tillgång skapad efter att Tillgång Kapitalisering {0} godkändes"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "Tillgång skapad efter att ha delats från Tillgång {0}"
 
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:706
 msgid "Asset decapitalized after Asset Capitalization {0} was submitted"
-msgstr "Tillgång avkapitaliserad efter att Tillgång Kapitalisering {0} godkändes"
+msgstr "Tillgång deaktiverad efter att Tillgång Aktivering {0} godkändes"
 
 #: erpnext/assets/doctype/asset/asset.py:200
 msgid "Asset deleted"
@@ -5954,7 +5960,7 @@ msgstr "Tillgång skrotad"
 
 #: erpnext/assets/doctype/asset/depreciation.py:477
 msgid "Asset scrapped via Journal Entry {0}"
-msgstr "Tillgång avskriven via Journal Post {0}"
+msgstr "Tillgång skrotad via Journal Post {0}"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1383
 msgid "Asset sold"
@@ -5968,7 +5974,7 @@ msgstr "Tillgång Godkänd"
 msgid "Asset transferred to Location {0}"
 msgstr "Tillgång överförd till Plats {0}"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "Tillgång uppdaterad efter att ha delats upp i Tillgång {0}"
 
@@ -6105,7 +6111,7 @@ msgstr "På rad #{0}: Plockad kvantitet {1} för artikel {2} är större än til
 msgid "At least one account with exchange gain or loss is required"
 msgstr "Minst ett konto med Valutaväxling Resultat erfordras"
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "Minst en Tillgång måste väljas."
 
@@ -6138,7 +6144,7 @@ msgstr "Minst ett Lager erfordras"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "Rad # {0}: sekvens nummer {1} får inte vara lägre än föregående rad sekvens nummer {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "Rad {0}: Parti Nummer erfordras för Artikel {1}"
 
@@ -6146,11 +6152,11 @@ msgstr "Rad {0}: Parti Nummer erfordras för Artikel {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "Rad {0}: Överordnad rad nummer kan inte anges för artikel {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "Rad {0}: Kvantitet erfordras för Artikel {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "Rad {0}: Serie Nummer erfordras för Artikel {1}"
 
@@ -6769,7 +6775,7 @@ msgstr "Lager Kvantitet"
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6782,7 +6788,7 @@ msgstr "Stycklista"
 msgid "BOM 1"
 msgstr "Stycklista 1"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "Stycklista 1 {0} och Stycklista 2 {1} ska inte vara lika"
 
@@ -7011,7 +7017,7 @@ msgstr "Stycklista och Produktion Kvantitet erfodras"
 msgid "BOM and Production"
 msgstr "Stycklista & Produktion"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "Stycklista innehåller inte någon Lager Artikel"
@@ -7020,23 +7026,23 @@ msgstr "Stycklista innehåller inte någon Lager Artikel"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "Stycklista Rekursion: {0} kan inte vara underordnad till {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "Stycklista Rekursion: {1} kan inte vara överordnad eller underordnad till {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "Stycklista {0} tillhör inte Artikel {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "Stycklista {0} måste vara aktiv"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "Stycklista {0} måste godkännas"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr "Stycklista {0} hittades inte för artikel {1}"
 
@@ -7106,7 +7112,7 @@ msgstr "Saldo"
 msgid "Balance (Dr - Cr)"
 msgstr "Saldo (Dr - Cr)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "Saldo ({0})"
 
@@ -7755,7 +7761,7 @@ msgstr "Parti Artikel Utgång Status"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7781,17 +7787,21 @@ msgstr "Parti Artikel Utgång Status"
 msgid "Batch No"
 msgstr "Parti Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr "Parti Nummer erfordras"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "Parti Nummer {0} finns inte"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Parti Nummer {0} är länkat till Artikel {1} som har serie nummer. Skanna serie nummer istället."
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+msgstr "Parti nr {0} finns inte i {1} {2}, därför kan du inte returnera det mot {1} {2}"
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
 #: erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -7804,7 +7814,7 @@ msgstr "Parti Nummer"
 msgid "Batch Nos"
 msgstr "Parti Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "Parti Nummer Skapade"
 
@@ -7907,7 +7917,7 @@ msgstr "Nedan Prenumeration Planer är i annan valuta än Parti standard valuta/
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7916,7 +7926,7 @@ msgstr "Faktura Datum"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7930,7 +7940,7 @@ msgstr "Faktura för Avvisad Kvantitet i Inköp Faktura"
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7949,8 +7959,8 @@ msgstr "Fakturerad"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7971,7 +7981,7 @@ msgstr "Fakturerad Belopp"
 msgid "Billed Items To Be Received"
 msgstr "Fakturerade Artiklar att Ta Emot"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "Fakturerad Kvantitet"
@@ -8374,7 +8384,7 @@ msgstr "Både Fordring Konto: {0} och Förskott Konto: {1} måste vara i samma v
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "Både Prov Period start datum och Prov Period slut datum måste anges"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr "Både {0} Konto: {1} och Förskott Konto: {2} måste vara i samma valuta för bolag: {3}"
 
@@ -9061,7 +9071,7 @@ msgstr "Kampanj Schema"
 msgid "Can be approved by {0}"
 msgstr "Kan godkännas av {0}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr "Kan inte stänga Arbetsorder, eftersom {0} Jobbkort har Arbete pågår status."
 
@@ -9069,7 +9079,7 @@ msgstr "Kan inte stänga Arbetsorder, eftersom {0} Jobbkort har Arbete pågår s
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "Kan inte filtrera baserat på Säljare, om grupperad efter Säljare"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr "Kan inte filtrera baserat på Underordnad Konto, om grupperat efter konto"
 
@@ -9085,7 +9095,7 @@ msgstr "Kan inte filtrera baserat på Kassa Profil, om grupperad efter Kassa Pro
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "Kan inte filtrera baserat på Betalning Sätt, om grupperad efter Betalning Sätt"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "Kan inte filtrera baserat på Verifikat nummer om grupperad efter Verifikat"
 
@@ -9100,15 +9110,15 @@ msgstr "Kan bara skapa betalning mot ofakturerad {0}"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Kan hänvisa till rad endast om avgiften är \"På Föregående Rad Belopp\" eller \"Föregående Rad Totalt\""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "Kan inte ändra värdering sätt, eftersom det finns transaktioner mot vissa artiklar som inte har egen värdering sätt"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr "Kan inte inaktivera partivis värdering för aktiva partier."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr "Kan inte inaktivera partivis värdering för artiklar med FIFO värdering metod."
 
@@ -9368,7 +9378,7 @@ msgstr "Kan inte skapa plocklista för Försäljning Order {0} eftersom den har 
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr "Kan inte skapa bokföring poster mot inaktiverade konto: {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "Kan inte inaktivera eller annullera Stycklista eftersom den är kopplat till andra Stycklistor"
 
@@ -9389,7 +9399,7 @@ msgstr "Kan inte ta bort Valutaväxling Resultat rad"
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "Kan inte ta bort Serie Nummer {0}, eftersom det används i Lager Transaktioner"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr "Kan inte inaktivera partivis värdering för FIFO värdering metod."
 
@@ -9406,7 +9416,7 @@ msgstr "Kan inte säkerställa leverans efter Serie Nummer eftersom Artikel {0} 
 msgid "Cannot find Item with this Barcode"
 msgstr "Kan inte hitta Artikel med denna Streck/QR Kod"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Kan inte hitta standardlager för artikel {0}. Ange det i Artikelinställningar eller i Lagerinställningar."
 
@@ -9469,11 +9479,11 @@ msgstr "Kan inte ange auktorisering på grund av Rabatt för {0}"
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Kan inte ange flera Artikel Standard för Bolag."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Kan inte ange kvantitet som är lägre än levererad kvantitet"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "Kan inte ange kvantitet som är lägre än mottagen kvantitet"
 
@@ -9572,7 +9582,7 @@ msgstr "Kapitalisera Reparation Kostnad"
 #. Option for the 'Status' (Select) field in DocType 'Asset'
 #: erpnext/assets/doctype/asset/asset.json
 msgid "Capitalized"
-msgstr "Kapitaliserad"
+msgstr "Aktiverad"
 
 #. Name of a UOM
 #: erpnext/setup/setup_wizard/data/uom_data.json
@@ -10036,7 +10046,7 @@ msgstr "Check Bredd"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "Referens Datum"
 
@@ -10308,7 +10318,7 @@ msgstr "Stängd Dokument"
 msgid "Closed Documents"
 msgstr "Stängda Dokument"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr "Stängd Arbetsorder kan inte stoppas eller öppnas igen"
 
@@ -10331,7 +10341,7 @@ msgstr "Stängning (Cr)"
 msgid "Closing (Dr)"
 msgstr "Stängning (Dr)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "Stängning (Öppning + Totalt)"
 
@@ -10354,7 +10364,7 @@ msgstr "Stängning Belopp"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "Stängning Saldo"
 
@@ -10804,7 +10814,7 @@ msgstr "Bolag"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10851,7 +10861,7 @@ msgstr "Bolag"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11171,7 +11181,7 @@ msgstr "Bolag och Bokföring Datum erfordras"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "Bolag Valutor för båda Bolag ska matcha för Moder Bolag Transaktioner."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "Bolag Fält erfordras"
@@ -12026,7 +12036,7 @@ msgid "Content Type"
 msgstr "Innehåll Typ"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Fortsätt"
@@ -12405,12 +12415,13 @@ msgstr "Kostnad"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12418,6 +12429,7 @@ msgstr "Kostnad"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12546,11 +12558,6 @@ msgstr "Kostnad Per Enhet"
 msgid "Cost and Freight"
 msgstr "Säljaren Betalar Frakt"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "Kostnad per den"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "Kostnad för Levererade Artiklar"
@@ -12567,14 +12574,6 @@ msgstr "Kostnad för Sålda Artiklar"
 msgid "Cost of Issued Items"
 msgstr "Kostnad för Utfärdade Artiklar"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr "Kostnad för ny Kapitaliserad Tillgång"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "Kostnader för Ny Inköp"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12583,14 +12582,6 @@ msgstr "Kostand för Dålig Kvalitet Rapport"
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "Kostnad för Inköpta Artiklar"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "Kostnad för Avskriven Tillgång"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "Kostnad för Såld Tillgång"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12830,7 +12821,7 @@ msgstr "Cr"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12845,7 +12836,7 @@ msgstr "Cr"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12890,7 +12881,7 @@ msgstr "Cr"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13088,7 +13079,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "Skapa Prov Lager Post"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "Skapa Lager Post"
 
@@ -13282,11 +13273,11 @@ msgstr "Skapande av {0} delvis klar.\n"
 msgid "Credit"
 msgstr "Kredit"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "Kredit (Transaktion)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "Kredit ({0})"
 
@@ -13402,7 +13393,7 @@ msgstr "Kredit Månader"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13624,12 +13615,12 @@ msgstr "Cup"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13742,7 +13733,7 @@ msgstr "Valuta för {0} måste vara {1}"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "Valuta för Stängning Konto måste vara {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "Valuta för Prislista {0} måste vara {1} eller {2}"
 
@@ -14151,7 +14142,7 @@ msgstr "Kund Kod"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14247,11 +14238,11 @@ msgstr "Kund Återkoppling"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14291,7 +14282,7 @@ msgstr "Kund Grupp Artikel"
 msgid "Customer Group Name"
 msgstr "Kund Grupp Namn"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "Kund Grupp: {0} finns inte"
 
@@ -14310,7 +14301,7 @@ msgstr "Kund Artikel"
 msgid "Customer Items"
 msgstr "Kund Artiklar"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "Kund Lokal Inköp Order"
 
@@ -14356,7 +14347,7 @@ msgstr "Kund Mobil Nummer"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14746,7 +14737,7 @@ msgstr "Data exporterad från Tally som består av Kontoplan, Kunder, Leverantö
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14982,11 +14973,11 @@ msgstr "Hej System Ansvarig,"
 msgid "Debit"
 msgstr "Debet"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "Debet (Transaktion)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "Debet ({0})"
 
@@ -15023,7 +15014,7 @@ msgstr "Debet Belopp i Transaktion Valuta"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15112,7 +15103,7 @@ msgstr "Dekapitalisering"
 #. Option for the 'Status' (Select) field in DocType 'Asset'
 #: erpnext/assets/doctype/asset/asset.json
 msgid "Decapitalized"
-msgstr "Dekapitaliserad"
+msgstr "Deaktiverad"
 
 #. Name of a UOM
 #: erpnext/setup/setup_wizard/data/uom_data.json
@@ -15233,7 +15224,7 @@ msgstr "Standard Stycklista ({0}) måste vara aktiv för denna artikel eller des
 msgid "Default BOM for {0} not found"
 msgstr "Standard Stycklista för {0} hittades inte"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Standard Stycklista hittades inte för Färdig Artikel {0}"
 
@@ -16064,7 +16055,7 @@ msgstr "Försäljning Följesedel {0} ej godkänd"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr "Försäljning Följesedel skapad för Plocklista"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Försäljning Följesedlar"
@@ -16263,7 +16254,7 @@ msgstr "Avskrivning"
 msgid "Depreciation Amount"
 msgstr "Avskrivning Belopp"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "Avskrivning Belopp under Period"
 
@@ -16277,7 +16268,7 @@ msgstr "Avskrivning Datum"
 msgid "Depreciation Details"
 msgstr "Avskrivning Detaljer"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "Avskrivning borttagen pga avskrivning av Tillgångar"
 
@@ -16338,15 +16329,15 @@ msgstr "Avskrivning Bokföring Datum kan inte vara före Tillgänglig för Anvä
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr "Avskrivning Rad {0}: Avskrivning Bokföring Datum kan inte vara före Tillgänglig för Användning Datum"
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "Avskrivning Rad {0}: Förväntad värde efter nyttjande tid måste vara högre än eller lika med {1}"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "Avskrivning Rad {0}: Nästa Avskrivning Datum kan inte vara före Tillgänglig för Användning Datum"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "Avskrivning Rad {0}: Nästa Avskrivning Datum kan inte vara före Inköp Datum"
 
@@ -16595,7 +16586,7 @@ msgstr "Avskrivning kan inte beräknas för fullt avskrivna tillgångar"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16778,7 +16769,7 @@ msgstr "Differens Konto"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "Differens Konto måste vara Tillgång / Skuld Konto Typ, eftersom denna Lager Post är Öppning Post"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Differens Konto måste vara Tillgång / Skuld Konto Typ, eftersom denna Inventering är Öppning Post"
 
@@ -17534,7 +17525,7 @@ msgstr "Ska avskriven Tillgång återställas?"
 msgid "Do you still want to enable negative inventory?"
 msgstr "Vill du fortfarande aktivera negativ Lager?"
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr "Vill du rensa valda {0}?"
 
@@ -17940,7 +17931,7 @@ msgstr "Förfallo/Referens Datum kan inte vara efter {0}"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18064,7 +18055,7 @@ msgstr "Kopia av Artikel Grupp finns i Artikel Grupp Tabell"
 msgid "Duplicate project has been created"
 msgstr "Kopia av Projekt är skapad"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "Kopiera Rad {0} med samma {1}"
 
@@ -18956,7 +18947,7 @@ msgstr "Ange Manuellt"
 msgid "Enter Serial Nos"
 msgstr "Ange Serie Nummer"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "Ange Leverantör"
 
@@ -19036,7 +19027,7 @@ msgstr "Ange namn på Bank eller Låne Bolag innan godkännande."
 msgid "Enter the opening stock units."
 msgstr "Ange Öppning Lager Enheter."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr "Ange kvantitet för Artikel som ska produceras från denna Stycklista."
 
@@ -19113,7 +19104,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Fel"
 
@@ -19683,6 +19674,12 @@ msgstr "Kostnader Inkluderade i Tillgång Värdering Konto"
 msgid "Expenses Included In Valuation"
 msgstr "Kostnader Inkluderade i Värdering Konto"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "Experimentell"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -20021,7 +20018,7 @@ msgstr "Hämta Tidrapport"
 msgid "Fetch Value From"
 msgstr "Hämta Värde Från"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "Hämta Utvidgade Stycklistor (inklusive Underenheter)"
@@ -20037,7 +20034,7 @@ msgid "Fetching Error"
 msgstr "Hämtar Fel"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "Hämtar växel kurs ..."
 
@@ -20334,15 +20331,15 @@ msgstr "Färdig Artikel Kvantitet"
 msgid "Finished Good Item Quantity"
 msgstr "Färdig Artikel Kvantitet"
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Färdig Artikel är inte specificerad för service artikel {0}"
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Färdig Artikel {0} kvantitet kan inte vara noll"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Färdig Artikel {0} måste vara underleverantör artikel"
 
@@ -20563,7 +20560,7 @@ msgstr "Fast Tillgång"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20714,7 +20711,7 @@ msgstr "För Inköp"
 msgid "For Company"
 msgstr "För Bolag"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "För Standard Leverantör (Valfri)"
 
@@ -20775,7 +20772,7 @@ msgstr "För Leverantör"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "För Lager"
@@ -20818,7 +20815,7 @@ msgstr "För Enskild Leverantör"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "För Artikel {0} pris måste vara positiv tal. Att tillåta negativa priser, aktivera {1} i {2}"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr "För Åtgärd {0}: Kvantitet ({1}) kan inte vara högre än pågående kvantitet ({2})"
 
@@ -21079,7 +21076,7 @@ msgstr "Från Kund"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21189,8 +21186,8 @@ msgstr "Från Datum kan inte vara senare än Till Datum"
 msgid "From Date is mandatory"
 msgstr "Från Datum Erfordras"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21566,14 +21563,14 @@ msgstr "Fler noder kan endast skapas under 'Grupp' Typ noder"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Framtida Betalning Belopp"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "Framtida Betalning Referens"
 
@@ -21598,7 +21595,7 @@ msgstr "Bokföring Register Saldo"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "Bokföring Register Post"
 
@@ -21892,7 +21889,7 @@ msgstr "Hämta Artiklar Från"
 msgid "Get Items From Purchase Receipts"
 msgstr "Hämta Artiklar från Inköp Följedlar"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22415,7 +22412,7 @@ msgstr "Grupp Nod"
 msgid "Group Same Items"
 msgstr "Sammanfoga lika Artikelrader"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "Grupp Lager kan inte användas i transaktioner. Ändra värde på {0}"
 
@@ -23857,11 +23854,11 @@ msgstr "I Lager Kvantitet"
 msgid "In Transit"
 msgstr "I Transit"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr "I Transit Överföring"
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr "I Transit Lager"
 
@@ -24331,7 +24328,7 @@ msgid "Incorrect Type of Transaction"
 msgstr "Felaktig Typ av Transaktion"
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "Felaktig Lager"
 
@@ -24589,8 +24586,8 @@ msgstr "Instruktioner"
 msgid "Insufficient Capacity"
 msgstr "Otillräcklig Kapacitet"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "Otillräckliga Behörigheter"
 
@@ -24839,7 +24836,7 @@ msgstr "Ogiltig Återkommande Datum"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Ogiltig Streck/QR Kod. Det finns ingen Artikel med denna Streck/QR Kod."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Ogiltig Blankoavtal Order för vald Kund och Artikel"
 
@@ -24916,7 +24913,7 @@ msgstr "Ogiltig Överordnad Konto"
 msgid "Invalid Part Number"
 msgstr "Ogiltig Artikel Nummer"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "Ogiltig Bokföring Tid"
 
@@ -24928,7 +24925,7 @@ msgstr "Ogiltig Primär Roll"
 msgid "Invalid Priority"
 msgstr "Ogiltig Prioritet"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr "Ogiltig Process Förlust Konfiguration"
 
@@ -24936,7 +24933,7 @@ msgstr "Ogiltig Process Förlust Konfiguration"
 msgid "Invalid Purchase Invoice"
 msgstr "Ogiltig Inköp Faktura"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "Ogiltig Kvantitet"
 
@@ -24944,9 +24941,9 @@ msgstr "Ogiltig Kvantitet"
 msgid "Invalid Quantity"
 msgstr "Ogiltig Kvantitet"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "Ogiltig Schema"
 
@@ -24958,7 +24955,7 @@ msgstr "Ogiltig Försäljning Pris"
 msgid "Invalid Serial and Batch Bundle"
 msgstr "Felaktig Serie och Parti Paket"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "Ogiltig URL"
 
@@ -24983,7 +24980,7 @@ msgstr "Ogiltig förlorad anledning {0}, skapa ny förlorad anledning"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Ogiltig nummer serie (. saknas) för {0}"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "Ogiltig referens {0} {1}"
 
@@ -25007,7 +25004,7 @@ msgstr "Ogiltig {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "Ogiltig {0} för Intern Bolag Transaktion."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "Ogiltig {0}: {1}"
@@ -25075,7 +25072,7 @@ msgstr "Faktura Datum"
 msgid "Invoice Discounting"
 msgstr "Faktura Rabatt"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "Fakturera Totalt Belopp"
 
@@ -25164,9 +25161,9 @@ msgstr "Faktura kan inte skapas för noll fakturerbar tid"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "Fakturerad Belopp"
 
@@ -25863,7 +25860,7 @@ msgstr "Utfärdande kan inte göras till plats. Ange personal att utfärda Tillg
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Det kan ta upp till några timmar för korrekta lagervärden att vara synliga efter sammanslagning av artiklar."
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "Behövs för att hämta Artikel Detaljer."
 
@@ -25915,7 +25912,7 @@ msgstr "Det är inte möjligt att fördela avgifter lika när det totala beloppe
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26157,7 +26154,7 @@ msgstr "Artikel Kundkorg"
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26188,7 +26185,7 @@ msgstr "Artikel Kundkorg"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26615,7 +26612,7 @@ msgstr "Artikel Producent"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26974,7 +26971,7 @@ msgstr "Artikel Namn"
 msgid "Item operation"
 msgstr "Artikel Åtgärd"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Artikel kvantitet kan inte uppdateras eftersom råmaterial redan är bearbetad."
 
@@ -27013,7 +27010,7 @@ msgstr "Artikel {0} kan inte skapas order för mer än {1} mot Blankoavtal Order
 msgid "Item {0} does not exist"
 msgstr "Artikel {0} finns inte"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "Artikel finns inte {0} i system eller har förfallit"
 
@@ -27101,7 +27098,7 @@ msgstr "Artikel {0}: Order Kvantitet {1} kan inte vara lägre än minimum order 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Artikel {0}: {1} Kvantitet producerad ."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "Artikel {} finns inte."
 
@@ -27138,7 +27135,7 @@ msgstr "Försäljning Historik per Artikel"
 msgid "Item-wise Sales Register"
 msgstr "Försäljning Register per Artikel"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "Artikel: {0} finns inte i system"
 
@@ -27243,7 +27240,7 @@ msgstr "Inköp Artiklar"
 msgid "Items and Pricing"
 msgstr "Artiklar & Prissättning"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Artiklar kan inte uppdateras eftersom underleverantör order är skapad mot Inköp Order {0}."
 
@@ -27452,7 +27449,7 @@ msgstr "Jobb Ansvarig Namn"
 msgid "Job Worker Warehouse"
 msgstr "Jobb Ansvarig Lager"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "Jobbkort {0} skapad"
 
@@ -29073,11 +29070,11 @@ msgstr "Verkställande Direktör"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30421,7 +30418,7 @@ msgstr "Diverse Kostnader"
 msgid "Mismatch"
 msgstr "Felavstämd"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr "Saknas"
 
@@ -30479,7 +30476,7 @@ msgstr "Erfordrade Värden Saknas"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "E-post Mall saknas för Leverans. Ange Mall i Leverans Inställningar."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr "Värde Saknas"
@@ -30960,7 +30957,7 @@ msgstr "Musik"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "Måste vara Heltal"
 
@@ -30993,7 +30990,7 @@ msgstr "N/A"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31131,11 +31128,11 @@ msgstr "Naturgas"
 msgid "Needs Analysis"
 msgstr "Behöver Analys"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "Negativ Kvantitet är inte tillåtet"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negativ Värderingssats är inte tillåtet"
 
@@ -31213,8 +31210,8 @@ msgstr "Netto Belopp"
 msgid "Net Amount (Company Currency)"
 msgstr "Netto Belopp (Bolag Valuta)"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "Netto Tillgång Värde per"
 
@@ -31785,7 +31782,7 @@ msgstr "Ingen Leverantör hittades för Intern Bolag Transaktioner som represent
 msgid "No Tax Withholding data found for the current posting date."
 msgstr "Ingen Moms Avdrag data hittades för aktuell bokföring datum."
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr "Inga Villkor"
 
@@ -31970,15 +31967,15 @@ msgstr "Inga nya transaktioner hittades"
 msgid "No record found"
 msgstr "Ingen post hittad"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr "Inga poster hittades i Tilldelning tabell"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr "Inga poster hittades i Faktura Tabell"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr "Inga poster hittades i Betalning Tabell"
 
@@ -32026,7 +32023,7 @@ msgstr "Kvalitet Avvikelse"
 msgid "Non Profit"
 msgstr "Förening"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "Ej Lager Artiklar"
 
@@ -32040,7 +32037,7 @@ msgstr "Ej Nollvärde"
 msgid "None"
 msgstr "Ingen"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "Ingen av Artiklar har någon förändring i kvantitet eller värde."
 
@@ -32155,8 +32152,8 @@ msgstr "Ej på Lager"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32178,7 +32175,7 @@ msgstr "Ej Tillåtet"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Anteckning"
@@ -32848,7 +32845,7 @@ msgstr "Öppna Arbetsorder"
 msgid "Open a new ticket"
 msgstr "Öppna ny Ärende"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "Öppning"
@@ -32880,7 +32877,7 @@ msgstr "Öppning (Dr)"
 msgid "Opening Accumulated Depreciation"
 msgstr "Öppning Ackumulerad Avskrivning"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr "Öppning Ackumulerad Avskrivning måste vara mindre än eller lika med {0}"
 
@@ -32894,7 +32891,7 @@ msgstr "Öppning Ackumulerad Avskrivning måste vara mindre än eller lika med {
 msgid "Opening Amount"
 msgstr "Öppning Belopp"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "Öppning Saldo"
 
@@ -33024,7 +33021,7 @@ msgstr "Drift Kostnad (Bolag Valuta)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr "Drift Kostnad per Stycklista Kvantitet"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "Drift Kostnad per Arbetsorder / Styckelista"
 
@@ -33054,7 +33051,7 @@ msgstr "Drift Kostnader"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33180,7 +33177,7 @@ msgstr "Åtgärder"
 msgid "Operations Routing"
 msgstr "Åtgärder Rutt"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "Åtgärder kan inte lämnas tomma"
 
@@ -33693,7 +33690,7 @@ msgstr "Utestående"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34248,9 +34245,9 @@ msgstr "Betald"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34699,12 +34696,12 @@ msgstr "Delar Per Million"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34725,7 +34722,7 @@ msgstr "Parti"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "Parti Konto"
 
@@ -34858,12 +34855,12 @@ msgstr "Parti Specifik Artikel"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34990,7 +34987,7 @@ msgid "Payable"
 msgstr "Betalning Konto"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35432,7 +35429,7 @@ msgstr "Betalning Schema"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35670,13 +35667,13 @@ msgstr "Väntar på Aktiviteter"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "Väntar på Kvantitet"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35965,7 +35962,7 @@ msgstr "Kontinuerlig Lager Hantering erfordras för bolag {0} om man ska kunna s
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
+msgid "Personal Details"
 msgstr "Personligt"
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
@@ -36579,7 +36576,7 @@ msgstr "Ange Växel Belopp Konto"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Ange Godkännande Roll eller Godkännande Användare"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "Ange Resultat Enhet"
 
@@ -36591,7 +36588,7 @@ msgstr "Ange Leverans Datum"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Ange Anställning ID för denna Säljare"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "Ange Kostnad Konto"
 
@@ -36600,7 +36597,7 @@ msgstr "Ange Kostnad Konto"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Ange Artikel Kod att hämta Parti Nummer"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "Ange Artikel Kod att hämta Parti Nummer"
 
@@ -36894,7 +36891,7 @@ msgstr "Välj Post Datum före val av Parti"
 msgid "Please select Posting Date first"
 msgstr "Välj Publicering Datum"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "Välj Prislista"
 
@@ -36922,7 +36919,7 @@ msgstr "Välj Underleverantör Order istället för Inköp Order {0}"
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Välj Orealiserad Resultat Konto eller ange standard konto för Orealiserad Resultat Konto för Bolag {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "Välj Stycklista"
 
@@ -36931,10 +36928,10 @@ msgid "Please select a Company"
 msgstr "Välj Bolag"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "Välj Bolag"
 
@@ -37084,7 +37081,7 @@ msgid "Please select {0}"
 msgstr "Välj {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "Välj {0}"
@@ -37154,7 +37151,7 @@ msgstr "Ange Org.Nr. för Offentlig Förvaltning \"%s\""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr "Ange Tillgång Konto i {} mot {}."
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr "Ange Öppning Nummer för Bokförda Avskrivningar"
 
@@ -37279,7 +37276,7 @@ msgstr "Ange Filter"
 msgid "Please set one of the following:"
 msgstr "Ange något av följande:"
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "Ange Återkommande efter spara"
 
@@ -37309,7 +37306,7 @@ msgstr "Ange Kampanj Schema i Kampanj {0}"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "Ange {0}"
@@ -37342,7 +37339,7 @@ msgstr "Konfigurera och aktivera Kontoplan Grupp med Kontoklass {0} för bolag {
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Dela detta e-post meddelande med support så att de kan hitta och åtgärda problem. "
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Specificera"
 
@@ -37362,7 +37359,7 @@ msgstr "Ange Bolag att fortsätta"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Ange giltig Rad ID för Rad {0} i Tabell {1}"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr "Ange {0}"
 
@@ -37370,7 +37367,7 @@ msgstr "Ange {0}"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Ange minst en Egenskap i Egenskap Tabell"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Ange antingen Kvantitet eller Värderingssats eller båda"
 
@@ -37550,14 +37547,14 @@ msgstr "Post Kostnader Konto"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -38046,7 +38043,7 @@ msgstr "Pris Per Enhet ({0})"
 msgid "Price is not set for the item."
 msgstr "Pris är inte angiven för Artikel"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "Pris hittades inte för artikel {0} i prislista {1}"
 
@@ -38577,7 +38574,7 @@ msgstr "Behandling Misslyckades"
 msgid "Process Loss"
 msgstr "Process Förlust"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr "Process Förlust i Procent får inte vara större än 100  "
 
@@ -39074,9 +39071,10 @@ msgstr "Framsteg(%)"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -39084,6 +39082,7 @@ msgstr "Framsteg(%)"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39095,7 +39094,7 @@ msgstr "Framsteg(%)"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39714,7 +39713,7 @@ msgstr "Inköp Huvudansvarig"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40174,12 +40173,12 @@ msgstr "Lägg Undan Regel finns redan för Artikel {0} i Lager {1}."
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40287,7 +40286,7 @@ msgstr "Kvantitet per Enhet"
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40382,7 +40381,7 @@ msgstr "Kvantitet Råmaterial kommer att bestämmas baserad på Kvantitet Färdi
 msgid "Qty to Be Consumed"
 msgstr "Kvantitet att Förbruka"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "Kvantitet att Betala"
@@ -40720,7 +40719,7 @@ msgstr "Kvalitet Granskning Avsikt"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40737,7 +40736,7 @@ msgstr "Kvalitet Granskning Avsikt"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40858,11 +40857,11 @@ msgstr "Kvantitet får inte vara mer än {0}"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "Kvantitet av Artikel erhållen efter produktion / ompackning från given kvantitet av Råmaterial"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "Kvantitet som erfodras för artikel {0} på rad {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40877,7 +40876,7 @@ msgstr "Kvantitet att Producera"
 msgid "Quantity to Manufacture"
 msgstr "Kvantitet att Producera"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "Kvantitet att Producera kan inte vara noll för åtgärd {0}"
 
@@ -41548,7 +41547,7 @@ msgstr "Råmaterial Lager"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41607,7 +41606,7 @@ msgstr "Råmaterial Levererans Kostnad"
 msgid "Raw Materials Warehouse"
 msgstr "Råmaterial Lager"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "Råmaterial kan inte vara tom."
 
@@ -41802,7 +41801,7 @@ msgid "Receivable / Payable Account"
 msgstr "Fordring / Skuld Konto"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41896,7 +41895,7 @@ msgstr "Mottogs"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41907,7 +41906,7 @@ msgstr "Mottogs"
 msgid "Received Qty"
 msgstr "Mottagen Kvantitet"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "Mottagen Kvantitet Belopp"
 
@@ -42257,7 +42256,7 @@ msgstr "Referens # {0} daterad {1}"
 msgid "Reference Date"
 msgstr "Referens Datum"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr "Referens Datum för Tidig Betalning Rabatt"
 
@@ -42680,7 +42679,7 @@ msgstr "Återstående"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Återstående Saldo"
@@ -42733,9 +42732,9 @@ msgstr "Anmärkning"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42769,7 +42768,7 @@ msgstr "Ta bort Överordnad Radnummer i Artikel Tabell"
 msgid "Remove item if charges is not applicable to that item"
 msgstr "Ta bort artikel om avgifter inte är tillämpliga för den"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "Borttagna Artiklar med inga förändringar i Kvantitet eller Värde."
 
@@ -43237,7 +43236,7 @@ msgstr "Förfrågande"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44268,11 +44267,11 @@ msgstr "Åtgärd Följd"
 msgid "Routing Name"
 msgstr "Åtgärd Följd Namn"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "Rad #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "Rad # {0}:"
 
@@ -44364,23 +44363,23 @@ msgstr "Rad # {0}: Parti Nummer {1} är redan vald."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Rad # {0}: Kan inte tilldela mer än {1} mot betalning villkor {2}"
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som redan är fakturerad."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Rad # {0}: Kan inte ta bort artikel {1} som redan är levererad"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Rad #{0}: Kan inte ta bort Artikel {1} som redan är mottagen"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som har tilldelad Arbetsorder."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som är tilldelad Kund Inköp Order."
 
@@ -44388,7 +44387,7 @@ msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som är tilldelad Kund Inköp Or
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "Rad # {0}: Kan inte välja Leverantör Lager samtidigt som Råmaterial tillhandahålls Underleverantör"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "Rad # {0}: Kan inte ange Pris om belopp är högre än fakturerad belopp för Artikel {1}."
 
@@ -44496,7 +44495,7 @@ msgstr "Rad # {0}: Artikel {1} finns inte"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Rad # {0}: Artikel {1} är plockad, reservera lager från Plocklista. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Rad # {0}: Artikel {1} är inte Serialiserad/Parti Artikel. Det kan inte ha Serie Nummer / Parti Nummer mot det."
 
@@ -44574,7 +44573,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Rad #{0}: Kvalitet Kontroll {1} avvisades för artikel {2}"
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Rad # {0}: Kvantitet för Artikel {1} kan inte vara noll."
 
@@ -44582,8 +44581,8 @@ msgstr "Rad # {0}: Kvantitet för Artikel {1} kan inte vara noll."
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr "Rad # {0}: Kvantitet att reservera för Artikel {1} ska vara högre än 0."
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr "Rad #{0}: Pris måste vara samma som {1}: {2} ({3} / {4}) "
 
@@ -44862,11 +44861,11 @@ msgstr "Rad # {0}: Förskott mot Kund måste vara Kredit"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "Rad # {0}: Förskott mot Leverantör måste vara Debet"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "Rad # {0}: Tilldelad belopp {1} måste vara lägre än eller lika med utestående faktura belopp {2}"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "Rad # {0}: Tilldelad belopp {1} måste vara lägre än eller lika med återstående betalning belopp {2}"
 
@@ -44899,7 +44898,7 @@ msgstr "Rad # {0}: Resultat Enhet erfodras för ett Artikel {1}"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "Rad # {0}: Kredit Post kan inte länkas till {1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "Rad # {0}: Valuta för Stycklista # {1} ska vara lika med vald valuta {2}"
 
@@ -44911,7 +44910,7 @@ msgstr "Rad # {0}: Debet Post kan inte länkas till {1}"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Rad # {0}: Leverans Lager ({1}) och Kund Lager ({2}) kan inte vara samma"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "Rad # {0}: Avskrivning Start Datum erfodras"
 
@@ -44932,7 +44931,7 @@ msgstr "Rad # {0}: Ange plats för Tillgång Artikel {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Rad # {0}: Valutaväxling Kurs erfodras"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "Rad # {0}: Förväntad värde efter nyttjande tid måste vara mindre än Brutto Inköp Belopp"
 
@@ -45102,7 +45101,7 @@ msgstr "Rad {0}: {3} Konto {1} tillhör inte bolag {2}"
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr "Rad # {0}: För att ange periodicitet för {1} måste skillnaden mellan från och till datum vara större än eller lika med {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr "Rad # {0}: Totalt Antal Avskrivningar får inte vara mindre än eller lika med antal bokförda avskrivningar"
 
@@ -45110,7 +45109,7 @@ msgstr "Rad # {0}: Totalt Antal Avskrivningar får inte vara mindre än eller li
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "Rad # {0}: Enhet Konvertering Faktor erfordras"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Rad {0}: Arbetsplats eller Arbetsplats Typ erfordras för åtgärd {1}"
@@ -45139,7 +45138,7 @@ msgstr "Rad # {0}: {1} {2} stämmer inte med {3}"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr "Rad # {0}: {2} Artikel {1} finns inte i {2} {3}"
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Rad # {1}: Kvantitet ({0}) kan inte vara bråkdel. För att tillåta detta, inaktivera '{2}' i Enhet {3}."
 
@@ -45778,7 +45777,7 @@ msgstr "Försäljning Ordrar att Leverera"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45876,7 +45875,7 @@ msgstr "Försäljning Betalning Översikt"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45962,7 +45961,7 @@ msgstr "Försäljning Register"
 msgid "Sales Representative"
 msgstr "Försäljningsrepresentant"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "Försäljning Retur"
@@ -46149,7 +46148,7 @@ msgstr "Samma Bolag angavs mer än en gång"
 msgid "Same Item"
 msgstr "Samma Artikel"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr "Samma artikel och lager kombination är redan angivna."
 
@@ -46176,7 +46175,7 @@ msgstr "Prov Lager"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Prov Kvantitet"
@@ -46714,7 +46713,7 @@ msgstr "Välj Artiklar"
 msgid "Select Items based on Delivery Date"
 msgstr "Välj Artiklar baserad på Leverans Datum"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr " Välj Artiklar för Kvalitet Kontroll"
 
@@ -46818,7 +46817,7 @@ msgstr "Välj Standard Prioritet."
 msgid "Select a Supplier"
 msgstr "Välj Leverantör"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "Välj Leverantör bland standard leverantörer av artiklar nedan. Vid val kommer Inköp Order skapas mot artiklar som tillhör vald Leverantör."
 
@@ -46864,7 +46863,7 @@ msgstr "Välj Finans Register för artikel {0} på rad {1}"
 msgid "Select item group"
 msgstr "Välj Artikel Grupp"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "Välj Mall Artikel"
 
@@ -46881,7 +46880,7 @@ msgstr "Välj Standard Arbetsstation där Åtgärd ska utföras. Detta kommer at
 msgid "Select the Item to be manufactured."
 msgstr "Välj Artikel som ska produceras."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "Välj Artikel som ska produceras. Artikel Namn, Enhet, Bolag och Valuta kommer att hämtas automatiskt."
 
@@ -46902,11 +46901,11 @@ msgstr "Välj datum"
 msgid "Select the date and your timezone"
 msgstr "Välj Datum och Tidzon"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr "Välj Råmaterial (Artiklar) som erfodras för att producera artikel"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "Välj Variant Artikel Kod för  Artikel Mall {0}"
 
@@ -47225,7 +47224,7 @@ msgstr "Serie / Parti Nummer"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47311,7 +47310,7 @@ msgstr "Serie Nummer och Parti Väljare kan inte användas när Använd Serie Nu
 msgid "Serial No and Batch for Finished Good"
 msgstr "Serie Nummer och Parti för Färdig Artikel"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr "Serie Nummer erfodras"
 
@@ -47340,13 +47339,17 @@ msgstr "Serie Nummer {0} tillhör inte Artikel {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Serie Nummer {0} finns inte"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr "Serie Nummer {0} finns inte "
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
 msgstr "Serie Nummer {0} har redan lagts till"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+msgstr "Serienummer {0} finns inte i {1} {2}, därför kan du inte returnera det mot {1} {2}"
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
 msgid "Serial No {0} is under maintenance contract upto {1}"
@@ -47385,7 +47388,7 @@ msgstr "Serie Nummer stämmer inte"
 msgid "Serial Nos and Batches"
 msgstr "Serie Nummer & Partier"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr "Serie Nummer skapade"
 
@@ -47458,11 +47461,11 @@ msgstr "Serie Nummer och Parti "
 msgid "Serial and Batch Bundle"
 msgstr "Serie och Parti Paket"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr "Serie och Parti Paket skapad"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr "Serie och Parti Paket uppdaterad"
 
@@ -47809,12 +47812,12 @@ msgid "Service Stop Date"
 msgstr "Service Stopp Datum"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Service Stopp Datum kan inte vara efter Service Slut Datum"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Service Stopp Datum kan inte vara före Service Start Datum"
 
@@ -47910,7 +47913,7 @@ msgstr "Ange Lösenord"
 msgid "Set Posting Date"
 msgstr "Ange Bokföring Datum"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr "Ange Process Förlust Artikel Kvantitet"
 
@@ -47924,7 +47927,7 @@ msgstr "Ange Projekt Status"
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "Ange Projekt och alla Uppgifter till status {0}?"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "Ange Kvantitet"
 
@@ -48019,7 +48022,7 @@ msgstr "Ange Standard {0} konto för Ej Lager Artiklar"
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr "Ange fältnamn från vilket data ska hämtas från överordnad formulär."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr "Ange kvantitet för Process Förlust Artikel:"
 
@@ -48049,15 +48052,15 @@ msgstr "Ange status manuellt."
 msgid "Set this if the customer is a Public Administration company."
 msgstr "Ange detta om Kund är Offentlig Administration."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr "Ange {0} i Tillgång Kategori {1} för Bolag {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "Ange {0} i Tillgång Kategori {1} eller Bolag {2}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "Ange {0} i Bolag {1}"
 
@@ -48124,7 +48127,7 @@ msgstr "Ange konto som Bolag Konto för Bank Avstämmning"
 msgid "Setting up company"
 msgstr "Konfigurerar Bolag"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr "Konfigurera {} erfodras"
@@ -48931,15 +48934,15 @@ msgstr "Försäljare"
 msgid "Something went wrong please try again"
 msgstr "Något gick snett! Försök igen."
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "Tyvärr Rabatt Kod är inte längre giltig"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "Tyvärr Rabatt Kod giltighet har upphört att gälla"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "Tyvärr Rabatt Kod giltighet har inte börjat gälla"
 
@@ -49021,7 +49024,7 @@ msgstr "Käll Typ"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49141,7 +49144,7 @@ msgstr "Delad Ärende"
 msgid "Split Qty"
 msgstr "Dela Kvantitet"
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr "Delad kvantitet får inte vara större än eller lika med tillgång kvantitet"
 
@@ -49566,7 +49569,7 @@ msgstr "Län"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -50064,7 +50067,7 @@ msgstr "Lager Ompostering Inställningar"
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -50073,10 +50076,10 @@ msgstr "Lager Ompostering Inställningar"
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr "Lager Reservation"
 
@@ -50916,7 +50919,7 @@ msgstr "Klar Inställningar"
 msgid "Successful"
 msgstr "Klar"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "Avstämd"
 
@@ -51128,7 +51131,7 @@ msgstr "Levererad Kvantitet"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51232,9 +51235,9 @@ msgstr "Leverantör Detaljer"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51287,7 +51290,7 @@ msgstr "Leverantör Faktura Datum kan inte vara senare än Bokföring Datum"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "Leverantör Faktura Nummer"
@@ -51332,7 +51335,7 @@ msgstr "Leverantör Register"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52949,11 +52952,11 @@ msgstr "Regler och Villkor Mall"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53329,7 +53332,7 @@ msgstr "Aktier finns inte med {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "Lager för artikel {0} i {1} lager var negativt {2}. Skapa positiv post {3} före {4} och {5} för att bokföra rätt Värderingssats. För mer information, läs dokumentation <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'><a>."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Lager är reserverad för följande Artiklar och Lager, ta bort reservation till {0} Lager Inventering : <br /><br /> {1}"
 
@@ -53342,11 +53345,11 @@ msgstr "Synkronisering startad i bakgrunden. Kolla {0} lista för nya poster."
 msgid "The task has been enqueued as a background job."
 msgstr "Uppgift är i kö som bakgrund jobb."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Uppgift är i kö som bakgrund jobb. Om det finns problem med behandling i bakgrund kommer system att lägga till kommentar om fel i denna Lager Inventering och återgå till Utkast status."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Uppgift är i kö som ett bakgrund jobb. Om det finns några problem med bearbetning i bakgrund kommer system att lägga till kommentar om fel på denna Lager Inventering och återgå till Godkänd status"
 
@@ -53400,7 +53403,7 @@ msgstr "{0} {1} är skapade"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr "{0} {1} används för att beräkna grund kostnad för färdig artikel {2}."
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "Det finns aktivt service eller reparationer mot tillgång. Du måste slutföra alla före annullering av tillgång."
 
@@ -53674,7 +53677,7 @@ msgstr "Detta schema skapades när Tillgång {0} skrotades."
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr "Detta schema skapades när Tillgång {0} såldes via Försäljning Faktura {1}."
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr "Detta schema skapades när Tillgång {0} uppdaterades efter att ha delats upp i ny Tillgång {1}."
 
@@ -53690,7 +53693,7 @@ msgstr "Detta schema skapades när Tillgång {0} Tillgång Värde Justering {1} 
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr "Detta schema skapades när Tillgång {0} förskjutning justerades genom Tillgång Förskjutning Tilldelning {1}."
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr "Detta schema skapades när ny Tillgång {0} delades från Tillgång {1}."
 
@@ -53893,7 +53896,7 @@ msgstr "Tidslinje"
 msgid "Timer"
 msgstr "Tidur"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "Tidur överskred angivna timmar."
 
@@ -54095,7 +54098,7 @@ msgstr "Till Valuta"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54394,7 +54397,7 @@ msgstr "Till Lager"
 msgid "To Warehouse (Optional)"
 msgstr "Till Lager (valfritt)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr "Att lägga till Åtgärder kryssa i rutan 'Med Åtgärder'."
 
@@ -54469,7 +54472,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr "Att använda annan finans register, inaktivera \"Inkludera Standard Finans Register Tillgångar\""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr "Att använda annan finans register, inaktivera \"Inkludera Standard Finans Register Tillgångar\""
@@ -54570,7 +54573,7 @@ msgstr "Torr"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56123,7 +56126,7 @@ msgstr "UPC-A"
 msgid "URL"
 msgstr "URL"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "URL kan bara vara sträng"
 
@@ -56733,7 +56736,7 @@ msgstr "Använd Artikel baserad Ompostering "
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56782,6 +56785,12 @@ msgstr "Använd Serie / Parti Nummer Fält"
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
 msgstr "Använd Serie / Parti Nummer Fält"
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
+msgstr "Använd Serversida Reaktivitet"
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
 #. 'Purchase Invoice'
@@ -57195,7 +57204,7 @@ msgstr "Värderingssats för Artikel {0} erfodras att skapa bokföring poster f�
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Värderingssats erfordras om Öppning Lager anges"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Värderingssats erfordras för Artikel {0} på rad {1}"
 
@@ -57205,7 +57214,7 @@ msgstr "Värderingssats erfordras för Artikel {0} på rad {1}"
 msgid "Valuation and Total"
 msgstr "Värdering och Totalt"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Värderingssats för Kund Försedda Artiklar angavs till noll."
 
@@ -57291,6 +57300,11 @@ msgstr "Värde eller Kvantitet"
 msgid "Value Proposition"
 msgstr "Värde Förslag"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr "Värde per"
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "Värde för Egenskap {0} måste vara inom intervall {1} till {2} i steg om {3} för Artikel {4}"
@@ -57299,6 +57313,22 @@ msgstr "Värde för Egenskap {0} måste vara inom intervall {1} till {2} i steg 
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
 msgstr "Gods Värde"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr "Värde av ny Aktiverad Tllgång"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr "Värde av ny Inköp"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr "Värde av Skrotad Tillgång"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
+msgstr "Värde på Såld Tillgång"
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
 msgid "Value of goods cannot be 0"
@@ -57379,7 +57409,7 @@ msgid "Variant Field"
 msgstr "Variant Fält"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "Variant Artikel"
 
@@ -57677,11 +57707,11 @@ msgstr "Verifikat Namn"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57707,7 +57737,7 @@ msgstr "Verifikat Namn"
 msgid "Voucher No"
 msgstr "Verifikat Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr "Verifikat Nummer Erfodras"
 
@@ -57719,7 +57749,7 @@ msgstr "Verifikat Kvantitet"
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr "Verifikat Undertyp"
 
@@ -57749,9 +57779,9 @@ msgstr "Verifikat Undertyp"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57919,7 +57949,7 @@ msgstr "Besök"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58104,7 +58134,7 @@ msgstr "Lager erfordras"
 msgid "Warehouse not found against the account {0}"
 msgstr "Lager hittades inte mot konto {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "Lager hittades inte i system"
 
@@ -58230,7 +58260,7 @@ msgstr "Varna för Inköp Offert Begäran"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "Varning"
 
@@ -58250,7 +58280,7 @@ msgstr "Varning!"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "Varning: Annan {0} # {1} finns mot lager post {2}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "Varning: Inköp Förslag Kvantitet är mindre än Minimum Order Kvantitet"
 
@@ -58783,8 +58813,8 @@ msgstr "Arbetsorder kan inte skapas för följande anledning:<br> {0}"
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "Arbetsorder kan inte skapas mot Artikel Mall"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "Arbetsorder har varit {0}"
 
@@ -59196,7 +59226,7 @@ msgstr "Ja"
 msgid "You are importing data for the code list:"
 msgstr "Du importerar data för Kod Lista:"
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Du är inte behörig att uppdatera enligt villkoren i {} Arbetsflöde."
 
@@ -59261,11 +59291,15 @@ msgstr "Du kan ange den som maskin namn eller åtgärd typ. Till exempel sy mask
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Du kan inte göra några ändringar i Jobbkort eftersom Arbetsorder är stängd."
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr "Du kan inte behandla serienummer {0} eftersom det redan har använts i Serienummer och Parti Paket {1}. {2} Om du vill leverera in samma serienummer flera gånger aktiverar du \"Tillåt att befintligt serienummer produceras/tas emot igen\" i {3}"
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr "Det går inte att lösa in Lojalitet Poäng som har mer värde än Avrundad Belopp."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr "Du kan inte ändra pris om Stycklista är angiven mot någon artikel."
 
@@ -59317,7 +59351,7 @@ msgstr "Du kan inte godkänna order utan betalning."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Du kan inte {0} detta dokument eftersom en annan Period Stängning Post {1} finns efter {2}"
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Du har inte behörighet att {} artikel i {}."
 
@@ -59469,7 +59503,7 @@ msgstr "som Beskrivning"
 msgid "as Title"
 msgstr "som Titel"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr "som procentsats av färdig artikel kvantitet"
 
@@ -59805,7 +59839,7 @@ msgstr "{0} <b>{1}</b> har godkänt tillgångar. Ta bort Artikel <b>{2}</b> frå
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} Konto hittades inte mot Kund {1}."
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr "{0} Konto: {1} ({2}) måste vara antingen i kundens faktura valuta: {3} eller bolag standard valuta: {4}"
 
@@ -59813,7 +59847,7 @@ msgstr "{0} Konto: {1} ({2}) måste vara antingen i kundens faktura valuta: {3} 
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr "{0} Budget för Konto {1} mot {2} {3} är {4}. Det {5} överstiger med {6}"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "{0} Kupong som används är {1}. Tillåten kvantitet är slut"
 
@@ -59873,7 +59907,7 @@ msgstr "{0} har redan Överordnad Procedur {1}."
 msgid "{0} and {1}"
 msgstr "{0} och {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} och {1} erfodras"
@@ -59964,7 +59998,7 @@ msgstr "{0} är spärrad så denna transaktion kan inte fortsätta"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -60046,7 +60080,7 @@ msgstr "{0} måste vara negativ i retur dokument"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr "{0} får inte göra transaktioner med {1}. Ändra fbolag eller lägg till bolag i  \"Tillåtet att handla med\" i kundregister."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{0} hittades inte för artikel {1}"
 
@@ -60062,7 +60096,7 @@ msgstr "{0} betalning poster kan inte filtreras efter {1}"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr "{0} kvantitet av artikel {1} tas emot i Lager {2} med kapacitet {3}."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} enheter är reserverade för Artikel {1} i Lager {2}, ta bort reservation för {3} Lager Inventering."
 

--- a/erpnext/locale/tr.po
+++ b/erpnext/locale/tr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-09 07:05\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:26\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Turkish\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr "Tamamlanma Yüzdesi Yöntemi"
 msgid "% Completed"
 msgstr "% Tamamlandı"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% Bitmiş Ürün Miktarı"
@@ -960,7 +960,7 @@ msgstr "Fiyat Listesi, Satılan, Alınan veya Her İkisi de Olan Ürün Fiyatlar
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr "Alınan, satılan veya stokta tutulan bir Ürün veya Hizmet."
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr "Aynı filtreler için {0} numaralı bir Mutabakat İşi çalışıyor. Şu anda mutabakat yapılamaz"
 
@@ -1165,7 +1165,7 @@ msgstr "Stok Biriminde Kabul Edilen Miktar"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1264,7 +1264,7 @@ msgstr "CEFACT/ICG/2010/IC013 veya CEFACT/ICG/2010/IC010 Standartına Göre"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1483,7 +1483,7 @@ msgstr "Ödeme kayıtlarını almak için hesap zorunludur"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "{0} gösterge tablosu grafiği için hesap ayarlanmadı"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr "Hesap bulunamadı"
 
@@ -1524,7 +1524,7 @@ msgstr "{0} isimli Hesap, {1} şirketine ait değil."
 msgid "Account {0} does not exist"
 msgstr "{0} Hesabı bulunamadı"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "{0} Hesabı bulunamadı"
 
@@ -1851,8 +1851,8 @@ msgstr "Muhasebe Boyutları Filtresi"
 msgid "Accounting Entries"
 msgstr "Muhasebe Girişleri"
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "Varlık İçin Muhasebe Girişi"
@@ -2263,8 +2263,8 @@ msgstr "Birikmiş Amortisman Hesabı"
 msgid "Accumulated Depreciation Amount"
 msgstr "Birikmiş Amortisman Tutarı"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "Birikmiş Amortisman"
 
@@ -2667,7 +2667,7 @@ msgstr "Gerçek tip vergi satırda Ürün fiyatına dahil edilemez {0}"
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2780,7 +2780,7 @@ msgid "Add Quote"
 msgstr "Teklif Ekle"
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr "Hammadde Ekle"
@@ -3392,7 +3392,7 @@ msgstr "Yönetici"
 msgid "Advance Account"
 msgstr "Avans Hesabı"
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr "Avans Hesabı: {0} müşteri fatura para biriminde olmalıdır: {1} veya Şirketin varsayılan para biriminde: {2}"
 
@@ -3524,7 +3524,7 @@ msgstr "Karşılığında"
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "Hesap"
 
@@ -3636,7 +3636,7 @@ msgstr "Tedarikçi Faturasına Karşı {0}"
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "Fatura"
 
@@ -3660,7 +3660,7 @@ msgstr "İlgili Belge No"
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "Fatura Türü"
@@ -3674,7 +3674,7 @@ msgstr "Gün"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "Yaş (Gün)"
 
@@ -3821,7 +3821,7 @@ msgstr "Tüm Aktiviteler"
 msgid "All Activities HTML"
 msgstr "Tüm Etkinlikler HTML"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "Tüm Ürün Ağaçları"
 
@@ -3974,7 +3974,7 @@ msgstr "Tüm ürünler zaten alındı"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Bu İş Emri için tüm öğeler zaten aktarıldı."
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Bu belgedeki tüm Ürünlerin zaten bağlantılı bir Kalite Kontrolü var."
 
@@ -4211,8 +4211,8 @@ msgstr "Bir Müşterinin Satın Alma Siparişine Karşı Birden Fazla Satış Si
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr "Eksi Stoğa İzin Ver"
 
@@ -4351,6 +4351,12 @@ msgstr "Sıfır Değerlemeye İzin Ver"
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
 msgstr "Sıfır Değerlemeye İzin Ver"
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
+msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
 #. DocType 'Manufacturing Settings'
@@ -4773,7 +4779,7 @@ msgstr "Değiştirildi"
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4912,7 +4918,7 @@ msgstr "İşlem para birimi cinsinden tutar"
 msgid "Amount in {0}"
 msgstr "{0} cinsinden Miktar"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5489,11 +5495,11 @@ msgstr "{0} alanı etkinleştirildiğinden, {1} alanının değeri 1'den fazla o
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "{0} Ürününe karşı mevcut gönderilmiş işlemler olduğundan, {1} değerini değiştiremezsiniz."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr "Negatif stok olduğu için {0} özelliğini aktif hale getiremezsiniz."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr "Depolarda Rezerv stok olduğu için {0} ayarını devre dışı bırakamazsınız."
 
@@ -5505,8 +5511,8 @@ msgstr "Yeterli Alt Montaj Ürünleri mevcut olduğundan, {0} Deposu için İş 
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "Yeterli hammadde olduğundan, {0} Deposu için Malzeme Talebi gerekli değildir."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr "{0} etkinleştirildiğinden {1} etkinleştirilemez."
 
@@ -5541,7 +5547,7 @@ msgstr "Montaj Ürünleri"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5608,7 +5614,7 @@ msgstr "Varlık Sermayesi Stok Kalemi"
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5754,7 +5760,7 @@ msgstr "Varlık Hareketleri"
 msgid "Asset Movement Item"
 msgstr "Varlık Hareketi Ürünü"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "Varlık Hareket kaydı {0} oluşturuldu"
 
@@ -5892,7 +5898,7 @@ msgstr "Varlık Değeri Analitiği"
 msgid "Asset cancelled"
 msgstr "Varlık iptal edildi"
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "Varlık iptal edilemez, çünkü zaten {0} durumda"
 
@@ -5912,7 +5918,7 @@ msgstr "Varlık oluşturuldu"
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr "Varlık Sermayelendirmesi {0} gönderildikten sonra oluşturulan varlık"
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr "Varlıktan ayrıldıktan sonra oluşturulan varlık {0}"
 
@@ -5968,7 +5974,7 @@ msgstr "Varlık Kaydedildi"
 msgid "Asset transferred to Location {0}"
 msgstr "Varlık {0} konumuna aktarıldı"
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr "Varlık, Varlığa bölündükten sonra güncellendi {0}"
 
@@ -6105,7 +6111,7 @@ msgstr "Satır #{0}: Ürün {2} için seçilen miktar {1}, depo {4} içinde mevc
 msgid "At least one account with exchange gain or loss is required"
 msgstr "En az bir adet döviz kazancı veya kaybı hesabının bulunması zorunludur"
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr "En azından bir varlığın seçilmesi gerekiyor."
 
@@ -6138,7 +6144,7 @@ msgstr "En az bir Depo zorunludur"
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "Satır #{0}: Sıra numarası {1}, önceki satırın sıra numarası {2} değerinden küçük olamaz"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "Satır {0}: Parti No, {1} Ürünü için zorunludur"
 
@@ -6146,11 +6152,11 @@ msgstr "Satır {0}: Parti No, {1} Ürünü için zorunludur"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "Satır {0}: Üst Satır No, {1} öğesi için ayarlanamıyor"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "Satır {0}: {1} partisi için miktar zorunludur"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "Satır {0}: Seri No, {1} Ürünü için zorunludur"
 
@@ -6769,7 +6775,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6782,7 +6788,7 @@ msgstr "Ürün Ağacı"
 msgid "BOM 1"
 msgstr "Ürün Ağacı 1"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "Ürün Ağacı 1 {0} ve Ürün Ağacı 2 {1} aynı olmamalıdır"
 
@@ -7011,7 +7017,7 @@ msgstr "Ürün Ağacı ve Üretim Miktarı gereklidir."
 msgid "BOM and Production"
 msgstr "Ürün Ağacı ve Üretim"
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "Ürün Ağacı herhangi bir stok kalemi içermiyor"
@@ -7020,23 +7026,23 @@ msgstr "Ürün Ağacı herhangi bir stok kalemi içermiyor"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "Ürün Ağacı yinelemesi: {0}, {1} alt öğesi olamaz"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr "Ürün Ağacı yinelemesi: {1}, {0} girişinin üst öğesi veya alt öğesi olamaz"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "{0} Ürün Ağacı {1} Ürününe ait değil"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "{0} Ürün Ağacı aktif olmalıdır"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "{0} Ürün Ağacı kaydedilmelidir"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr "{1} Ürünü için {0} Ürün Ağacı bulunamadı"
 
@@ -7106,7 +7112,7 @@ msgstr "Bakiye"
 msgid "Balance (Dr - Cr)"
 msgstr "Bakiye (Borç - Alacak)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "Bakiye ({0})"
 
@@ -7755,7 +7761,7 @@ msgstr "Parti Ürünü Son Kullanma Durumu"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7781,17 +7787,21 @@ msgstr "Parti Ürünü Son Kullanma Durumu"
 msgid "Batch No"
 msgstr "Parti No"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr "Parti Numarası Zorunlu"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr "Parti No {0} mevcut değil"
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Parti No {0} , seri numarası olan {1} öğesi ile bağlantılıdır. Lütfen bunun yerine seri numarasını tarayın."
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
 #: erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -7804,7 +7814,7 @@ msgstr "Parti No."
 msgid "Batch Nos"
 msgstr "Parti Numaraları"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr "Parti Numaraları başarıyla oluşturuldu"
 
@@ -7907,7 +7917,7 @@ msgstr "Aşağıdaki Abonelik Planları, carinin varsayılan Fatura Para Birimi 
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7916,7 +7926,7 @@ msgstr "Fatura Tarihi"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7930,7 +7940,7 @@ msgstr "Alış Faturasında Reddedilen Miktar Faturası"
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7949,8 +7959,8 @@ msgstr "Faturalandı"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7971,7 +7981,7 @@ msgstr "Fatura Tutarı"
 msgid "Billed Items To Be Received"
 msgstr "Alınacak Faturalı Ürünler"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "Faturalanan Miktar"
@@ -8374,7 +8384,7 @@ msgstr "Hem Alacak Hesabı: {0} hem de Avans Hesabı: {1} şirket için aynı pa
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "Hem Deneme Süresi Başlangıç Tarihi hem de Deneme Süresi Bitiş Tarihi ayarlanmalıdır"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr "Hem {0} Hesap: {1} hem de Avans Hesap: {2} şirket için aynı para biriminde olmalıdır: {3}"
 
@@ -9061,7 +9071,7 @@ msgstr "Kampanya Takvimleri"
 msgid "Can be approved by {0}"
 msgstr "{0} tarafından onaylanabilir"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr "{0} İş Kartı Devam Ediyor durumunda olduğu için İş Emri kapatılamıyor."
 
@@ -9069,7 +9079,7 @@ msgstr "{0} İş Kartı Devam Ediyor durumunda olduğu için İş Emri kapatıla
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr "Hesaba göre gruplanmışsa Alt Hesaba göre filtreleme yapılamaz"
 
@@ -9085,7 +9095,7 @@ msgstr "POS Profiline göre gruplandırılırsa, POS Profiline göre filtreleme 
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "Ödeme Yöntemine göre gruplandırılırsa, Ödeme Yöntemine göre filtreleme yapılamaz"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr ""
 
@@ -9100,15 +9110,15 @@ msgstr "Sadece faturalandırılmamış ödemeler yapılabilir {0}"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Yalnızca ücret türü 'Önceki Satır Tutarında' veya 'Önceki Satır Toplamında' ise satıra referans verebilir"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr "Kendi değerleme yöntemi olmayan bazı kalemlere karşı işlemler olduğu için değerleme yöntemi değiştirilemez"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr "Aktif partiler için parti bazında değerleme devre dışı bırakılamıyor."
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr "FIFO değerleme yöntemine sahip kalemler için parti bazında değerleme devre dışı bırakılamıyor."
 
@@ -9368,7 +9378,7 @@ msgstr "Rezerve stok olduğundan {0} Satış Siparişi için bir Çekme Listesi 
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr "Devre dışı bırakılan hesaplar için muhasebe girişleri oluşturulamıyor: {0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "Diğer Ürün Ağaçları ile bağlantılı olan bir Ürün Ağacı iptal edilemez."
 
@@ -9389,7 +9399,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "{0} Seri Numarası stok işlemlerinde kullanıldığından silinemiyor"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr "FIFO değerleme yöntemi için parti bazında değerleme devre dışı bırakılamıyor."
 
@@ -9406,7 +9416,7 @@ msgstr "{0} Ürünü Seri No ile \"Teslimatı Sağla ile ve Seri No ile Teslimat
 msgid "Cannot find Item with this Barcode"
 msgstr "Bu Barkoda Sahip Ürün Bulunamadı"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "{0} ürünü için varsayılan bir depo bulunamadı. Lütfen Ürün Ana Verisi'nde veya Stok Ayarları'nda bir tane ayarlayın."
 
@@ -9469,11 +9479,11 @@ msgstr "{0} için İndirim bazında yetkilendirme ayarlanamıyor"
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Bir şirket için birden fazla Ürün Varsayılanı belirlenemez."
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Teslim edilen miktardan daha az miktar ayarlanamıyor"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "Alınan miktardan daha az miktar ayarlanamıyor"
 
@@ -10036,7 +10046,7 @@ msgstr "Çek Genişliği"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "Çek Vade Tarihi"
 
@@ -10308,7 +10318,7 @@ msgstr "Kapalı Belge"
 msgid "Closed Documents"
 msgstr "Kapalı Belgeler"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr "Kapatılan İş Emri durdurulamaz veya Yeniden Açılamaz"
 
@@ -10331,7 +10341,7 @@ msgstr "Kapanış Alacağı"
 msgid "Closing (Dr)"
 msgstr "Kapanış Borcu"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "Kapanış (Açılış + Toplam)"
 
@@ -10354,7 +10364,7 @@ msgstr "Kapanış Tutarı"
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "Kapanış Bakiyesi"
 
@@ -10804,7 +10814,7 @@ msgstr "Şirketler"
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10851,7 +10861,7 @@ msgstr "Şirketler"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11171,7 +11181,7 @@ msgstr "Şirket ve Kaydetme Tarihi zorunludur"
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "Şirketler Arası İşlemler için her iki şirketin para birimlerinin eşleşmesi gerekir."
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "Şirket alanı gereklidir"
@@ -12026,7 +12036,7 @@ msgid "Content Type"
 msgstr "İçerik Türü"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "Devam Et"
@@ -12405,12 +12415,13 @@ msgstr "Maliyet"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12418,6 +12429,7 @@ msgstr "Maliyet"
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12546,11 +12558,6 @@ msgstr "Birim Başına Maliyet"
 msgid "Cost and Freight"
 msgstr "Maliyet ve Nakliye"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "Şu anki maliyet"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "Teslim edilen Ürün Maliyeti"
@@ -12567,14 +12574,6 @@ msgstr "Satılan Ürünün Maliyeti"
 msgid "Cost of Issued Items"
 msgstr "Verilen Ürünlerin Maliyeti"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr "Yeni Sermayelendirilmiş Varlığın Maliyeti"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "Yeni Satın Alma Maliyeti"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12583,14 +12582,6 @@ msgstr "Kalitesizlik Maliyeti Raporu"
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "Satın Alınan Ürünlerin Maliyeti"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "Hurdaya Çıkarılan Varlığın Maliyeti"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "Satılan Varlığın Maliyeti"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12830,7 +12821,7 @@ msgstr "Alacak"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12845,7 +12836,7 @@ msgstr "Alacak"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12890,7 +12881,7 @@ msgstr "Alacak"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -13088,7 +13079,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "Numune Saklama Stok Hareketi Oluştur"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr "Stok Girişi Oluştur"
 
@@ -13282,11 +13273,11 @@ msgstr "{0} oluşturulması kısmen başarılı.\n"
 msgid "Credit"
 msgstr "Alacak"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr "Alacak (İşlem)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "Alacak ({0})"
 
@@ -13402,7 +13393,7 @@ msgstr "Alacak Ayı"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13624,12 +13615,12 @@ msgstr "Fincan"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13742,7 +13733,7 @@ msgstr "{0} için para birimi {1} olmalıdır"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "Kapanış Hesabının Para Birimi {0} olmalıdır"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "Fiyat listesinin para birimi {0} , {1} veya {2} olmalıdır"
 
@@ -14151,7 +14142,7 @@ msgstr "Müşteri Kodu"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14247,11 +14238,11 @@ msgstr "Müşteri Görüşleri"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14291,7 +14282,7 @@ msgstr "Müşteri Grubu Öğesi"
 msgid "Customer Group Name"
 msgstr "Müşteri Grubu"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr "Müşteri Grubu: {0} mevcut değil"
 
@@ -14310,7 +14301,7 @@ msgstr "Müşteri Ürünü"
 msgid "Customer Items"
 msgstr "Müşteri Ürünleri"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "Müşteri Yerel Satın Alma Emri"
 
@@ -14356,7 +14347,7 @@ msgstr "Müşteri Mobil No"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14746,7 +14737,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14982,11 +14973,11 @@ msgstr "Sayın Sistem Yöneticisi,"
 msgid "Debit"
 msgstr "Borç"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr "Borç (İşlem)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "Borç ({0})"
 
@@ -15023,7 +15014,7 @@ msgstr "İşlem Para Birimindeki Borç Tutarı"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15233,7 +15224,7 @@ msgstr "Bu ürün veya şablonu için varsayılan Ürün Ağacı ({0}) aktif olm
 msgid "Default BOM for {0} not found"
 msgstr "{0} İçin Ürün Ağacı Bulunamadı"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr "{0} Ürünü için Varsayılan Ürün Ağacı bulunamadı"
 
@@ -16064,7 +16055,7 @@ msgstr "Satış İrsaliyesi {0} kaydedilmedi"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr "İrsaliyeler, Paketleme için oluşturuldu"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "İrsaliyeler"
@@ -16263,7 +16254,7 @@ msgstr "Amortisman"
 msgid "Depreciation Amount"
 msgstr "Amortisman Tutarı"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "Dönem içindeki Amortisman Tutarı"
 
@@ -16277,7 +16268,7 @@ msgstr "Amortisman Tarihi"
 msgid "Depreciation Details"
 msgstr "Amortisman Detayları"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "Amortisman Varlıklar elden çıkarılması nedeniyle elimine edilmiştir.\n"
 
@@ -16338,15 +16329,15 @@ msgstr "Amortisman Kayıt Tarihi, Kullanıma Hazır Tarihten önce olamaz"
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr "Amortisman Satırı {0}: Amortisman Kayıt Tarihi, Kullanıma Hazır Tarihinden önce olamaz"
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "Amortisman Satırı {0}: Faydalı ömürden sonra beklenen değer {1}'den büyük veya eşit olmalıdır."
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "Amortisman Satırı {0}: Sonraki Amortisman Tarihi, Kullanıma Hazır Tarihten önce olamaz"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "Amortisman Satırı {0}: Sonraki Amortisman Tarihi Satın Alma Tarihinden önce olamaz"
 
@@ -16595,7 +16586,7 @@ msgstr "Tam amortismana tabi varlıklar için amortisman hesaplanamaz"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16778,7 +16769,7 @@ msgstr "Fark Hesabı"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "Bu Stok Girişi bir Açılış Girişi olduğu için Fark Hesabı bir Varlık/Yükümlülük tipi hesap olmalıdır"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Fark Hesabı, bu Stok Mutabakatı bir Açılış Girişi olduğundan Varlık/Yükümlülük türü bir hesap olmalıdır"
 
@@ -17534,7 +17525,7 @@ msgstr "Gerçekten bu hurdaya ayrılmış varlığı geri getirmek istiyor musun
 msgid "Do you still want to enable negative inventory?"
 msgstr "Hala negatif envanteri etkinleştirmek istiyor musunuz?"
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr "Seçilen {0} öğesini temizlemek istiyor musunuz?"
 
@@ -17940,7 +17931,7 @@ msgstr "Son Tarih / Referans Tarihi {0} tarihinden sonra olamaz"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18064,7 +18055,7 @@ msgstr "Öğe grubu tablosunda yinelenen öğe grubu bulundu"
 msgid "Duplicate project has been created"
 msgstr "Projenin yeni bir kopyası oluşturuldu"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "{0} satırı ile {1} satırı aynı değerde"
 
@@ -18956,7 +18947,7 @@ msgstr "Elle Girin"
 msgid "Enter Serial Nos"
 msgstr "Seri Numaralarını Girin"
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "Tedarikçi Girin"
 
@@ -19036,7 +19027,7 @@ msgstr "Göndermeden önce bankanın veya kredi veren kurumun adını girin."
 msgid "Enter the opening stock units."
 msgstr "Açılış stok birimlerini girin."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr "Bu Ürün Ağacından üretilecek Ürünün miktarını girin."
 
@@ -19113,7 +19104,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "Hata"
 
@@ -19684,6 +19675,12 @@ msgstr "Varlık Değerlemesine Dahil Giderler"
 msgid "Expenses Included In Valuation"
 msgstr "Değerlemeye Dahil Giderler"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr "Deneysel"
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -20022,7 +20019,7 @@ msgstr "Zaman Çizelgesinden Getir"
 msgid "Fetch Value From"
 msgstr "Değeri Şuradan Getir"
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "Patlatılmış Ürün Ağacını Getir"
@@ -20038,7 +20035,7 @@ msgid "Fetching Error"
 msgstr "Veri Çekme Hatası"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr "Döviz kurları alınıyor ..."
 
@@ -20335,15 +20332,15 @@ msgstr "Bitmiş Ürün Miktarı"
 msgid "Finished Good Item Quantity"
 msgstr "Bitmiş Ürün Miktarı"
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "{0} Hizmet kalemi için Tamamlanmış Ürün belirtilmemiş"
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Bitmiş Ürün {0} Miktarı sıfır olamaz"
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Bitmiş Ürün {0} alt yüklenici ürünü olmalıdır"
 
@@ -20564,7 +20561,7 @@ msgstr "Sabit Varlık"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20715,7 +20712,7 @@ msgstr "Alış için"
 msgid "For Company"
 msgstr "Şirket Seçimi"
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "Varsayılan Tedarikçi (İsteğe Bağlı)"
 
@@ -20776,7 +20773,7 @@ msgstr "Tedarikçi"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "Hedef Depo"
@@ -20819,7 +20816,7 @@ msgstr "Bireysel tedarikçi için"
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr "{0} Ürünü için oran pozitif bir sayı olmalıdır. Negatif oranlara izin vermek için {2} sayfasında {1} ayarını etkinleştirin"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr "{0} Operasyonu için: Miktar ({1}) bekleyen ({2}) miktarıdan büyük olamaz"
 
@@ -21080,7 +21077,7 @@ msgstr "Müşteriden"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21190,8 +21187,8 @@ msgstr "Başlangıç Tarihi Bitiş Tarihinden büyük olamaz"
 msgid "From Date is mandatory"
 msgstr "Başlangıç Tarihi zorunludur"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21567,14 +21564,14 @@ msgstr "Alt elemanlar yalnızca 'Grup' altında oluşturulabilir."
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Gelecekteki Ödeme Tutarı"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "Yaklaşan Ödeme Referansı"
 
@@ -21599,7 +21596,7 @@ msgstr "Genel Muhasebe Bakiyesi"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "Genel Muhasebe Girişi"
 
@@ -21893,7 +21890,7 @@ msgstr "Ürünleri Getir"
 msgid "Get Items From Purchase Receipts"
 msgstr "Ürünleri Satın Alma İrsaliyesinden Getir"
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22416,7 +22413,7 @@ msgstr "Grup Kategorisi"
 msgid "Group Same Items"
 msgstr "Aynı Ögeleri Grupla"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "Grup Depoları işlemlerde kullanılamaz. Lütfen {0} değerini değiştirin."
 
@@ -23858,11 +23855,11 @@ msgstr "Stok Miktarı"
 msgid "In Transit"
 msgstr "Taşınma Durumunda"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr "Transfer Sürecinde"
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr "Taşıma Deposu"
 
@@ -24332,7 +24329,7 @@ msgid "Incorrect Type of Transaction"
 msgstr "Yanlış İşlem Türü"
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "Yanlış Depo"
 
@@ -24590,8 +24587,8 @@ msgstr "Talimatlar"
 msgid "Insufficient Capacity"
 msgstr "Yetersiz Kapasite"
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "Yetersiz Yetki"
 
@@ -24840,7 +24837,7 @@ msgstr "Geçersiz Otomatik Tekrar Tarihi"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Geçersiz Barkod. Bu barkoda bağlı bir Ürün yok."
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Seçilen Müşteri ve Ürün için Geçersiz Genel Sipariş"
 
@@ -24917,7 +24914,7 @@ msgstr "Geçersiz Ana Hesap"
 msgid "Invalid Part Number"
 msgstr "Geçersiz Parça Numarası"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "Geçersiz Gönderim Zamanı"
 
@@ -24929,7 +24926,7 @@ msgstr "Geçersiz Birincil Rol"
 msgid "Invalid Priority"
 msgstr "Geçersiz Öncelik"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr "Geçersiz Proses Kaybı Yapılandırması"
 
@@ -24937,7 +24934,7 @@ msgstr "Geçersiz Proses Kaybı Yapılandırması"
 msgid "Invalid Purchase Invoice"
 msgstr "Geçersiz Satın Alma Faturası"
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr "Geçersiz Miktar"
 
@@ -24945,9 +24942,9 @@ msgstr "Geçersiz Miktar"
 msgid "Invalid Quantity"
 msgstr "Geçersiz Miktar"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr "Geçersiz Program"
 
@@ -24959,7 +24956,7 @@ msgstr "Geçersiz Satış Fiyatı"
 msgid "Invalid Serial and Batch Bundle"
 msgstr "Geçersiz Seri ve Parti"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "Geçersiz URL"
 
@@ -24984,7 +24981,7 @@ msgstr "Geçersiz kayıp nedeni {0}, lütfen yeni bir kayıp nedeni oluşturun"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "{0} için geçersiz adlandırma serisi (. eksik)"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "Geçersiz referans {0} {1}"
 
@@ -25008,7 +25005,7 @@ msgstr "Geçersiz {0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "Şirketler Arası İşlem için geçersiz {0}."
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "Geçersiz {0}: {1}"
@@ -25076,7 +25073,7 @@ msgstr "Fatura Tarihi"
 msgid "Invoice Discounting"
 msgstr "Fatura İndirimi"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "Fatura Genel Toplamı"
 
@@ -25165,9 +25162,9 @@ msgstr "Sıfır fatura saati için fatura kesilemez"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "Fatura Edilen Tutar"
 
@@ -25864,7 +25861,7 @@ msgstr "Çıkış işlemi bir lokasyona yapılamaz. Lütfen {0} varlığını ç
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Ürünlerin birleştirilmesinden sonra doğru stok değerlerinin görünür hale gelmesi birkaç saat sürebilir."
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "Ürün Detaylarını almak için gereklidir."
 
@@ -25916,7 +25913,7 @@ msgstr "Toplam tutar sıfır olduğunda ücretleri eşit olarak dağıtmak mümk
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26158,7 +26155,7 @@ msgstr "Ürün Sepeti"
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26189,7 +26186,7 @@ msgstr "Ürün Sepeti"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26616,7 +26613,7 @@ msgstr "Üretici Firma"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26975,7 +26972,7 @@ msgstr "Ürün Adı"
 msgid "Item operation"
 msgstr "Operasyon"
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Ürün miktarı güncellenemez çünkü hammaddeler zaten işlenmiş durumda."
 
@@ -27014,7 +27011,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr "{0} ürünü mevcut değil"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "{0} Ürünü sistemde mevcut değil veya süresi dolmuş"
 
@@ -27102,7 +27099,7 @@ msgstr "{0} ürünü {1} adetten daha az sipariş edilemez. Bu ayar ürün sayfa
 msgid "Item {0}: {1} qty produced. "
 msgstr "{0} Ürünü {1} adet üretildi. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr "{0} Ürünü mevcut değil."
 
@@ -27139,7 +27136,7 @@ msgstr "Ürün Bazında Satış Geçmişi"
 msgid "Item-wise Sales Register"
 msgstr "Ürün Bazında Satış Kaydı"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "{0} Ürünü sistemde mevcut değil"
 
@@ -27244,7 +27241,7 @@ msgstr "Talep Edilen Ürünler"
 msgid "Items and Pricing"
 msgstr "Ürünler ve Fiyatlar"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Alt Yüklenici Siparişi {0} Satın Alma Siparişine karşı oluşturulduğu için kalemler güncellenemez."
 
@@ -27453,7 +27450,7 @@ msgstr "Yetkili Kişi Adı"
 msgid "Job Worker Warehouse"
 msgstr "Alt Yüklenici Deposu"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "İş Kartı {0} oluşturuldu"
 
@@ -29075,11 +29072,11 @@ msgstr "Genel Müdür"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30423,7 +30420,7 @@ msgstr "Çeşitli Giderler"
 msgid "Mismatch"
 msgstr "Uyuşmazlık"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr "Eksik"
 
@@ -30481,7 +30478,7 @@ msgstr "Gerekli Eksik Değerler"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "Sevkiyat için e-posta şablonu eksik. Lütfen Teslimat Ayarlarında bir tane belirleyin."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr "Eksik Değer"
@@ -30962,7 +30959,7 @@ msgstr "Müzik"
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "Tam Sayı"
 
@@ -30995,7 +30992,7 @@ msgstr "N / A"
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31133,11 +31130,11 @@ msgstr "Doğal gaz"
 msgid "Needs Analysis"
 msgstr "İhtiyaç Analizi"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "Negatif Miktara izin verilmez"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negatif Değerleme Oranına izin verilmez"
 
@@ -31215,8 +31212,8 @@ msgstr "Net Tutar"
 msgid "Net Amount (Company Currency)"
 msgstr "Net Tutar"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "Tarihindeki Net Varlık Değeri"
 
@@ -31787,7 +31784,7 @@ msgstr "{0} şirketini temsil eden Şirketler Arası İşlemler için Tedarikçi
 msgid "No Tax Withholding data found for the current posting date."
 msgstr "Geçerli kayıt tarihi için Vergi Stopajı verisi bulunamadı."
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr "Şart Yok"
 
@@ -31972,15 +31969,15 @@ msgstr ""
 msgid "No record found"
 msgstr "Kayıt Bulunamadı"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr "Tahsis tablosunda kayıt bulunamadı"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr "Fatura tablosunda kayıt bulunamadı"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr "Ödemeler tablosunda kayıt bulunamadı"
 
@@ -32028,7 +32025,7 @@ msgstr "Uygunsuzluk"
 msgid "Non Profit"
 msgstr "Kâr Amacı Gütmeyen"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "Stok dışı ürünler"
 
@@ -32042,7 +32039,7 @@ msgstr "Sıfır Olmayanlar"
 msgid "None"
 msgstr "Yok"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "Ürünlerin hiçbirinde miktar veya değer değişikliği yoktur."
 
@@ -32157,8 +32154,8 @@ msgstr "Stokta Yok"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32180,7 +32177,7 @@ msgstr "İzin Verilmedi"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Not"
@@ -32850,7 +32847,7 @@ msgstr "İş Emirlerini Aç"
 msgid "Open a new ticket"
 msgstr "Yeni bir destek talebi oluştur"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "Açılış"
@@ -32882,7 +32879,7 @@ msgstr "Açılış Borcu"
 msgid "Opening Accumulated Depreciation"
 msgstr "Birikmiş Amortisman Açılışı"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr "Açılış Birikmiş Amortismanı {0} sayısına küçük veya eşit olmalıdır."
 
@@ -32896,7 +32893,7 @@ msgstr "Açılış Birikmiş Amortismanı {0} sayısına küçük veya eşit olm
 msgid "Opening Amount"
 msgstr "Açılış Tutarı"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "Açılış Bakiyesi"
 
@@ -33026,7 +33023,7 @@ msgstr "Operasyon Maliyeti (Şirket Para Birimi)"
 msgid "Operating Cost Per BOM Quantity"
 msgstr "Ürün Ağacındaki Miktara Göre Operasyon Maliyeti"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "İş Emri / Ürün Ağacına Göre İşletme Maliyeti"
 
@@ -33056,7 +33053,7 @@ msgstr "Operasyon Maliyeti"
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33182,7 +33179,7 @@ msgstr "Operasyonlar"
 msgid "Operations Routing"
 msgstr "Operasyonların Rotası"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "Operasyonlar boş bırakılamaz"
 
@@ -33695,7 +33692,7 @@ msgstr "Ödenmemiş"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34250,9 +34247,9 @@ msgstr "Ödenmiş"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34701,12 +34698,12 @@ msgstr "Milyonda Parça Sayısı"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34727,7 +34724,7 @@ msgstr "Cari"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "Cari Hesabı"
 
@@ -34860,12 +34857,12 @@ msgstr "Partiye Özel Ürün"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34992,7 +34989,7 @@ msgid "Payable"
 msgstr "Ödenecek Borç"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35434,7 +35431,7 @@ msgstr "Ödeme Planı"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35672,13 +35669,13 @@ msgstr "Bekleyen Etkinlikler"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "Bekleyen Tutar"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35967,8 +35964,8 @@ msgstr "{0} şirketinin bu kanıtı görüntülemesi için sürekli envanter ger
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
-msgstr "Kişisel"
+msgid "Personal Details"
+msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
 #. 'Employee'
@@ -36581,7 +36578,7 @@ msgstr "Değişim Miktarı Hesabı girin"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Lütfen Onaylayan Rolü veya Onaylayan Kullanıcıyı girin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "Lütfen maliyet merkezini girin"
 
@@ -36593,7 +36590,7 @@ msgstr "Lütfen Teslimat Tarihini giriniz"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Lütfen bu satış elemanının Personel Kimliğini girin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "Lütfen Gider Hesabını girin"
 
@@ -36602,7 +36599,7 @@ msgstr "Lütfen Gider Hesabını girin"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Parti Numarasını almak için lütfen Ürün Kodunu girin"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "Parti numarasını almak için lütfen Ürün Kodunu girin"
 
@@ -36896,7 +36893,7 @@ msgstr "Cariyi seçmeden önce Gönderme Tarihi seçiniz"
 msgid "Please select Posting Date first"
 msgstr "Lütfen önce Gönderi Tarihini seçin"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "Lütfen Fiyat Listesini Seçin"
 
@@ -36924,7 +36921,7 @@ msgstr "Lütfen Satın Alma Siparişi yerine Alt Yüklenici Siparişini seçin {
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Lütfen Gerçekleşmemiş Kâr / Zarar hesabını seçin veya {0} şirketi için varsayılan Gerçekleşmemiş Kâr / Zarar hesabı hesabını ekleyin"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "Ürün Ağacı Seçin"
 
@@ -36933,10 +36930,10 @@ msgid "Please select a Company"
 msgstr "Bir Şirket Seçiniz"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "Lütfen önce bir Şirket seçin."
 
@@ -37086,7 +37083,7 @@ msgid "Please select {0}"
 msgstr "Lütfen {0} seçin"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "Lütfen Önce {0} Seçin"
@@ -37156,7 +37153,7 @@ msgstr "Lütfen kamu idaresi için Mali Kodu belirleyin '%s'"
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr "Lütfen {} içindeki Sabit Kıymet Hesabını {} ile karşılaştırın."
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr "Lütfen Kayıtlı Amortismanların Açılış Sayısını ayarlayın"
 
@@ -37281,7 +37278,7 @@ msgstr "Lütfen filtreleri ayarlayın"
 msgid "Please set one of the following:"
 msgstr "Lütfen aşağıdakilerden birini ayarlayın:"
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "Lütfen kaydettikten sonra yinelemeyi ayarlayın"
 
@@ -37311,7 +37308,7 @@ msgstr "Lütfen Kampanya Programını Kampanya {0} adresinden ayarlayın"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "Lütfen {0} değerini ayarlayın"
@@ -37344,7 +37341,7 @@ msgstr "Lütfen {1} şirketi için Hesap Türü {0} olan bir grup hesabı kurun 
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Sorunu bulup çözebilmeleri için lütfen bu e-postayı destek ekibinizle paylaşın."
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "Lütfen belirtin"
 
@@ -37364,7 +37361,7 @@ msgstr "Lütfen devam etmek için Şirketi belirtin"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Lütfen {1} tablosundaki {0} satırında geçerli bir Satır Kimliği belirtin"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr "Lütfen {0} belirtin"
 
@@ -37372,7 +37369,7 @@ msgstr "Lütfen {0} belirtin"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Lütfen Özellikler tablosunda en az bir özelliği belirtin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Miktar veya Birim Fiyatı ya da her ikisini de belirtiniz"
 
@@ -37552,14 +37549,14 @@ msgstr "Posta Giderleri"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -38048,7 +38045,7 @@ msgstr "Birim Fiyatı ({0})"
 msgid "Price is not set for the item."
 msgstr "Ürün için fiyat belirlenmedi."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "{0} Ürünü için {1} fiyat listesinde fiyat bulunamadı"
 
@@ -38579,7 +38576,7 @@ msgstr "İşlem Başarısız"
 msgid "Process Loss"
 msgstr "Proses Kaybı"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr "Proses Kaybı Yüzdesi 100'den büyük olamaz"
 
@@ -39076,9 +39073,10 @@ msgstr "İlerleme (%)"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -39086,6 +39084,7 @@ msgstr "İlerleme (%)"
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -39097,7 +39096,7 @@ msgstr "İlerleme (%)"
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39716,7 +39715,7 @@ msgstr "Satın Alma Genel Müdürü"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40176,12 +40175,12 @@ msgstr "{1} Deposundaki {0} Ürünü için zaten bir Paketten Çıkarma Kuralı 
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40289,7 +40288,7 @@ msgstr "Birim Başına Miktar"
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40384,7 +40383,7 @@ msgstr "Hammadde Miktarı, Bitmiş Ürün Miktarına göre belirlenecektir."
 msgid "Qty to Be Consumed"
 msgstr "Tüketilecek Miktar"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "Faturalandırılacak Miktar"
@@ -40722,7 +40721,7 @@ msgstr "Kalite Hedefi Amaçları"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40739,7 +40738,7 @@ msgstr "Kalite Hedefi Amaçları"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40860,11 +40859,11 @@ msgstr "Miktar {0} değerinden fazla olmamalıdır"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr "Belirli miktarlardaki hammaddelerden üretilen veya montaj / paketleme sonrası elde edilen miktar."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "Satır {1} deki Ürün {0} için gereken miktar"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40879,7 +40878,7 @@ msgstr "Yapılması Gereken Miktar"
 msgid "Quantity to Manufacture"
 msgstr "Üretilecek Miktar"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "{0} işlemi için Üretim Miktarı sıfır olamaz"
 
@@ -41550,7 +41549,7 @@ msgstr "Hammadde Deposu"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41609,7 +41608,7 @@ msgstr "Tedarik edilen Hammadde Maliyeti"
 msgid "Raw Materials Warehouse"
 msgstr "Hammadde Deposu"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "Hammadde alanı boş bırakılamaz."
 
@@ -41804,7 +41803,7 @@ msgid "Receivable / Payable Account"
 msgstr "Alacak / Borç Hesabı"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41898,7 +41897,7 @@ msgstr "Alınan Tarih"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41909,7 +41908,7 @@ msgstr "Alınan Tarih"
 msgid "Received Qty"
 msgstr "Alınan Miktar"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "Alınan Miktar Tutarı"
 
@@ -42259,7 +42258,7 @@ msgstr "Referans #{0} tarih {1}"
 msgid "Reference Date"
 msgstr "Referans Tarihi"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42682,7 +42681,7 @@ msgstr "Kalan"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Kalan Bakiye"
@@ -42735,9 +42734,9 @@ msgstr "Açıklama"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42771,7 +42770,7 @@ msgstr "Ürünler Tablosunda Üst Satır Numarasını Kaldır"
 msgid "Remove item if charges is not applicable to that item"
 msgstr "Ürüne uygulanamayan masraflar varsa ürünü kaldırın."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "Miktarında veya değerinde değişiklik olmayan ürünler kaldırıldı."
 
@@ -43238,7 +43237,7 @@ msgstr "Talep Eden"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44269,11 +44268,11 @@ msgstr "Rota"
 msgid "Routing Name"
 msgstr "Rota İsmi"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr "Satır #"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr "Satır # {0}:"
 
@@ -44365,23 +44364,23 @@ msgstr "Satır #{0}: Parti No {1} zaten seçili."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Satır #{0}: Ödeme süresi {2} için {1} değerinden daha fazla tahsis edilemez"
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Satır #{0}: Zaten faturalandırılmış olan {1} kalemi silinemiyor."
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Satır #{0}: Zaten teslim edilmiş olan {1} kalem silinemiyor"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Satır #{0}: Daha önce alınmış olan {1} kalem silinemiyor"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Satır # {0}: İş emri atanmış {1} kalem silinemez."
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Satır #{0}: Müşterinin satın alma siparişine atanmış olan {1} kalem silinemiyor."
 
@@ -44389,7 +44388,7 @@ msgstr "Satır #{0}: Müşterinin satın alma siparişine atanmış olan {1} kal
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "Satır #{0}: Alt yükleniciye hammadde tedarik ederken Tedarikçi Deposu seçilemez"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "Satır #{0}: {1} Ürünü için tutar fatura tutarından büyükse Oran belirlenemez."
 
@@ -44497,7 +44496,7 @@ msgstr "Satır #{0}: {1} öğesi mevcut değil"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Satır #{0}: Ürün {1} toplandı, lütfen Toplama Listesinden stok ayırın."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Satır #{0}: Ürün {1}, Serili/Partili bir ürün değil. Seri No/Parti No’su atanamaz."
 
@@ -44575,7 +44574,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Satır #{0}: {1} kalemi için miktar sıfır olamaz."
 
@@ -44583,8 +44582,8 @@ msgstr "Satır #{0}: {1} kalemi için miktar sıfır olamaz."
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr "Satır #{0}: {1} Kalemi için rezerve edilecek miktar 0'dan büyük olmalıdır."
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr "Satır #{0}: {1} işlemindeki fiyat ile aynı olmalıdır: {2} ({3} / {4})"
 
@@ -44860,11 +44859,11 @@ msgstr ""
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "Satır {0}: Tedarikçiye karşı avans borçlandırılmalıdır"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr "Satır {0}: Tahsis edilen tutar {1}, fatura kalan tutarı {2}’den az veya ona eşit olmalıdır"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr "Satır {0}: Tahsis edilen tutar {1}, kalan ödeme tutarı {2} değerinden az veya ona eşit olmalıdır."
 
@@ -44897,7 +44896,7 @@ msgstr "Satır {0}: Bir Ürün için maliyet merkezi gereklidir {1}"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "Satır {0}: Alacak kaydı {1} ile ilişkilendirilemez"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "Satır {0}: Ürün Ağacı #{1} para birimi, seçilen para birimi {2} ile aynı olmalıdır"
 
@@ -44909,7 +44908,7 @@ msgstr "Satır {0}: Borç girişi {1} ile ilişkilendirilemez"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Satır {0}: Teslimat Deposu ({1}) ve Müşteri Deposu ({2}) aynı olamaz"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "Satır {0}: Amortisman Başlangıç Tarihi gerekli"
 
@@ -44930,7 +44929,7 @@ msgstr "Satır {0}: Varlık kalemi için konum girin {1}"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Satır {0}: Döviz Kuru zorunludur"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "Satır {0}: Faydalı Ömürden Sonra Beklenen Değer, Brüt Satın Alma Tutarından az olmalıdır"
 
@@ -45100,7 +45099,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr "Satır {0}: Toplam Amortisman Sayısı, Kayıtlı Amortismanların Açılış Sayısından az veya eşit olamaz"
 
@@ -45108,7 +45107,7 @@ msgstr "Satır {0}: Toplam Amortisman Sayısı, Kayıtlı Amortismanların Açı
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "Satır {0}: Ölçü Birimi Dönüşüm Faktörü zorunludur"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Satır {0}: Bir Operasyon için İş İstasyonu veya İş İstasyonu Türü zorunludur {1}"
@@ -45137,7 +45136,7 @@ msgstr "Satır {0}: {1} {2} {3} ile eşleşmiyor"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr "Satır {0}: {2} Öğe {1} {2} {3} içinde mevcut değil"
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Satır {1}: Miktar ({0}) kesirli olamaz. Bunu etkinleştirmek için, {3} Ölçü Biriminde ‘{2}’ seçeneğini devre dışı bırakın."
 
@@ -45775,7 +45774,7 @@ msgstr "Teslim Edilecek Satış Siparişleri"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45873,7 +45872,7 @@ msgstr "Satış Ödeme Özeti"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45959,7 +45958,7 @@ msgstr "Satış Kaydı"
 msgid "Sales Representative"
 msgstr "Satış Temsilcisi"
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "Satış İadesi"
@@ -46146,7 +46145,7 @@ msgstr "Aynı şirket birden fazla kızılır"
 msgid "Same Item"
 msgstr "Aynı Ürün"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr "Aynı Ürün ve Depo kombinasyonu zaten girilmiş."
 
@@ -46173,7 +46172,7 @@ msgstr "Numune Saklama Deposu"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Numune Boyutu"
@@ -46711,7 +46710,7 @@ msgstr "Ürünleri Seçin"
 msgid "Select Items based on Delivery Date"
 msgstr "Ürünleri Teslimat Tarihine Göre Seçin"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr "Kalite Kontrolü için Ürün Seçimi"
 
@@ -46815,7 +46814,7 @@ msgstr "Bir Varsayılan Öncelik seçin."
 msgid "Select a Supplier"
 msgstr "Bir Tedarikçi Seçin"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "Aşağıdaki kalemlerin Varsayılan Tedarikçilerinden bir Tedarikçi seçin. Seçim yapıldığında, yalnızca seçilen Tedarikçiye ait kalemler için bir Satın Alma Siparişi verilecektir."
 
@@ -46861,7 +46860,7 @@ msgstr "{1} satırındaki {0} kalemi için finans defterini seçin"
 msgid "Select item group"
 msgstr "Ürün Grubunu Seçin"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "Şablon öğesini seçin"
 
@@ -46878,7 +46877,7 @@ msgstr "İşlemin gerçekleştirileceği Varsayılan İş İstasyonunu seçin. �
 msgid "Select the Item to be manufactured."
 msgstr "Üretilecek Ürünleri Seçin."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr "Üretilecek Ürünü seçin. Ürün adı, Ölçü Birimi, Şirket ve Para Birimi otomatik olarak alınacaktır."
 
@@ -46899,11 +46898,11 @@ msgstr "Tarihi seçin"
 msgid "Select the date and your timezone"
 msgstr "Tarihi ve saat diliminizi seçin"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr "Ürünü üretmek için gerekli ham maddeleri seçin"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "Şablon ürün için değişken ürün kodunu seçin {0}"
 
@@ -47222,7 +47221,7 @@ msgstr "Seri ve Parti Numaraları"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47308,7 +47307,7 @@ msgstr "Seri / Parti Alanlarını Kullan etkinleştirildiğinde Seri No ve Parti
 msgid "Serial No and Batch for Finished Good"
 msgstr "Bitmiş Ürün İçin Seri No ve Parti No"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr "Seri No zorunludur"
 
@@ -47337,13 +47336,17 @@ msgstr "Seri No {0} {1} Ürününe ait değildir"
 msgid "Serial No {0} does not exist"
 msgstr "Seri No {0} mevcut değil"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr "Seri No {0} mevcut değil"
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
 msgstr "Seri No {0} zaten eklendi"
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
 msgid "Serial No {0} is under maintenance contract upto {1}"
@@ -47382,7 +47385,7 @@ msgstr "Seri Numaraları Uyuşmuyor"
 msgid "Serial Nos and Batches"
 msgstr "Seri No ve Partiler"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr "Seri Numaraları başarıyla oluşturuldu"
 
@@ -47455,11 +47458,11 @@ msgstr "Seri No ve Parti"
 msgid "Serial and Batch Bundle"
 msgstr "Seri ve Parti Paketi"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr "Seri ve Toplu Paket oluşturuldu"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr "Seri ve Toplu Paket güncellendi"
 
@@ -47806,12 +47809,12 @@ msgid "Service Stop Date"
 msgstr "Servis Durdurma Tarihi"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Hizmet Durdurma Tarihi, Hizmet Bitiş Tarihinden sonra olamaz"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Hizmet Durdurma Tarihi, Hizmet Başlangıç Tarihinden önce olamaz"
 
@@ -47907,7 +47910,7 @@ msgstr "Şifre Belirle"
 msgid "Set Posting Date"
 msgstr "Kayıt Tarihini Ayarla"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47921,7 +47924,7 @@ msgstr "Proje Durumunu Ayarla"
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "Proje ve tüm Görevlerin durumunu {0} olarak ayarla?"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr "Miktarı Ayarla"
 
@@ -48016,7 +48019,7 @@ msgstr "Stokta olmayan ürünler için varsayılan {0} hesabını ayarlayın"
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr "Üst formdan veri almak istediğiniz alanı ayarlayın."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr "İşlem kaybı kaleminin miktarını ayarlayın:"
 
@@ -48046,15 +48049,15 @@ msgstr "Durumu manuel olarak ayarlayın."
 msgid "Set this if the customer is a Public Administration company."
 msgstr "Müşteri bir Kamu Yönetimi şirketi ise bunu ayarlayın."
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr "Şirket {2} için {1} varlık kategorisinde {0} değerini ayarlayın"
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "Varlık kategorisi {1} veya şirket {2} için {0} değerini ayarlayın"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "{1} şirketinde {0} Ayarlayın"
 
@@ -48121,7 +48124,7 @@ msgstr "Hesabın Şirket Hesabı olarak ayarlanması Banka Mutabakatı için ger
 msgid "Setting up company"
 msgstr "Şirket kuruluyor"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr "{} Ayarı Gerekli"
@@ -48928,15 +48931,15 @@ msgstr "Tarafından satılan"
 msgid "Something went wrong please try again"
 msgstr "Bir şeyler ters gitti lütfen tekrar deneyin"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "Üzgünüz, bu kupon kodu artık geçerli değil"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "Üzgünüz, bu kupon kodunun geçerlilik süresi doldu"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "Üzgünüz, bu kupon kodunun geçerliliği henüz başlamadı"
 
@@ -49018,7 +49021,7 @@ msgstr "Kaynak Türü"
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49138,7 +49141,7 @@ msgstr "Sorunu Böl"
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49563,7 +49566,7 @@ msgstr "Durum"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -50061,7 +50064,7 @@ msgstr "Stok Yeniden Gönderim Ayarları"
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -50070,10 +50073,10 @@ msgstr "Stok Yeniden Gönderim Ayarları"
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr "Stok Rezervasyonu"
 
@@ -50913,7 +50916,7 @@ msgstr "Başarı Ayarları"
 msgid "Successful"
 msgstr "Başarılı"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "Başarıyla Uzlaştırıldı"
 
@@ -51125,7 +51128,7 @@ msgstr "Tedarik Edilen Miktar"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51229,9 +51232,9 @@ msgstr "Tedarikçi Detayları"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51284,7 +51287,7 @@ msgstr "Tedarikçi Fatura Tarihi, Kaydedilme Tarihinden büyük olamaz"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "Tedarikçi Fatura No"
@@ -51329,7 +51332,7 @@ msgstr "Tedarikçi Defteri Özeti"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52946,11 +52949,11 @@ msgstr "Şartlar ve Koşullar"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53326,7 +53329,7 @@ msgstr "{0} ile paylaşımlar mevcut değil"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Stok aşağıdaki Ürünler ve Depolar için rezerve edilmiştir, Stok Sayımı {0} için rezerve edilmeyen hale getirin: <br /><br /> {1}"
 
@@ -53339,11 +53342,11 @@ msgstr "Senkronizasyon arka planda başladı, lütfen yeni kayıtlar için {0} l
 msgid "The task has been enqueued as a background job."
 msgstr "Görev arka plan işi olarak kuyruğa alındı."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Görev arka plan işi olarak sıraya alındı. Arka planda işlemede herhangi bir sorun olması durumunda, sistem bu Stok Sayımı hata hakkında bir yorum ekleyecek ve Taslak aşamasına geri dönecektir."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Görev arka plan işi olarak kuyruğa alındı. Arka planda işlem yapılmasında herhangi bir sorun olması durumunda sistem bu Stok Sayımı hata hakkında yorum ekleyecek ve Gönderildi aşamasına geri dönecektir."
 
@@ -53397,7 +53400,7 @@ msgstr "{0} {1} başarıyla oluşturuldu"
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "Varlık üzerinde aktif bakım veya onarımlar var. Varlığı iptal etmeden önce bunların hepsini tamamlamanız gerekir."
 
@@ -53671,7 +53674,7 @@ msgstr "Bu program, Varlık {0} hurdaya çıkarıldığında oluşturuldu."
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53687,7 +53690,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53890,7 +53893,7 @@ msgstr "Zaman cetveli"
 msgid "Timer"
 msgstr "Zamanlayıcı"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "Zamanlayıcı belirtilen saati aştı."
 
@@ -54092,7 +54095,7 @@ msgstr "Para Birimine"
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54391,7 +54394,7 @@ msgstr "Hedef Depo"
 msgid "To Warehouse (Optional)"
 msgstr "Depo (İsteğe bağlı)"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr "Operasyonları Yönetmek için 'Operasyonlar' kutusunu işaretleyin."
 
@@ -54466,7 +54469,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr "Farklı bir finans defteri kullanmak için lütfen 'Varsayılan FD Varlıklarını Dahil Et' seçeneğinin işaretini kaldırın"
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54567,7 +54570,7 @@ msgstr "Torr"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56120,7 +56123,7 @@ msgstr "UPC-A"
 msgid "URL"
 msgstr "URL"
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "URL yalnızca bir dize olabilir"
 
@@ -56730,7 +56733,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56779,6 +56782,12 @@ msgstr "Seri / Parti Alanları Kullan"
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
 msgstr "Seri No / Parti Alanlarını Kullanın"
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
+msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
 #. 'Purchase Invoice'
@@ -57192,7 +57201,7 @@ msgstr ""
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Açılış Stoku girilirse Değerleme Oranı zorunludur"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "{1} nolu satırdaki {0} Ürünü için Değerleme Oranı gereklidir"
 
@@ -57202,7 +57211,7 @@ msgstr "{1} nolu satırdaki {0} Ürünü için Değerleme Oranı gereklidir"
 msgid "Valuation and Total"
 msgstr "Değerleme ve Toplam"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Müşteri tarafından sağlanan ürünler için değerleme oranı sıfır olarak ayarlandı."
 
@@ -57288,6 +57297,11 @@ msgstr "Değer veya Miktar"
 msgid "Value Proposition"
 msgstr "Değer Önerisi"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr ""
@@ -57296,6 +57310,22 @@ msgstr ""
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
 msgstr "Malların Değeri"
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
+msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
 msgid "Value of goods cannot be 0"
@@ -57376,7 +57406,7 @@ msgid "Variant Field"
 msgstr "Varyant Alanı"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "Varyant Ürün"
 
@@ -57674,11 +57704,11 @@ msgstr "Belge Adı"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57704,7 +57734,7 @@ msgstr "Belge Adı"
 msgid "Voucher No"
 msgstr "Belge Numarası"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr "Belge No Zorunludur"
 
@@ -57716,7 +57746,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr "Giriş Türü"
 
@@ -57746,9 +57776,9 @@ msgstr "Giriş Türü"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57916,7 +57946,7 @@ msgstr "Rezervasyonsuz Müşteri"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -58101,7 +58131,7 @@ msgstr "Depo Zorunludur"
 msgid "Warehouse not found against the account {0}"
 msgstr "Hesap {0} karşılığında depo bulunamadı."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "Depo sistemde bulunamadı"
 
@@ -58227,7 +58257,7 @@ msgstr "Yeni Fiyat Teklifi Talebi için Uyar"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "Uyarı"
 
@@ -58247,7 +58277,7 @@ msgstr "Uyarı!"
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "Uyarı: Talep Edilen Malzeme Miktarı Minimum Sipariş Miktarından Az"
 
@@ -58780,8 +58810,8 @@ msgstr "Aşağıdaki nedenden dolayı İş Emri oluşturulamıyor: <br> {0}"
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "İş Emri bir Ürün Şablonuna karşı oluşturulamaz"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "İş Emri {0}"
 
@@ -59193,7 +59223,7 @@ msgstr "Evet"
 msgid "You are importing data for the code list:"
 msgstr "Kod listesi için veri aktarıyorsunuz:"
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "{} İş Akışında belirlenen koşullara göre güncelleme yapmanıza izin verilmiyor."
 
@@ -59258,11 +59288,15 @@ msgstr "Bunu bir makine adı veya işlem türü olarak ayarlayabilirsiniz. Örne
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "İş Emri kapalı olduğundan İş Kartında herhangi bir değişiklik yapamazsınız."
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr "Yuvarlatılmış Toplam değerinden daha fazla değere sahip Sadakat Puanlarını kullanamazsınız."
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr "Herhangi bir Ürün için Ürün Ağacı belirtilmişse fiyatı değiştiremezsiniz."
 
@@ -59314,7 +59348,7 @@ msgstr "Ödeme yapılmadan siparişi gönderemezsiniz."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "{} içindeki {} öğelerine ilişkin izniniz yok."
 
@@ -59466,7 +59500,7 @@ msgstr "Açıklama olarak"
 msgid "as Title"
 msgstr "Başlık olarak"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr "bitmiş ürün miktarının yüzdesi olarak"
 
@@ -59802,7 +59836,7 @@ msgstr "{0} <b>{1}</b> Varlıklar gönderdi. Devam etmek için tablodan <b>{2}</
 msgid "{0} Account not found against Customer {1}."
 msgstr "{1} Müşterisine ait {0} hesabı bulunamadı."
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59810,7 +59844,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "{0} Kupon kullanıldı {1}. İzin verilen miktar tükendi"
 
@@ -59870,7 +59904,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr "{0} ve {1}"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0} ve {1} zorunludur"
@@ -59961,7 +59995,7 @@ msgstr "{0} engellendi, bu işleme devam edilemiyor"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -60043,7 +60077,7 @@ msgstr "{0} iade faturasında negatif değer olmalıdır"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr "{0} {1} ile işlem yapmaya izin verilmiyor. Lütfen Şirketi değiştirin veya Müşteri kaydındaki 'İşlem Yapmaya İzin Verilenler' bölümüne Şirketi ekleyin."
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "{1} için {0} bulunamadı"
 
@@ -60059,7 +60093,7 @@ msgstr "{0} ödeme girişleri {1} ile filtrelenemez"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr "{1} ürününden {0} miktarı, {3} kapasiteli {2} deposuna alınmaktadır."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} birim {1} Ürünü için {2} Deposunda rezerve edilmiştir, lütfen Stok Doğrulamasını {3} yapabilmek için stok rezevini kaldırın."
 

--- a/erpnext/locale/zh.po
+++ b/erpnext/locale/zh.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: info@erpnext.com\n"
-"POT-Creation-Date: 2024-12-08 09:35+0000\n"
-"PO-Revision-Date: 2024-12-08 15:14\n"
+"POT-Creation-Date: 2024-12-15 09:35+0000\n"
+"PO-Revision-Date: 2024-12-16 07:27\n"
 "Last-Translator: info@erpnext.com\n"
 "Language-Team: Chinese Simplified\n"
 "MIME-Version: 1.0\n"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "% Completed"
 msgstr "% 已完成"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:872
+#: erpnext/manufacturing/doctype/bom/bom.js:886
 #, python-format
 msgid "% Finished Item Quantity"
 msgstr "% 成品数量"
@@ -856,7 +856,7 @@ msgstr ""
 msgid "A Product or a Service that is bought, sold or kept in stock."
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:540
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:538
 msgid "A Reconciliation Job {0} is running for the same filters. Cannot reconcile now"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2296
+#: erpnext/public/js/controllers/transaction.js:2319
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:30
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:190
 #: erpnext/accounts/report/general_ledger/general_ledger.js:38
-#: erpnext/accounts/report/general_ledger/general_ledger.py:604
+#: erpnext/accounts/report/general_ledger/general_ledger.py:606
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:30
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:146
@@ -1379,7 +1379,7 @@ msgstr "必须输入帐户才能获得付款条目"
 msgid "Account is not set for the dashboard chart {0}"
 msgstr "没有为仪表板图表{0}设置帐户"
 
-#: erpnext/assets/doctype/asset/asset.py:695
+#: erpnext/assets/doctype/asset/asset.py:701
 msgid "Account not Found"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgstr "科目{0}不属于公司{1}"
 msgid "Account {0} does not exist"
 msgstr "科目{0}不存在"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:67
+#: erpnext/accounts/report/general_ledger/general_ledger.py:64
 msgid "Account {0} does not exists"
 msgstr "科目{0}不存在"
 
@@ -1747,8 +1747,8 @@ msgstr ""
 msgid "Accounting Entries"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:729
-#: erpnext/assets/doctype/asset/asset.py:744
+#: erpnext/assets/doctype/asset/asset.py:735
+#: erpnext/assets/doctype/asset/asset.py:750
 #: erpnext/assets/doctype/asset_capitalization/asset_capitalization.py:586
 msgid "Accounting Entry for Asset"
 msgstr "资产会计分录"
@@ -2159,8 +2159,8 @@ msgstr ""
 msgid "Accumulated Depreciation Amount"
 msgstr "累计折旧额"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:485
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:503
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:483
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:501
 msgid "Accumulated Depreciation as on"
 msgstr "作为累计折旧"
 
@@ -2563,7 +2563,7 @@ msgstr "实际类型税不能被包含在连续的物料等级中{0}"
 #: erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
 #: erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
 #: erpnext/crm/doctype/lead/lead.js:84
-#: erpnext/manufacturing/doctype/bom/bom.js:902
+#: erpnext/manufacturing/doctype/bom/bom.js:916
 #: erpnext/manufacturing/doctype/plant_floor/stock_summary_template.html:55
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:235
 #: erpnext/public/js/bom_configurator/bom_configurator.bundle.js:264
@@ -2676,7 +2676,7 @@ msgid "Add Quote"
 msgstr ""
 
 #. Label of the add_raw_materials (Button) field in DocType 'BOM Operation'
-#: erpnext/manufacturing/doctype/bom/bom.js:900
+#: erpnext/manufacturing/doctype/bom/bom.js:914
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 msgid "Add Raw Materials"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr "管理员"
 msgid "Advance Account"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:209
+#: erpnext/utilities/transaction_base.py:212
 msgid "Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:39
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:91
-#: erpnext/accounts/report/general_ledger/general_ledger.py:670
+#: erpnext/accounts/report/general_ledger/general_ledger.py:672
 msgid "Against Account"
 msgstr "针对的科目"
 
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #. Label of the against_voucher (Dynamic Link) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:689
+#: erpnext/accounts/report/general_ledger/general_ledger.py:691
 msgid "Against Voucher"
 msgstr "针对的凭证"
 
@@ -3556,7 +3556,7 @@ msgstr ""
 #: erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
 #: erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:687
+#: erpnext/accounts/report/general_ledger/general_ledger.py:689
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:177
 msgid "Against Voucher Type"
 msgstr "针对的凭证类型"
@@ -3570,7 +3570,7 @@ msgstr "账龄"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1095
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
 msgid "Age (Days)"
 msgstr "时间（天）"
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "All Activities HTML"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:286
+#: erpnext/manufacturing/doctype/bom/bom.py:303
 msgid "All BOMs"
 msgstr "全部物料清单"
 
@@ -3870,7 +3870,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "所有物料已发料到该工单。"
 
-#: erpnext/public/js/controllers/transaction.js:2385
+#: erpnext/public/js/controllers/transaction.js:2408
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4107,8 +4107,8 @@ msgstr ""
 #: erpnext/stock/doctype/item/item.json
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
 msgid "Allow Negative Stock"
 msgstr ""
 
@@ -4246,6 +4246,12 @@ msgstr ""
 #: erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
 #: erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
 msgid "Allow Zero Valuation Rate"
+msgstr ""
+
+#. Label of the allow_existing_serial_no (Check) field in DocType 'Stock
+#. Settings'
+#: erpnext/stock/doctype/stock_settings/stock_settings.json
+msgid "Allow existing Serial No to be Manufactured/Received again"
 msgstr ""
 
 #. Description of the 'Allow Continuous Material Consumption' (Check) field in
@@ -4669,7 +4675,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:72
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:269
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:272
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
 #: erpnext/crm/doctype/prospect_opportunity/prospect_opportunity.json
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -4808,7 +4814,7 @@ msgstr ""
 msgid "Amount in {0}"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 msgid "Amount to Bill"
 msgstr ""
@@ -5385,11 +5391,11 @@ msgstr "启用字段{0}时，字段{1}的值应大于1。"
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:209
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
 msgid "As there are negative stock, you can not enable {0}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:223
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
 msgid "As there are reserved stock, you cannot disable {0}."
 msgstr ""
 
@@ -5401,8 +5407,8 @@ msgstr ""
 msgid "As there are sufficient raw materials, Material Request is not required for Warehouse {0}."
 msgstr "由于有足够的原材料，因此仓库{0}不需要“物料请求”。"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:177
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:189
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
 msgid "As {0} is enabled, you can not enable {1}."
 msgstr ""
 
@@ -5437,7 +5443,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:30
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:140
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:44
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:439
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:437
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_activity/asset_activity.json
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -5504,7 +5510,7 @@ msgstr ""
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:36
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:190
 #: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.js:37
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:429
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:427
 #: erpnext/assets/doctype/asset/asset.json
 #: erpnext/assets/doctype/asset_category/asset_category.json
 #: erpnext/assets/doctype/asset_maintenance/asset_maintenance.json
@@ -5650,7 +5656,7 @@ msgstr "资产移动"
 msgid "Asset Movement Item"
 msgstr "资产变动项目"
 
-#: erpnext/assets/doctype/asset/asset.py:963
+#: erpnext/assets/doctype/asset/asset.py:972
 msgid "Asset Movement record {0} created"
 msgstr "资产移动记录{0}创建"
 
@@ -5788,7 +5794,7 @@ msgstr "资产价值分析"
 msgid "Asset cancelled"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:527
+#: erpnext/assets/doctype/asset/asset.py:533
 msgid "Asset cannot be cancelled, as it is already {0}"
 msgstr "资产不能被取消，因为它已经是{0}"
 
@@ -5808,7 +5814,7 @@ msgstr ""
 msgid "Asset created after Asset Capitalization {0} was submitted"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1212
+#: erpnext/assets/doctype/asset/asset.py:1221
 msgid "Asset created after being split from Asset {0}"
 msgstr ""
 
@@ -5864,7 +5870,7 @@ msgstr ""
 msgid "Asset transferred to Location {0}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1146
+#: erpnext/assets/doctype/asset/asset.py:1155
 msgid "Asset updated after being split into Asset {0}"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "At least one account with exchange gain or loss is required"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1069
+#: erpnext/assets/doctype/asset/asset.py:1078
 msgid "At least one asset has to be selected."
 msgstr ""
 
@@ -6034,7 +6040,7 @@ msgstr ""
 msgid "At row #{0}: the sequence id {1} cannot be less than previous row sequence id {2}"
 msgstr "在第{0}行：序列ID {1}不能小于上一行的序列ID {2}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:711
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:775
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6042,11 +6048,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:696
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:760
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:703
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:767
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6665,7 +6671,7 @@ msgstr ""
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:109
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/selling/doctype/sales_order/sales_order.js:1001
-#: erpnext/stock/doctype/material_request/material_request.js:308
+#: erpnext/stock/doctype/material_request/material_request.js:311
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:641
 #: erpnext/stock/report/bom_search/bom_search.py:38
@@ -6678,7 +6684,7 @@ msgstr ""
 msgid "BOM 1"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1426
+#: erpnext/manufacturing/doctype/bom/bom.py:1443
 msgid "BOM 1 {0} and BOM 2 {1} should not be same"
 msgstr "BOM 1 {0}和BOM 2 {1}不应相同"
 
@@ -6907,7 +6913,7 @@ msgstr "物料清单和生产量是必需的"
 msgid "BOM and Production"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:340
+#: erpnext/stock/doctype/material_request/material_request.js:343
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:693
 msgid "BOM does not contain any stock item"
 msgstr "物料清单不包含任何库存物料"
@@ -6916,23 +6922,23 @@ msgstr "物料清单不包含任何库存物料"
 msgid "BOM recursion: {0} cannot be child of {1}"
 msgstr "BOM递归：{0}不能是{1}的子代"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:650
+#: erpnext/manufacturing/doctype/bom/bom.py:667
 msgid "BOM recursion: {1} cannot be parent or child of {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1297
+#: erpnext/manufacturing/doctype/bom/bom.py:1314
 msgid "BOM {0} does not belong to Item {1}"
 msgstr "物料清单{0}不属于物料{1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1279
+#: erpnext/manufacturing/doctype/bom/bom.py:1296
 msgid "BOM {0} must be active"
 msgstr "物料清单{0}必须处于激活状态"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1282
+#: erpnext/manufacturing/doctype/bom/bom.py:1299
 msgid "BOM {0} must be submitted"
 msgstr "BOM{0}未提交"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:699
+#: erpnext/manufacturing/doctype/bom/bom.py:716
 msgid "BOM {0} not found for the item {1}"
 msgstr ""
 
@@ -7002,7 +7008,7 @@ msgstr "余额"
 msgid "Balance (Dr - Cr)"
 msgstr "结余（Dr  -  Cr）"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:623
+#: erpnext/accounts/report/general_ledger/general_ledger.py:625
 msgid "Balance ({0})"
 msgstr "余额（{0}）"
 
@@ -7651,7 +7657,7 @@ msgstr "物料批号到期状态"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2322
+#: erpnext/public/js/controllers/transaction.js:2345
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7677,16 +7683,20 @@ msgstr "物料批号到期状态"
 msgid "Batch No"
 msgstr "批号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:714
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:778
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2393
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2465
 msgid "Batch No {0} does not exists"
 msgstr ""
 
 #: erpnext/stock/utils.py:624
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:296
+msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #. Label of the batch_no (Int) field in DocType 'BOM Update Batch'
@@ -7700,7 +7710,7 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1285
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1349
 msgid "Batch Nos are created successfully"
 msgstr ""
 
@@ -7803,7 +7813,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1078
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -7812,7 +7822,7 @@ msgstr "账单日期"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -7826,7 +7836,7 @@ msgstr ""
 
 #. Label of a Card Break in the Manufacturing Workspace
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.py:1153
+#: erpnext/manufacturing/doctype/bom/bom.py:1170
 #: erpnext/manufacturing/workspace/manufacturing/manufacturing.json
 #: erpnext/stock/doctype/material_request/material_request.js:107
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:623
@@ -7845,8 +7855,8 @@ msgstr "已开票"
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:50
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:125
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:183
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:277
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:186
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:280
 #: erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py:107
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:209
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:298
@@ -7867,7 +7877,7 @@ msgstr ""
 msgid "Billed Items To Be Received"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:255
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:258
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:276
 msgid "Billed Qty"
 msgstr "开票数量"
@@ -8270,7 +8280,7 @@ msgstr ""
 msgid "Both Trial Period Start Date and Trial Period End Date must be set"
 msgstr "必须设置试用期开始日期和试用期结束日期"
 
-#: erpnext/utilities/transaction_base.py:224
+#: erpnext/utilities/transaction_base.py:227
 msgid "Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
 msgstr ""
 
@@ -8957,7 +8967,7 @@ msgstr ""
 msgid "Can be approved by {0}"
 msgstr "可以被{0}的批准"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1572
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1574
 msgid "Can not close Work Order. Since {0} Job Cards are in Work In Progress state."
 msgstr ""
 
@@ -8965,7 +8975,7 @@ msgstr ""
 msgid "Can not filter based on Cashier, if grouped by Cashier"
 msgstr "如果按收银员分组，则无法根据收银员进行过滤"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:73
+#: erpnext/accounts/report/general_ledger/general_ledger.py:70
 msgid "Can not filter based on Child Account, if grouped by Account"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr "如果按POS配置文件分组，则无法基于POS配置文件进行过
 msgid "Can not filter based on Payment Method, if grouped by Payment Method"
 msgstr "如果按付款方式分组，则无法基于付款方式进行过滤"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:76
+#: erpnext/accounts/report/general_ledger/general_ledger.py:73
 msgid "Can not filter based on Voucher No, if grouped by Voucher"
 msgstr "按凭证分类后不能根据凭证编号过滤"
 
@@ -8996,15 +9006,15 @@ msgstr "只能为未开票{0}付款"
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "收取类型类型必须是“基于上一行的金额”或者“前一行的总计”才能引用组"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:147
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:148
 msgid "Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:119
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:120
 msgid "Can't disable batch wise valuation for active batches."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:116
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:117
 msgid "Can't disable batch wise valuation for items with FIFO valuation method."
 msgstr ""
 
@@ -9264,7 +9274,7 @@ msgstr ""
 msgid "Cannot create accounting entries against disabled accounts: {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1009
+#: erpnext/manufacturing/doctype/bom/bom.py:1026
 msgid "Cannot deactivate or cancel BOM as it is linked with other BOMs"
 msgstr "无法停用或取消BOM，因为它被其他BOM引用。"
 
@@ -9285,7 +9295,7 @@ msgstr ""
 msgid "Cannot delete Serial No {0}, as it is used in stock transactions"
 msgstr "无法删除序列号{0}，因为它已被库存活动使用"
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:111
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:112
 msgid "Cannot disable batch wise valuation for FIFO valuation method."
 msgstr ""
 
@@ -9302,7 +9312,7 @@ msgstr "无法确保按序列号交货，因为添加和不保证按序列号交
 msgid "Cannot find Item with this Barcode"
 msgstr "用此条形码找不到物品"
 
-#: erpnext/controllers/accounts_controller.py:3290
+#: erpnext/controllers/accounts_controller.py:3302
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9365,11 +9375,11 @@ msgstr "不能为{0}设置折扣授权"
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "无法为公司设置多个项目默认值。"
 
-#: erpnext/controllers/accounts_controller.py:3438
+#: erpnext/controllers/accounts_controller.py:3450
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "无法设定数量小于交货数量"
 
-#: erpnext/controllers/accounts_controller.py:3441
+#: erpnext/controllers/accounts_controller.py:3453
 msgid "Cannot set quantity less than received quantity"
 msgstr "无法设置小于收货数量的数量"
 
@@ -9932,7 +9942,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2233
+#: erpnext/public/js/controllers/transaction.js:2256
 msgid "Cheque/Reference Date"
 msgstr "支票/参考日期"
 
@@ -10204,7 +10214,7 @@ msgstr "已关闭文件"
 msgid "Closed Documents"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1499
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1501
 msgid "Closed Work Order can not be stopped or Re-opened"
 msgstr ""
 
@@ -10227,7 +10237,7 @@ msgstr "结算(信用)"
 msgid "Closing (Dr)"
 msgstr "结算(借记)"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:416
+#: erpnext/accounts/report/general_ledger/general_ledger.py:418
 msgid "Closing (Opening + Total)"
 msgstr "期末（期初+总计）"
 
@@ -10250,7 +10260,7 @@ msgstr ""
 #. Label of the bank_statement_closing_balance (Currency) field in DocType
 #. 'Bank Reconciliation Tool'
 #: erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:138
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
 msgid "Closing Balance"
 msgstr "结算余额"
 
@@ -10700,7 +10710,7 @@ msgstr ""
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:8
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:180
 #: erpnext/accounts/report/general_ledger/general_ledger.js:8
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/gross_profit/gross_profit.js:8
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:8
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:40
@@ -10747,7 +10757,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:8
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:49
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:8
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:308
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:311
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.js:8
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:266
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.js:7
@@ -11067,7 +11077,7 @@ msgstr ""
 msgid "Company currencies of both the companies should match for Inter Company Transactions."
 msgstr "两家公司的公司货币应该符合Inter公司交易。"
 
-#: erpnext/stock/doctype/material_request/material_request.js:334
+#: erpnext/stock/doctype/material_request/material_request.js:337
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:687
 msgid "Company field is required"
 msgstr "公司字段是必填项"
@@ -11922,7 +11932,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:157
-#: erpnext/public/js/controllers/transaction.js:2246
+#: erpnext/public/js/controllers/transaction.js:2269
 #: erpnext/selling/doctype/quotation/quotation.js:345
 msgid "Continue"
 msgstr "继续"
@@ -12301,12 +12311,13 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1066
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1064
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:97
 #: erpnext/accounts/report/general_ledger/general_ledger.js:152
-#: erpnext/accounts/report/general_ledger/general_ledger.py:682
+#: erpnext/accounts/report/general_ledger/general_ledger.py:684
 #: erpnext/accounts/report/gross_profit/gross_profit.js:68
 #: erpnext/accounts/report/gross_profit/gross_profit.py:317
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:307
@@ -12314,6 +12325,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py:29
 #: erpnext/accounts/report/sales_register/sales_register.js:52
 #: erpnext/accounts/report/sales_register/sales_register.py:252
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:79
 #: erpnext/accounts/report/trial_balance/trial_balance.js:49
 #: erpnext/accounts/workspace/receivables/receivables.json
 #: erpnext/assets/doctype/asset/asset.json
@@ -12442,11 +12454,6 @@ msgstr ""
 msgid "Cost and Freight"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:449
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:479
-msgid "Cost as on"
-msgstr "成本上"
-
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:41
 msgid "Cost of Delivered Items"
 msgstr "出货物料成本"
@@ -12463,14 +12470,6 @@ msgstr "销货成本"
 msgid "Cost of Issued Items"
 msgstr "已发料物料成本"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:473
-msgid "Cost of New Capitalized Asset"
-msgstr ""
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:455
-msgid "Cost of New Purchase"
-msgstr "新的采购成本"
-
 #. Name of a report
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.json
 msgid "Cost of Poor Quality Report"
@@ -12479,14 +12478,6 @@ msgstr ""
 #: erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py:39
 msgid "Cost of Purchased Items"
 msgstr "采购物料成本"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:467
-msgid "Cost of Scrapped Asset"
-msgstr "报废资产成本"
-
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:461
-msgid "Cost of Sold Asset"
-msgstr "出售资产的成本"
 
 #: erpnext/config/projects.py:67
 msgid "Cost of various activities"
@@ -12726,7 +12717,7 @@ msgstr "信用"
 #: erpnext/manufacturing/doctype/bom/bom.js:180
 #: erpnext/manufacturing/doctype/bom/bom.js:190
 #: erpnext/manufacturing/doctype/bom/bom.js:194
-#: erpnext/manufacturing/doctype/bom/bom.js:422
+#: erpnext/manufacturing/doctype/bom/bom.js:436
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:99
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:268
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:125
@@ -12741,7 +12732,7 @@ msgstr "信用"
 #: erpnext/public/js/communication.js:41
 #: erpnext/public/js/controllers/transaction.js:309
 #: erpnext/public/js/controllers/transaction.js:310
-#: erpnext/public/js/controllers/transaction.js:2363
+#: erpnext/public/js/controllers/transaction.js:2386
 #: erpnext/selling/doctype/customer/customer.js:176
 #: erpnext/selling/doctype/quotation/quotation.js:113
 #: erpnext/selling/doctype/quotation/quotation.js:122
@@ -12786,7 +12777,7 @@ msgstr "信用"
 #: erpnext/stock/doctype/material_request/material_request.js:180
 #: erpnext/stock/doctype/material_request/material_request.js:188
 #: erpnext/stock/doctype/material_request/material_request.js:192
-#: erpnext/stock/doctype/material_request/material_request.js:392
+#: erpnext/stock/doctype/material_request/material_request.js:395
 #: erpnext/stock/doctype/pick_list/pick_list.js:112
 #: erpnext/stock/doctype/pick_list/pick_list.js:118
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:68
@@ -12984,7 +12975,7 @@ msgid "Create Sample Retention Stock Entry"
 msgstr "创建样本保留库存条目"
 
 #: erpnext/stock/dashboard/item_dashboard.js:280
-#: erpnext/stock/doctype/material_request/material_request.js:454
+#: erpnext/stock/doctype/material_request/material_request.js:457
 msgid "Create Stock Entry"
 msgstr ""
 
@@ -13176,11 +13167,11 @@ msgstr ""
 msgid "Credit"
 msgstr "贷方"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:640
+#: erpnext/accounts/report/general_ledger/general_ledger.py:642
 msgid "Credit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:617
+#: erpnext/accounts/report/general_ledger/general_ledger.py:619
 msgid "Credit ({0})"
 msgstr "信用（{0}）"
 
@@ -13296,7 +13287,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1089
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
 #: erpnext/controllers/sales_and_purchase_return.py:351
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:288
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13518,12 +13509,12 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py:293
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:145
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:152
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:208
 #: erpnext/accounts/report/financial_statements.html:29
 #: erpnext/accounts/report/financial_statements.py:634
@@ -13636,7 +13627,7 @@ msgstr "货币{0}必须{1}"
 msgid "Currency of the Closing Account must be {0}"
 msgstr "在关闭科目的货币必须是{0}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:594
+#: erpnext/manufacturing/doctype/bom/bom.py:611
 msgid "Currency of the price list {0} must be {1} or {2}"
 msgstr "价格清单{0}的货币必须是{1}或{2}"
 
@@ -14045,7 +14036,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1060
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1058
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14141,11 +14132,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:99
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:80
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:55
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:171
 #: erpnext/accounts/report/gross_profit/gross_profit.py:345
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:210
 #: erpnext/accounts/report/sales_register/sales_register.js:27
@@ -14185,7 +14176,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1209
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1207
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14204,7 +14195,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
 msgid "Customer LPO"
 msgstr "客户采购订单号"
 
@@ -14250,7 +14241,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:91
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:34
@@ -14640,7 +14631,7 @@ msgstr ""
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:194
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:190
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:28
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:28
@@ -14876,11 +14867,11 @@ msgstr "亲爱的系统管理经理，"
 msgid "Debit"
 msgstr "借方"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:633
+#: erpnext/accounts/report/general_ledger/general_ledger.py:635
 msgid "Debit (Transaction)"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:611
+#: erpnext/accounts/report/general_ledger/general_ledger.py:613
 msgid "Debit ({0})"
 msgstr "借记卡（{0}）"
 
@@ -14917,7 +14908,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
 #: erpnext/controllers/sales_and_purchase_return.py:355
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:289
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15127,7 +15118,7 @@ msgstr "该物料或其模板物料的默认物料清单状态必须是激活的
 msgid "Default BOM for {0} not found"
 msgstr "默认BOM {0}未找到"
 
-#: erpnext/controllers/accounts_controller.py:3479
+#: erpnext/controllers/accounts_controller.py:3491
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15958,7 +15949,7 @@ msgstr "销售出货单{0}未提交"
 msgid "Delivery Note(s) created for the Pick List"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "送货单"
@@ -16157,7 +16148,7 @@ msgstr "折旧"
 msgid "Depreciation Amount"
 msgstr "折旧额"
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:491
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:489
 msgid "Depreciation Amount during the period"
 msgstr "期间折旧额"
 
@@ -16171,7 +16162,7 @@ msgstr "折旧日期"
 msgid "Depreciation Details"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:497
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:495
 msgid "Depreciation Eliminated due to disposal of assets"
 msgstr "折旧淘汰因处置资产"
 
@@ -16232,15 +16223,15 @@ msgstr ""
 msgid "Depreciation Row {0}: Depreciation Posting Date cannot be before Available-for-use Date"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:512
+#: erpnext/assets/doctype/asset/asset.py:518
 msgid "Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}"
 msgstr "折旧行{0}：使用寿命后的预期值必须大于或等于{1}"
 
-#: erpnext/assets/doctype/asset/asset.py:467
+#: erpnext/assets/doctype/asset/asset.py:473
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Available-for-use Date"
 msgstr "折旧行{0}：下一个折旧日期不能在可供使用的日期之前"
 
-#: erpnext/assets/doctype/asset/asset.py:458
+#: erpnext/assets/doctype/asset/asset.py:464
 msgid "Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date"
 msgstr "折旧行{0}：下一个折旧日期不能在采购日期之前"
 
@@ -16489,7 +16480,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2310
+#: erpnext/public/js/controllers/transaction.js:2333
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16672,7 +16663,7 @@ msgstr "差异科目"
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Entry is an Opening Entry"
 msgstr "差异账户必须是资产/负债类型账户，因为此库存分录是开仓分录"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:900
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:901
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "差异科目必须是资产/负债类型的科目，因为此库存盘点在期初进行"
 
@@ -17428,7 +17419,7 @@ msgstr "难道你真的想恢复这个报废的资产？"
 msgid "Do you still want to enable negative inventory?"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1040
+#: erpnext/public/js/controllers/transaction.js:1063
 msgid "Do you want to clear the selected {0}?"
 msgstr ""
 
@@ -17834,7 +17825,7 @@ msgstr "到期/参照日期不能迟于{0}"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1076
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1074
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -17958,7 +17949,7 @@ msgstr "在物料组中有重复物料组"
 msgid "Duplicate project has been created"
 msgstr "复制项目已创建"
 
-#: erpnext/utilities/transaction_base.py:51
+#: erpnext/utilities/transaction_base.py:54
 msgid "Duplicate row {0} with same {1}"
 msgstr "重复的行{0}同{1}"
 
@@ -18850,7 +18841,7 @@ msgstr ""
 msgid "Enter Serial Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:391
+#: erpnext/stock/doctype/material_request/material_request.js:394
 msgid "Enter Supplier"
 msgstr "输入供应商"
 
@@ -18929,7 +18920,7 @@ msgstr ""
 msgid "Enter the opening stock units."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:845
+#: erpnext/manufacturing/doctype/bom/bom.js:859
 msgid "Enter the quantity of the Item that will be manufactured from this Bill of Materials."
 msgstr ""
 
@@ -19006,7 +18997,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:847
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:198
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:244
 msgid "Error"
 msgstr "错误"
 
@@ -19574,6 +19565,12 @@ msgstr "包含在资产评估价中的费用科目"
 msgid "Expenses Included In Valuation"
 msgstr "计入库存评估价的费用科目"
 
+#. Label of the experimental_section (Section Break) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Experimental"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Supplier Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Quotation'
 #. Option for the 'Status' (Select) field in DocType 'Serial No'
@@ -19912,7 +19909,7 @@ msgstr ""
 msgid "Fetch Value From"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:326
+#: erpnext/stock/doctype/material_request/material_request.js:329
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:664
 msgid "Fetch exploded BOM (including sub-assemblies)"
 msgstr "获取展开BOM（包括子物料）"
@@ -19928,7 +19925,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1200
+#: erpnext/public/js/controllers/transaction.js:1223
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20225,15 +20222,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3465
+#: erpnext/controllers/accounts_controller.py:3477
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3482
+#: erpnext/controllers/accounts_controller.py:3494
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3476
+#: erpnext/controllers/accounts_controller.py:3488
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20454,7 +20451,7 @@ msgstr "固定资产"
 #. Capitalization Asset Item'
 #. Label of the fixed_asset_account (Link) field in DocType 'Asset Category
 #. Account'
-#: erpnext/assets/doctype/asset/asset.py:691
+#: erpnext/assets/doctype/asset/asset.py:697
 #: erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
 #: erpnext/assets/doctype/asset_category_account/asset_category_account.json
 msgid "Fixed Asset Account"
@@ -20605,7 +20602,7 @@ msgstr ""
 msgid "For Company"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:369
+#: erpnext/stock/doctype/material_request/material_request.js:372
 msgid "For Default Supplier (Optional)"
 msgstr "对于默认供应商（可选）"
 
@@ -20666,7 +20663,7 @@ msgstr "对供应商"
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.js:358
 #: erpnext/selling/doctype/sales_order/sales_order.js:993
-#: erpnext/stock/doctype/material_request/material_request.js:318
+#: erpnext/stock/doctype/material_request/material_request.js:321
 #: erpnext/templates/form_grid/material_request_grid.html:36
 msgid "For Warehouse"
 msgstr "仓库"
@@ -20709,7 +20706,7 @@ msgstr ""
 msgid "For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1642
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1644
 msgid "For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})"
 msgstr ""
 
@@ -20970,7 +20967,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:37
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:41
 #: erpnext/accounts/report/general_ledger/general_ledger.js:22
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:16
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:8
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:8
@@ -21080,8 +21077,8 @@ msgstr "起始日期不能大于结束日期"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:21
-#: erpnext/accounts/report/general_ledger/general_ledger.py:79
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:28
+#: erpnext/accounts/report/general_ledger/general_ledger.py:76
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:37
 #: erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py:41
@@ -21457,14 +21454,14 @@ msgstr "只能在“组”节点下新建节点"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1104
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1102
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "未来付款金额"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 msgid "Future Payment Ref"
 msgstr "未来付款参考"
 
@@ -21489,7 +21486,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:596
+#: erpnext/accounts/report/general_ledger/general_ledger.py:598
 msgid "GL Entry"
 msgstr "总账分录"
 
@@ -21783,7 +21780,7 @@ msgstr "从...获取物料"
 msgid "Get Items From Purchase Receipts"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:303
+#: erpnext/stock/doctype/material_request/material_request.js:306
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:667
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:680
 msgid "Get Items from BOM"
@@ -22306,7 +22303,7 @@ msgstr "组节点"
 msgid "Group Same Items"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:126
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:127
 msgid "Group Warehouses cannot be used in transactions. Please change the value of {0}"
 msgstr "不能在事务中使用组仓库。请更改值{0}"
 
@@ -23746,11 +23743,11 @@ msgstr "库存量"
 msgid "In Transit"
 msgstr "运输中"
 
-#: erpnext/stock/doctype/material_request/material_request.js:453
+#: erpnext/stock/doctype/material_request/material_request.js:456
 msgid "In Transit Transfer"
 msgstr ""
 
-#: erpnext/stock/doctype/material_request/material_request.js:422
+#: erpnext/stock/doctype/material_request/material_request.js:425
 msgid "In Transit Warehouse"
 msgstr ""
 
@@ -24220,7 +24217,7 @@ msgid "Incorrect Type of Transaction"
 msgstr ""
 
 #: erpnext/stock/doctype/pick_list/pick_list.py:140
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:129
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:130
 msgid "Incorrect Warehouse"
 msgstr "仓库不正确"
 
@@ -24478,8 +24475,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3397
-#: erpnext/controllers/accounts_controller.py:3421
+#: erpnext/controllers/accounts_controller.py:3409
+#: erpnext/controllers/accounts_controller.py:3433
 msgid "Insufficient Permissions"
 msgstr "权限不足"
 
@@ -24728,7 +24725,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "无效的条形码。该条形码没有附件。"
 
-#: erpnext/public/js/controllers/transaction.js:2548
+#: erpnext/public/js/controllers/transaction.js:2571
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "无效框架订单对所选客户和物料无效"
 
@@ -24805,7 +24802,7 @@ msgstr "无效的上级帐户"
 msgid "Invalid Part Number"
 msgstr "无效的零件号"
 
-#: erpnext/utilities/transaction_base.py:31
+#: erpnext/utilities/transaction_base.py:34
 msgid "Invalid Posting Time"
 msgstr "记帐时间无效"
 
@@ -24817,7 +24814,7 @@ msgstr ""
 msgid "Invalid Priority"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1058
+#: erpnext/manufacturing/doctype/bom/bom.py:1075
 msgid "Invalid Process Loss Configuration"
 msgstr ""
 
@@ -24825,7 +24822,7 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3434
+#: erpnext/controllers/accounts_controller.py:3446
 msgid "Invalid Qty"
 msgstr ""
 
@@ -24833,9 +24830,9 @@ msgstr ""
 msgid "Invalid Quantity"
 msgstr "无效数量"
 
-#: erpnext/assets/doctype/asset/asset.py:419
-#: erpnext/assets/doctype/asset/asset.py:426
-#: erpnext/assets/doctype/asset/asset.py:453
+#: erpnext/assets/doctype/asset/asset.py:422
+#: erpnext/assets/doctype/asset/asset.py:429
+#: erpnext/assets/doctype/asset/asset.py:459
 msgid "Invalid Schedule"
 msgstr ""
 
@@ -24847,7 +24844,7 @@ msgstr "无效的售价"
 msgid "Invalid Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "Invalid URL"
 msgstr "无效的网址"
 
@@ -24872,7 +24869,7 @@ msgstr "无效的丢失原因{0}，请创建一个新的丢失原因"
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "{0}的无效命名系列（。丢失）"
 
-#: erpnext/utilities/transaction_base.py:65
+#: erpnext/utilities/transaction_base.py:68
 msgid "Invalid reference {0} {1}"
 msgstr "无效的参考{0} {1}"
 
@@ -24896,7 +24893,7 @@ msgstr "无效的{0}"
 msgid "Invalid {0} for Inter Company Transaction."
 msgstr "Inter Company Transaction无效{0}。"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:94
+#: erpnext/accounts/report/general_ledger/general_ledger.py:91
 #: erpnext/controllers/sales_and_purchase_return.py:36
 msgid "Invalid {0}: {1}"
 msgstr "无效的{0}：{1}"
@@ -24964,7 +24961,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr "发票贴现"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 msgid "Invoice Grand Total"
 msgstr "发票总计"
 
@@ -25053,9 +25050,9 @@ msgstr "在零计费时间内无法开具费用清单"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1086
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1084
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
 msgid "Invoiced Amount"
 msgstr "费用清单金额"
 
@@ -25752,7 +25749,7 @@ msgstr ""
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2009
+#: erpnext/public/js/controllers/transaction.js:2032
 msgid "It is needed to fetch Item Details."
 msgstr "需要获取物料详细信息。"
 
@@ -25804,7 +25801,7 @@ msgstr ""
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/taxes_and_totals.py:1084
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
-#: erpnext/manufacturing/doctype/bom/bom.js:924
+#: erpnext/manufacturing/doctype/bom/bom.js:938
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.js:109
 #: erpnext/manufacturing/doctype/workstation/workstation_job_card.html:25
@@ -26046,7 +26043,7 @@ msgstr ""
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:26
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:223
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:226
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:198
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.py:36
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
@@ -26077,7 +26074,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2284
+#: erpnext/public/js/controllers/transaction.js:2307
 #: erpnext/public/js/utils.js:495 erpnext/public/js/utils.js:650
 #: erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.json
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -26504,7 +26501,7 @@ msgstr "产品制造商"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:128
-#: erpnext/public/js/controllers/transaction.js:2290
+#: erpnext/public/js/controllers/transaction.js:2313
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
 #: erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py:35
@@ -26863,7 +26860,7 @@ msgstr "物料名称"
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3457
+#: erpnext/controllers/accounts_controller.py:3469
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -26902,7 +26899,7 @@ msgstr ""
 msgid "Item {0} does not exist"
 msgstr "物料{0}不存在"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:579
+#: erpnext/manufacturing/doctype/bom/bom.py:596
 msgid "Item {0} does not exist in the system or has expired"
 msgstr "物料{0}不存在于系统中或已过期"
 
@@ -26990,7 +26987,7 @@ msgstr "物料{0}的订单数量{1}不能小于最低订货量{2}（物料主数
 msgid "Item {0}: {1} qty produced. "
 msgstr "项目{0}：产生了{1}数量。"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1324
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1327
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27027,7 +27024,7 @@ msgstr "产品销售历史记录"
 msgid "Item-wise Sales Register"
 msgstr "物料销售台帐"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:329
+#: erpnext/manufacturing/doctype/bom/bom.py:346
 msgid "Item: {0} does not exist in the system"
 msgstr "项目{0}不存在"
 
@@ -27132,7 +27129,7 @@ msgstr "待申请物料"
 msgid "Items and Pricing"
 msgstr "物料和定价"
 
-#: erpnext/controllers/accounts_controller.py:3676
+#: erpnext/controllers/accounts_controller.py:3688
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -27341,7 +27338,7 @@ msgstr ""
 msgid "Job Worker Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1691
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1693
 msgid "Job card {0} created"
 msgstr "已创建作业卡{0}"
 
@@ -28962,11 +28959,11 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py:147
 #: erpnext/buying/doctype/supplier_quotation/supplier_quotation.js:69
 #: erpnext/manufacturing/doctype/bom/bom.js:85
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 #: erpnext/public/js/utils/party.js:317
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30310,7 +30307,7 @@ msgstr "杂项费用"
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1325
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1328
 msgid "Missing"
 msgstr ""
 
@@ -30368,7 +30365,7 @@ msgstr "缺少需要的值"
 msgid "Missing email template for dispatch. Please set one in Delivery Settings."
 msgstr "缺少发送的电子邮件模板。请在“发送设置”中设置一个。"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1017
+#: erpnext/manufacturing/doctype/bom/bom.py:1034
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1064
 msgid "Missing value"
 msgstr ""
@@ -30849,7 +30846,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1020
 #: erpnext/setup/doctype/uom/uom.json
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:137
-#: erpnext/utilities/transaction_base.py:284
+#: erpnext/utilities/transaction_base.py:540
 msgid "Must be Whole Number"
 msgstr "必须是整数"
 
@@ -30882,7 +30879,7 @@ msgstr ""
 #: erpnext/accounts/doctype/finance_book/finance_book.json
 #: erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
 #: erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:84
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:91
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py:358
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log_detail/bulk_transaction_log_detail.json
 #: erpnext/crm/doctype/appointment/appointment.json
@@ -31020,11 +31017,11 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr "需求分析"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:566
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:567
 msgid "Negative Quantity is not allowed"
 msgstr "不允许负数量"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:571
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:572
 msgid "Negative Valuation Rate is not allowed"
 msgstr "评估价不可以为负数"
 
@@ -31102,8 +31099,8 @@ msgstr ""
 msgid "Net Amount (Company Currency)"
 msgstr ""
 
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:509
-#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:515
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:507
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:513
 msgid "Net Asset value as on"
 msgstr "净资产值作为"
 
@@ -31674,7 +31671,7 @@ msgstr "找不到代表公司{0}的公司间交易的供应商"
 msgid "No Tax Withholding data found for the current posting date."
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 msgid "No Terms"
 msgstr ""
 
@@ -31859,15 +31856,15 @@ msgstr ""
 msgid "No record found"
 msgstr "未找到记录"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:690
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:688
 msgid "No records found in Allocation table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:589
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:587
 msgid "No records found in the Invoices table"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:592
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:590
 msgid "No records found in the Payments table"
 msgstr ""
 
@@ -31915,7 +31912,7 @@ msgstr "不合格"
 msgid "Non Profit"
 msgstr "非营利"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1385
+#: erpnext/manufacturing/doctype/bom/bom.py:1402
 msgid "Non stock items"
 msgstr "非库存物品"
 
@@ -31929,7 +31926,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:499
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:500
 msgid "None of the items have any change in quantity or value."
 msgstr "没有一个项目无论在数量或价值的任何变化。"
 
@@ -32044,8 +32041,8 @@ msgstr "没存货"
 
 #: erpnext/buying/doctype/purchase_order/purchase_order.py:686
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1342
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1494
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1561
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1496
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1563
 #: erpnext/selling/doctype/sales_order/sales_order.py:797
 #: erpnext/selling/doctype/sales_order/sales_order.py:1591
 msgid "Not permitted"
@@ -32067,7 +32064,7 @@ msgstr "不允许"
 #: erpnext/stock/doctype/item/item.py:565
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1365
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:919
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "注"
@@ -32736,7 +32733,7 @@ msgstr "打开工单"
 msgid "Open a new ticket"
 msgstr "打开一张新票"
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:414
+#: erpnext/accounts/report/general_ledger/general_ledger.py:416
 #: erpnext/public/js/stock_analytics.js:97
 msgid "Opening"
 msgstr "开帐"
@@ -32768,7 +32765,7 @@ msgstr "期初（借方）"
 msgid "Opening Accumulated Depreciation"
 msgstr "期初累计折旧"
 
-#: erpnext/assets/doctype/asset/asset.py:437
+#: erpnext/assets/doctype/asset/asset.py:443
 msgid "Opening Accumulated Depreciation must be less than or equal to {0}"
 msgstr ""
 
@@ -32782,7 +32779,7 @@ msgstr ""
 msgid "Opening Amount"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:95
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:102
 msgid "Opening Balance"
 msgstr "期初余额"
 
@@ -32912,7 +32909,7 @@ msgstr ""
 msgid "Operating Cost Per BOM Quantity"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1401
+#: erpnext/manufacturing/doctype/bom/bom.py:1418
 msgid "Operating Cost as per Work Order / BOM"
 msgstr "根据工单/物料单的运营成本"
 
@@ -32942,7 +32939,7 @@ msgstr ""
 #. Label of the operation (Link) field in DocType 'Work Order Item'
 #. Label of the operation (Link) field in DocType 'Work Order Operation'
 #. Label of a Link in the Manufacturing Workspace
-#: erpnext/manufacturing/doctype/bom/bom.js:393
+#: erpnext/manufacturing/doctype/bom/bom.js:407
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -33068,7 +33065,7 @@ msgstr "操作"
 msgid "Operations Routing"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1026
+#: erpnext/manufacturing/doctype/bom/bom.py:1043
 msgid "Operations cannot be left blank"
 msgstr "操作不能留空"
 
@@ -33581,7 +33578,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1093
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1091
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34136,9 +34133,9 @@ msgstr "已付款"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1087
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1085
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:109
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:116
 #: erpnext/accounts/report/pos_register/pos_register.py:209
 #: erpnext/selling/page/point_of_sale/pos_payment.js:595
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:56
@@ -34587,12 +34584,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1024
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1022
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
 #: erpnext/accounts/report/general_ledger/general_ledger.js:74
-#: erpnext/accounts/report/general_ledger/general_ledger.py:672
+#: erpnext/accounts/report/general_ledger/general_ledger.py:674
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:51
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:155
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:46
@@ -34613,7 +34610,7 @@ msgstr "往来单位"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1035
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
 msgid "Party Account"
 msgstr "往来单位科目"
 
@@ -34746,12 +34743,12 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:77
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1018
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
 #: erpnext/accounts/report/general_ledger/general_ledger.js:65
-#: erpnext/accounts/report/general_ledger/general_ledger.py:671
+#: erpnext/accounts/report/general_ledger/general_ledger.py:673
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:41
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:151
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js:35
@@ -34878,7 +34875,7 @@ msgid "Payable"
 msgstr "应付"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1033
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35320,7 +35317,7 @@ msgstr "付款工时单"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1083
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1081
 #: erpnext/accounts/report/gross_profit/gross_profit.py:365
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -35558,13 +35555,13 @@ msgstr "待活动"
 
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:64
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:64
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:285
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:288
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:306
 msgid "Pending Amount"
 msgstr "待审核金额"
 
 #. Label of the pending_qty (Float) field in DocType 'Production Plan Item'
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:248
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:251
 #: erpnext/manufacturing/doctype/production_plan_item/production_plan_item.json
 #: erpnext/manufacturing/doctype/work_order/work_order.js:270
 #: erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py:174
@@ -35853,7 +35850,7 @@ msgstr "公司{0}查看此报告所需的永久清单。"
 
 #. Label of the personal_details (Tab Break) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
-msgid "Personal"
+msgid "Personal Details"
 msgstr ""
 
 #. Option for the 'Preferred Contact Email' (Select) field in DocType
@@ -36467,7 +36464,7 @@ msgstr "请输入零钱科目"
 msgid "Please enter Approving Role or Approving User"
 msgstr "请输入角色核准或审批用户"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:885
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:886
 msgid "Please enter Cost Center"
 msgstr "请输入成本中心"
 
@@ -36479,7 +36476,7 @@ msgstr "请输入交货日期"
 msgid "Please enter Employee Id of this sales person"
 msgstr "请输入这个销售人员的员工标识"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:894
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:895
 msgid "Please enter Expense Account"
 msgstr "请输入您的费用科目"
 
@@ -36488,7 +36485,7 @@ msgstr "请输入您的费用科目"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "请输入产品代码来获得批号"
 
-#: erpnext/public/js/controllers/transaction.js:2421
+#: erpnext/public/js/controllers/transaction.js:2444
 msgid "Please enter Item Code to get batch no"
 msgstr "请输入物料代码，以获得批号"
 
@@ -36782,7 +36779,7 @@ msgstr "在选择往来单位之前请先选择记帐日期"
 msgid "Please select Posting Date first"
 msgstr "请先选择记帐日期"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1071
+#: erpnext/manufacturing/doctype/bom/bom.py:1088
 msgid "Please select Price List"
 msgstr "请选择价格清单"
 
@@ -36810,7 +36807,7 @@ msgstr ""
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1303
+#: erpnext/manufacturing/doctype/bom/bom.py:1320
 msgid "Please select a BOM"
 msgstr "请选择一个物料清单"
 
@@ -36819,10 +36816,10 @@ msgid "Please select a Company"
 msgstr "请选择一个公司"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:251
-#: erpnext/manufacturing/doctype/bom/bom.js:583
-#: erpnext/manufacturing/doctype/bom/bom.py:244
+#: erpnext/manufacturing/doctype/bom/bom.js:597
+#: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2670
+#: erpnext/public/js/controllers/transaction.js:2693
 msgid "Please select a Company first."
 msgstr "请先选择一个公司。"
 
@@ -36972,7 +36969,7 @@ msgid "Please select {0}"
 msgstr "请选择{0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1189
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:585
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:583
 #: erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py:82
 msgid "Please select {0} first"
 msgstr "请先选择{0}"
@@ -37042,7 +37039,7 @@ msgstr ""
 msgid "Please set Fixed Asset Account in {} against {}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:444
+#: erpnext/assets/doctype/asset/asset.py:450
 msgid "Please set Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -37167,7 +37164,7 @@ msgstr ""
 msgid "Please set one of the following:"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2139
+#: erpnext/public/js/controllers/transaction.js:2162
 msgid "Please set recurring after saving"
 msgstr "请设置保存后复发"
 
@@ -37197,7 +37194,7 @@ msgstr "请在广告系列{0}中设置广告系列计划"
 
 #: erpnext/public/js/queries.js:32 erpnext/public/js/queries.js:44
 #: erpnext/public/js/queries.js:61 erpnext/public/js/queries.js:75
-#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:111
+#: erpnext/public/js/queries.js:92 erpnext/public/js/queries.js:114
 #: erpnext/stock/report/reserved_stock/reserved_stock.py:26
 msgid "Please set {0}"
 msgstr "请设置{0}"
@@ -37230,7 +37227,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2007
+#: erpnext/public/js/controllers/transaction.js:2030
 msgid "Please specify"
 msgstr "请注明"
 
@@ -37250,7 +37247,7 @@ msgstr "请注明公司进行"
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "请指定行{0}在表中的有效行ID {1}"
 
-#: erpnext/public/js/queries.js:121
+#: erpnext/public/js/queries.js:124
 msgid "Please specify a {0}"
 msgstr ""
 
@@ -37258,7 +37255,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "请指定属性表中的至少一个属性"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:561
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:562
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "请注明无论是数量或估价率或两者"
 
@@ -37438,14 +37435,14 @@ msgstr "邮政费用"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1016
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1014
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:10
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:61
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:65
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.py:151
-#: erpnext/accounts/report/general_ledger/general_ledger.py:602
+#: erpnext/accounts/report/general_ledger/general_ledger.py:604
 #: erpnext/accounts/report/gross_profit/gross_profit.py:222
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:183
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:202
@@ -37934,7 +37931,7 @@ msgstr ""
 msgid "Price is not set for the item."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:475
+#: erpnext/manufacturing/doctype/bom/bom.py:492
 msgid "Price not found for item {0} in price list {1}"
 msgstr "价格表{1}中的商品{0}找不到价格"
 
@@ -38465,7 +38462,7 @@ msgstr "处理失败"
 msgid "Process Loss"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1054
+#: erpnext/manufacturing/doctype/bom/bom.py:1071
 msgid "Process Loss Percentage cannot be greater than 100"
 msgstr ""
 
@@ -38962,9 +38959,10 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:1017
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:107
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:73
 #: erpnext/accounts/report/general_ledger/general_ledger.js:162
-#: erpnext/accounts/report/general_ledger/general_ledger.py:673
+#: erpnext/accounts/report/general_ledger/general_ledger.py:675
 #: erpnext/accounts/report/gross_profit/gross_profit.js:78
 #: erpnext/accounts/report/gross_profit/gross_profit.py:310
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:225
@@ -38972,6 +38970,7 @@ msgstr ""
 #: erpnext/accounts/report/purchase_register/purchase_register.py:207
 #: erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py:73
 #: erpnext/accounts/report/sales_register/sales_register.py:230
+#: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:89
 #: erpnext/accounts/report/trial_balance/trial_balance.js:64
 #: erpnext/assets/doctype/asset_repair/asset_repair.json
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -38983,7 +38982,7 @@ msgstr ""
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.js:21
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:39
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:33
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:212
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:215
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39602,7 +39601,7 @@ msgstr "采购方面的主要经理"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:79
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:82
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:40
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:197
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:200
 #: erpnext/buying/workspace/buying/buying.json
 #: erpnext/controllers/buying_controller.py:677
 #: erpnext/crm/doctype/contract/contract.json
@@ -40062,12 +40061,12 @@ msgstr ""
 #: erpnext/accounts/report/gross_profit/gross_profit.py:267
 #: erpnext/assets/doctype/asset_capitalization_service_item/asset_capitalization_service_item.json
 #: erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:234
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:237
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:224
 #: erpnext/controllers/trends.py:238 erpnext/controllers/trends.py:250
 #: erpnext/controllers/trends.py:255
 #: erpnext/crm/doctype/opportunity_item/opportunity_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:944
+#: erpnext/manufacturing/doctype/bom/bom.js:958
 #: erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_scrap_item/bom_scrap_item.json
@@ -40175,7 +40174,7 @@ msgstr ""
 
 #. Label of the for_quantity (Float) field in DocType 'Job Card'
 #. Label of the qty (Float) field in DocType 'Work Order'
-#: erpnext/manufacturing/doctype/bom/bom.js:316
+#: erpnext/manufacturing/doctype/bom/bom.js:309
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/manufacturing/report/process_loss_report/process_loss_report.py:82
@@ -40270,7 +40269,7 @@ msgstr ""
 msgid "Qty to Be Consumed"
 msgstr ""
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:262
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:265
 #: erpnext/selling/report/sales_order_analysis/sales_order_analysis.py:283
 msgid "Qty to Bill"
 msgstr "账单数量"
@@ -40608,7 +40607,7 @@ msgstr "质量审查目标"
 #: erpnext/buying/report/purchase_analytics/purchase_analytics.js:28
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:211
 #: erpnext/manufacturing/doctype/blanket_order_item/blanket_order_item.json
-#: erpnext/manufacturing/doctype/bom/bom.js:380
+#: erpnext/manufacturing/doctype/bom/bom.js:394
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.js:68
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -40625,7 +40624,7 @@ msgstr "质量审查目标"
 #: erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py:67
 #: erpnext/stock/dashboard/item_dashboard.js:245
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
-#: erpnext/stock/doctype/material_request/material_request.js:322
+#: erpnext/stock/doctype/material_request/material_request.js:325
 #: erpnext/stock/doctype/material_request_item/material_request_item.json
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -40746,11 +40745,11 @@ msgstr "数量不能超过{0}"
 msgid "Quantity of item obtained after manufacturing / repacking from given quantities of raw materials"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:642
+#: erpnext/manufacturing/doctype/bom/bom.py:659
 msgid "Quantity required for Item {0} in row {1}"
 msgstr "行{1}中的物料{0}必须指定数量"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:587
+#: erpnext/manufacturing/doctype/bom/bom.py:604
 #: erpnext/manufacturing/doctype/job_card/job_card.js:234
 #: erpnext/manufacturing/doctype/job_card/job_card.js:302
 #: erpnext/manufacturing/doctype/workstation/workstation.js:303
@@ -40765,7 +40764,7 @@ msgstr "待生产数量"
 msgid "Quantity to Manufacture"
 msgstr "制造数量"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1635
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1637
 msgid "Quantity to Manufacture can not be zero for the operation {0}"
 msgstr "操作{0}的制造数量不能为零"
 
@@ -41436,7 +41435,7 @@ msgstr "原料仓库"
 #. Label of the section_break_8 (Section Break) field in DocType 'Job Card'
 #. Label of the mr_items (Table) field in DocType 'Production Plan'
 #: erpnext/manufacturing/doctype/bom/bom.js:347
-#: erpnext/manufacturing/doctype/bom/bom.js:918
+#: erpnext/manufacturing/doctype/bom/bom.js:932
 #: erpnext/manufacturing/doctype/bom/bom.json
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -41495,7 +41494,7 @@ msgstr ""
 msgid "Raw Materials Warehouse"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:635
+#: erpnext/manufacturing/doctype/bom/bom.py:652
 msgid "Raw Materials cannot be blank."
 msgstr "原材料不能为空。"
 
@@ -41690,7 +41689,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:70
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1031
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1029
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -41784,7 +41783,7 @@ msgstr "收到的"
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py:76
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:241
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:244
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:170
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:245
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:143
@@ -41795,7 +41794,7 @@ msgstr "收到的"
 msgid "Received Qty"
 msgstr "收到数量"
 
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:293
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:296
 msgid "Received Qty Amount"
 msgstr "收到的数量"
 
@@ -42145,7 +42144,7 @@ msgstr "参考＃ {0}记载日期为{1}"
 msgid "Reference Date"
 msgstr "参考日期"
 
-#: erpnext/public/js/controllers/transaction.js:2245
+#: erpnext/public/js/controllers/transaction.js:2268
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -42568,7 +42567,7 @@ msgstr "剩余"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1105
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1103
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "余额"
@@ -42621,9 +42620,9 @@ msgstr "备注"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 #: erpnext/accounts/report/general_ledger/general_ledger.html:115
-#: erpnext/accounts/report/general_ledger/general_ledger.py:700
+#: erpnext/accounts/report/general_ledger/general_ledger.py:702
 #: erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py:112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:296
 #: erpnext/accounts/report/sales_register/sales_register.py:335
@@ -42657,7 +42656,7 @@ msgstr ""
 msgid "Remove item if charges is not applicable to that item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:507
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:508
 msgid "Removed items with no change in quantity or value."
 msgstr "删除的项目在数量或价值没有变化。"
 
@@ -43124,7 +43123,7 @@ msgstr "请求者"
 #. Item'
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:195
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:198
 #: erpnext/buying/report/requested_items_to_order_and_receive/requested_items_to_order_and_receive.py:191
 #: erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
 #: erpnext/stock/doctype/material_request/material_request.json
@@ -44155,11 +44154,11 @@ msgstr "路由"
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:623
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:624
 msgid "Row #"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:523
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:524
 msgid "Row # {0}:"
 msgstr ""
 
@@ -44251,23 +44250,23 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3331
+#: erpnext/controllers/accounts_controller.py:3343
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "第＃{0}行：无法删除已计费的项目{1}。"
 
-#: erpnext/controllers/accounts_controller.py:3305
+#: erpnext/controllers/accounts_controller.py:3317
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "第{0}行：无法删除已交付的项目{1}"
 
-#: erpnext/controllers/accounts_controller.py:3324
+#: erpnext/controllers/accounts_controller.py:3336
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "第＃0行：无法删除已收到的项目{1}"
 
-#: erpnext/controllers/accounts_controller.py:3311
+#: erpnext/controllers/accounts_controller.py:3323
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "第＃{0}行：无法删除已为其分配了工作订单的项目{1}。"
 
-#: erpnext/controllers/accounts_controller.py:3317
+#: erpnext/controllers/accounts_controller.py:3329
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "第＃{0}行：无法删除分配给客户采购订单的项目{1}。"
 
@@ -44275,7 +44274,7 @@ msgstr "第＃{0}行：无法删除分配给客户采购订单的项目{1}。"
 msgid "Row #{0}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor"
 msgstr "第{0}行：在向分包商供应原材料时无法选择供应商仓库"
 
-#: erpnext/controllers/accounts_controller.py:3572
+#: erpnext/controllers/accounts_controller.py:3584
 msgid "Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}."
 msgstr "行＃{0}：如果金额大于项目{1}的开帐单金额，则无法设置费率。"
 
@@ -44383,7 +44382,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:685
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "行＃{0}：项目{1}不是序列化/批量项目。它不能有序列号/批号。"
 
@@ -44461,7 +44460,7 @@ msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
 #: erpnext/controllers/accounts_controller.py:1145
-#: erpnext/controllers/accounts_controller.py:3431
+#: erpnext/controllers/accounts_controller.py:3443
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "行 # {0}: 商品 {1} 的数量不能为零。"
 
@@ -44469,8 +44468,8 @@ msgstr "行 # {0}: 商品 {1} 的数量不能为零。"
 msgid "Row #{0}: Quantity to reserve for the Item {1} should be greater than 0."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:111
-#: erpnext/utilities/transaction_base.py:117
+#: erpnext/utilities/transaction_base.py:114
+#: erpnext/utilities/transaction_base.py:120
 msgid "Row #{0}: Rate must be same as {1}: {2} ({3} / {4})"
 msgstr ""
 
@@ -44746,11 +44745,11 @@ msgstr "行{0}：预收客户款项须记在贷方"
 msgid "Row {0}: Advance against Supplier must be debit"
 msgstr "行{0}：对供应商预付应为借方"
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:684
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:682
 msgid "Row {0}: Allocated amount {1} must be less than or equal to invoice outstanding amount {2}"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:676
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:674
 msgid "Row {0}: Allocated amount {1} must be less than or equal to remaining payment amount {2}"
 msgstr ""
 
@@ -44783,7 +44782,7 @@ msgstr "行{0}：项目{1}需要费用中心"
 msgid "Row {0}: Credit entry can not be linked with a {1}"
 msgstr "行{0}：信用记录无法被链接的{1}"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:449
+#: erpnext/manufacturing/doctype/bom/bom.py:466
 msgid "Row {0}: Currency of the BOM #{1} should be equal to the selected currency {2}"
 msgstr "行{0}：BOM＃的货币{1}应等于所选货币{2}"
 
@@ -44795,7 +44794,7 @@ msgstr "行{0}：借记分录不能与连接的{1}"
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "第{0}行：交货仓库（{1}）和客户仓库（{2}）不能相同"
 
-#: erpnext/assets/doctype/asset/asset.py:425
+#: erpnext/assets/doctype/asset/asset.py:428
 msgid "Row {0}: Depreciation Start Date is required"
 msgstr "行{0}：折旧开始日期是必需的"
 
@@ -44816,7 +44815,7 @@ msgstr "行{0}：请为第{0}行的资产，即物料号{1}输入位置信息"
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "行{0}：汇率是必须的"
 
-#: erpnext/assets/doctype/asset/asset.py:416
+#: erpnext/assets/doctype/asset/asset.py:419
 msgid "Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount"
 msgstr "行{0}：使用寿命后的预期值必须小于总采购额"
 
@@ -44986,7 +44985,7 @@ msgstr ""
 msgid "Row {0}: To set {1} periodicity, difference between from and to date must be greater than or equal to {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:450
+#: erpnext/assets/doctype/asset/asset.py:456
 msgid "Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 msgstr ""
 
@@ -44994,7 +44993,7 @@ msgstr ""
 msgid "Row {0}: UOM Conversion Factor is mandatory"
 msgstr "行{0}：计量单位转换系数是必需的"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1037
+#: erpnext/manufacturing/doctype/bom/bom.py:1054
 #: erpnext/manufacturing/doctype/work_order/work_order.py:208
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
@@ -45023,7 +45022,7 @@ msgstr "行{0}：{1} {2}不相匹配{3}"
 msgid "Row {0}: {2} Item {1} does not exist in {2} {3}"
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:279
+#: erpnext/utilities/transaction_base.py:535
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "第{1}行：数量（{0}）不能为小数。为此，请在UOM {3}中禁用“ {2}”。"
 
@@ -45661,7 +45660,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:114
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1126
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:98
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:73
@@ -45759,7 +45758,7 @@ msgstr "销售付款摘要"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:120
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:104
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:79
@@ -45845,7 +45844,7 @@ msgstr "销售台帐"
 msgid "Sales Representative"
 msgstr ""
 
-#: erpnext/accounts/report/gross_profit/gross_profit.py:804
+#: erpnext/accounts/report/gross_profit/gross_profit.py:807
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:218
 msgid "Sales Return"
 msgstr "销售退货"
@@ -46032,7 +46031,7 @@ msgstr "公司代码在另一行已输入过，重复了"
 msgid "Same Item"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:539
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:540
 msgid "Same item and warehouse combination already entered."
 msgstr ""
 
@@ -46059,7 +46058,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2303
+#: erpnext/public/js/controllers/transaction.js:2326
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "样本大小"
@@ -46595,7 +46594,7 @@ msgstr "选择项目"
 msgid "Select Items based on Delivery Date"
 msgstr "根据交货日期选择物料"
 
-#: erpnext/public/js/controllers/transaction.js:2333
+#: erpnext/public/js/controllers/transaction.js:2356
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -46699,7 +46698,7 @@ msgstr "选择默认优先级。"
 msgid "Select a Supplier"
 msgstr "选择供应商"
 
-#: erpnext/stock/doctype/material_request/material_request.js:373
+#: erpnext/stock/doctype/material_request/material_request.js:376
 msgid "Select a Supplier from the Default Suppliers of the items below. On selection, a Purchase Order will be made against items belonging to the selected Supplier only."
 msgstr "从以下各项的默认供应商中选择供应商。选择后，将针对仅属于所选供应商的项目下达采购订单。"
 
@@ -46745,7 +46744,7 @@ msgstr "为行{1}中的项{0}选择财务手册"
 msgid "Select item group"
 msgstr "选择项目组"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:367
+#: erpnext/manufacturing/doctype/bom/bom.js:374
 msgid "Select template item"
 msgstr "选择模板项目"
 
@@ -46762,7 +46761,7 @@ msgstr ""
 msgid "Select the Item to be manufactured."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:838
+#: erpnext/manufacturing/doctype/bom/bom.js:852
 msgid "Select the Item to be manufactured. The Item name, UoM, Company, and Currency will be fetched automatically."
 msgstr ""
 
@@ -46783,11 +46782,11 @@ msgstr ""
 msgid "Select the date and your timezone"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:857
+#: erpnext/manufacturing/doctype/bom/bom.js:871
 msgid "Select the raw materials (Items) required to manufacture the Item"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:415
+#: erpnext/manufacturing/doctype/bom/bom.js:429
 msgid "Select variant item code for the template item {0}"
 msgstr "选择模板项目{0}的变体项目代码"
 
@@ -47105,7 +47104,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2316
+#: erpnext/public/js/controllers/transaction.js:2339
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47191,7 +47190,7 @@ msgstr ""
 msgid "Serial No and Batch for Finished Good"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:706
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:770
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47220,12 +47219,16 @@ msgstr "序列号{0}不属于物料{1}"
 msgid "Serial No {0} does not exist"
 msgstr "序列号{0}不存在"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2387
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2459
 msgid "Serial No {0} does not exists"
 msgstr ""
 
 #: erpnext/public/js/utils/barcode_scanner.js:402
 msgid "Serial No {0} is already added"
+msgstr ""
+
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:289
+msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py:338
@@ -47265,7 +47268,7 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1234
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1298
 msgid "Serial Nos are created successfully"
 msgstr ""
 
@@ -47338,11 +47341,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1462
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1526
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1528
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1592
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -47689,12 +47692,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1374
+#: erpnext/public/js/controllers/transaction.js:1397
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "服务停止日期不能在服务结束日期之后"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1371
+#: erpnext/public/js/controllers/transaction.js:1394
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "服务停止日期不能早于服务开始日期"
 
@@ -47790,7 +47793,7 @@ msgstr "设置密码"
 msgid "Set Posting Date"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:884
+#: erpnext/manufacturing/doctype/bom/bom.js:898
 msgid "Set Process Loss Item Quantity"
 msgstr ""
 
@@ -47804,7 +47807,7 @@ msgstr ""
 msgid "Set Project and all Tasks to status {0}?"
 msgstr "将项目和所有任务设置为状态{0}？"
 
-#: erpnext/manufacturing/doctype/bom/bom.js:885
+#: erpnext/manufacturing/doctype/bom/bom.js:899
 msgid "Set Quantity"
 msgstr ""
 
@@ -47899,7 +47902,7 @@ msgstr ""
 msgid "Set fieldname from which you want to fetch the data from the parent form."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:874
+#: erpnext/manufacturing/doctype/bom/bom.js:888
 msgid "Set quantity of process loss item:"
 msgstr ""
 
@@ -47929,15 +47932,15 @@ msgstr ""
 msgid "Set this if the customer is a Public Administration company."
 msgstr "如果客户是公共管理公司，请设置此项。"
 
-#: erpnext/assets/doctype/asset/asset.py:690
+#: erpnext/assets/doctype/asset/asset.py:696
 msgid "Set {0} in asset category {1} for company {2}"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1011
+#: erpnext/assets/doctype/asset/asset.py:1020
 msgid "Set {0} in asset category {1} or company {2}"
 msgstr "在资产类别{1}或公司{2}中设置{0}"
 
-#: erpnext/assets/doctype/asset/asset.py:1008
+#: erpnext/assets/doctype/asset/asset.py:1017
 msgid "Set {0} in company {1}"
 msgstr "在公司{1}中设置{0}"
 
@@ -48004,7 +48007,7 @@ msgstr ""
 msgid "Setting up company"
 msgstr "建立公司"
 
-#: erpnext/manufacturing/doctype/bom/bom.py:1016
+#: erpnext/manufacturing/doctype/bom/bom.py:1033
 #: erpnext/manufacturing/doctype/work_order/work_order.py:1063
 msgid "Setting {} is required"
 msgstr ""
@@ -48809,15 +48812,15 @@ msgstr ""
 msgid "Something went wrong please try again"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:736
+#: erpnext/accounts/doctype/pricing_rule/utils.py:745
 msgid "Sorry, this coupon code is no longer valid"
 msgstr "抱歉，此优惠券代码不再有效"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:734
+#: erpnext/accounts/doctype/pricing_rule/utils.py:743
 msgid "Sorry, this coupon code's validity has expired"
 msgstr "抱歉，此优惠券代码的有效性已过期"
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:732
+#: erpnext/accounts/doctype/pricing_rule/utils.py:741
 msgid "Sorry, this coupon code's validity has not started"
 msgstr "抱歉，此优惠券代码的有效性尚未开始"
 
@@ -48899,7 +48902,7 @@ msgstr ""
 #. Label of the s_warehouse (Link) field in DocType 'Stock Entry Detail'
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/manufacturing/doctype/bom/bom.js:387
+#: erpnext/manufacturing/doctype/bom/bom.js:401
 #: erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
 #: erpnext/manufacturing/doctype/bom_item/bom_item.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -49019,7 +49022,7 @@ msgstr "拆分问题"
 msgid "Split Qty"
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1116
+#: erpnext/assets/doctype/asset/asset.py:1125
 msgid "Split qty cannot be grater than or equal to asset qty"
 msgstr ""
 
@@ -49444,7 +49447,7 @@ msgstr "州"
 #: erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.json
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:74
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:52
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:206
 #: erpnext/buying/report/subcontract_order_summary/subcontract_order_summary.py:134
 #: erpnext/crm/doctype/appointment/appointment.json
 #: erpnext/crm/doctype/contract/contract.json
@@ -49942,7 +49945,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:128
 #: erpnext/stock/doctype/pick_list/pick_list.js:143
 #: erpnext/stock/doctype/pick_list/pick_list.js:148
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:662
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:500
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:954
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:967
@@ -49951,10 +49954,10 @@ msgstr ""
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1009
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1026
 #: erpnext/stock/doctype/stock_settings/stock_settings.json
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:178
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:190
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:210
-#: erpnext/stock/doctype/stock_settings/stock_settings.py:224
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:179
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:191
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:211
+#: erpnext/stock/doctype/stock_settings/stock_settings.py:225
 msgid "Stock Reservation"
 msgstr ""
 
@@ -50794,7 +50797,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:548
+#: erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py:546
 msgid "Successfully Reconciled"
 msgstr "核消/对账成功"
 
@@ -51006,7 +51009,7 @@ msgstr "供应的数量"
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.js:47
 #: erpnext/buying/report/item_wise_purchase_history/item_wise_purchase_history.py:92
 #: erpnext/buying/report/procurement_tracker/procurement_tracker.py:89
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:205
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:208
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.js:15
 #: erpnext/buying/report/subcontracted_item_to_be_received/subcontracted_item_to_be_received.py:30
 #: erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/subcontracted_raw_materials_to_be_transferred.js:15
@@ -51110,9 +51113,9 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:103
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:86
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1130
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1128
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:174
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:181
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
 #: erpnext/accounts/report/purchase_register/purchase_register.py:186
 #: erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js:55
@@ -51165,7 +51168,7 @@ msgstr "供应商费用清单的日期不能超过过帐日期更大"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html:59
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/report/general_ledger/general_ledger.html:109
-#: erpnext/accounts/report/general_ledger/general_ledger.py:695
+#: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:210
 msgid "Supplier Invoice No"
 msgstr "供应商费用清单编号"
@@ -51210,7 +51213,7 @@ msgstr "供应商分类帐摘要"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1047
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1045
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52826,11 +52829,11 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:126
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:92
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:67
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:157
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:164
 #: erpnext/accounts/report/gross_profit/gross_profit.py:352
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.js:8
 #: erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py:21
@@ -53206,7 +53209,7 @@ msgstr "这些份额不存在{0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:656
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:657
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -53219,11 +53222,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:940
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:941
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "该任务已被列入后台工作。如果在后台处理有任何问题，系统将在此库存对帐中添加有关错误的注释并恢复到草稿阶段"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:951
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:952
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -53277,7 +53280,7 @@ msgstr ""
 msgid "The {0} {1} is used to calculate the valuation cost for the finished good {2}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:522
+#: erpnext/assets/doctype/asset/asset.py:528
 msgid "There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."
 msgstr "对资产进行了积极的维护或修理。您必须先完成所有操作，然后才能取消资产。"
 
@@ -53551,7 +53554,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0} was sold through Sales Invoice {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1177
+#: erpnext/assets/doctype/asset/asset.py:1186
 msgid "This schedule was created when Asset {0} was updated after being split into new Asset {1}."
 msgstr ""
 
@@ -53567,7 +53570,7 @@ msgstr ""
 msgid "This schedule was created when Asset {0}'s shifts were adjusted through Asset Shift Allocation {1}."
 msgstr ""
 
-#: erpnext/assets/doctype/asset/asset.py:1234
+#: erpnext/assets/doctype/asset/asset.py:1243
 msgid "This schedule was created when new Asset {0} was split from Asset {1}."
 msgstr ""
 
@@ -53770,7 +53773,7 @@ msgstr ""
 msgid "Timer"
 msgstr "计时器"
 
-#: erpnext/public/js/projects/timer.js:149
+#: erpnext/public/js/projects/timer.js:148
 msgid "Timer exceeded the given hours."
 msgstr "计时器超出了指定的小时数"
 
@@ -53972,7 +53975,7 @@ msgstr ""
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:44
 #: erpnext/accounts/report/financial_ratios/financial_ratios.js:48
 #: erpnext/accounts/report/general_ledger/general_ledger.js:30
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/gross_profit/gross_profit.js:23
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.js:15
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js:15
@@ -54271,7 +54274,7 @@ msgstr "到仓库"
 msgid "To Warehouse (Optional)"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:852
+#: erpnext/manufacturing/doctype/bom/bom.js:866
 msgid "To add Operations tick the 'With Operations' checkbox."
 msgstr ""
 
@@ -54346,7 +54349,7 @@ msgid "To use a different finance book, please uncheck 'Include Default FB Asset
 msgstr ""
 
 #: erpnext/accounts/report/financial_statements.py:578
-#: erpnext/accounts/report/general_ledger/general_ledger.py:289
+#: erpnext/accounts/report/general_ledger/general_ledger.py:286
 #: erpnext/accounts/report/trial_balance/trial_balance.py:266
 msgid "To use a different finance book, please uncheck 'Include Default FB Entries'"
 msgstr ""
@@ -54447,7 +54450,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:273
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py:229
 #: erpnext/accounts/report/financial_statements.py:655
-#: erpnext/accounts/report/general_ledger/general_ledger.py:415
+#: erpnext/accounts/report/general_ledger/general_ledger.py:417
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:681
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:93
 #: erpnext/accounts/report/profitability_analysis/profitability_analysis.py:98
@@ -56000,7 +56003,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: erpnext/utilities/doctype/video/video.py:113
+#: erpnext/utilities/doctype/video/video.py:114
 msgid "URL can only be a string"
 msgstr "网址只能是一个字符串"
 
@@ -56610,7 +56613,7 @@ msgstr ""
 
 #. Label of the use_multi_level_bom (Check) field in DocType 'Work Order'
 #. Label of the use_multi_level_bom (Check) field in DocType 'Stock Entry'
-#: erpnext/manufacturing/doctype/bom/bom.js:308
+#: erpnext/manufacturing/doctype/bom/bom.js:336
 #: erpnext/manufacturing/doctype/work_order/work_order.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.json
 msgid "Use Multi-Level BOM"
@@ -56658,6 +56661,12 @@ msgstr ""
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
 msgid "Use Serial No / Batch Fields"
+msgstr ""
+
+#. Label of the use_server_side_reactivity (Check) field in DocType 'Selling
+#. Settings'
+#: erpnext/selling/doctype/selling_settings/selling_settings.json
+msgid "Use Server Side Reactivity"
 msgstr ""
 
 #. Label of the use_transaction_date_exchange_rate (Check) field in DocType
@@ -57072,7 +57081,7 @@ msgstr "要为{1} {2}进行会计分录，必须使用项目{0}的评估率。"
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "库存开帐凭证中评估价字段必填"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:708
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:709
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "第{1}行的第{0}项所需的估价率"
 
@@ -57082,7 +57091,7 @@ msgstr "第{1}行的第{0}项所需的估价率"
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:917
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:918
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -57168,6 +57177,11 @@ msgstr "价值或数量"
 msgid "Value Proposition"
 msgstr "价值主张"
 
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:447
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:477
+msgid "Value as on"
+msgstr ""
+
 #: erpnext/controllers/item_variant.py:124
 msgid "Value for Attribute {0} must be within the range of {1} to {2} in the increments of {3} for Item {4}"
 msgstr "物料{4}的属性{0}其属性值必须{1}到{2}范围内，且增量{3}"
@@ -57175,6 +57189,22 @@ msgstr "物料{4}的属性{0}其属性值必须{1}到{2}范围内，且增量{3}
 #. Label of the value_of_goods (Currency) field in DocType 'Shipment'
 #: erpnext/stock/doctype/shipment/shipment.json
 msgid "Value of Goods"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:471
+msgid "Value of New Capitalized Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:453
+msgid "Value of New Purchase"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:465
+msgid "Value of Scrapped Asset"
+msgstr ""
+
+#: erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py:459
+msgid "Value of Sold Asset"
 msgstr ""
 
 #: erpnext/stock/doctype/shipment/shipment.py:85
@@ -57256,7 +57286,7 @@ msgid "Variant Field"
 msgstr "变量字段"
 
 #: erpnext/manufacturing/doctype/bom/bom.js:291
-#: erpnext/manufacturing/doctype/bom/bom.js:361
+#: erpnext/manufacturing/doctype/bom/bom.js:368
 msgid "Variant Item"
 msgstr "变项"
 
@@ -57554,11 +57584,11 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1069
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
-#: erpnext/accounts/report/general_ledger/general_ledger.py:664
+#: erpnext/accounts/report/general_ledger/general_ledger.py:666
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.js:41
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:33
 #: erpnext/accounts/report/payment_ledger/payment_ledger.js:64
@@ -57584,7 +57614,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "凭证编号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:934
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:998
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -57596,7 +57626,7 @@ msgstr ""
 
 #. Label of the voucher_subtype (Small Text) field in DocType 'GL Entry'
 #: erpnext/accounts/doctype/gl_entry/gl_entry.json
-#: erpnext/accounts/report/general_ledger/general_ledger.py:658
+#: erpnext/accounts/report/general_ledger/general_ledger.py:660
 msgid "Voucher Subtype"
 msgstr ""
 
@@ -57626,9 +57656,9 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
-#: erpnext/accounts/report/general_ledger/general_ledger.py:656
+#: erpnext/accounts/report/general_ledger/general_ledger.py:658
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
 #: erpnext/accounts/report/payment_ledger/payment_ledger.py:159
 #: erpnext/accounts/report/purchase_register/purchase_register.py:158
@@ -57796,7 +57826,7 @@ msgstr "主动上门"
 #: erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
 #: erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:301
+#: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:304
 #: erpnext/manufacturing/doctype/bom_creator/bom_creator.json
 #: erpnext/manufacturing/doctype/bom_operation/bom_operation.json
 #: erpnext/manufacturing/doctype/plant_floor/plant_floor.json
@@ -57981,7 +58011,7 @@ msgstr "仓库信息必填"
 msgid "Warehouse not found against the account {0}"
 msgstr "在帐户{0}中找不到仓库"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:556
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:557
 msgid "Warehouse not found in the system"
 msgstr "仓库在系统中未找到"
 
@@ -58107,7 +58137,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:727
 #: erpnext/controllers/accounts_controller.py:1833
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
-#: erpnext/utilities/transaction_base.py:120
+#: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
 msgstr "警告"
 
@@ -58127,7 +58157,7 @@ msgstr ""
 msgid "Warning: Another {0} # {1} exists against stock entry {2}"
 msgstr "警告：库存凭证{2}中已存在另一个{0}＃{1}"
 
-#: erpnext/stock/doctype/material_request/material_request.js:492
+#: erpnext/stock/doctype/material_request/material_request.js:495
 msgid "Warning: Material Requested Qty is less than Minimum Order Qty"
 msgstr "警告：物料需求数量低于最小起订量"
 
@@ -58660,8 +58690,8 @@ msgstr "由于以下原因，无法创建工作订单：<br> {0}"
 msgid "Work Order cannot be raised against a Item Template"
 msgstr "不能为模板物料新建工单"
 
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1503
-#: erpnext/manufacturing/doctype/work_order/work_order.py:1579
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1505
+#: erpnext/manufacturing/doctype/work_order/work_order.py:1581
 msgid "Work Order has been {0}"
 msgstr "工单已{0}"
 
@@ -59073,7 +59103,7 @@ msgstr "是"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3418
+#: erpnext/controllers/accounts_controller.py:3430
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "您无法按照{}工作流程中设置的条件进行更新。"
 
@@ -59138,11 +59168,15 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:135
+msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+msgstr ""
+
 #: erpnext/accounts/doctype/loyalty_program/loyalty_program.py:182
 msgid "You can't redeem Loyalty Points having more value than the Rounded Total."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:633
+#: erpnext/manufacturing/doctype/bom/bom.js:647
 msgid "You cannot change the rate if BOM is mentioned against any Item."
 msgstr ""
 
@@ -59194,7 +59228,7 @@ msgstr "您必须先付款才能提交订单。"
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3394
+#: erpnext/controllers/accounts_controller.py:3406
 msgid "You do not have permissions to {} items in a {}."
 msgstr "您无权访问{}中的{}个项目。"
 
@@ -59346,7 +59380,7 @@ msgstr ""
 msgid "as Title"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.js:876
+#: erpnext/manufacturing/doctype/bom/bom.js:890
 msgid "as a percentage of finished item quantity"
 msgstr ""
 
@@ -59682,7 +59716,7 @@ msgstr ""
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
-#: erpnext/utilities/transaction_base.py:193
+#: erpnext/utilities/transaction_base.py:196
 msgid "{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 msgstr ""
 
@@ -59690,7 +59724,7 @@ msgstr ""
 msgid "{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}"
 msgstr ""
 
-#: erpnext/accounts/doctype/pricing_rule/utils.py:751
+#: erpnext/accounts/doctype/pricing_rule/utils.py:760
 msgid "{0} Coupon used are {1}. Allowed quantity is exhausted"
 msgstr "{0}使用的优惠券是{1}。允许数量已耗尽"
 
@@ -59750,7 +59784,7 @@ msgstr "{0}已有父程序{1}。"
 msgid "{0} and {1}"
 msgstr ""
 
-#: erpnext/accounts/report/general_ledger/general_ledger.py:60
+#: erpnext/accounts/report/general_ledger/general_ledger.py:57
 #: erpnext/accounts/report/pos_register/pos_register.py:111
 msgid "{0} and {1} are mandatory"
 msgstr "{0}和{1}是强制性的"
@@ -59841,7 +59875,7 @@ msgstr "{0}被阻止，所以此事务无法继续"
 
 #: erpnext/accounts/doctype/budget/budget.py:57
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:624
-#: erpnext/accounts/report/general_ledger/general_ledger.py:56
+#: erpnext/accounts/report/general_ledger/general_ledger.py:53
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
 msgid "{0} is mandatory"
@@ -59923,7 +59957,7 @@ msgstr "{0}在退货凭证中必须为负"
 msgid "{0} not allowed to transact with {1}. Please change the Company or add the Company in the 'Allowed To Transact With'-Section in the Customer record."
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom/bom.py:482
+#: erpnext/manufacturing/doctype/bom/bom.py:499
 msgid "{0} not found for item {1}"
 msgstr "在{0}中找不到物料{1}"
 
@@ -59939,7 +59973,7 @@ msgstr "{0}付款凭证不能由{1}过滤"
 msgid "{0} qty of Item {1} is being received into Warehouse {2} with capacity {3}."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:646
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:647
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -392,3 +392,4 @@ erpnext.patches.v15_0.migrate_old_item_wise_tax_detail_data_format
 erpnext.patches.v15_0.set_is_exchange_gain_loss_in_payment_entry_deductions
 erpnext.patches.v14_0.update_stock_uom_in_work_order_item
 erpnext.patches.v15_0.enable_allow_existing_serial_no
+erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,10 +1,16 @@
 import frappe
+from frappe import qb
 
 
 def execute():
-	data = frappe.db.sql(
-		"""SELECT name, cc_to FROM `tabProcess Statement Of Accounts` WHERE cc_to IS NOT NULL""", as_dict=True
-	)
+	process_statement_of_accounts = qb.DocType("Process Statement Of Accounts")
+
+	data = (
+		frappe.qb.from_(process_statement_of_accounts)
+		.select(process_statement_of_accounts.name, process_statement_of_accounts.cc_to)
+		.where(process_statement_of_accounts.cc_to.isnotnull())
+	).run(as_dict=True)
+
 	for d in data:
 		doc = frappe.get_doc("Process Statement Of Accounts", d.name)
 		doc.append("cc_to", {"cc": d.cc_to})

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	data = frappe.db.sql(
+		"""SELECT name, cc_to FROM `tabProcess Statement Of Accounts` WHERE cc_to IS NOT NULL""", as_dict=True
+	)
+	for d in data:
+		doc = frappe.get_doc("Process Statement Of Accounts", d.name)
+		doc.append("cc_to", {"cc": d.cc_to})
+		doc.save()

--- a/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
+++ b/erpnext/patches/v15_0/update_cc_in_process_statement_of_accounts.py
@@ -1,9 +1,8 @@
 import frappe
-from frappe import qb
 
 
 def execute():
-	process_statement_of_accounts = qb.DocType("Process Statement Of Accounts")
+	process_statement_of_accounts = frappe.qb.DocType("Process Statement Of Accounts")
 
 	data = (
 		frappe.qb.from_(process_statement_of_accounts)


### PR DESCRIPTION
**Issue:**
In TDS Computation Summary tax withholding category not fetching from the journal entry, it is fetching from the party.
**ref:** [27210](https://support.frappe.io/helpdesk/tickets/27210)

**Journal Entry:**
![image](https://github.com/user-attachments/assets/afbe6716-e259-4df6-98fb-672ab8e39d46)

**Before:**
![image](https://github.com/user-attachments/assets/583142ff-401e-4c73-ae60-f89f09776a5e)


**After:**
![image](https://github.com/user-attachments/assets/12641bed-358d-44a0-b291-476c3752f0d7)


**Backport needed for v15 & v14**