### PR TITLE
fix: set billing and shipping address on change of company

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -157,10 +157,13 @@ erpnext.buying = {
 				if(!frappe.meta.has_field(this.frm.doc.doctype, "billing_address")) return;
 
 				frappe.call({
-					method: "erpnext.setup.doctype.company.company.get_default_company_address",
+					method: "erpnext.setup.doctype.company.company.get_billing_shipping_address",
 					args: { name: this.frm.doc.company, existing_address:this.frm.doc.billing_address },
 					callback: (r) => {
-						this.frm.set_value("billing_address", r.message || "");
+						this.frm.set_value("billing_address", r.message.primary_address || "");
+
+						if(!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) return;
+						this.frm.set_value("shipping_address", r.message.shipping_address || "");
 					},
 				});
 			}

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -158,7 +158,11 @@ erpnext.buying = {
 
 				frappe.call({
 					method: "erpnext.setup.doctype.company.company.get_billing_shipping_address",
-					args: { name: this.frm.doc.company, existing_address:this.frm.doc.billing_address },
+					args: {
+						name: this.frm.doc.company,
+						billing_address:this.frm.doc.billing_address,
+						shipping_address: this.frm.doc.shipping_address
+					},
 					callback: (r) => {
 						this.frm.set_value("billing_address", r.message.primary_address || "");
 

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -910,6 +910,14 @@ def get_default_company_address(name, sort_key="is_primary_address", existing_ad
 
 
 @frappe.whitelist()
+def get_billing_shipping_address(name, existing_address=None):
+	primart_address = get_default_company_address(name, "is_primary_address", existing_address)
+	shipping_address = get_default_company_address(name, "is_shipping_address", existing_address)
+
+	return {"primary_address": primart_address, "shipping_address": shipping_address}
+
+
+@frappe.whitelist()
 def create_transaction_deletion_request(company):
 	from erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record import (
 		is_deletion_doc_running,

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -910,11 +910,11 @@ def get_default_company_address(name, sort_key="is_primary_address", existing_ad
 
 
 @frappe.whitelist()
-def get_billing_shipping_address(name, existing_address=None):
-	primart_address = get_default_company_address(name, "is_primary_address", existing_address)
-	shipping_address = get_default_company_address(name, "is_shipping_address", existing_address)
+def get_billing_shipping_address(name, billing_address=None, shipping_address=None):
+	primary_address = get_default_company_address(name, "is_primary_address", billing_address)
+	shipping_address = get_default_company_address(name, "is_shipping_address", shipping_address)
 
-	return {"primary_address": primart_address, "shipping_address": shipping_address}
+	return {"primary_address": primary_address, "shipping_address": shipping_address}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Issue: [Support Ticket  - 20620](https://support.frappe.io/helpdesk/tickets/20620)

In the Purchase Invoice, the shipping address was not updating when the company was changed.