### PR TITLE
fix: accept non-default mop on pos return

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -859,26 +859,22 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				precision("base_grand_total")
 			);
 		}
+
 		// set the default payment method amount
 		// adjust the total_amount_to_pay based on non-default payment methods
 		let default_payment_index;
 		this.frm.doc.payments.find((payment, index) => {
-			if (payment.default) {
-				default_payment_index = index
-				payment.amount = total_amount_to_pay;
-			} else if (payment.amount) {
-				//calculate remaining_amount and update it to default mop
-				let remaining_amount = flt(
-					total_amount_to_pay - payment.amount,
-					precision("total_amount_to_pay")
-				)
+		if (payment.default) {
+			default_payment_index = index
+			payment.amount = total_amount_to_pay;
+		} else if (payment.amount) {
+			//calculate remaining_amount and update it to default mop
+			total_amount_to_pay -= payment.amount
 
-				if (default_payment_index === undefined) {
-					total_amount_to_pay = remaining_amount
-				} else {
-					this.frm.doc.payments[default_payment_index].amount = remaining_amount
-				}
+			if (default_payment_index !== undefined) {
+				this.frm.doc.payments[default_payment_index].amount = total_amount_to_pay
 			}
+		}
 		});
 
 		this.frm.refresh_fields();

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -859,12 +859,25 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				precision("base_grand_total")
 			);
 		}
-
-		this.frm.doc.payments.find(payment => {
+		// set the default payment method amount
+		// adjust the total_amount_to_pay based on non-default payment methods
+		let default_payment_index;
+		this.frm.doc.payments.find((payment, index) => {
 			if (payment.default) {
+				default_payment_index = index
 				payment.amount = total_amount_to_pay;
-			} else {
-				payment.amount = 0
+			} else if (payment.amount) {
+				//calculate remaining_amount and update it to default mop
+				let remaining_amount = flt(
+					total_amount_to_pay - payment.amount,
+					precision("total_amount_to_pay")
+				)
+
+				if (default_payment_index === undefined) {
+					total_amount_to_pay = remaining_amount
+				} else {
+					this.frm.doc.payments[default_payment_index].amount = remaining_amount
+				}
 			}
 		});
 


### PR DESCRIPTION
**Issue:**
Unable to add payment amount for non-default MOP (mode of payment) on POS return.

**Ref:** [28130](https://support.frappe.io/helpdesk/tickets/28130)

**Before:**
[non default mop pos return issue.webm](https://github.com/user-attachments/assets/7b7b3455-9c15-4972-ba59-980cfc265dff)

**After:** 
[non default mop pos return fixeed.webm](https://github.com/user-attachments/assets/74735198-4c17-4df4-9c82-199a60324e4c)

**Backport Needed:** v15
