### PR TITLE
refactor: use db_set instead of set_value to trigger notification

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -117,9 +117,9 @@ class BankClearance(Document):
 					)
 
 				else:
-					frappe.db.set_value(
-						d.payment_document, d.payment_entry, "clearance_date", d.clearance_date
-					)
+					# using db_set to trigger notification
+					payment_entry = frappe.get_doc(d.payment_document, d.payment_entry)
+					payment_entry.db_set("clearance_date", d.clearance_date)
 
 				clearance_date_updated = True
 


### PR DESCRIPTION
**Issue:**
Notification is not triggering while updating the clearance date.
**ref:** [27780](https://support.frappe.io/helpdesk/tickets/27780)

**Notification:**
![image](https://github.com/user-attachments/assets/6bb583d8-f99b-4801-9d7d-00c7ac5d0b6f)

**Before:**

https://github.com/user-attachments/assets/f34a2fc1-54e9-46bb-a476-badcc2d956f6


**After:**

https://github.com/user-attachments/assets/be2feceb-b446-4648-bd79-170d3f50b61d


Backport needed for v15