### PR TITLE
fix: change string from Left to Ended and possibility to translate

### DIFF
--- a/erpnext/setup/doctype/driver/driver.json
+++ b/erpnext/setup/doctype/driver/driver.json
@@ -46,7 +46,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Active\nSuspended\nLeft",
+   "options": "Active\nSuspended\nEnded",
    "reqd": 1
   },
   {

--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -212,7 +212,7 @@
    "label": "Status",
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "Active\nInactive\nSuspended\nLeft",
+   "options": "Active\nInactive\nSuspended\nEnded",
    "reqd": 1,
    "search_index": 1
   },
@@ -616,7 +616,7 @@
    "fieldname": "relieving_date",
    "fieldtype": "Date",
    "label": "Relieving Date",
-   "mandatory_depends_on": "eval:doc.status == \"Left\"",
+   "mandatory_depends_on": "eval:doc.status == \"Ended\"",
    "no_copy": 1,
    "oldfieldname": "relieving_date",
    "oldfieldtype": "Date"

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -33,7 +33,7 @@ class Employee(NestedSet):
 	def validate(self):
 		from erpnext.controllers.status_updater import validate_status
 
-		validate_status(self.status, ["Active", "Inactive", "Suspended", "Left"])
+		validate_status(self.status, ["Active", "Inactive", "Suspended", "Ended"])
 
 		self.employee = self.name
 		self.set_employee_name()
@@ -165,7 +165,7 @@ class Employee(NestedSet):
 			self.prefered_email = preferred_email
 
 	def validate_status(self):
-		if self.status == "Left":
+		if self.status == "Ended":
 			reports_to = frappe.db.get_all(
 				"Employee",
 				filters={"reports_to": self.name, "status": "Active"},
@@ -314,7 +314,7 @@ def is_holiday(employee, date=None, raise_exception=True, only_non_weekly=False,
 
 @frappe.whitelist()
 def deactivate_sales_person(status=None, employee=None):
-	if status == "Left":
+	if status == "Ended":
 		sales_person = frappe.db.get_value("Sales Person", {"Employee": employee})
 		if sales_person:
 			frappe.db.set_value("Sales Person", sales_person, "enabled", 0)

--- a/erpnext/setup/doctype/employee/employee_list.js
+++ b/erpnext/setup/doctype/employee/employee_list.js
@@ -3,7 +3,7 @@ frappe.listview_settings["Employee"] = {
 	filters: [["status", "=", "Active"]],
 	get_indicator: function (doc) {
 		var indicator = [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
-		indicator[1] = { Active: "green", Inactive: "red", Left: "gray", Suspended: "orange" }[doc.status];
+		indicator[1] = { Active: "green", Inactive: "red", Ended: "gray", Suspended: "orange" }[doc.status];
 		return indicator;
 	},
 };


### PR DESCRIPTION
"Left" is used in both Frappe and Erpnext for different meanings
Change it in Erpnext to "Ended" for more exact representation 

Backport to version-15 