### PR TITLE
fix: Validate party on non receivable / payable account

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -13,7 +13,11 @@ import erpnext
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
 )
-from erpnext.accounts.party import validate_party_frozen_disabled, validate_party_gle_currency
+from erpnext.accounts.party import (
+	validate_account_party_type,
+	validate_party_frozen_disabled,
+	validate_party_gle_currency,
+)
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year
 from erpnext.exceptions import InvalidAccountCurrency
 
@@ -268,6 +272,7 @@ class GLEntry(Document):
 
 	def validate_party(self):
 		validate_party_frozen_disabled(self.party_type, self.party)
+		validate_account_party_type(self)
 
 	def validate_currency(self):
 		company_currency = erpnext.get_company_currency(self.company)

--- a/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
@@ -78,3 +78,48 @@ class TestGLEntry(IntegrationTestCase):
 			"SELECT current from tabSeries where name = %s", naming_series
 		)[0][0]
 		self.assertEqual(old_naming_series_current_value + 2, new_naming_series_current_value)
+
+	def test_validate_account_party_type(self):
+		jv = make_journal_entry(
+			"_Test Account Cost for Goods Sold - _TC",
+			"_Test Bank - _TC",
+			100,
+			"_Test Cost Center - _TC",
+			save=False,
+			submit=False,
+		)
+
+		for row in jv.accounts:
+			row.party_type = "Supplier"
+			break
+
+		jv.save()
+		try:
+			jv.submit()
+		except Exception as e:
+			self.assertEqual(
+				str(e),
+				"Party Type and Party can only be set for Receivable / Payable account_Test Account Cost for Goods Sold - _TC",
+			)
+
+		jv1 = make_journal_entry(
+			"_Test Account Cost for Goods Sold - _TC",
+			"_Test Bank - _TC",
+			100,
+			"_Test Cost Center - _TC",
+			save=False,
+			submit=False,
+		)
+
+		for row in jv.accounts:
+			row.party_type = "Customer"
+			break
+
+		jv1.save()
+		try:
+			jv1.submit()
+		except Exception as e:
+			self.assertEqual(
+				str(e),
+				"Party Type and Party can only be set for Receivable / Payable account_Test Account Cost for Goods Sold - _TC",
+			)

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1519,7 +1519,7 @@ class TestPaymentEntry(IntegrationTestCase):
 			parent_account="Current Liabilities - _TC",
 			account_name="Advances Paid",
 			company=company,
-			account_type="Liability",
+			account_type="Payable",
 		)
 
 		frappe.db.set_value(

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -764,6 +764,17 @@ def validate_party_frozen_disabled(party_type, party_name):
 				frappe.msgprint(_("{0} {1} is not active").format(party_type, party_name), alert=True)
 
 
+def validate_account_party_type(self):
+	if self.party_type and self.party:
+		account_type = frappe.get_cached_value("Account", self.account, "account_type")
+		if account_type and (account_type not in ["Receivable", "Payable"]):
+			frappe.throw(
+				_(
+					"Party Type and Party can only be set for Receivable / Payable account<br><br>" "{0}"
+				).format(self.account)
+			)
+
+
 def get_dashboard_info(party_type, party, loyalty_program=None):
 	current_fiscal_year = get_fiscal_year(nowdate(), as_dict=True)
 


### PR DESCRIPTION
Issue: Allows specifying a party type and party for non-receivable and non-payable accounts.

Fix: Validate the party type against the account type in the GL entry and display an error message if there's a mismatch.

Ref: [27331](https://support.frappe.io/helpdesk/tickets/27331)

Before:

[before party type validation.webm](https://github.com/user-attachments/assets/bcd5f79f-b894-48bf-8ecd-bdf4dc5fe1d4)


After:

[after party type validation.webm](https://github.com/user-attachments/assets/400ebdaa-2284-422c-b7ea-a5480875bc11)

Backport needed for v14 & v15
