### PR TITLE
fix: 'str' object has no attribute 'get_sql'

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -529,12 +529,11 @@ def get_accounting_entries(
 
 	from frappe.desk.reportview import build_match_conditions
 
+	query, params = query.walk()
 	match_conditions = build_match_conditions(doctype)
 
 	if match_conditions:
 		query += "and" + match_conditions
-
-	query, params = query.walk()
 
 	return frappe.db.sql(query, params, as_dict=True)
 


### PR DESCRIPTION
Related: https://github.com/frappe/erpnext/pull/44695
Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 50, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1726, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 879, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 224, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 879, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 84, in generate_report_result
    res = get_report_result(report, filters) or []
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 65, in get_report_result
    res = report.execute_script_report(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 163, in execute_script_report
    res = self.execute_module(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 180, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py", line 30, in execute
    income = get_data(
             ^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 182, in get_data
    set_gl_entries_by_account(
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 466, in set_gl_entries_by_account
    gl_entries += get_accounting_entries(
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 537, in get_accounting_entries
    query, params = query.walk()
                    ^^^^^^^^^^^^
  File "apps/frappe/frappe/query_builder/utils.py", line 111, in prepare_query
    query = query.get_sql(param_wrapper=param_collector)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/queries.py", line 607, in get_sql
    set_operation_querystring = set_operation_query.get_sql(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get_sql'
```

closes: https://github.com/frappe/erpnext/issues/44766

backport version-15-hotfix
backport version-14-hotfix