### PR TITLE
fix: don't create invoice if `current_invoice_start ` is in future

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -697,7 +697,7 @@ class Subscription(Document):
 		self.status = "Cancelled"
 		self.cancelation_date = nowdate()
 
-		if to_generate_invoice and nowdate() >= self.current_invoice_start:
+		if to_generate_invoice and self.cancelation_date >= self.current_invoice_start:
 			self.generate_invoice(self.current_invoice_start, self.cancelation_date)
 
 		self.save()

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -697,7 +697,7 @@ class Subscription(Document):
 		self.status = "Cancelled"
 		self.cancelation_date = nowdate()
 
-		if to_generate_invoice:
+		if to_generate_invoice and nowdate() >= self.current_invoice_start:
 			self.generate_invoice(self.current_invoice_start, self.cancelation_date)
 
 		self.save()


### PR DESCRIPTION
Issue: [Support Ticket  - 27883](https://support.frappe.io/helpdesk/tickets/27883)

If `current_invoice_start` is in the future, then we don't need to create an invoice.