### PR TITLE
fix: slow stock transactions

### DIFF
--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -80,7 +80,7 @@ def get_balance_qty_from_sle(item_code, warehouse):
 	balance_qty = frappe.db.sql(
 		"""select qty_after_transaction from `tabStock Ledger Entry`
 		where item_code=%s and warehouse=%s and is_cancelled=0
-		order by posting_date desc, posting_time desc, creation desc
+		order by posting_datetime desc, creation desc
 		limit 1""",
 		(item_code, warehouse),
 	)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1571,7 +1571,7 @@ def get_previous_sle_of_current_voucher(args, operator="<", exclude_current_vouc
 			and (
 				posting_datetime {operator} %(posting_datetime)s
 			)
-		order by posting_date desc, posting_time desc, creation desc
+		order by posting_datetime desc, creation desc
 		limit 1
 		for update""",
 		{
@@ -1665,7 +1665,7 @@ def get_stock_ledger_entries(
 		where item_code = %(item_code)s
 		and is_cancelled = 0
 		{conditions}
-		order by posting_date {order}, posting_time {order}, creation {order}
+		order by posting_datetime {order}, creation {order}
 		{limit} {for_update}""".format(
 			conditions=conditions,
 			limit=limit or "",
@@ -1787,7 +1787,7 @@ def get_valuation_rate(
 			AND valuation_rate >= 0
 			AND is_cancelled = 0
 			AND NOT (voucher_no = %s AND voucher_type = %s)
-		order by posting_date desc, posting_time desc, name desc limit 1""",
+		order by posting_datetime desc, creation desc limit 1""",
 		(item_code, warehouse, voucher_no, voucher_type),
 	):
 		return flt(last_valuation_rate[0][0])
@@ -2038,7 +2038,7 @@ def get_future_sle_with_negative_qty(sle_args):
 			and posting_datetime >= %(posting_datetime)s
 			and is_cancelled = 0
 			and qty_after_transaction < 0
-		order by posting_date asc, posting_time asc
+		order by posting_datetime asc, creation asc
 		limit 1
 	""",
 		sle_args,
@@ -2052,14 +2052,14 @@ def get_future_sle_with_negative_batch_qty(sle_args):
 		with batch_ledger as (
 			select
 				posting_date, posting_time, posting_datetime, voucher_type, voucher_no,
-				sum(actual_qty) over (order by posting_date, posting_time, creation) as cumulative_total
+				sum(actual_qty) over (order by posting_datetime, creation) as cumulative_total
 			from `tabStock Ledger Entry`
 			where
 				item_code = %(item_code)s
 				and warehouse = %(warehouse)s
 				and batch_no=%(batch_no)s
 				and is_cancelled = 0
-			order by posting_date, posting_time, creation
+			order by posting_datetime, creation
 		)
 		select * from batch_ledger
 		where


### PR DESCRIPTION
```
 Query   |  162 | Creating sort index | select *, posting_datetime as "timestamp"
                from `tabStock Ledger Entry`
                where item_code = 'ABC001'
                        and warehouse = 'WH-001'
                        and is_cancelled = 0
                        and creation < '2025-01-01 13:21:26.738690'
                        and (
                                posting_datetime <= '2024-12-31 08:49:39'
                        )
                order by posting_date desc, posting_time desc, creation desc
                limit 1

```

order by posting_date and posting_time is not indexed

<img width="1159" alt="Screenshot 2025-01-01 at 1 56 46 PM" src="https://github.com/user-attachments/assets/1bf7c046-01d3-41d9-9020-9e2ecc2bd0c9" />
