### PR TITLE
fix: use currency defined in plan for subscription invoice

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -415,7 +415,6 @@ class Subscription(Document):
 				invoice.apply_tds = 1
 
 		# Add currency to invoice
-		# We have already validated default currency
 		invoice.currency = frappe.db.get_value("Subscription Plan", {"name": self.plans[0].plan}, "currency")
 
 		# Add dimensions in invoice for subscription:

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -414,8 +414,9 @@ class Subscription(Document):
 			if frappe.db.get_value("Supplier", self.party, "tax_withholding_category"):
 				invoice.apply_tds = 1
 
-		# Add party currency to invoice
-		invoice.currency = get_party_account_currency(self.party_type, self.party, self.company)
+		# Add currency to invoice
+		# We have already validated default currency
+		invoice.currency = frappe.db.get_value("Subscription Plan", {"name": self.plans[0].plan}, "currency")
 
 		# Add dimensions in invoice for subscription:
 		accounting_dimensions = get_accounting_dimensions()

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -483,7 +483,7 @@ class TestSubscription(IntegrationTestCase):
 		"Accounts Settings",
 		{"allow_multi_currency_invoices_against_single_party_account": 1},
 	)
-	def test_multi_currency_subscription_with_defalut_company_currency(self):
+	def test_multi_currency_subscription_with_default_company_currency(self):
 		party = "Test Subscription Customer Multi Currency"
 		frappe.db.set_value("Customer", party, "default_currency", "USD")
 		subscription = create_subscription(

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -479,6 +479,28 @@ class TestSubscription(IntegrationTestCase):
 		currency = frappe.db.get_value("Sales Invoice", subscription.invoices[0].name, "currency")
 		self.assertEqual(currency, "USD")
 
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings",
+		{"allow_multi_currency_invoices_against_single_party_account": 1},
+	)
+	def test_multi_currency_subscription_with_defalut_company_currency(self):
+		party = "Test Subscription Customer Multi Currency"
+		frappe.db.set_value("Customer", party, "default_currency", "USD")
+		subscription = create_subscription(
+			start_date="2018-01-01",
+			generate_invoice_at="Beginning of the current subscription period",
+			plans=[{"plan": "_Test Plan Multicurrency", "qty": 1, "currency": "USD"}],
+			party=party,
+		)
+
+		subscription.process(posting_date="2018-01-01")
+		self.assertEqual(len(subscription.invoices), 1)
+		self.assertEqual(subscription.status, "Unpaid")
+
+		# Check the currency of the created invoice
+		currency = frappe.db.get_value("Sales Invoice", subscription.invoices[0].name, "currency")
+		self.assertEqual(currency, "USD")
+
 	def test_subscription_recovery(self):
 		"""Test if Subscription recovers when start/end date run out of sync with created invoices."""
 		subscription = create_subscription(
@@ -588,6 +610,12 @@ def create_parties():
 		customer.customer_name = "_Test Subscription Customer"
 		customer.default_currency = "USD"
 		customer.append("accounts", {"company": "_Test Company", "account": "_Test Receivable USD - _TC"})
+		customer.insert()
+
+	if not frappe.db.exists("Customer", "_Test Subscription Customer Multi Currency"):
+		customer = frappe.new_doc("Customer")
+		customer.customer_name = "Test Subscription Customer Multi Currency"
+		customer.default_currency = "USD"
 		customer.insert()
 
 	if not frappe.db.exists("Customer", "_Test Subscription Customer John Doe"):


### PR DESCRIPTION
Issue: Subscription Invoice is not based on plan currency.

Steps to replicate:

- Allow "allow_multi_currency_invoices_against_single_party_account" from account settings.
- Create a customer with defualt_billing_currency that is different from Company Currency.
- Create a Subscription Plan in Customer Currency.
- Create a Subscription.

The invoice will be in company default receivable account currency because no default account is set in the Party.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/28511

backport-version-15
backport-version-14
