### PR TITLE
fix (pos closing entry): validation for 100 pc discount on pos invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -506,7 +506,7 @@ class SalesInvoice(SellingController):
 				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
 
 	def validate_pos_paid_amount(self):
-		if len(self.payments) == 0 and self.is_pos:
+		if len(self.payments) == 0 and self.is_pos and flt(self.grand_total) > 0:
 			frappe.throw(_("At least one mode of payment is required for POS invoice."))
 
 	def check_if_consolidated_invoice(self):


### PR DESCRIPTION
The following error occurs when a POS closing entry is submitted with a POS invoice with a 100% discount.

![image](https://github.com/user-attachments/assets/2c622fb4-fba0-4fa4-aabb-2f8125971466)

The above message is generated every time a POS Closing Entry is created. It validates that each Linked Sales Invoice generated through the POS has at least one associated `SalesInvoicePayment`. However, for invoices that have a 100% discount, no payment is required and thus, no `SalesInvoicePayment` document is appended to the Invoice.

@nabinhait suggested that validation should only take place for invoices having a positive Grand Total to fix this issue.