### PR TITLE
fix: fetch advance payment entries on pos invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1233,7 +1233,7 @@ class AccountsController(TransactionBase):
 		party_account = []
 		default_advance_account = None
 
-		if self.doctype == "Sales Invoice":
+		if self.doctype in ["Sales Invoice", "POS Invoice"]:
 			party_type = "Customer"
 			party = self.customer
 			amount_field = "credit_in_account_currency"


### PR DESCRIPTION
Resolved the server error when clicking the 'Get Advances Received' button in the POS Invoice's 'Advance Payment' section.

Before:

![image](https://github.com/user-attachments/assets/e63c919c-504e-437b-a2a9-fda4ec4f7253)

After:

![image](https://github.com/user-attachments/assets/71c10bcd-090a-490a-9d28-1f310a02dcd7)

fixes: #43715 #44518 