### PR TITLE
feat: add company validation for all accounting dimension doctypes

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -957,7 +957,10 @@ class TestPurchaseOrder(IntegrationTestCase):
 		supplier = "_Test Internal Supplier 2"
 
 		mr = make_material_request(
-			qty=2, company="_Test Company with perpetual inventory", warehouse="Stores - TCP1"
+			qty=2,
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			cost_center="_Test Company with perpetual inventory - TCP1",
 		)
 
 		po = create_purchase_order(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -270,6 +270,20 @@ class AccountsController(TransactionBase):
 		self.set_total_in_words()
 		self.set_default_letter_head()
 
+		if self.get("docstatus") == 1 and self.get("company"):
+			accounting_dimensions = ["Cost Center", "Project"]
+			accounting_dimensions += frappe.get_all("Accounting Dimension", pluck="name")
+
+			for dimension in accounting_dimensions:
+				if self.get(frappe.scrub(dimension)):
+					doc = frappe.get_doc(dimension, self.get(frappe.scrub(dimension)))
+					if hasattr(doc, "company") and doc.company != self.company:
+						frappe.throw(
+							_("{0} {1} is not part of the current company").format(
+								dimension, frappe.bold(self.get(frappe.scrub(dimension)))
+							)
+						)
+
 	def set_default_letter_head(self):
 		if hasattr(self, "letter_head") and not self.letter_head:
 			self.letter_head = frappe.db.get_value("Company", self.company, "default_letter_head")

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -1467,6 +1467,13 @@ class TestAccountsController(IntegrationTestCase):
 		"""
 		self.setup_dimensions()
 		rate_in_account_currency = 1
+		department = frappe.get_all(
+			"Department",
+			{"name": ["in", ["Management", "Operations", "Legal", "Research & Development"]]},
+			["name", "company"],
+		)
+		for dept in department:
+			frappe.db.set_value("Department", dept.name, "company", "_Test Company")
 
 		# Invoices
 		si1 = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_submit=True)
@@ -1535,6 +1542,7 @@ class TestAccountsController(IntegrationTestCase):
 	def test_91_cr_note_should_inherit_dimension(self):
 		self.setup_dimensions()
 		rate_in_account_currency = 1
+		frappe.db.set_value("Department", "Management", "company", "_Test Company")
 
 		# Invoice
 		si = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_submit=True)
@@ -1581,6 +1589,7 @@ class TestAccountsController(IntegrationTestCase):
 		self.setup_dimensions()
 		rate_in_account_currency = 1
 		dpt = "Research & Development"
+		frappe.db.set_value("Department", dpt, "company", "_Test Company")
 
 		si = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_save=True)
 		si.department = dpt
@@ -1616,6 +1625,7 @@ class TestAccountsController(IntegrationTestCase):
 	def test_93_dimension_inheritance_on_advance(self):
 		self.setup_dimensions()
 		dpt = "Research & Development"
+		frappe.db.set_value("Department", dpt, "company", "_Test Company")
 
 		adv = self.create_payment_entry(amount=1, source_exc_rate=85)
 		adv.department = dpt

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -55,19 +55,22 @@ class TestTimesheet(IntegrationTestCase):
 
 	def test_timesheet_billing_based_on_project(self):
 		emp = make_employee("test_employee_6@salary.com")
-		project = frappe.get_doc("Project", "_T-Project-00001")
-		project.company = "_Test Company"
-		project.save()
-
-		location = frappe.get_doc("Accounting Dimension", "Location")
-		location.dimension_defaults[0].mandatory_for_bs = 0
-		location.save()
+		project = frappe.get_value("Project", {"project_name": "_Test Project"})
 
 		timesheet = make_timesheet(
-			emp, simulate=True, is_billable=1, project=project.name, company="_Test Company"
+			emp, simulate=True, is_billable=1, project=project, company="Wind Power LLC"
 		)
-		sales_invoice = create_sales_invoice(do_not_save=True)
-		sales_invoice.project = project.name
+		sales_invoice = create_sales_invoice(
+			company="Wind Power LLC",
+			cost_center="Main - WP",
+			currency="USD",
+			conversion_rate=82,
+			debit_to="Debtors - WP",
+			income_account="Sales - WP",
+			expense_account="Cost of Goods Sold - WP",
+			do_not_save=True,
+		)
+		sales_invoice.project = project
 		sales_invoice.submit()
 
 		ts = frappe.get_doc("Timesheet", timesheet.name)

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -55,13 +55,19 @@ class TestTimesheet(IntegrationTestCase):
 
 	def test_timesheet_billing_based_on_project(self):
 		emp = make_employee("test_employee_6@salary.com")
-		project = frappe.get_value("Project", {"project_name": "_Test Project"})
+		project = frappe.get_doc("Project", "_T-Project-00001")
+		project.company = "_Test Company"
+		project.save()
+
+		location = frappe.get_doc("Accounting Dimension", "Location")
+		location.dimension_defaults[0].mandatory_for_bs = 0
+		location.save()
 
 		timesheet = make_timesheet(
-			emp, simulate=True, is_billable=1, project=project, company="_Test Company"
+			emp, simulate=True, is_billable=1, project=project.name, company="_Test Company"
 		)
 		sales_invoice = create_sales_invoice(do_not_save=True)
-		sales_invoice.project = project
+		sales_invoice.project = project.name
 		sales_invoice.submit()
 
 		ts = frappe.get_doc("Timesheet", timesheet.name)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1408,6 +1408,7 @@ class TestDeliveryNote(IntegrationTestCase):
 			qty=4,
 			warehouse=warehouse,
 			target_warehouse=target,
+			cost_center="_Test Company with perpetual inventory - TCP1",
 		)
 		self.assertFalse(frappe.db.exists("GL Entry", {"voucher_no": dn.name, "voucher_type": dn.doctype}))
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1163,6 +1163,10 @@ def create_dn_with_so(sales_dict, pick_list):
 
 
 def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
+	delivery_note.pick_list = pick_list.name
+	delivery_note.company = pick_list.company
+	delivery_note.customer = frappe.get_value("Sales Order", sales_order, "customer")
+
 	for location in pick_list.locations:
 		if location.sales_order != sales_order or location.product_bundle_item:
 			continue
@@ -1188,10 +1192,6 @@ def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
 
 	add_product_bundles_to_delivery_note(pick_list, delivery_note, item_mapper)
 	set_delivery_note_missing_values(delivery_note)
-
-	delivery_note.pick_list = pick_list.name
-	delivery_note.company = pick_list.company
-	delivery_note.customer = frappe.get_value("Sales Order", sales_order, "customer")
 
 
 def add_product_bundles_to_delivery_note(pick_list: "PickList", delivery_note, item_mapper) -> None:
@@ -1307,6 +1307,8 @@ def update_delivery_note_item(source, target, delivery_note):
 	if not cost_center:
 		cost_center = get_cost_center(source.item_group, "Item Group", delivery_note.company)
 
+	if not cost_center:
+		cost_center = frappe.get_cached_value("Company", delivery_note.company, "cost_center")
 	target.cost_center = cost_center
 
 

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -111,6 +111,7 @@ class TestSerialNo(IntegrationTestCase):
 			qty=1,
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
+			cost_center="_Test Company 1 - _TC1",
 			warehouse=wh,
 		)
 		sn_doc.reload()
@@ -126,6 +127,7 @@ class TestSerialNo(IntegrationTestCase):
 			qty=1,
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
+			cost_center="_Test Company 1 - _TC1",
 			warehouse=wh,
 		)
 		sn_doc.reload()
@@ -161,6 +163,7 @@ class TestSerialNo(IntegrationTestCase):
 			qty=1,
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
+			cost_center="_Test Company 1 - _TC1",
 			warehouse=wh,
 		)
 
@@ -170,6 +173,7 @@ class TestSerialNo(IntegrationTestCase):
 			qty=1,
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
+			cost_center="_Test Company 1 - _TC1",
 			warehouse=wh,
 		)
 		sn_doc.reload()


### PR DESCRIPTION
Issue:
Accounting Dimension Validations are not happening as per Company

ref: [22387](https://support.frappe.io/helpdesk/tickets/22387)

Before:

[accounting_dimension_bf.webm](https://github.com/user-attachments/assets/22f80d9d-f235-420d-a687-dca9958b1a77)

After:

[accounting_dimension_af.webm](https://github.com/user-attachments/assets/5ae4ca0d-2769-487b-bddb-0c5bff67bdd8)
