### PR TITLE
fix(style): set image width in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom_item_preview.html
+++ b/erpnext/manufacturing/doctype/bom/bom_item_preview.html
@@ -3,7 +3,7 @@
 		<div class="col-md-5" style="max-height: 500px">
 			{% if data.image %}
 				<div class="border image-field " style="overflow: hidden;border-color:#e6e6e6">
-					<img class="responsive" src={{ data.image }}>
+					<img class="responsive" style="width: 100%;" src={{ data.image }}>
 				</div>
 			{% endif %}
 		</div>


### PR DESCRIPTION
Resolves #45049 
Before:
![6300665995181802084](https://github.com/user-attachments/assets/7aaeecaf-82b5-4cbc-9561-800c412796c7)


After:

<img width="1439" alt="Screenshot 2025-01-02 at 5 35 23 PM" src="https://github.com/user-attachments/assets/7e7ffb41-71ea-494b-8511-7c2b2bdbe35b" />


