### PR TITLE
Version 14

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -110,8 +110,15 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 			"AND bin.warehouse = %(warehouse)s AND bin.item_code = item.name AND bin.actual_qty > 0"
 		)
 
-	items_data = frappe.db.sql(
-		"""
+	#custom changes
+	company = frappe.db.get_value(
+		"User Permission",
+		{"user": frappe.session.user, "allow": "Company"},
+		"for_value"
+	)
+
+	# Define the query and use parameterized inputs
+	query = """
 		SELECT
 			item.name AS item_code,
 			item.item_name,
@@ -125,25 +132,72 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 			item.disabled = 0
 			AND item.has_variants = 0
 			AND item.is_sales_item = 1
+			AND item.custom_company = %(company)s
 			AND item.is_fixed_asset = 0
-			AND item.item_group in (SELECT name FROM `tabItem Group` WHERE lft >= {lft} AND rgt <= {rgt})
+			AND item.item_group IN (
+				SELECT name
+				FROM `tabItem Group`
+				WHERE lft >= %(lft)s AND rgt <= %(rgt)s
+			)
 			AND {condition}
 			{bin_join_condition}
 		ORDER BY
-			item.name asc
+			item.name ASC
 		LIMIT
-			{page_length} offset {start}""".format(
-			start=cint(start),
-			page_length=cint(page_length),
-			lft=cint(lft),
-			rgt=cint(rgt),
-			condition=condition,
-			bin_join_selection=bin_join_selection,
-			bin_join_condition=bin_join_condition,
-		),
-		{"warehouse": warehouse},
+			%(page_length)s OFFSET %(start)s
+	""".format(
+		bin_join_selection=bin_join_selection,
+		bin_join_condition=bin_join_condition,
+		condition=condition,
+	)
+
+	# Execute the query with parameterized inputs
+	items_data = frappe.db.sql(
+		query,
+		{
+			"company": company,
+			"lft": cint(lft),
+			"rgt": cint(rgt),
+			"start": cint(start),
+			"page_length": cint(page_length),
+			"warehouse": warehouse,
+		},
 		as_dict=1,
 	)
+	# items_data = frappe.db.sql(
+	# 	"""
+	# 	SELECT
+	# 		item.name AS item_code,
+	# 		item.item_name,
+	# 		item.description,
+	# 		item.stock_uom,
+	# 		item.image AS item_image,
+	# 		item.is_stock_item
+	# 	FROM
+	# 		`tabItem` item {bin_join_selection}
+	# 	WHERE
+	# 		item.disabled = 0
+	# 		AND item.has_variants = 0
+	# 		AND item.is_sales_item = 1
+	# 		AND item.is_fixed_asset = 0
+	# 		AND item.item_group in (SELECT name FROM `tabItem Group` WHERE lft >= {lft} AND rgt <= {rgt})
+	# 		AND {condition}
+	# 		{bin_join_condition}
+	# 	ORDER BY
+	# 		item.name asc
+	# 	LIMIT
+	# 		{page_length} offset {start}""".format(
+	# 		start=cint(start),
+	# 		page_length=cint(page_length),
+	# 		lft=cint(lft),
+	# 		rgt=cint(rgt),
+	# 		condition=condition,
+	# 		bin_join_selection=bin_join_selection,
+	# 		bin_join_condition=bin_join_condition,
+	# 	),
+	# 	{"warehouse": warehouse},
+	# 	as_dict=1,
+	# )
 
 	if items_data:
 		items = [d.item_code for d in items_data]

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -118,86 +118,88 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 	)
 
 	# Define the query and use parameterized inputs
