### PR TITLE
fix: Paid + Write Off Amount issue in Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1010,9 +1010,9 @@ class SalesInvoice(SellingController):
 	def validate_pos(self):
 		if self.is_return:
 			invoice_total = self.rounded_total or self.grand_total
-			if flt(self.paid_amount) + flt(self.write_off_amount) - flt(invoice_total) > 1.0 / (
-				10.0 ** (self.precision("grand_total") + 1.0)
-			):
+			if abs(flt(self.paid_amount)) + abs(flt(self.write_off_amount)) - abs(
+				flt(invoice_total)
+			) > 1.0 / (10.0 ** (self.precision("grand_total") + 1.0)):
 				frappe.throw(_("Paid amount + Write Off Amount can not be greater than Grand Total"))
 
 	def validate_warehouse(self):


### PR DESCRIPTION
Issue: https://support.frappe.io/helpdesk/tickets/26091
![image](https://github.com/user-attachments/assets/f649cdf6-433e-4044-973c-9c774ba828fc)

In the case of Return the validation `validate_pos` is comparing the amounts as negative amounts and when trying to make a partial return it throws the above error.

Fix: Perform the comparision after taking their absolute value
