### PR TITLE
feat: Validate sub assembly and material request items in Production …

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -559,7 +559,7 @@ class PurchaseOrder(BuyingController):
 				"source_dt": "Purchase Order Item",
 				"target_dt": "Production Plan Sub Assembly Item",
 				"join_field": "production_plan_sub_assembly_item",
-				"target_field": "ordered_qty",
+				"target_field": "received_qty",
 				"target_parent_dt": "Production Plan",
 				"target_parent_field": "",
 				"target_ref_field": "qty",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -469,6 +469,9 @@ class PurchaseOrder(BuyingController):
 		if self.is_against_so():
 			self.update_status_updater()
 
+		if self.is_against_pp():
+			self.update_status_updater_if_from_pp()
+
 		self.update_prevdoc_status()
 		if not self.is_subcontracted or self.is_old_subcontracting_flow:
 			self.update_requested_qty()
@@ -550,6 +553,20 @@ class PurchaseOrder(BuyingController):
 			}
 		)
 
+	def update_status_updater_if_from_pp(self):
+		self.status_updater.append(
+			{
+				"source_dt": "Purchase Order Item",
+				"target_dt": "Production Plan Sub Assembly Item",
+				"join_field": "production_plan_sub_assembly_item",
+				"target_field": "ordered_qty",
+				"target_parent_dt": "Production Plan",
+				"target_parent_field": "",
+				"target_ref_field": "qty",
+				"source_field": "fg_item_qty",
+			}
+		)
+
 	def update_delivered_qty_in_sales_order(self):
 		"""Update delivered qty in Sales Order for drop ship"""
 		sales_orders_to_update = []
@@ -569,6 +586,9 @@ class PurchaseOrder(BuyingController):
 
 	def is_against_so(self):
 		return any(d.sales_order for d in self.items if d.sales_order)
+
+	def is_against_pp(self):
+		return any(d.production_plan for d in self.items if d.production_plan)
 
 	def set_received_qty_for_drop_ship_items(self):
 		for item in self.items:

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -201,19 +201,19 @@ class StatusUpdater(Document):
 		Get the status of the document.
 
 		Returns:
-		        dict: A dictionary containing the status. This allows callers to receive
-		        a dictionary for efficient bulk updates, for example when `per_billed`
-		        and other status fields also need to be updated.
+		                                dict: A dictionary containing the status. This allows callers to receive
+		                                a dictionary for efficient bulk updates, for example when `per_billed`
+		                                and other status fields also need to be updated.
 
 		Note:
-		        Can be overriden on a doctype to implement more localized status updater logic.
+		                                Can be overriden on a doctype to implement more localized status updater logic.
 
 		Example:
-		        {
-		                "status": "Draft",
-		                "per_billed": 50,
-		                "billing_status": "Partly Billed"
-		        }
+		                                {
+		                                                                "status": "Draft",
+		                                                                "per_billed": 50,
+		                                                                "billing_status": "Partly Billed"
+		                                }
 		"""
 		if self.doctype not in status_map:
 			return {"status": self.status}
@@ -275,9 +275,20 @@ class StatusUpdater(Document):
 				if d.doctype == args["source_dt"] and d.get(args["join_field"]):
 					args["name"] = d.get(args["join_field"])
 
+					is_from_pp = (
+						hasattr(d, "production_plan_sub_assembly_item")
+						and frappe.db.get_value(
+							"Production Plan Sub Assembly Item",
+							d.production_plan_sub_assembly_item,
+							"type_of_manufacturing",
+						)
+						== "Subcontract"
+					)
+					args["item_code"] = "production_item" if is_from_pp else "item_code"
+
 					# get all qty where qty > target_field
 					item = frappe.db.sql(
-						"""select item_code, `{target_ref_field}`,
+						"""select `{item_code}` as item_code, `{target_ref_field}`,
 						`{target_field}`, parenttype, parent from `tab{target_dt}`
 						where `{target_ref_field}` < `{target_field}`
 						and name=%s and docstatus=1""".format(**args),

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -201,19 +201,19 @@ class StatusUpdater(Document):
 		Get the status of the document.
 
 		Returns:
-		                                dict: A dictionary containing the status. This allows callers to receive
-		                                a dictionary for efficient bulk updates, for example when `per_billed`
-		                                and other status fields also need to be updated.
+		dict: A dictionary containing the status. This allows callers to receive
+		a dictionary for efficient bulk updates, for example when `per_billed`
+		and other status fields also need to be updated.
 
 		Note:
