### PR TITLE
fix: picked qty continuation

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -766,7 +766,7 @@ def get_items_with_location_and_quantity(item_doc, item_location_map, docstatus)
 			qty = floor(qty)
 			stock_qty = qty * item_doc.conversion_factor
 			if not stock_qty:
-				break
+				continue
 
 		serial_nos = None
 		if item_location.serial_nos:


### PR DESCRIPTION
### Fix: Correctly Handle Zero Stock Quantity in Pick List Location Logic  

**Description**  
Previously, the logic incorrectly used the `break` statement when the `stock_qty` was zero. This caused the system to stop processing further locations and prevented the pick list location table from being fully populated.  

The fix replaces the `break` statement with `continue`, allowing the system to skip the current iteration and continue processing remaining locations.  

**Impact**  
- Ensures that the pick list location table is correctly filled with all available item data.  
- Improves the accuracy of pick list generation, particularly in cases where stock quantities fluctuate.  

**Changes**  
- Replaced `break` with `continue` in the `get_items_with_location_and_quantity` function.  

**Testing**  
- Verified that pick list generation now correctly populates all item data.  
- Tested with various scenarios, including zero and non-zero stock quantities, and confirmed expected behavior.  