### PR TITLE
fix: show profit and loss after period closing

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -351,7 +351,7 @@ def get_data(companies, root_type, balance_must_be, fiscal_year, filters=None, i
 			gl_entries_by_account,
 			accounts_by_name,
 			accounts,
-			ignore_closing_entries=False,
+			ignore_closing_entries=ignore_closing_entries,
 			root_type=root_type,
 		)
 


### PR DESCRIPTION
**Issue:**
Consolidated Financial Statement not showing profit and loss after period closing voucher is posted
**ref:** [27328](https://support.frappe.io/helpdesk/tickets/27328)

**Period Closing Voucher:**
![image](https://github.com/user-attachments/assets/011fb7d4-0010-4559-b176-f185466c6026)

Before:
![image](https://github.com/user-attachments/assets/8e066217-939c-4bb2-bbef-dfbc3cc4fb75)

After:
![image](https://github.com/user-attachments/assets/29eef466-3e26-4661-86fc-8647be69f19e)


**Backport needed for v14 & v15**