### PR TITLE
fix: apply apply_pricing_rule on date change

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -837,6 +837,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	validate() {
+		this.apply_pricing_rule()
 		this.calculate_taxes_and_totals(false);
 	}
 
@@ -999,6 +1000,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	transaction_date() {
+		this.apply_pricing_rule()
 		if (this.frm.doc.transaction_date) {
 			this.frm.transaction_date = this.frm.doc.transaction_date;
 			frappe.ui.form.trigger(this.frm.doc.doctype, "currency");
@@ -1007,6 +1009,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	posting_date() {
 		var me = this;
+		me.apply_pricing_rule()
 		if (this.frm.doc.posting_date) {
 			this.frm.posting_date = this.frm.doc.posting_date;
 


### PR DESCRIPTION
**Issue:**
The pricing rule is not getting added/removed after the change in date
**ref**: [28201](https://support.frappe.io/helpdesk/tickets/28201)

**Before:**

[Screencast from 30-12-24 11:07:10 PM IST.webm](https://github.com/user-attachments/assets/1a94f00d-60bd-4616-a9b5-6ef0673c348a)

**After:**

[Screencast from 30-12-24 11:08:59 PM IST.webm](https://github.com/user-attachments/assets/af325cb0-24af-4fa3-8951-fe37f50b82a6)


Backport needed for v15 and V14
