### PR TITLE
fix: deduct tds on excess amount if checked

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -555,9 +555,11 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 	else:
 		tax_withholding_net_total = inv.get("tax_withholding_net_total", 0)
 
-	if (threshold and tax_withholding_net_total >= threshold) or (
+	has_cumulative_threshold_breached = (
 		cumulative_threshold and (supp_credit_amt + supp_inv_credit_amt) >= cumulative_threshold
-	):
+	)
+
+	if (threshold and tax_withholding_net_total >= threshold) or (has_cumulative_threshold_breached):
 		# Get net total again as TDS is calculated on net total
 		# Grand is used to just check for threshold breach
 		net_total = (
@@ -565,9 +567,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, vouchers):
 		)
 		supp_credit_amt += net_total
 
-		if (cumulative_threshold and supp_credit_amt >= cumulative_threshold) and cint(
-			tax_details.tax_on_excess_amount
-		):
+		if has_cumulative_threshold_breached and cint(tax_details.tax_on_excess_amount):
 			supp_credit_amt = net_total + tax_withholding_net_total - cumulative_threshold
 
 		if ldc and is_valid_certificate(ldc, inv.get("posting_date") or inv.get("transaction_date"), 0):


### PR DESCRIPTION
Issue: TDS gets deducted on the whole amount even if tax_on_excess_amount is checked in the tax withholding category.

If consider_party_ledger_amount is checked in the tax withholding category, the threshold is checked based on grand total of the invoice. But while checking tax_on_excess_amount, again threshold is checked based on the net amount of the invoice and if the threshold has not been breached tds is deducted from the whole amount.

Steps to replicate:
- Create a tax withholding category with cumulative threshold 10,00,000/-  and check tax_on_excess_amount and consider_party_ledger_amount.
- Create a supplier with the above category.
- Create a Purchase invoice with item amount 800000 and add taxes of 80,000.
- Create another Purchase Invoice with item amount 130000.


Before:
TDS will be deducted on 9,30,000 even though tax_on_excess_amount is checked.


Solution:
Do not deduct tax if the threshold has not breached the net amount total.


After: 
Tax will not be deducted because the threshold has not breached the net amount total.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/28268

backport-version-15
backport-version-14