### PR TITLE
fix: incorrect quality inspection linked in purchase receipt

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2344,6 +2344,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 						fieldname: "batch_no",
 						label: __("Batch No"),
 						hidden: true
+					},
+					{
+						fieldtype: "Data",
+						fieldname: "child_row_reference",
+						label: __("Child Row Reference"),
+						hidden: true
 					}
 				]
 			}
@@ -2390,14 +2396,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			if (this.has_inspection_required(item)) {
 				let dialog_items = dialog.fields_dict.items;
 				dialog_items.df.data.push({
-					"docname": item.name,
 					"item_code": item.item_code,
 					"item_name": item.item_name,
 					"qty": item.qty,
 					"description": item.description,
 					"serial_no": item.serial_no,
 					"batch_no": item.batch_no,
-					"sample_size": item.sample_quantity
+					"sample_size": item.sample_quantity,
+					"child_row_reference": item.name,
 				});
 				dialog_items.grid.refresh();
 			}

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.json
@@ -15,6 +15,7 @@
   "inspection_type",
   "reference_type",
   "reference_name",
+  "child_row_reference",
   "section_break_7",
   "item_code",
   "item_serial_no",
@@ -238,6 +239,15 @@
    "fieldname": "manual_inspection",
    "fieldtype": "Check",
    "label": "Manual Inspection"
+  },
+  {
+   "fieldname": "child_row_reference",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Child Row Reference",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "icon": "fa fa-search",
@@ -245,7 +255,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:28.680815",
+ "modified": "2024-12-30 19:08:16.611192",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection",


### PR DESCRIPTION
- Create two purchase orders for the same item A
- Create the single purchase receipt against the above two purchase orders
- System will add two line items in the purchase receipt
- Create the two quality inspections and submit them
- In the purchase receipt both rows show the same quality inspection

Solution

Added a child row reference in the quality inspection to correctly update the QC back to the stock transaction.