### PR TITLE
fix: attribute order in create multiple variants dialog

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -545,7 +545,7 @@ $.extend(erpnext.item, {
 
 		function make_fields_from_attribute_values(attr_dict) {
 			let fields = [];
-			let att_key = frm.doc.attributes.map(idx => idx.attribute);
+			let att_key = frm.doc.attributes.map((idx) => idx.attribute);
 			att_key.forEach((name, i) => {
 				if (i % 3 === 0) {
 					fields.push({ fieldtype: "Section Break" });

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -545,7 +545,8 @@ $.extend(erpnext.item, {
 
 		function make_fields_from_attribute_values(attr_dict) {
 			let fields = [];
-			Object.keys(attr_dict).forEach((name, i) => {
+			let att_key = frm.doc.attributes.map(idx => idx.attribute);
+			att_key.forEach((name, i) => {
 				if (i % 3 === 0) {
 					fields.push({ fieldtype: "Section Break" });
 				}


### PR DESCRIPTION
In Item , **Create >  Multiple Variants** dialog displays Attributes in Different Order each time

https://github.com/user-attachments/assets/4af99638-bee8-4cb9-885a-aab3e3a6cd3e

Replaced [this](https://github.com/frappe/erpnext/blob/3662a6a41d2e1e4631c964dffa4d215542a38af1/erpnext/stock/doctype/item/item.js#L548) with `
frm.doc.attributes.map(idx => idx.attribute)
`

https://github.com/user-attachments/assets/01ae5b13-f645-4260-b636-380408c6946d


This pull request includes a change to the `erpnext/stock/doctype/item/item.js` file. The modification improves the way attribute keys are handled when creating fields from attribute values.

* [`erpnext/stock/doctype/item/item.js`](diffhunk://#diff-58fff835aa996507507ac95e98c025f7eb4b152fdd547045755a374c13641679L548-R549): Changed the method of iterating over attribute keys by using `frm.doc.attributes.map(idx => idx.attribute)` instead of `Object.keys(attr_dict)`.
