### PR TITLE
fix: ignore currency validation while canceling the voucher

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -275,6 +275,9 @@ class GLEntry(Document):
 		validate_account_party_type(self)
 
 	def validate_currency(self):
+		if self.is_cancelled:
+			return
+
 		company_currency = erpnext.get_company_currency(self.company)
 		account_currency = get_account_currency(self.account)
 

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -765,6 +765,9 @@ def validate_party_frozen_disabled(party_type, party_name):
 
 
 def validate_account_party_type(self):
+	if self.is_cancelled:
+		return
+
 	if self.party_type and self.party:
 		account_type = frappe.get_cached_value("Account", self.account, "account_type")
 		if account_type and (account_type not in ["Receivable", "Payable"]):


### PR DESCRIPTION
**Issue:**
Unable to cancel the voucher, which has a party in a different currency
**ref:** [28309](https://support.frappe.io/helpdesk/tickets/28309)

![image](https://github.com/user-attachments/assets/d6445d9a-531e-4289-9a00-fb4ee99fc77c)


backport needed for v15