### PR TITLE
chore: partial revert #44989

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -837,7 +837,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	validate() {
-		this.apply_pricing_rule()
 		this.calculate_taxes_and_totals(false);
 	}
 


### PR DESCRIPTION
Removing `apply_pricing_rule()` on `validate()` 

reported on: https://github.com/frappe/erpnext/pull/44989
internal ref: https://support.frappe.io/helpdesk/my-tickets/28558
regression: https://github.com/frappe/erpnext/pull/44989