### PR TITLE
feat: Added difference_posting_date field in Sales Invoice Advance and Purchase Invoice Advance

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.json
+++ b/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.json
@@ -14,7 +14,8 @@
   "advance_amount",
   "allocated_amount",
   "exchange_gain_loss",
-  "ref_exchange_rate"
+  "ref_exchange_rate",
+  "difference_posting_date"
  ],
  "fields": [
   {
@@ -30,7 +31,7 @@
    "width": "180px"
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "reference_name",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
@@ -40,7 +41,7 @@
    "read_only": 1
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "remarks",
    "fieldtype": "Text",
    "in_list_view": 1,
@@ -111,13 +112,20 @@
    "label": "Reference Exchange Rate",
    "non_negative": 1,
    "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "difference_posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Difference Posting Date"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:24.072896",
+ "modified": "2024-12-20 12:04:46.729972",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Advance",

--- a/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.py
+++ b/erpnext/accounts/doctype/purchase_invoice_advance/purchase_invoice_advance.py
@@ -16,6 +16,7 @@ class PurchaseInvoiceAdvance(Document):
 
 		advance_amount: DF.Currency
 		allocated_amount: DF.Currency
+		difference_posting_date: DF.Date | None
 		exchange_gain_loss: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext/accounts/doctype/sales_invoice_advance/sales_invoice_advance.json
+++ b/erpnext/accounts/doctype/sales_invoice_advance/sales_invoice_advance.json
@@ -14,7 +14,8 @@
   "advance_amount",
   "allocated_amount",
   "exchange_gain_loss",
-  "ref_exchange_rate"
+  "ref_exchange_rate",
+  "difference_posting_date"
  ],
  "fields": [
   {
@@ -30,7 +31,7 @@
    "width": "250px"
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "reference_name",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
@@ -41,7 +42,7 @@
    "read_only": 1
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "remarks",
    "fieldtype": "Text",
    "in_list_view": 1,
@@ -112,13 +113,20 @@
    "label": "Reference Exchange Rate",
    "non_negative": 1,
    "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "difference_posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Difference Posting Date"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:36.003704",
+ "modified": "2024-12-20 11:58:28.962370",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Advance",

--- a/erpnext/accounts/doctype/sales_invoice_advance/sales_invoice_advance.py
+++ b/erpnext/accounts/doctype/sales_invoice_advance/sales_invoice_advance.py
@@ -16,6 +16,7 @@ class SalesInvoiceAdvance(Document):
 
 		advance_amount: DF.Currency
 		allocated_amount: DF.Currency
+		difference_posting_date: DF.Date | None
 		exchange_gain_loss: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -383,13 +383,14 @@ class AccountsController(TransactionBase):
 					== 1
 				)
 			).run()
-			frappe.db.sql(
-				"delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name)
-			)
-			frappe.db.sql(
-				"delete from `tabStock Ledger Entry` where voucher_type=%s and voucher_no=%s",
-				(self.doctype, self.name),
-			)
+			gle = frappe.qb.DocType("GL Entry")
+			frappe.qb.from_(gle).delete().where(
+				(gle.voucher_type == self.doctype) & (gle.voucher_no == self.name)
+			).run()
+			sle = frappe.qb.DocType("Stock Ledger Entry")
+			frappe.qb.from_(gle).delete().where(
+				(sle.voucher_type == self.doctype) & (sle.voucher_no == self.name)
+			).run()
 
 	def remove_serial_and_batch_bundle(self):
 		bundles = frappe.get_all(
@@ -1164,11 +1165,12 @@ class AccountsController(TransactionBase):
 	def clear_unallocated_advances(self, childtype, parentfield):
 		self.set(parentfield, self.get(parentfield, {"allocated_amount": ["not in", [0, None, ""]]}))
 
-		frappe.db.sql(
-			"""delete from `tab{}` where parentfield={} and parent = {}
-			and allocated_amount = 0""".format(childtype, "%s", "%s"),
-			(parentfield, self.name),
-		)
+		doctype = frappe.qb.DocType(childtype)
+		frappe.qb.from_(doctype).delete().where(
+			(doctype.parentfield == parentfield)
+			& (doctype.parent == self.name)
+			& (doctype.allocated_amount == 0)
+		).run()
 
 	@frappe.whitelist()
 	def apply_shipping_rule(self):
@@ -2143,11 +2145,9 @@ class AccountsController(TransactionBase):
 		for adv in self.advances:
 			consider_for_total_advance = True
 			if adv.reference_name == linked_doc_name:
-				frappe.db.sql(
-					f"""delete from `tab{self.doctype} Advance`
-					where name = %s""",
-					adv.name,
-				)
+				doctype = frappe.qb.DocType(self.doctype + " Advance")
+				frappe.qb.from_(doctype).delete().where(doctype.name == adv.name).run()
+
 				consider_for_total_advance = False
 
 			if consider_for_total_advance:

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -388,7 +388,7 @@ class AccountsController(TransactionBase):
 				(gle.voucher_type == self.doctype) & (gle.voucher_no == self.name)
 			).run()
 			sle = frappe.qb.DocType("Stock Ledger Entry")
-			frappe.qb.from_(gle).delete().where(
+			frappe.qb.from_(sle).delete().where(
 				(sle.voucher_type == self.doctype) & (sle.voucher_no == self.name)
 			).run()
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1218,6 +1218,7 @@ class AccountsController(TransactionBase):
 				"advance_amount": flt(d.amount),
 				"allocated_amount": allocated_amount,
 				"ref_exchange_rate": flt(d.exchange_rate),  # exchange_rate of advance entry
+				"difference_posting_date": self.posting_date,
 			}
 			if d.get("paid_from"):
 				advance_row["account"] = d.paid_from
@@ -1511,7 +1512,6 @@ class AccountsController(TransactionBase):
 						gain_loss_account = frappe.get_cached_value(
 							"Company", self.company, "exchange_gain_loss_account"
 						)
-
 						je = create_gain_loss_journal(
 							self.company,
 							args.get("difference_posting_date") if args else self.posting_date,
@@ -1597,6 +1597,7 @@ class AccountsController(TransactionBase):
 							"Company", self.company, "exchange_gain_loss_account"
 						),
 						"exchange_gain_loss": flt(d.get("exchange_gain_loss")),
+						"difference_posting_date": d.get("difference_posting_date"),
 					}
 				)
 				lst.append(args)

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2,6 +2,8 @@
 # For license information, please see license.txt
 
 
