### PR TITLE
fix: limit discount value to 100 in pos cart

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -390,6 +390,14 @@ erpnext.PointOfSale.ItemCart = class {
 				input_class: "input-xs",
 				onchange: function () {
 					this.value = flt(this.value);
+					if (this.value > 100) {
+						frappe.msgprint({
+							title: __("Point of Sale"),
+							indicator: "red",
+							message: __("Discount cannot be greater than 100%."),
+						});
+						this.value = 0;
+					}
 					frappe.model.set_value(
 						frm.doc.doctype,
 						frm.doc.name,

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -392,7 +392,7 @@ erpnext.PointOfSale.ItemCart = class {
 					this.value = flt(this.value);
 					if (this.value > 100) {
 						frappe.msgprint({
-							title: __("Point of Sale"),
+							title: __("Invalid Discount"),
 							indicator: "red",
 							message: __("Discount cannot be greater than 100%."),
 						});


### PR DESCRIPTION
In POS Cart, the discount field could accept a value of more than 100, resulting in a negative grand total. 

![image](https://github.com/user-attachments/assets/742c345d-c3e4-482a-983f-8398a2d3b111)

However, when clicking the "Checkout" button, an error message 'Incorrect value:Grand Total (Company Currency) must be >= 0.0' was displayed.

![image](https://github.com/user-attachments/assets/b0f278d9-7bba-46fa-92d4-dd033b16892f)

This fix aims to inform users that the maximum discount can be 100% when filling out the discount field and resets the discount to 0% in case the user enters a value of more than 100.

![image](https://github.com/user-attachments/assets/124b801a-54db-4b5c-bda7-f3046d6a52c4)

