### PR TITLE
fix: add `Stock UOM` when adding new item in POS list

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -574,7 +574,7 @@ erpnext.PointOfSale.Controller = class {
 			} else {
 				if (!this.frm.doc.customer) return this.raise_customer_selection_alert();
 
-				const { item_code, batch_no, serial_no, rate, uom } = item;
+				const { item_code, batch_no, serial_no, rate, uom, stock_uom } = item;
 
 				if (!item_code) return;
 
@@ -586,7 +586,7 @@ erpnext.PointOfSale.Controller = class {
 					frappe.utils.play_sound("error");
 					return;
 				}
-				const new_item = { item_code, batch_no, rate, uom, [field]: value };
+				const new_item = { item_code, batch_no, rate, uom, [field]: value, stock_uom };
 
 				if (serial_no) {
 					await this.check_serial_no_availablilty(item_code, this.frm.doc.set_warehouse, serial_no);

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -118,6 +118,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				data-item-code="${escape(item.item_code)}" data-serial-no="${escape(serial_no)}"
 				data-batch-no="${escape(batch_no)}" data-uom="${escape(uom)}"
 				data-rate="${escape(price_list_rate || 0)}"
+				data-stock-uom="${escape(item.stock_uom)}"
 				title="${item.item_name}">
 
 				${get_item_image_html()}
@@ -251,17 +252,19 @@ erpnext.PointOfSale.ItemSelector = class {
 			let serial_no = unescape($item.attr("data-serial-no"));
 			let uom = unescape($item.attr("data-uom"));
 			let rate = unescape($item.attr("data-rate"));
+			let stock_uom = unescape($item.attr("data-stock-uom"));
 
 			// escape(undefined) returns "undefined" then unescape returns "undefined"
 			batch_no = batch_no === "undefined" ? undefined : batch_no;
 			serial_no = serial_no === "undefined" ? undefined : serial_no;
 			uom = uom === "undefined" ? undefined : uom;
 			rate = rate === "undefined" ? undefined : rate;
+			stock_uom = stock_uom === "undefined" ? undefined : stock_uom;
 
 			me.events.item_selected({
 				field: "qty",
 				value: "+1",
-				item: { item_code, batch_no, serial_no, uom, rate },
+				item: { item_code, batch_no, serial_no, uom, rate, stock_uom },
 			});
 			me.search_field.set_focus();
 		});


### PR DESCRIPTION
## Issue: [Frappe Support - 27653](https://support.frappe.io/helpdesk/tickets/27653)

<details>

<summary> <strong>Error Log </strong> </summary>

```
TypeError: e.stock_uom is undefined
    check_stock_availability point-of-sale line 294 > injectedScript:308
    on_cart_update point-of-sale line 294 > injectedScript:308
    item_selected point-of-sale line 294 > injectedScript:306
    bind_events point-of-sale line 294 > injectedScript:38
    jQuery 8
    bind_events point-of-sale line 294 > injectedScript:38
    inti_component point-of-sale line 294 > injectedScript:1
    <anonymous> point-of-sale line 294 > injectedScript:1
    init_item_selector point-of-sale line 294 > injectedScript:306
    prepare_components point-of-sale line 294 > injectedScript:306
    make_app point-of-sale line 294 > injectedScript:306
    callback point-of-sale line 294 > injectedScript:302
    e request.js:85
    200 request.js:133
    call request.js:305
    jQuery 6
    call request.js:279
    call request.js:109
    prepare_app_defaults point-of-sale line 294 > injectedScript:302
    check_opening_entry point-of-sale line 294 > injectedScript:302
    jQuery 12
    call request.js:279
    call request.js:109
    fetch_opening_entry point-of-sale line 294 > injectedScript:302
    check_opening_entry point-of-sale line 294 > injectedScript:302
    <anonymous> point-of-sale line 294 > injectedScript:302
    on_page_load point_of_sale.js:11
    require assets.js:17
    execute assets.js:114
    promise callback*execute assets.js:108
    require assets.js:15
    require assets.js:14
    on_page_load point_of_sale.js:10
point-of-sale line 294 > injectedScript:308:464

```

</details>

--- 

### Failure Line

https://github.com/frappe/erpnext/blob/6f99e9959d06c60cf2c59f7aee46d675cd8d3b50/erpnext/selling/page/point_of_sale/pos_controller.js#L698

### Root cause of Issue

In PR #44320, if enough stock is not available, the error message shows `Stock UOM` instead of `UOM` to get accurate stock details.

Arguments for creating a new item row when selecting:

https://github.com/frappe/erpnext/blob/6f99e9959d06c60cf2c59f7aee46d675cd8d3b50/erpnext/selling/page/point_of_sale/pos_controller.js#L577 

https://github.com/frappe/erpnext/blob/6f99e9959d06c60cf2c59f7aee46d675cd8d3b50/erpnext/selling/page/point_of_sale/pos_controller.js#L589

These args does not have `stock_uom`.

> [!IMPORTANT]
> Backport to Version-15

