### PR TITLE
fix: set/update billing address on change of company

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -721,6 +721,14 @@ frappe.ui.form.on("Purchase Invoice", {
 					if (response) frm.set_value("credit_to", response.message);
 				},
 			});
+
+			frappe.call({
+				method: "erpnext.setup.doctype.company.company.get_default_company_address",
+				args: { name: frm.doc.company },
+				callback: (r) => {
+					frm.set_value("billing_address", r.message || "");
+				},
+			});
 		}
 	},
 });

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -721,14 +721,6 @@ frappe.ui.form.on("Purchase Invoice", {
 					if (response) frm.set_value("credit_to", response.message);
 				},
 			});
-
-			frappe.call({
-				method: "erpnext.setup.doctype.company.company.get_default_company_address",
-				args: { name: frm.doc.company },
-				callback: (r) => {
-					frm.set_value("billing_address", r.message || "");
-				},
-			});
 		}
 	},
 });

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -145,6 +145,18 @@ erpnext.buying = {
 				});
 			}
 
+			company(){
+				if(this.frm.doc.doctype == "Material Request") return;
+
+				frappe.call({
+					method: "erpnext.setup.doctype.company.company.get_default_company_address",
+					args: { name: this.frm.doc.company, existing_address:this.frm.doc.billing_address },
+					callback: (r) => {
+						this.frm.set_value("billing_address", r.message || "");
+					},
+				});
+			}
+
 			supplier_address() {
 				erpnext.utils.get_address_display(this.frm);
 				erpnext.utils.set_taxes_from_address(this.frm, "supplier_address", "supplier_address", "supplier_address");

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -146,7 +146,7 @@ erpnext.buying = {
 			}
 
 			company(){
-				if(this.frm.doc.doctype == "Material Request") return;
+				if(!frappe.meta.has_field(this.frm.doc.doctype, "billing_address")) return;
 
 				frappe.call({
 					method: "erpnext.setup.doctype.company.company.get_default_company_address",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -983,7 +983,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				let is_drop_ship = me.frm.doc.items.some(item => item.delivered_by_supplier);
 
 				if (!is_drop_ship) {
-					console.log('get_shipping_address');
 					erpnext.utils.get_shipping_address(this.frm, function() {
 						set_party_account(set_pricing);
 					});


### PR DESCRIPTION
In the Purchase Invoice, the billing address is not being set correctly during onload. Additionally, when the company is updated, the billing address does not change accordingly.

Issue: [Support Ticket  - 20620](https://support.frappe.io/app/hd-ticket/20620)