### PR TITLE
feat: work in progress status for asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -353,7 +353,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nDecapitalized",
+   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nDecapitalized\nWork in Progress",
    "read_only": 1
   },
   {
@@ -592,7 +592,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-11-29 14:25:56.436124",
+ "modified": "2024-12-26 14:23:20.968882",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -353,7 +353,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nDecapitalized\nWork in Progress",
+   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nDecapitalized\nWork In Progress",
    "read_only": 1
   },
   {

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -112,7 +112,7 @@ class Asset(AccountsController):
 			"Receipt",
 			"Capitalized",
 			"Decapitalized",
-			"Work in Progress",
+			"Work In Progress",
 		]
 		supplier: DF.Link | None
 		total_asset_cost: DF.Currency

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -112,6 +112,7 @@ class Asset(AccountsController):
 			"Receipt",
 			"Capitalized",
 			"Decapitalized",
+			"Work in Progress",
 		]
 		supplier: DF.Link | None
 		total_asset_cost: DF.Currency

--- a/erpnext/assets/doctype/asset/asset_list.js
+++ b/erpnext/assets/doctype/asset/asset_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings["Asset"] = {
-	add_fields: ["status"],
+	add_fields: ["status", "docstatus"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status === "Fully Depreciated") {
 			return [__("Fully Depreciated"), "green", "status,=,Fully Depreciated"];
@@ -7,6 +8,8 @@ frappe.listview_settings["Asset"] = {
 			return [__("Partially Depreciated"), "grey", "status,=,Partially Depreciated"];
 		} else if (doc.status === "Sold") {
 			return [__("Sold"), "green", "status,=,Sold"];
+		} else if (doc.status === "Work in Progress") {
+			return [__("Work in Progress"), "orange", "status,=,Work in Progress"];
 		} else if (["Capitalized", "Decapitalized"].includes(doc.status)) {
 			return [__(doc.status), "grey", "status,=," + doc.status];
 		} else if (doc.status === "Scrapped") {
@@ -21,7 +24,7 @@ frappe.listview_settings["Asset"] = {
 			return [__("Receipt"), "green", "status,=,Receipt"];
 		} else if (doc.status === "Submitted") {
 			return [__("Submitted"), "blue", "status,=,Submitted"];
-		} else if (doc.status === "Draft") {
+		} else if (doc.status === "Draft" || doc.docstatus === 0) {
 			return [__("Draft"), "red", "status,=,Draft"];
 		}
 	},

--- a/erpnext/assets/doctype/asset/asset_list.js
+++ b/erpnext/assets/doctype/asset/asset_list.js
@@ -8,8 +8,8 @@ frappe.listview_settings["Asset"] = {
 			return [__("Partially Depreciated"), "grey", "status,=,Partially Depreciated"];
 		} else if (doc.status === "Sold") {
 			return [__("Sold"), "green", "status,=,Sold"];
-		} else if (doc.status === "Work in Progress") {
-			return [__("Work in Progress"), "orange", "status,=,Work in Progress"];
+		} else if (doc.status === "Work In Progress") {
+			return [__("Work In Progress"), "orange", "status,=,Work In Progress"];
 		} else if (["Capitalized", "Decapitalized"].includes(doc.status)) {
 			return [__(doc.status), "grey", "status,=," + doc.status];
 		} else if (doc.status === "Scrapped") {

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1752,6 +1752,10 @@ def create_asset(**args):
 			},
 		)
 
+	if asset.is_composite_asset:
+		asset.gross_purchase_amount = 0
+		asset.purchase_amount = 0
+
 	if not args.do_not_save:
 		try:
 			asset.insert(ignore_if_duplicate=True)

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -639,6 +639,7 @@ class AssetCapitalization(StockController):
 		self.target_fixed_asset_account = get_asset_category_account(
 			"fixed_asset_account", item=self.target_item_code, company=asset_doc.company
 		)
+		asset_doc.set_status("Work in Progress")
 
 		add_asset_activity(
 			asset_doc.name,
@@ -663,8 +664,9 @@ class AssetCapitalization(StockController):
 		total_target_asset_value = flt(self.total_value, self.precision("total_value"))
 
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
-		asset_doc.gross_purchase_amount = total_target_asset_value
-		asset_doc.purchase_amount = total_target_asset_value
+		asset_doc.gross_purchase_amount += total_target_asset_value
+		asset_doc.purchase_amount += total_target_asset_value
+		asset_doc.set_status("Work in Progress")
 		asset_doc.flags.ignore_validate = True
 		asset_doc.save()
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -639,7 +639,7 @@ class AssetCapitalization(StockController):
 		self.target_fixed_asset_account = get_asset_category_account(
 			"fixed_asset_account", item=self.target_item_code, company=asset_doc.company
 		)
-		asset_doc.set_status("Work in Progress")
+		asset_doc.set_status("Work In Progress")
 
 		add_asset_activity(
 			asset_doc.name,
@@ -666,7 +666,7 @@ class AssetCapitalization(StockController):
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 		asset_doc.gross_purchase_amount += total_target_asset_value
 		asset_doc.purchase_amount += total_target_asset_value
-		asset_doc.set_status("Work in Progress")
+		asset_doc.set_status("Work In Progress")
 		asset_doc.flags.ignore_validate = True
 		asset_doc.save()
 

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -96,6 +96,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
 		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
+		self.assertEqual(target_asset.status, "Work In Progress")
 
 		# Test Consumed Asset values
 		self.assertEqual(consumed_asset.db_get("status"), "Capitalized")
@@ -270,6 +271,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
 		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
+		self.assertEqual(target_asset.status, "Work In Progress")
 
 		# Test General Ledger Entries
 		expected_gle = {

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -13,6 +13,7 @@ from frappe.utils import (
 	flt,
 	get_first_day,
 	get_last_day,
+	get_link_to_form,
 	getdate,
 	is_last_day_of_the_month,
 	month_diff,
@@ -1062,7 +1063,7 @@ def make_new_active_asset_depr_schedules_and_cancel_current_ones(
 		if not current_asset_depr_schedule_doc:
 			frappe.throw(
 				_("Asset Depreciation Schedule not found for Asset {0} and Finance Book {1}").format(
-					asset_doc.name, row.finance_book
+					get_link_to_form("Asset", asset_doc.name), row.finance_book
 				)
 			)
 
@@ -1108,7 +1109,7 @@ def get_temp_asset_depr_schedule_doc(
 	if not current_asset_depr_schedule_doc:
 		frappe.throw(
 			_("Asset Depreciation Schedule not found for Asset {0} and Finance Book {1}").format(
-				asset_doc.name, row.finance_book
+				get_link_to_form("Asset", asset_doc.name), row.finance_book
 			)
 		)
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -394,3 +394,4 @@ erpnext.patches.v14_0.update_stock_uom_in_work_order_item
 erpnext.patches.v15_0.enable_allow_existing_serial_no
 erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts
 erpnext.patches.v15_0.refactor_closing_stock_balance #5
+erpnext.patches.v15_0.update_asset_status_to_work_in_progress

--- a/erpnext/patches/v15_0/update_asset_status_to_work_in_progress.py
+++ b/erpnext/patches/v15_0/update_asset_status_to_work_in_progress.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	Asset = frappe.qb.DocType("Asset")
+	query = (
+		frappe.qb.update(Asset)
+		.set(Asset.status, "Work In Progress")
+		.where((Asset.docstatus == 0) & (Asset.is_composite_asset == 1))
+	)
+	query.run()


### PR DESCRIPTION
The asset status will now display "Work In Progress" for assets that are not yet ready for use and are still under development.

<img width="1391" alt="Screenshot 2025-01-06 at 2 26 08 PM" src="https://github.com/user-attachments/assets/2965a268-8302-45e2-bc6a-3c90af7bf59a" />


`no-docs`
