### PR TITLE
fix(Bank Reconciliation Tool): fetch amount in company  currency

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -723,7 +723,7 @@ def get_pe_matching_query(
 			(ref_rank + amount_rank + party_rank + 1).as_("rank"),
 			ConstantColumn("Payment Entry").as_("doctype"),
 			pe.name,
-			pe.paid_amount_after_tax.as_("paid_amount"),
+			pe.base_paid_amount_after_tax.as_("paid_amount"),
 			pe.reference_no,
 			pe.reference_date,
 			pe.party,


### PR DESCRIPTION
**Issue:**
The Bank Reconciliation Tool fetches the USD amount but displays it as the company currency INR.
**ref: [27881](https://support.frappe.io/helpdesk/tickets/27881)**

**Before:**

[Screencast from 27-12-24 04:28:53 PM IST.webm](https://github.com/user-attachments/assets/65dfa72c-1d11-4389-8770-c2767ffe215d)

**After:**

[Screencast from 27-12-24 04:29:49 PM IST.webm](https://github.com/user-attachments/assets/b554c0d1-7e25-4637-990f-934288729667)

**Backport needed for v15**