### PR TITLE
fix: fetch tax withholding category from the voucher

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -539,7 +539,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 	)
 
 	supp_credit_amt = supp_jv_credit_amt
-	supp_credit_amt += inv.tax_withholding_net_total
+	supp_credit_amt += inv.get("tax_withholding_net_total", 0)
 
 	for type in payment_entry_amounts:
 		if type.payment_type == "Pay":
@@ -551,9 +551,9 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
 	if inv.doctype != "Payment Entry":
-		tax_withholding_net_total = inv.base_tax_withholding_net_total
+		tax_withholding_net_total = inv.get("base_tax_withholding_net_total", 0)
 	else:
-		tax_withholding_net_total = inv.tax_withholding_net_total
+		tax_withholding_net_total = inv.get("tax_withholding_net_total", 0)
 
 	if (threshold and tax_withholding_net_total >= threshold) or (
 		cumulative_threshold and (supp_credit_amt + supp_inv_credit_amt) >= cumulative_threshold

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -409,7 +409,7 @@ def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
 			"paid_amount_after_tax",
 			"base_paid_amount",
 		],
-		"Journal Entry": ["total_debit"],
+		"Journal Entry": ["tax_withholding_category", "total_debit"],
 	}
 
 	entries = frappe.get_all(


### PR DESCRIPTION
**Issue:**
In TDS Computation Summary tax withholding category not fetching from the journal entry, it is fetching from the party.
**ref:** [27210](https://support.frappe.io/helpdesk/tickets/27210)

**Journal Entry:**
![image](https://github.com/user-attachments/assets/afbe6716-e259-4df6-98fb-672ab8e39d46)

**Before:**
![image](https://github.com/user-attachments/assets/583142ff-401e-4c73-ae60-f89f09776a5e)


**After:**
![image](https://github.com/user-attachments/assets/12641bed-358d-44a0-b291-476c3752f0d7)


**Backport needed for v15 & v14**