### PR TITLE
fix: fetch only active sales persons

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -163,13 +163,30 @@ def _get_party_details(
 
 	# sales team
 	if party_type == "Customer":
+		sales_person = frappe.qb.DocType("Sales Person")
+		sales_team = frappe.qb.DocType("Sales Team")
+		sales_persons = (frappe.qb.from_(sales_person)
+				   .inner_join(sales_team)
+				   .on(sales_team.sales_person == sales_person.name)
+				   .select(
+					   sales_person.enabled,
+					   sales_team.sales_person,
+					   sales_team.allocated_percentage,
+                       sales_team.commission_rate,
+				   )
+				   .where(
+					   (sales_person.enabled == 1)
+					   & (sales_team.parent == party.name)
+			  		)
+				).run(as_dict=True)
+		
 		party_details["sales_team"] = [
 			{
 				"sales_person": d.sales_person,
 				"allocated_percentage": d.allocated_percentage or None,
 				"commission_rate": d.commission_rate,
 			}
-			for d in party.get("sales_team")
+			for d in sales_persons if d.enabled
 		]
 
 	# supplier tax withholding category

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -177,6 +177,7 @@ def _get_party_details(
 				   .where(
 					   (sales_person.enabled == 1)
 					   & (sales_team.parent == party.name)
+					   & (sales_team.parenttype == "Customer")
 			  		)
 				).run(as_dict=True)
 		


### PR DESCRIPTION
Issue: Showing Disabled Sales Person

Ref: [28327](https://support.frappe.io/helpdesk/tickets/28327)

Before: 

https://github.com/user-attachments/assets/411118d9-41ea-47b7-b864-2ab5bc53356a

After:

https://github.com/user-attachments/assets/1828ec8a-348e-42d6-a835-62056eefd9e0

Backport needed for v14 & v15


