### PR TITLE
fix: Remove typo from `Bank Account` on trash

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -48,7 +48,7 @@ class BankAccount(Document):
 		self.name = self.account_name + " - " + self.bank
 
 	def on_trash(self):
-		delete_contact_and_address("BankAccount", self.name)
+		delete_contact_and_address("Bank Account", self.name)
 
 	def validate(self):
 		self.validate_company()


### PR DESCRIPTION
Backport to : V-15 and V-14