### PR TITLE
refactor: use `idx` for identifying row

### DIFF
--- a/erpnext/controllers/tests/test_reactivity.py
+++ b/erpnext/controllers/tests/test_reactivity.py
@@ -56,7 +56,7 @@ class TestReactivity(AccountsTestMixin, IntegrationTestCase):
 		)
 		itm = si.append("items")
 		itm.item_code = self.item
-		si.process_item_selection(si.items[0].name)
+		si.process_item_selection(itm.idx)
 		self.assertEqual(itm.rate, 90)
 
 		df = qb.DocType("DocField")

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -505,7 +505,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				doc: doc,
 				method: "process_item_selection",
 				args: {
-					item: item.name
+					item_idx: item.idx
 				},
 				callback: function(r) {
 					if(!r.exc) {

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -288,9 +288,9 @@ class TransactionBase(StatusUpdater):
 		)
 
 	@frappe.whitelist()
-	def process_item_selection(self, item):
+	def process_item_selection(self, item_idx):
 		# Server side 'item' doc. Update this to reflect in UI
-		item_obj = self.get("items", {"name": item})[0]
+		item_obj = self.get("items", {"idx": item_idx})[0]
 
 		# 'item_details' has latest item related values
 		item_details = self.fetch_item_details(item_obj)


### PR DESCRIPTION
# Flaky child row identification
`name` for child table rows aren't generated on server-side until saved. Which means test `test_01_basic_item_details` was working purely on the coincidence that `get` returned the first row that matched `None`[^1], which happened to be the one we just added.
https://github.com/frappe/erpnext/blob/53d8e329611d9286c93f27404bf233db55b2f0e6/erpnext/controllers/tests/test_reactivity.py#L57-L59

introduced in: https://github.com/frappe/erpnext/pull/44293

`idx` is a better alternative for row identification.



[^1]: https://github.com/frappe/frappe/blob/7239cb680cb8fe569d0f50bc4e907bf86b6b1122/frappe/model/base_document.py#L1354,