### PR TITLE
fix: serial and batch no. buttons on pos

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -210,10 +210,21 @@ erpnext.PointOfSale.ItemDetails = class {
 
 	make_auto_serial_selection_btn(item) {
 		if (item.has_serial_no || item.has_batch_no) {
-			const label = item.has_serial_no ? __("Select Serial No") : __("Select Batch No");
-			this.$form_container.append(
-				`<div class="btn btn-sm btn-secondary auto-fetch-btn">${label}</div>`
-			);
+			if (item.has_serial_no && item.has_batch_no) {
+				this.$form_container.append(
+					`<div class="btn btn-sm btn-secondary auto-fetch-btn" style="margin-top: 6px">${__(
+						"Select Serial No / Batch No"
+					)}</div>`
+				);
+			} else {
+				const classname = item.has_serial_no ? ".serial_no-control" : ".batch_no-control";
+				const label = item.has_serial_no ? __("Select Serial No") : __("Select Batch No");
+				this.$form_container
+					.find(classname)
+					.append(
+						`<div class="btn btn-sm btn-secondary auto-fetch-btn" style="margin-top: 6px">${label}</div>`
+					);
+			}
 			this.$form_container.find(".serial_no-control").find("textarea").css("height", "6rem");
 		}
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a29aa5ab-9f18-4176-9f85-60e77986832b)

There was an issue with the buttons for adding serial or batch numbers—they were too large and not aligned, as shown in the screenshot on #44659.

I made the changes that maintain the size and alignment of the button as posted.

---

![image](https://github.com/user-attachments/assets/b9e5c8b3-c9af-4190-9281-bc31d981bac2)

![image](https://github.com/user-attachments/assets/88c5d373-5753-4ca7-b605-f49d203038fb)

![image](https://github.com/user-attachments/assets/92546a6f-dc48-4726-81db-1fc28a10a2ce)