-		                                Can be overriden on a doctype to implement more localized status updater logic.
+		Can be overriden on a doctype to implement more localized status updater logic.
 
 		Example:
-		                                {
-		                                                                "status": "Draft",
-		                                                                "per_billed": 50,
-		                                                                "billing_status": "Partly Billed"
-		                                }
+		{
+		"status": "Draft",
+		"per_billed": 50,
+		"billing_status": "Partly Billed"
+		}
 		"""
 		if self.doctype not in status_map:
 			return {"status": self.status}

--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -63,7 +63,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "\nPurchase\nMaterial Transfer\nMaterial Issue\nManufacture\nCustomer Provided"
+   "options": "\nPurchase\nMaterial Transfer\nMaterial Issue\nManufacture\nSubcontracting\nCustomer Provided"
   },
   {
    "fieldname": "column_break_4",
@@ -115,9 +115,12 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
+   "default": "0",
    "fieldname": "requested_qty",
    "fieldtype": "Float",
    "label": "Requested Qty",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -202,7 +205,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:05.436575",
+ "modified": "2024-12-30 18:06:22.288340",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.py
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.py
@@ -21,7 +21,13 @@ class MaterialRequestPlanItem(Document):
 		item_code: DF.Link
 		item_name: DF.Data | None
 		material_request_type: DF.Literal[
-			"", "Purchase", "Material Transfer", "Material Issue", "Manufacture", "Customer Provided"
+			"",
+			"Purchase",
+			"Material Transfer",
+			"Material Issue",
+			"Manufacture",
+			"Subcontracting",
+			"Customer Provided",
 		]
 		min_order_qty: DF.Float
 		ordered_qty: DF.Float

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -789,23 +789,10 @@ class ProductionPlan(Document):
 			items_to_remove = defaultdict(list)
 			for supplier, items in subcontracted_po.items():
 				for item in items:
-					table = frappe.qb.DocType("Purchase Order Item")
-					total_received_qty = (
-						frappe.qb.from_(table)
-						.select(
-							Sum(table.received_qty / (table.received_qty / table.fg_item_qty)).as_(
-								"total_received_qty"
-							)
-						)
-						.where(
-							(table.production_plan_sub_assembly_item == item.name) & (table.docstatus == 1)
-						)
-					).run(as_dict=True)[0].total_received_qty or 0
-
-					if item.qty == total_received_qty:
+					if item.qty == item.received_qty:
 						items_to_remove[supplier].append(item)
-					elif total_received_qty:
-						item.qty -= total_received_qty
+					elif item.received_qty:
+						item.qty -= item.received_qty
 
 				subcontracted_po[supplier] = [item for item in items if item not in items_to_remove[supplier]]
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -4,6 +4,7 @@
 
 import copy
 import json
+from collections import defaultdict
 
 import frappe
 from frappe import _, msgprint
@@ -722,6 +723,9 @@ class ProductionPlan(Document):
 		if not wo_list:
 			frappe.msgprint(_("No Work Orders were created"))
 
+		if not po_list:
+			frappe.msgprint(_("No Purchase Orders were created"))
+
 	def make_work_order_for_finished_goods(self, wo_list, default_warehouses):
 		items_data = self.get_production_items()
 
@@ -780,6 +784,34 @@ class ProductionPlan(Document):
 	def make_subcontracted_purchase_order(self, subcontracted_po, purchase_orders):
 		if not subcontracted_po:
 			return
+
+		def calculate_sub_assembly_items():
+			items_to_remove = defaultdict(list)
+			for supplier, items in subcontracted_po.items():
+				for item in items:
+					table = frappe.qb.DocType("Purchase Order Item")
+					total_received_qty = (
+						frappe.qb.from_(table)
+						.select(
+							Sum(table.received_qty / (table.received_qty / table.fg_item_qty)).as_(
+								"total_received_qty"
+							)
+						)
+						.where(
+							(table.production_plan_sub_assembly_item == item.name) & (table.docstatus == 1)
+						)
+					).run(as_dict=True)[0].total_received_qty or 0
+
+					if item.qty == total_received_qty:
+						items_to_remove[supplier].append(item)
+					elif total_received_qty:
+						item.qty -= total_received_qty
+
+				subcontracted_po[supplier] = [item for item in items if item not in items_to_remove[supplier]]
+
+			return {key: value for key, value in subcontracted_po.items() if value}
+
+		subcontracted_po = calculate_sub_assembly_items()
 
 		for supplier, po_list in subcontracted_po.items():
 			po = frappe.new_doc("Purchase Order")
@@ -847,13 +879,31 @@ class ProductionPlan(Document):
 		except OverProductionError:
 			pass
 
+	def validate_mr_subcontracted(self):
+		for row in self.mr_items:
+			if row.material_request_type == "Subcontracting":
+				if not frappe.db.get_value("Item", row.item_code, "is_sub_contracted_item"):
+					frappe.throw(
+						_("Item {0} is not a subcontracted item").format(row.item_code),
+						title=_("Invalid Item"),
+					)
+
 	@frappe.whitelist()
 	def make_material_request(self):
+		self.validate_mr_subcontracted()
+
 		"""Create Material Requests grouped by Sales Order and Material Request Type"""
 		material_request_list = []
 		material_request_map = {}
 
+		if all([item.requested_qty == item.quantity for item in self.mr_items]):
+			msgprint(_("All items are already requested"))
+			return
+
 		for item in self.mr_items:
+			if item.quantity == item.requested_qty:
+				continue
+
 			item_doc = frappe.get_cached_doc("Item", item.item_code)
 
 			material_request_type = item.material_request_type or item_doc.default_material_request_type
@@ -887,7 +937,7 @@ class ProductionPlan(Document):
 					"from_warehouse": item.from_warehouse
 					if material_request_type == "Material Transfer"
 					else None,
-					"qty": item.quantity,
+					"qty": item.quantity - item.requested_qty,
 					"schedule_date": schedule_date,
 					"warehouse": item.warehouse,
 					"sales_order": item.sales_order,
@@ -1047,7 +1097,7 @@ class ProductionPlan(Document):
 			filters={
 				"production_plan": self.name,
 				"status": ("not in", ["Closed", "Stopped"]),
-				"docstatus": ("<", 2),
+				"docstatus": 1,
 			},
 			fields="status",
 			pluck="status",

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -540,6 +540,7 @@ class TestProductionPlan(IntegrationTestCase):
 		po_doc.submit()
 		make_purchase_receipt_from_po(po_doc)
 
+		plan.reload()
 		plan.make_work_order()
 		po = frappe.db.get_value("Purchase Order Item", {"production_plan": plan.name}, "parent")
 		po_doc = frappe.get_doc("Purchase Order", po)

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -449,10 +449,37 @@ class TestProductionPlan(IntegrationTestCase):
 		self.assertEqual(plan.sub_assembly_items[0].supplier, "_Test Supplier")
 
 	def test_production_plan_for_subcontracting_po(self):
+		from erpnext.controllers.status_updater import OverAllowanceError
 		from erpnext.manufacturing.doctype.bom.test_bom import create_nested_bom
 		from erpnext.subcontracting.doctype.subcontracting_bom.test_subcontracting_bom import (
 			create_subcontracting_bom,
 		)
+
+		def make_purchase_receipt_from_po(po_doc):
+			from erpnext.buying.doctype.purchase_order.purchase_order import make_subcontracting_order
+			from erpnext.controllers.subcontracting_controller import make_rm_stock_entry
+			from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+			from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
+				make_subcontracting_receipt,
+			)
+			from erpnext.subcontracting.doctype.subcontracting_receipt.subcontracting_receipt import (
+				make_purchase_receipt as scr_make_purchase_receipt,
+			)
+
+			sco = make_subcontracting_order(po_doc.name)
+			sco.supplier_warehouse = "Work In Progress - _TC1"
+			sco.items[0].warehouse = "Finished Goods - _TC1"
+			sco.submit()
+			make_purchase_receipt(
+				qty=10,
+				item_code="Test Motherboard Wires 1",
+				company="_Test Company 1",
+				warehouse="Work In Progress - _TC1",
+			).submit()
+			make_rm_stock_entry(sco.name)
+			scr = make_subcontracting_receipt(sco.name)
+			scr.submit()
+			scr_make_purchase_receipt(scr.name).submit()
 
 		fg_item = "Test Motherboard 1"
 		bom_tree_1 = {"Test Laptop 1": {fg_item: {"Test Motherboard Wires 1": {}}}}
@@ -478,7 +505,12 @@ class TestProductionPlan(IntegrationTestCase):
 		)
 
 		plan = create_production_plan(
-			item_code="Test Laptop 1", planned_qty=10, use_multi_level_bom=1, do_not_submit=True
+			item_code="Test Laptop 1",
+			planned_qty=10,
+			use_multi_level_bom=1,
+			do_not_submit=True,
+			company="_Test Company 1",
+			skip_getting_mr_items=True,
 		)
 		plan.get_sub_assembly_items()
 		plan.set_default_supplier_for_subcontracting_order()
@@ -492,9 +524,107 @@ class TestProductionPlan(IntegrationTestCase):
 		self.assertEqual(po_doc.supplier, "_Test Supplier")
 		self.assertEqual(po_doc.items[0].qty, 10.0)
 		self.assertEqual(po_doc.items[0].fg_item_qty, 10.0)
-		self.assertEqual(po_doc.items[0].fg_item_qty, 10.0)
 		self.assertEqual(po_doc.items[0].fg_item, fg_item)
 		self.assertEqual(po_doc.items[0].item_code, service_item)
+
+		po_doc.items[0].qty = 11
+		po_doc.items[0].fg_item_qty = 11
+
+		# Test - 1 : Quantity of item cannot exceed quantity in production plan
+		self.assertRaises(OverAllowanceError, po_doc.submit)
+
+		po_doc.cancel()
+		po_doc = frappe.copy_doc(po_doc)
+		po_doc.items[0].qty = 5
+		po_doc.items[0].fg_item_qty = 5
+		po_doc.submit()
+		make_purchase_receipt_from_po(po_doc)
+
+		plan.make_work_order()
+		po = frappe.db.get_value("Purchase Order Item", {"production_plan": plan.name}, "parent")
+		po_doc = frappe.get_doc("Purchase Order", po)
+
+		# Test - 2 : Quantity of item in new PO should be the available quantity from Production Plan
+		self.assertEqual(po_doc.items[0].qty, 5.0)
+
+		po_doc.submit()
+		plan.make_work_order()
+
+		# Test - 3 : New POs should not be created since the quantity is already fulfilled
+		self.assertEqual(
+			frappe.db.count("Purchase Order Item", {"production_plan": plan.name, "docstatus": 1}), 2
+		)  # 2 since we have already created and submitted 2 POs
+
+	def test_production_plan_for_mr_items(self):
+		from erpnext.manufacturing.doctype.bom.test_bom import create_nested_bom
+
+		def setup_item(fg_item):
+			item_doc = frappe.get_doc("Item", fg_item)
+			company = "_Test Company"
+
+			item_doc.is_sub_contracted_item = 1
+			for row in item_doc.item_defaults:
+				if row.company == company and not row.default_supplier:
+					row.default_supplier = "_Test Supplier"
+
+			if not item_doc.item_defaults:
+				item_doc.append("item_defaults", {"company": company, "default_supplier": "_Test Supplier"})
+
+			item_doc.save()
+
+		fg_item = "Test Motherboard 1"
+		fg_item_2 = "Test CPU 1"
+		bom_tree_1 = {
+			"Test Laptop 1": {fg_item: {"Test Motherboard Wires 1": {}}, fg_item_2: {"Test Pins 1": {}}}
+		}
+		create_nested_bom(bom_tree_1, prefix="")
+
+		setup_item(fg_item)
+		setup_item(fg_item_2)
+
+		plan = create_production_plan(
+			item_code="Test Laptop 1", planned_qty=10, use_multi_level_bom=1, do_not_submit=True
+		)
+		plan.get_sub_assembly_items()
+		plan.set_default_supplier_for_subcontracting_order()
+		plan.submit()
+
+		plan.make_material_request()
+		mr_item = frappe.db.get_value("Material Request Item", {"production_plan": plan.name}, "parent")
+		mr_doc = frappe.get_doc("Material Request", mr_item)
+		mr_doc.submit()
+		plan.reload()
+		plan.make_material_request()
+
+		# Test 1 : No more MRs should be created as quantity from Production Plan is fulfilled
+		self.assertEqual(frappe.db.count("Material Request Item", {"production_plan": plan.name}), 2)
+
+		mr_doc.cancel()
+		plan.reload()
+
+		# Test 2 : Requested quantity should be updated in Production Plan on cancellation of MR
+		self.assertEqual(plan.mr_items[0].requested_qty, 0)
+
+		plan.make_material_request()
+		mr_item = frappe.db.get_value("Material Request Item", {"production_plan": plan.name}, "parent")
+		mr_doc = frappe.get_doc("Material Request", mr_item)
+		mr_doc.items[0].qty = 5
+		mr_doc.submit()
+		plan.reload()
+		plan.make_material_request()
+		mr_item = frappe.db.get_value("Material Request Item", {"production_plan": plan.name}, "parent")
+		mr_doc = frappe.get_doc("Material Request", mr_item)
+
+		# Test 3 : Since Item 2 has been fully requested, it should not be included in the new MR by default
+		self.assertEqual(len(mr_doc.items), 1)
+
+		# Test 4 : Quantity in new MR should be the available quantity from Production Plan
+		self.assertEqual(mr_doc.items[0].qty, 5.0)
+
+		mr_doc.items[0].qty = 6
+
+		# Test 5 : Quantity of item cannot exceed available quantity from Production Plan
+		self.assertRaises(frappe.ValidationError, mr_doc.submit)
 
 	def test_production_plan_combine_subassembly(self):
 		"""