-	query = """
-		SELECT
-			item.name AS item_code,
-			item.item_name,
-			item.description,
-			item.stock_uom,
-			item.image AS item_image,
-			item.is_stock_item
-		FROM
-			`tabItem` item {bin_join_selection}
-		WHERE
-			item.disabled = 0
-			AND item.has_variants = 0
-			AND item.is_sales_item = 1
-			AND item.custom_company = %(company)s
-			AND item.is_fixed_asset = 0
-			AND item.item_group IN (
-				SELECT name
-				FROM `tabItem Group`
-				WHERE lft >= %(lft)s AND rgt <= %(rgt)s
-			)
-			AND {condition}
-			{bin_join_condition}
-		ORDER BY
-			item.name ASC
-		LIMIT
-			%(page_length)s OFFSET %(start)s
-	""".format(
-		bin_join_selection=bin_join_selection,
-		bin_join_condition=bin_join_condition,
-		condition=condition,
-	)
-
-	# Execute the query with parameterized inputs
-	items_data = frappe.db.sql(
-		query,
-		{
-			"company": company,
-			"lft": cint(lft),
-			"rgt": cint(rgt),
-			"start": cint(start),
-			"page_length": cint(page_length),
-			"warehouse": warehouse,
-		},
-		as_dict=1,
-	)
-	# items_data = frappe.db.sql(
-	# 	"""
-	# 	SELECT
-	# 		item.name AS item_code,
-	# 		item.item_name,
-	# 		item.description,
-	# 		item.stock_uom,
-	# 		item.image AS item_image,
-	# 		item.is_stock_item
-	# 	FROM
-	# 		`tabItem` item {bin_join_selection}
-	# 	WHERE
-	# 		item.disabled = 0
-	# 		AND item.has_variants = 0
-	# 		AND item.is_sales_item = 1
-	# 		AND item.is_fixed_asset = 0
-	# 		AND item.item_group in (SELECT name FROM `tabItem Group` WHERE lft >= {lft} AND rgt <= {rgt})
-	# 		AND {condition}
-	# 		{bin_join_condition}
-	# 	ORDER BY
-	# 		item.name asc
-	# 	LIMIT
-	# 		{page_length} offset {start}""".format(
-	# 		start=cint(start),
-	# 		page_length=cint(page_length),
-	# 		lft=cint(lft),
-	# 		rgt=cint(rgt),
-	# 		condition=condition,
-	# 		bin_join_selection=bin_join_selection,
-	# 		bin_join_condition=bin_join_condition,
-	# 	),
-	# 	{"warehouse": warehouse},
-	# 	as_dict=1,
-	# )
+	if company:
+		query = """
+			SELECT
+				item.name AS item_code,
+				item.item_name,
+				item.description,
+				item.stock_uom,
+				item.image AS item_image,
+				item.is_stock_item
+			FROM
+				`tabItem` item {bin_join_selection}
+			WHERE
+				item.disabled = 0
+				AND item.has_variants = 0
+				AND item.is_sales_item = 1
+				AND item.custom_company = %(company)s
+				AND item.is_fixed_asset = 0
+				AND item.item_group IN (
+					SELECT name
+					FROM `tabItem Group`
+					WHERE lft >= %(lft)s AND rgt <= %(rgt)s
+				)
+				AND {condition}
+				{bin_join_condition}
+			ORDER BY
+				item.name ASC
+			LIMIT
+				%(page_length)s OFFSET %(start)s
+		""".format(
+			bin_join_selection=bin_join_selection,
+			bin_join_condition=bin_join_condition,
+			condition=condition,
+		)
+	
+		# Execute the query with parameterized inputs
+		items_data = frappe.db.sql(
+			query,
+			{
+				"company": company,
+				"lft": cint(lft),
+				"rgt": cint(rgt),
+				"start": cint(start),
+				"page_length": cint(page_length),
+				"warehouse": warehouse,
+			},
+			as_dict=1,
+		)
+	else:	
+		items_data = frappe.db.sql(
+			"""
+			SELECT
+				item.name AS item_code,
+				item.item_name,
+				item.description,
+				item.stock_uom,
+				item.image AS item_image,
+				item.is_stock_item
+			FROM
+				`tabItem` item {bin_join_selection}
+			WHERE
+				item.disabled = 0
+				AND item.has_variants = 0
+				AND item.is_sales_item = 1
+				AND item.is_fixed_asset = 0
+				AND item.item_group in (SELECT name FROM `tabItem Group` WHERE lft >= {lft} AND rgt <= {rgt})
+				AND {condition}
+				{bin_join_condition}
+			ORDER BY
+				item.name asc
+			LIMIT
+				{page_length} offset {start}""".format(
+				start=cint(start),
+				page_length=cint(page_length),
+				lft=cint(lft),
+				rgt=cint(rgt),
+				condition=condition,
+				bin_join_selection=bin_join_selection,
+				bin_join_condition=bin_join_condition,
+			),
+			{"warehouse": warehouse},
+			as_dict=1,
+		)
 
 	if items_data:
 		items = [d.item_code for d in items_data]


### PR DESCRIPTION
<!--
Description: This change ensures that the standard Point-of-Sale (POS) page filters and displays items company-wise, enabling multiple companies to efficiently use POS functionality within a single ERPNext instance.

Problem Solved:
Previously, the Point-of-Sale (POS) page displayed all items regardless of the company, creating confusion for multi-company setups. This issue limited the usability of POS for organizations managing multiple companies within a single instance.

Solution:
Introduced a company filter to the POS page to display items specific to the logged-in user's company. The changes ensure a seamless multi-company experience without disrupting the existing functionality.

Impact:
  - Improves usability for multi-company setups.
  - No breaking changes for single-company users.

Testing:
  - Tested with multiple companies and validated that items displayed correctly based on the company filter.

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