+from datetime import datetime
+
 import frappe
 from frappe import qb
 from frappe.query_builder.functions import Sum
@@ -1981,3 +1983,94 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertEqual(len(exc_je_for_adv), 0)
 
 		self.remove_advance_accounts_from_party_master()
+
+	def test_difference_posting_date_in_pi_and_si(self):
+		self.setup_advance_accounts_in_party_master()
+
+		# create payment entry for customer
+		adv = self.create_payment_entry(amount=1, source_exc_rate=83)
+		adv.save()
+		self.assertEqual(adv.paid_from, self.advance_received_usd)
+		adv.submit()
+
+		# create sales invoice with advance received
+		si = self.create_sales_invoice(qty=1, conversion_rate=80, rate=1, do_not_submit=True)
+		si.debit_to = self.debtors_usd
+		si.append(
+			"advances",
+			{
+				"reference_type": "Payment Entry",
+				"reference_name": "ACC-PAY-2024-00001",
+				"remarks": "Amount INR 1 received from _Test MC Customer USD\nTransaction reference no Test001 dated 2024-12-19",
+				"advance_amount": 1.0,
+				"allocated_amount": 1.0,
+				"exchange_gain_loss": 3.0,
+				"ref_exchange_rate": 83.0,
+				"difference_posting_date": add_days(nowdate(), -2),
+			},
+		)
+		si.save().submit()
+
+		# exc Gain/Loss journal should've been creatad
+		exc_je_for_si = self.get_journals_for(si.doctype, si.name)
+		exc_je_for_adv = self.get_journals_for(adv.doctype, adv.name)
+		self.assertEqual(len(exc_je_for_si), 1)
+		self.assertEqual(len(exc_je_for_adv), 1)
+		self.assertEqual(exc_je_for_si, exc_je_for_adv)
+
+		# check jv created with difference_posting_date in sales invoice
+		jv = frappe.get_doc("Journal Entry", exc_je_for_si[0].parent)
+		sales_invoice = frappe.get_doc("Sales Invoice", si.name)
+		self.assertEqual(sales_invoice.advances[0].difference_posting_date, jv.posting_date)
+
+		# create payment entry for supplier
+		usd_amount = 1
+		inr_amount = 85
+		exc_rate = 85
+		adv = create_payment_entry(
+			company=self.company,
+			payment_type="Pay",
+			party_type="Supplier",
+			party=self.supplier,
+			paid_from=self.cash,
+			paid_to=self.advance_paid_usd,
+			paid_amount=inr_amount,
+		)
+		adv.source_exchange_rate = 1
+		adv.target_exchange_rate = exc_rate
+		adv.received_amount = usd_amount
+		adv.paid_amount = exc_rate * usd_amount
+		adv.posting_date = nowdate()
+		adv.save()
+		self.assertEqual(adv.paid_to, self.advance_paid_usd)
+		adv.submit()
+
+		# create purchase invoice with advance paid
+		pi = self.create_purchase_invoice(qty=1, conversion_rate=80, rate=1, do_not_submit=True)
+		pi.append(
+			"advances",
+			{
+				"reference_type": "Payment Entry",
+				"reference_name": "ACC-PAY-2024-00002",
+				"remarks": "Amount INR 1 paid to _Test MC Supplier USD\nTransaction reference no Test001 dated 2024-12-20",
+				"advance_amount": 1.0,
+				"allocated_amount": 1.0,
+				"exchange_gain_loss": 5.0,
+				"ref_exchange_rate": 85.0,
+				"difference_posting_date": add_days(nowdate(), -2),
+			},
+		)
+		pi.save().submit()
+		self.assertEqual(pi.credit_to, self.creditors_usd)
+
+		# exc Gain/Loss journal should've been creatad
+		exc_je_for_pi = self.get_journals_for(pi.doctype, pi.name)
+		exc_je_for_adv = self.get_journals_for(adv.doctype, adv.name)
+		self.assertEqual(len(exc_je_for_pi), 1)
+		self.assertEqual(len(exc_je_for_adv), 1)
+		self.assertEqual(exc_je_for_pi, exc_je_for_adv)
+
+		# check jv created with difference_posting_date in purchase invoice
+		journal_voucher = frappe.get_doc("Journal Entry", exc_je_for_pi[0].parent)
+		purchase_invoice = frappe.get_doc("Purchase Invoice", pi.name)
+		self.assertEqual(purchase_invoice.advances[0].difference_posting_date, journal_voucher.posting_date)


### PR DESCRIPTION
**Issue:**
unable to select posting date of the exchange gain/loss journal while linking advance  payment in invoice

**Solution:**
Added difference_posting_date field in Sales Invoice Advance and Purchase Invoice Advance

**Before:**

[before.webm](https://github.com/user-attachments/assets/9c1b5f64-7626-426f-b36c-4be14913593a)

**After:**

[after.webm](https://github.com/user-attachments/assets/6cbc6791-1a7a-4896-b5ab-7ed2f3099b83)

**Backport needed for v15**