### PR TITLE
fix: get item tax template based on posting date

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -630,7 +630,9 @@ def _get_item_tax_template(
 			if tax.valid_from or tax.maximum_net_rate:
 				# In purchase Invoice first preference will be given to supplier invoice date
 				# if supplier date is not present then posting date
-				validation_date = ctx.get("bill_date") or ctx.get("transaction_date")
+				validation_date = (
+					ctx.get("bill_date") or ctx.get("posting_date") or ctx.get("transaction_date")
+				)
 
 				if getdate(tax.valid_from) <= getdate(validation_date) and is_within_valid_range(ctx, tax):
 					taxes_with_validity.append(tax)


### PR DESCRIPTION
Item tax template is not validated based on the Posting Date in the Sales Invoice.

backport-version-15-hotfix
backport-version-14-hotfix