### PR TITLE
fix: incorrect Material Transferred for Manufacturing qty

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -993,8 +993,9 @@ class JobCard(Document):
 		if doc.transfer_material_against == "Job Card" and not doc.skip_transfer:
 			min_qty = []
 			for d in doc.operations:
-				if d.completed_qty:
-					min_qty.append(d.completed_qty)
+				completed_qty = flt(d.completed_qty) + flt(d.process_loss_qty)
+				if completed_qty:
+					min_qty.append(completed_qty)
 				else:
 					min_qty = []
 					break

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -7,6 +7,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase, timeout
 from frappe.utils import add_days, add_months, add_to_date, cint, flt, now, today
 
 from erpnext.manufacturing.doctype.job_card.job_card import JobCardCancelError
+from erpnext.manufacturing.doctype.job_card.job_card import make_stock_entry as make_stock_entry_from_jc
 from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 from erpnext.manufacturing.doctype.work_order.work_order import (
 	CapacityError,
@@ -514,6 +515,60 @@ class TestWorkOrder(IntegrationTestCase):
 		stock_entries.reverse()
 		for stock_entry in stock_entries:
 			stock_entry.cancel()
+
+	def test_work_order_material_transferred_qty_with_process_loss(self):
+		stock_entries = []
+		bom = frappe.get_doc("BOM", {"docstatus": 1, "with_operations": 1, "company": "_Test Company"})
+
+		work_order = make_wo_order_test_record(
+			item=bom.item,
+			qty=2,
+			bom_no=bom.name,
+			source_warehouse="_Test Warehouse - _TC",
+			transfer_material_against="Job Card",
+		)
+
+		self.assertEqual(work_order.qty, 2)
+
+		for row in work_order.required_items:
+			stock_entry_doc = test_stock_entry.make_stock_entry(
+				item_code=row.item_code, target="_Test Warehouse - _TC", qty=row.required_qty, basic_rate=100
+			)
+			stock_entries.append(stock_entry_doc)
+
+		job_cards = frappe.get_all(
+			"Job Card", filters={"work_order": work_order.name}, order_by="creation asc"
+		)
+
+		for row in job_cards:
+			transfer_entry_1 = make_stock_entry_from_jc(row.name)
+			transfer_entry_1.submit()
+
+			doc = frappe.get_doc("Job Card", row.name)
+			for row in doc.scheduled_time_logs:
+				doc.append(
+					"time_logs",
+					{
+						"from_time": row.from_time,
+						"to_time": row.to_time,
+						"time_in_mins": row.time_in_mins,
+						"completed_qty": 1,
+					},
+				)
+
+			doc.save()
+			doc.submit()
+
+			self.assertEqual(doc.total_completed_qty, 1)
+			self.assertEqual(doc.process_loss_qty, 1)
+
+		work_order.reload()
+
+		self.assertEqual(work_order.material_transferred_for_manufacturing, 2)
+
+		for row in work_order.operations:
+			self.assertEqual(row.completed_qty, 1)
+			self.assertEqual(row.process_loss_qty, 1)
 
 	def test_capcity_planning(self):
 		frappe.db.set_single_value(


### PR DESCRIPTION
Steps to replicate issue

- Make work order with BOM having single operation and qty 2
- Keep the "Transfer Material Against" as "Job Card"
- Against the job card make a stock entry for 2 quantity
- While finishing the job card keep the completed qty as 1 and process loss qty as 1
- Now try to make finish good entry, system will not add the finished good. 