### PR TITLE
Add Phone Number Field to Payment Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -58,7 +58,9 @@
   "payment_account",
   "payment_channel",
   "payment_order",
-  "amended_from"
+  "amended_from",
+  "column_break_iiuv",
+  "phone_number"
  ],
  "fields": [
   {
@@ -376,6 +378,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval: doc.payment_channel==\"Phone\"",
    "fetch_from": "payment_gateway_account.payment_channel",
    "fieldname": "payment_channel",
    "fieldtype": "Select",
@@ -429,13 +432,23 @@
    "fieldtype": "Data",
    "label": "Party Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_iiuv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.payment_channel==\"Phone\"",
+   "fieldname": "phone_number",
+   "fieldtype": "Data",
+   "label": "Phone Number"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-23 12:23:40.117336",
+ "modified": "2024-12-27 20:32:16.317103",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -224,8 +224,8 @@ class PaymentRequest(Document):
 			sender=self.email_to,
 			currency=self.currency,
 			payment_gateway=self.payment_gateway,
+			phone_number=self.phone_number,
 		)
-
 		controller.validate_transaction_currency(self.currency)
 		controller.request_for_payment(**payment_record)
 
@@ -635,6 +635,7 @@ def make_payment_request(**args):
 				"party": args.get("party") or ref_doc.get("customer"),
 				"bank_account": bank_account,
 				"party_name": args.get("party_name") or ref_doc.get("customer_name"),
+				"phone_number": args.get("phone_number"),
 			}
 		)
 


### PR DESCRIPTION
#### Summary:
Fixing issue #44945 

This PR introduces enhancements to the Payment Request functionality in ERPNext, specifically targeted at phone-based payment channels like **Mpesa STK Push**. The feature allows the system to capture and process a phone number during payment requests, ensuring seamless integration with payment gateways.

----------
![Uploading image.png…]()


#### Changes Implemented:

1.  **Added Phone Number Field**:
    
    -   Introduced a new **Phone Number** field in the **Payment Request** doctype.
    -   The field is conditionally visible and required when the selected payment channel is **Phone**.
2.  **External Argument Handling**:
    
    -   Enhanced the system to accept a **Phone Number** via external arguments (e.g., from Webshop or POS).

3.  **Integration with `request_for_payment`**:
    -   Included the Phone Number in the arguments passed to the `request_for_payment` method.
    -   Ensured compatibility with the **Mpesa Settings** doctype, where the STK push process is initiated.