--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -21,6 +21,7 @@
   "purchase_order",
   "production_plan_item",
   "column_break_7",
+  "ordered_qty",
   "received_qty",
   "indent",
   "section_break_19",
@@ -204,12 +205,20 @@
    "fieldtype": "Float",
    "label": "Produced Qty",
    "read_only": 1
+  },
+  {
+   "fieldname": "ordered_qty",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Ordered Qty",
+   "non_negative": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:20.876695",
+ "modified": "2024-12-20 17:00:15.335880",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan Sub Assembly Item",

--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -210,7 +210,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-01 14:27:52.956484",
+ "modified": "2025-01-01 17:50:32.273610",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan Sub Assembly Item",

--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -21,7 +21,6 @@
   "purchase_order",
   "production_plan_item",
   "column_break_7",
-  "ordered_qty",
   "received_qty",
   "indent",
   "section_break_19",
@@ -72,6 +71,7 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "received_qty",
    "fieldtype": "Float",
    "label": "Received Qty",
@@ -205,20 +205,12 @@
    "fieldtype": "Float",
    "label": "Produced Qty",
    "read_only": 1
-  },
-  {
-   "fieldname": "ordered_qty",
-   "fieldtype": "Float",
-   "hidden": 1,
-   "label": "Ordered Qty",
-   "non_negative": 1,
-   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-20 17:00:15.335880",
+ "modified": "2025-01-01 14:27:52.956484",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan Sub Assembly Item",

--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.py
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.py
@@ -22,6 +22,7 @@ class ProductionPlanSubAssemblyItem(Document):
 		fg_warehouse: DF.Link | None
 		indent: DF.Int
 		item_name: DF.Data | None
+		ordered_qty: DF.Float
 		parent: DF.Data
 		parent_item_code: DF.Link | None
 		parentfield: DF.Data

--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.py
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.py
@@ -22,7 +22,6 @@ class ProductionPlanSubAssemblyItem(Document):
 		fg_warehouse: DF.Link | None
 		indent: DF.Int
 		item_name: DF.Data | None
-		ordered_qty: DF.Float
 		parent: DF.Data
 		parent_item_code: DF.Link | None
 		parentfield: DF.Data

--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
@@ -116,7 +116,7 @@ def get_production_plan_sub_assembly_item_details(filters, row, production_plan_
 					"pending_qty": flt(item.qty)
 					- flt(order_details.get((docname, item.production_item), {}).get("produced_qty", 0)),
 				}
-				if data[-1] and data[-1]["indent"] == data_to_append["indent"]:
+				if data[-1] and data[-1]["item_code"] == item.production_item:
 					data_to_append["pending_qty"] = data[-1]["pending_qty"] - data_to_append["produced_qty"]
 				data.append(data_to_append)
 
@@ -124,7 +124,7 @@ def get_production_plan_sub_assembly_item_details(filters, row, production_plan_
 def get_work_order_details(filters, order_details):
 	for row in frappe.get_all(
 		"Work Order",
-		filters={"production_plan": filters.get("production_plan")},
+		filters={"production_plan": filters.get("production_plan"), "docstatus": 1},
 		fields=["name", "produced_qty", "production_plan", "production_item", "sales_order"],
 	):
 		order_details.setdefault((row.name, row.production_item), row)
@@ -133,11 +133,11 @@ def get_work_order_details(filters, order_details):
 def get_purchase_order_details(filters, order_details):
 	for row in frappe.get_all(
 		"Purchase Order Item",
-		filters={"production_plan": filters.get("production_plan")},
-		fields=["parent", "received_qty as produced_qty", "item_code", "fg_item", "fg_item_qty"],
+		filters={"production_plan": filters.get("production_plan"), "docstatus": 1},
+		fields=["parent", "qty", "received_qty as produced_qty", "item_code", "fg_item", "fg_item_qty"],
 	):
 		if row.fg_item:
-			row.produced_qty /= row.produced_qty / row.fg_item_qty or 1
+			row.produced_qty /= row.qty / row.fg_item_qty or 1
 		order_details.setdefault((row.parent, row.fg_item or row.item_code), row)
 
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -385,39 +385,36 @@ class PurchaseReceipt(BuyingController):
 		self.reserve_stock_for_sales_order()
 		self.update_received_qty_if_from_pp()
 
-	def update_received_qty_if_from_pp(self, cancel=False):
+	def update_received_qty_if_from_pp(self):
 		from frappe.query_builder.functions import Sum
 
-		items_with_po_item = [item for item in self.items if item.purchase_order_item]
-		if items_with_po_item:
-			po_items = [item.purchase_order_item for item in items_with_po_item]
+		items_from_po = [item.purchase_order_item for item in self.items if item.purchase_order_item]
+		if items_from_po:
 			table = frappe.qb.DocType("Purchase Order Item")
-			query = (
+			subquery = (
 				frappe.qb.from_(table)
-				.select(
-					table.name,
-					(table.qty / table.fg_item_qty).as_("sc_conversion_factor"),
-					table.production_plan_sub_assembly_item,
-					Sum(table.received_qty).as_("received_qty"),
-				)
-				.where(table.name.isin(po_items))
-				.groupby(table.name)
+				.select(table.production_plan_sub_assembly_item)
+				.distinct()
+				.where(table.name.isin(items_from_po) & table.production_plan_sub_assembly_item.isnotnull())
 			)
-			result = query.run(as_dict=True)
-
-			for item in items_with_po_item:
-				row = next(d for d in result if d.name == item.purchase_order_item)
-				if row.production_plan_sub_assembly_item:
-					received_qty = (
-						(row.received_qty + (item.qty / row.sc_conversion_factor))
-						if not cancel
-						else (row.received_qty - (item.qty / row.sc_conversion_factor))
+			result = subquery.run(as_dict=True)
+			if result:
+				result = [item.production_plan_sub_assembly_item for item in result]
+				query = (
+					frappe.qb.from_(table)
+					.select(
+						table.production_plan_sub_assembly_item,
+						Sum(table.received_qty / (table.qty / table.fg_item_qty)).as_("received_qty"),
 					)
+					.where(table.production_plan_sub_assembly_item.isin(result))
+					.groupby(table.production_plan_sub_assembly_item)
+				)
+				for row in query.run(as_dict=True):
 					frappe.set_value(
 						"Production Plan Sub Assembly Item",
 						row.production_plan_sub_assembly_item,
 						"received_qty",
-						received_qty,
+						row.received_qty,
 					)
 
 	def check_next_docstatus(self):
@@ -460,7 +457,7 @@ class PurchaseReceipt(BuyingController):
 		)
 		self.delete_auto_created_batches()
 		self.set_consumed_qty_in_subcontract_order()
-		self.update_received_qty_if_from_pp(cancel=True)
+		self.update_received_qty_if_from_pp()
 
 	def get_gl_entries(self, warehouse_account=None, via_landed_cost_voucher=False):
 		from erpnext.accounts.general_ledger import process_gl_map


### PR DESCRIPTION
Reference issue #35225 

The referenced issue highlighted a bug in the Production Plan Summary report, where the subcontracted Purchase Order's received/produced quantity (created from the Production Plan Sub Assembly Items) was not being correctly updated.

Apart from fixing this issue, several other validations and features have also been added:

- Purchase Orders created from Sub Assembly Items
1. User is now **not** allowed to create POs whose line item's quantity exceed the quantity from its corresponding available quantity of Sub Assembly Items from the Production Plan
2. Purchase Orders will now **not** be created for those Sub Assembly Items if Purchase Orders have been created against them AND those POs cover the full quantity of that item from the Production Plan
3. Purchase Orders created against Sub Assembly Items will now have only the remaining quantity as the quantity of the line item by default

- Material Request created from Material Request Plan Items
1. Added `Subcontracting` as a type of Material Request
2. Added validation which checks if item is a subcontracted item or not if type of MR is Subcontracting
3. Added validation which checks if item in MR is not more than available quantity to request from Production Plan

- Production Plan Summary
1. Summaries now show all submitted Purchase Orders and Work Orders created from the Production Plan

`no-docs` since I feel documentation is not really required for this??