### PR TITLE
ci: Reduce one container for parallel tests

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2, 3, 4]
+        container: [1, 2, 3]
 
     name: Python Unit Tests
 


### PR DESCRIPTION
Multiple random changes later, tests are 1.67x faster. No need to waste
4 containers now.

![image](https://github.com/user-attachments/assets/b82a2be7-3fd1-40fd-8658-9fadebf7e41f)
