### PR TITLE
fix: show new button in coa if create access

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -237,19 +237,22 @@ frappe.treeview_settings["Account"] = {
 	},
 	post_render: function (treeview) {
 		frappe.treeview_settings["Account"].treeview["tree"] = treeview.tree;
-		treeview.page.set_primary_action(
-			__("New"),
-			function () {
-				let root_company = treeview.page.fields_dict.root_company.get_value();
-
-				if (root_company) {
-					frappe.throw(__("Please add the account to root level Company - {0}"), [root_company]);
-				} else {
-					treeview.new_node();
-				}
-			},
-			"add"
-		);
+		if (treeview.can_create) {
+			treeview.page.set_primary_action(
+				__("New"),
+				function () {
+					let root_company = treeview.page.fields_dict.root_company.get_value();
+					if (root_company) {
+						frappe.throw(__("Please add the account to root level Company - {0}"), [
+							root_company,
+						]);
+					} else {
+						treeview.new_node();
+					}
+				},
+				"add"
+			);
+		}
 	},
 	toolbar: [
 		{


### PR DESCRIPTION
If user has a role where he/she only has read access the new button in coa was shown and but when actual submission happened it was not allowed 
![Alt text](https://support.frappe.io/files/7wPDI8U.png "a title")

But not showing the button if no create access is the correct way to go
<img width="1392" alt="Screenshot 2025-01-06 at 12 34 49 PM" src="https://github.com/user-attachments/assets/36911453-753e-4ceb-8d70-641d8838d8f7" />

For Frappe Team: 
Support ticket https://support.frappe.io/helpdesk/tickets/28447
