### PR TITLE
fix: Missing company filter breaks `get_account_balance` in Bank Reco

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -120,6 +120,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 				args: {
 					bank_account: frm.doc.bank_account,
 					till_date: frappe.datetime.add_days(frm.doc.bank_statement_from_date, -1),
+					company: frm.doc.company,
 				},
 				callback: (response) => {
 					frm.set_value("account_opening_balance", response.message);
@@ -135,6 +136,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 				args: {
 					bank_account: frm.doc.bank_account,
 					till_date: frm.doc.bank_statement_to_date,
+					company: frm.doc.company,
 				},
 				callback: (response) => {
 					frm.cleared_balance = response.message;

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -5,6 +5,11 @@
 import json
 
 import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.query_builder.custom import ConstantColumn
+from frappe.utils import cint, flt
+
 from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_total_allocated_amount
 from erpnext.accounts.party import get_party_account
@@ -14,10 +19,6 @@ from erpnext.accounts.report.bank_reconciliation_statement.bank_reconciliation_s
 )
 from erpnext.accounts.utils import get_account_currency, get_balance_on
 from erpnext.setup.utils import get_exchange_rate
-from frappe import _
-from frappe.model.document import Document
-from frappe.query_builder.custom import ConstantColumn
-from frappe.utils import cint, flt
 
 
 class BankReconciliationTool(Document):

--- a/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
@@ -16,7 +16,7 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 	}
 
 	make_dt() {
-		var me = this;
+		const me = this;
 		frappe.call({
 			method: "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_bank_transactions",
 			args: {
@@ -193,6 +193,7 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 				args: {
 					bank_account: this.bank_account,
 					till_date: this.bank_statement_to_date,
+					company: this.company,
 				},
 				callback: (response) => (this.cleared_balance = response.message),
 			});


### PR DESCRIPTION
## Issue:

Introduced via https://github.com/frappe/erpnext/pull/44943

<img width="1492" alt="Screenshot 2025-01-06 at 8 31 02 PM" src="https://github.com/user-attachments/assets/8907775c-dce5-40c6-af15-67dd981702db" />

### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 117, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 92, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1721, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py", line 86, in get_account_balance
    data = get_entries(filters)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py", line 113, in get_entries
    entries += frappe.get_attr(method_name)(filters) or []
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py", line 122, in get_entries_for_bank_reconciliation_statement
    journal_entries = get_journal_entries(filters)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py", line 134, in get_journal_entries
    return frappe.db.sql(
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 238, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 151, in execute
    query = self.mogrify(query, args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 129, in mogrify
    query = query % self._escape_args(args, conn)
            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
KeyError: 'company'

```

## Fix

`get_account_balance` -> `get_entries` -> `get_entries_for_bank_reconciliation_statement` -> `get_journal_entries` requires `company`

> Miscellanous changes mostly by pre-commit