### PR TITLE
fix: clear payment schedule in purchase invoice for is_paid

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -403,6 +403,8 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		hide_fields(this.frm.doc);
 		if (cint(this.frm.doc.is_paid)) {
 			this.frm.set_value("allocate_advances_automatically", 0);
+			this.frm.set_value("payment_terms_template", "");
+			this.frm.set_value("payment_schedule", []);
 			if (!this.frm.doc.company) {
 				this.frm.set_value("is_paid", 0);
 				frappe.msgprint(__("Please specify Company to proceed"));

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -468,10 +468,14 @@ class AccountsController(TransactionBase):
 					)
 
 	def validate_invoice_documents_schedule(self):
-		if self.is_return:
+		if (
+			self.is_return
+			or (self.doctype == "Purchase Invoice" and self.is_paid)
+			or (self.doctype == "Sales Invoice" and self.is_pos)
+			or self.get("is_opening") == "Yes"
+		):
 			self.payment_terms_template = ""
 			self.payment_schedule = []
-			return
 
 		self.validate_payment_schedule_dates()
 		self.set_due_date()
@@ -2370,9 +2374,6 @@ class AccountsController(TransactionBase):
 		dates = []
 		li = []
 
-		if self.doctype == "Sales Invoice" and self.is_pos:
-			return
-
 		for d in self.get("payment_schedule"):
 			d.validate_from_to_dates("discount_date", "due_date")
 			if self.doctype == "Sales Order" and getdate(d.due_date) < getdate(self.transaction_date):
@@ -2390,9 +2391,6 @@ class AccountsController(TransactionBase):
 			frappe.throw(_("Rows with duplicate due dates in other rows were found: {0}").format(duplicates))
 
 	def validate_payment_schedule_amount(self):
-		if (self.doctype == "Sales Invoice" and self.is_pos) or self.get("is_opening") == "Yes":
-			return
-
 		party_account_currency = self.get("party_account_currency")
 		if not party_account_currency:
 			party_type, party = self.get_party()

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -477,6 +477,9 @@ class AccountsController(TransactionBase):
 			self.payment_terms_template = ""
 			self.payment_schedule = []
 
+		if self.is_return:
+			return
+
 		self.validate_payment_schedule_dates()
 		self.set_due_date()
 		self.set_payment_schedule()
@@ -2374,6 +2377,9 @@ class AccountsController(TransactionBase):
 		dates = []
 		li = []
 
+		if self.doctype == "Sales Invoice" and self.is_pos:
+			return
+
 		for d in self.get("payment_schedule"):
 			d.validate_from_to_dates("discount_date", "due_date")
 			if self.doctype == "Sales Order" and getdate(d.due_date) < getdate(self.transaction_date):
@@ -2391,6 +2397,9 @@ class AccountsController(TransactionBase):
 			frappe.throw(_("Rows with duplicate due dates in other rows were found: {0}").format(duplicates))
 
 	def validate_payment_schedule_amount(self):
+		if (self.doctype == "Sales Invoice" and self.is_pos) or self.get("is_opening") == "Yes":
+			return
+
 		party_account_currency = self.get("party_account_currency")
 		if not party_account_currency:
 			party_type, party = self.get_party()


### PR DESCRIPTION
 Issue: [Support Ticket  - 25598](https://support.frappe.io/app/hd-ticket/25598)

When `is_paid` is marked for a purchase invoice, the `payment_terms_template` was not cleared, which resulted in an error during the validation process.
<img width="705" alt="Screenshot 2024-12-24 at 4 46 41 PM" src="https://github.com/user-attachments/assets/f975b790-8429-41b4-b406-52a75c514255" />
