### PR TITLE
fix: correct tds rate with lower deduction certificate

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -247,14 +247,14 @@ def get_tax_row_for_tds(tax_details, tax_amount):
 	}
 
 
-def get_lower_deduction_certificate(company, tax_details, pan_no):
+def get_lower_deduction_certificate(company, posting_date, tax_details, pan_no):
 	ldc_name = frappe.db.get_value(
 		"Lower Deduction Certificate",
 		{
 			"pan_no": pan_no,
 			"tax_withholding_category": tax_details.tax_withholding_category,
-			"valid_from": (">=", tax_details.from_date),
-			"valid_upto": ("<=", tax_details.to_date),
+			"valid_from": ("<=", posting_date),
+			"valid_upto": (">=", posting_date),
 			"company": company,
 		},
 		"name",
@@ -302,7 +302,7 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 	tax_amount = 0
 
 	if party_type == "Supplier":
-		ldc = get_lower_deduction_certificate(inv.company, tax_details, pan_no)
+		ldc = get_lower_deduction_certificate(inv.company, posting_date, tax_details, pan_no)
 		if tax_deducted:
 			net_total = inv.tax_withholding_net_total
 			if ldc:


### PR DESCRIPTION
Issue:
The tax withholding rate is incorrect if tax withholding from_date doesn't match with lower deduction certificate period.
Steps to replicate:
- Create a tax withholding category with period 1-10-2024 to 31-3-2025.
- Create a Supplier with a tax withholding category.
- Create a Lower Deduction Certification for the supplier,valid from 1-4-2024  and valid up to 31-3-2025.
- Even though LDC is valid and within the period, it will not be applied due to incorrect date filters.

Solution:
Validating LDC based on inv date. 

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/27014

backport version-15-hotfix
backport version-14-hotfix
