### PR TITLE
fix: copy accounting dimensions to asset and sales invoice

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -19,6 +19,7 @@ from frappe.utils import (
 )
 
 import erpnext
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_dimensions
 from erpnext.accounts.general_ledger import make_reverse_gl_entries
 from erpnext.assets.doctype.asset.depreciation import (
 	get_comma_separated_links,
@@ -906,7 +907,7 @@ def make_sales_invoice(asset, item_code, company, serial_no=None):
 		},
 	)
 
-	accounting_dimensions = get_accounting_dimensions()
+	accounting_dimensions = get_dimensions(True)
 	for dimension in accounting_dimensions:
 		si.update(
 			{
@@ -917,26 +918,6 @@ def make_sales_invoice(asset, item_code, company, serial_no=None):
 
 	si.set_missing_values()
 	return si
-
-
-def get_accounting_dimensions():
-	AccountingDimension = frappe.query_builder.DocType("Accounting Dimension")
-	AccountingDimensionDetail = frappe.query_builder.DocType("Accounting Dimension Detail")
-
-	accounting_dimensions = (
-		frappe.qb.from_(AccountingDimension)
-		.join(AccountingDimensionDetail)
-		.on(AccountingDimension.name == AccountingDimensionDetail.parent)
-		.select(
-			AccountingDimension.label,
-			AccountingDimension.disabled,
-			AccountingDimension.fieldname,
-			AccountingDimensionDetail.default_dimension,
-			AccountingDimensionDetail.company,
-		)
-	).run(as_dict=True)
-
-	return accounting_dimensions
 
 
 @frappe.whitelist()

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -908,7 +908,7 @@ def make_sales_invoice(asset, item_code, company, serial_no=None):
 	)
 
 	accounting_dimensions = get_dimensions(True)
-	for dimension in accounting_dimensions:
+	for dimension in accounting_dimensions[0]:
 		si.update(
 			{
 				dimension["fieldname"]: asset_doc.get(dimension["fieldname"])

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -907,7 +907,7 @@ def make_sales_invoice(asset, item_code, company, serial_no=None):
 		},
 	)
 
-	accounting_dimensions = get_dimensions(True)
+	accounting_dimensions = get_dimensions(with_cost_center_and_project=True)
 	for dimension in accounting_dimensions[0]:
 		si.update(
 			{

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -920,12 +920,21 @@ def make_sales_invoice(asset, item_code, company, serial_no=None):
 
 
 def get_accounting_dimensions():
-	accounting_dimensions = frappe.db.sql(
-		"""SELECT p.label, p.disabled, p.fieldname, c.default_dimension, c.company
-		FROM `tabAccounting Dimension`p ,`tabAccounting Dimension Detail` c
-		WHERE p.name = c.parent""",
-		as_dict=1,
-	)
+	AccountingDimension = frappe.query_builder.DocType("Accounting Dimension")
+	AccountingDimensionDetail = frappe.query_builder.DocType("Accounting Dimension Detail")
+
+	accounting_dimensions = (
+		frappe.qb.from_(AccountingDimension)
+		.join(AccountingDimensionDetail)
+		.on(AccountingDimension.name == AccountingDimensionDetail.parent)
+		.select(
+			AccountingDimension.label,
+			AccountingDimension.disabled,
+			AccountingDimension.fieldname,
+			AccountingDimensionDetail.default_dimension,
+			AccountingDimensionDetail.company,
+		)
+	).run(as_dict=True)
 
 	return accounting_dimensions
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -746,7 +746,7 @@ class BuyingController(SubcontractingController):
 		items_data = get_asset_item_details(asset_items)
 		messages = []
 		alert = False
-		accounting_dimensions = get_dimensions(True)
+		accounting_dimensions = get_dimensions(with_cost_center_and_project=True)
 
 		for d in self.items:
 			if d.is_fixed_asset:

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -9,11 +9,9 @@ from frappe.utils import cint, flt, getdate
 from frappe.utils.data import nowtime
 
 import erpnext
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_dimensions
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.accounts.party import get_party_details
-from erpnext.assets.doctype.asset.asset import (
-	get_accounting_dimensions,
-)
 from erpnext.buying.utils import update_last_purchase_rate, validate_for_items
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.subcontracting_controller import SubcontractingController
@@ -748,7 +746,7 @@ class BuyingController(SubcontractingController):
 		items_data = get_asset_item_details(asset_items)
 		messages = []
 		alert = False
-		accounting_dimensions = get_accounting_dimensions()
+		accounting_dimensions = get_dimensions(True)
 
 		for d in self.items:
 			if d.is_fixed_asset:
@@ -834,7 +832,7 @@ class BuyingController(SubcontractingController):
 				"purchase_invoice_item": row.name if self.doctype == "Purchase Invoice" else None,
 			}
 		)
-		for dimension in accounting_dimensions:
+		for dimension in accounting_dimensions[0]:
 			asset.update(
 				{
 					dimension["fieldname"]: self.get(dimension["fieldname"])

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -11,6 +11,9 @@ from frappe.utils.data import nowtime
 import erpnext
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.accounts.party import get_party_details
+from erpnext.assets.doctype.asset.asset import (
+	get_accounting_dimensions,
+)
 from erpnext.buying.utils import update_last_purchase_rate, validate_for_items
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.subcontracting_controller import SubcontractingController
@@ -745,6 +748,7 @@ class BuyingController(SubcontractingController):
 		items_data = get_asset_item_details(asset_items)
 		messages = []
 		alert = False
+		accounting_dimensions = get_accounting_dimensions()
 
 		for d in self.items:
 			if d.is_fixed_asset:
@@ -756,11 +760,11 @@ class BuyingController(SubcontractingController):
 					if item_data.get("asset_naming_series"):
 						created_assets = []
 						if item_data.get("is_grouped_asset"):
-							asset = self.make_asset(d, is_grouped_asset=True)
+							asset = self.make_asset(d, accounting_dimensions, is_grouped_asset=True)
 							created_assets.append(asset)
 						else:
 							for _qty in range(cint(d.qty)):
-								asset = self.make_asset(d)
+								asset = self.make_asset(d, accounting_dimensions)
 								created_assets.append(asset)
 
 						if len(created_assets) > 5:
@@ -799,7 +803,7 @@ class BuyingController(SubcontractingController):
 		for message in messages:
 			frappe.msgprint(message, title="Success", indicator="green", alert=alert)
 
-	def make_asset(self, row, is_grouped_asset=False):
+	def make_asset(self, row, accounting_dimensions, is_grouped_asset=False):
 		if not row.asset_location:
 			frappe.throw(_("Row {0}: Enter location for the asset item {1}").format(row.idx, row.item_code))
 
@@ -830,6 +834,13 @@ class BuyingController(SubcontractingController):
 				"purchase_invoice_item": row.name if self.doctype == "Purchase Invoice" else None,
 			}
 		)
+		for dimension in accounting_dimensions:
+			asset.update(
+				{
+					dimension["fieldname"]: self.get(dimension["fieldname"])
+					or dimension.get("default_dimension")
+				}
+			)
 
 		asset.flags.ignore_validate = True
 		asset.flags.ignore_mandatory = True


### PR DESCRIPTION
This fix ensures accounting dimensions are copied from the Purchase Invoice/Purchase Receipt  to the Asset and from Asset to Sales Invoice when it's created.