### PR TITLE
feat: Add corrective job card operating cost as additional costs in s…

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1433,6 +1433,16 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 				},
 			)
 
+	if work_order and work_order.corrective_operation_cost:
+		stock_entry.append(
+			"additional_costs",
+			{
+				"expense_account": expense_account,
+				"description": "Total Corrective Operations Cost",
+				"amount": work_order.corrective_operation_cost,
+			},
+		)
+
 
 @frappe.whitelist()
 def get_bom_diff(bom1, bom2):

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -658,20 +658,24 @@ class JobCard(Document):
 						d.idx, d.item_code
 					)
 				)
-
-			self.append(
-				"items",
-				{
-					"item_code": d.item_code,
-					"source_warehouse": self.source_warehouse or d.source_warehouse,
-					"uom": frappe.db.get_value("Item", d.item_code, "stock_uom"),
-					"item_name": d.item_name,
-					"description": d.description,
-					"required_qty": (d.required_qty * flt(self.for_quantity)) / doc.qty,
-					"rate": d.rate,
-					"amount": d.amount,
-				},
-			)
+			if (
+				self.get("operation") == d.operation
+				or self.operation_row_id == d.operation_row_id
+				or self.is_corrective_job_card
+			):
+				self.append(
+					"items",
+					{
+						"item_code": d.item_code,
+						"source_warehouse": self.source_warehouse or d.source_warehouse,
+						"uom": frappe.db.get_value("Item", d.item_code, "stock_uom"),
+						"item_name": d.item_name,
+						"description": d.description,
+						"required_qty": (d.required_qty * flt(self.for_quantity)) / doc.qty,
+						"rate": d.rate,
+						"amount": d.amount,
+					},
+				)
 
 	def before_save(self):
 		self.set_expected_and_actual_time()

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -659,20 +659,19 @@ class JobCard(Document):
 					)
 				)
 
-			if self.get("operation") == d.operation or self.operation_row_id == d.operation_row_id:
-				self.append(
-					"items",
-					{
-						"item_code": d.item_code,
-						"source_warehouse": self.source_warehouse or d.source_warehouse,
-						"uom": frappe.db.get_value("Item", d.item_code, "stock_uom"),
-						"item_name": d.item_name,
-						"description": d.description,
-						"required_qty": (d.required_qty * flt(self.for_quantity)) / doc.qty,
-						"rate": d.rate,
-						"amount": d.amount,
-					},
-				)
+			self.append(
+				"items",
+				{
+					"item_code": d.item_code,
+					"source_warehouse": self.source_warehouse or d.source_warehouse,
+					"uom": frappe.db.get_value("Item", d.item_code, "stock_uom"),
+					"item_name": d.item_name,
+					"description": d.description,
+					"required_qty": (d.required_qty * flt(self.for_quantity)) / doc.qty,
+					"rate": d.rate,
+					"amount": d.amount,
+				},
+			)
 
 	def before_save(self):
 		self.set_expected_and_actual_time()

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -442,6 +442,73 @@ class TestJobCard(IntegrationTestCase):
 		cost_after_cancel = self.work_order.total_operating_cost
 		self.assertEqual(cost_after_cancel, original_cost)
 
+	@IntegrationTestCase.change_settings(
+		"Manufacturing Settings", {"add_corrective_operation_cost_in_finished_good_valuation": 1}
+	)
+	def test_if_corrective_jc_ops_cost_is_added_to_manufacture_stock_entry(self):
+		job_card = frappe.get_last_doc("Job Card", {"work_order": self.work_order.name})
+		job_card.append(
+			"time_logs",
+			{"from_time": now(), "to_time": add_to_date(now(), hours=1), "completed_qty": 2},
+		)
+		job_card.submit()
+
+		corrective_action = frappe.get_doc(
+			doctype="Operation", is_corrective_operation=1, name=frappe.generate_hash()
+		).insert()
+
+		corrective_job_card = make_corrective_job_card(
+			job_card.name, operation=corrective_action.name, for_operation=job_card.operation
+		)
+		corrective_job_card.hour_rate = 100
+		corrective_job_card.insert()
+		corrective_job_card.append(
+			"time_logs",
+			{
+				"from_time": add_to_date(now(), hours=2),
+				"to_time": add_to_date(now(), hours=2, minutes=30),
+				"completed_qty": 2,
+			},
+		)
+		corrective_job_card.submit()
+		self.work_order.reload()
+
+		from erpnext.manufacturing.doctype.work_order.work_order import (
+			make_stock_entry as make_stock_entry_for_wo,
+		)
+
+		stock_entry = make_stock_entry_for_wo(self.work_order.name, "Manufacture")
+		self.assertEqual(stock_entry.additional_costs[1].description, "Total Corrective Operations Cost")
+		self.assertEqual(stock_entry.additional_costs[1].amount, 50)
+		self.assertEqual(stock_entry["items"][-1].additional_cost, 6050)
+
+	def test_if_corrective_jc_items_are_same_as_parent_jc(self):
+		create_bom_with_multiple_operations()
+		work_order = make_wo_with_transfer_against_jc(same=True)
+		self.generate_required_stock(work_order)
+
+		job_card_name = frappe.db.get_value(
+			"Job Card", {"work_order": work_order.name, "operation": "_Test Operation 1"}
+		)
+		job_card = frappe.get_doc("Job Card", job_card_name)
+		make_stock_entry_from_jc(job_card.name).submit()
+		job_card.reload()
+		job_card.append(
+			"time_logs",
+			{"from_time": now(), "to_time": add_to_date(now(), hours=1), "completed_qty": 4},
+		)
+		job_card.submit()
+
+		corrective_action = frappe.get_doc(
+			doctype="Operation", is_corrective_operation=1, name=frappe.generate_hash()
+		).insert()
+
+		corrective_job_card = make_corrective_job_card(
+			job_card.name, operation=corrective_action.name, for_operation=job_card.operation
+		)
+
+		self.assertEqual(len(job_card.items), len(corrective_job_card.items))
+
 	def test_job_card_statuses(self):
 		def assertStatus(status):
 			jc.set_status()
@@ -661,7 +728,7 @@ def create_bom_with_multiple_operations():
 	return bom_doc
 
 
-def make_wo_with_transfer_against_jc():
+def make_wo_with_transfer_against_jc(same=False):
 	"Create a WO with multiple operations and Material Transfer against Job Card"
 
 	work_order = make_wo_order_test_record(
@@ -671,7 +738,7 @@ def make_wo_with_transfer_against_jc():
 		source_warehouse="Stores - _TC",
 		do_not_submit=True,
 	)
-	work_order.required_items[0].operation = "Test Operation A"
+	work_order.required_items[0].operation = "_Test Operation 1" if same else "Test Operation A"
 	work_order.required_items[1].operation = "_Test Operation 1"
 	work_order.submit()
 


### PR DESCRIPTION
Reference issue #44976 

This PR does two new things:
1. The operating cost of corrective job cards will now be added to the additional costs table of Manufacture Stock Entry.
2. Newly created corrective job cards will now have raw materials table pre-filled based on the job card it is being created from.

`no-docs`