### PR TITLE
fix: update fields on change of item code In `Update Items` of `Sales Order`

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -713,10 +713,10 @@ erpnext.utils.update_child_items = function (opts) {
 							);
 							if (row) {
 								Object.assign(row, {
-									conversion_factor: me.doc.conversion_factor || conversion_factor,
-									uom: me.doc.uom || uom,
-									qty: me.doc.qty || qty,
-									rate: me.doc.rate || rate,
+									conversion_factor: conversion_factor,
+									uom: uom,
+									qty: qty,
+									rate: rate,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -713,10 +713,10 @@ erpnext.utils.update_child_items = function (opts) {
 							);
 							if (row) {
 								Object.assign(row, {
-									conversion_factor: conversion_factor,
-									uom: uom,
-									qty: qty,
-									rate: rate,
+									conversion_factor: me.doc.conversion_factor || conversion_factor,
+									uom: me.doc.uom || uom,
+									qty: me.doc.qty || qty,
+									rate: me.doc.rate || rate,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -670,7 +670,6 @@ erpnext.utils.update_child_items = function (opts) {
 			},
 			onchange: function () {
 				const me = this;
-				const row_index = me.doc.idx;
 
 				frm.call({
 					method: "erpnext.stock.get_item_details.get_item_details",
@@ -710,7 +709,7 @@ erpnext.utils.update_child_items = function (opts) {
 							const { qty, price_list_rate: rate, uom, conversion_factor } = r.message;
 
 							const row = dialog.fields_dict.trans_items.df.data.find(
-								(doc) => doc.idx == row_index
+								(doc) => doc.idx == me.doc.idx
 							);
 							if (row) {
 								Object.assign(row, {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -668,6 +668,63 @@ erpnext.utils.update_child_items = function (opts) {
 					filters: filters,
 				};
 			},
+			onchange: function () {
+				const me = this;
+				const row_index = me.doc.idx;
+
+				frm.call({
+					method: "erpnext.stock.get_item_details.get_item_details",
+					args: {
+						doc: frm.doc,
+						ctx: {
+							item_code: this.value,
+							set_warehouse: frm.doc.set_warehouse,
+							customer: frm.doc.customer || frm.doc.party_name,
+							quotation_to: frm.doc.quotation_to,
+							supplier: frm.doc.supplier,
+							currency: frm.doc.currency,
+							is_internal_supplier: frm.doc.is_internal_supplier,
+							is_internal_customer: frm.doc.is_internal_customer,
+							conversion_rate: frm.doc.conversion_rate,
+							price_list: frm.doc.selling_price_list || frm.doc.buying_price_list,
+							price_list_currency: frm.doc.price_list_currency,
+							plc_conversion_rate: frm.doc.plc_conversion_rate,
+							company: frm.doc.company,
+							order_type: frm.doc.order_type,
+							is_pos: cint(frm.doc.is_pos),
+							is_return: cint(frm.doc.is_return),
+							is_subcontracted: frm.doc.is_subcontracted,
+							ignore_pricing_rule: frm.doc.ignore_pricing_rule,
+							doctype: frm.doc.doctype,
+							name: frm.doc.name,
+							qty: me.doc.qty || 1,
+							uom: me.doc.uom,
+							pos_profile: cint(frm.doc.is_pos) ? frm.doc.pos_profile : "",
+							tax_category: frm.doc.tax_category,
+							child_doctype: frm.doc.doctype + " Item",
+							is_old_subcontracting_flow: frm.doc.is_old_subcontracting_flow,
+						},
+					},
+					callback: function (r) {
+						if (r.message) {
+							const { qty, price_list_rate: rate, uom, conversion_factor } = r.message;
+
+							const row = dialog.fields_dict.trans_items.df.data.find(
+								(doc) => doc.idx == row_index
+							);
+							if (row) {
+								Object.assign(row, {
+									conversion_factor: me.doc.conversion_factor || conversion_factor,
+									uom: me.doc.uom || uom,
+									qty: me.doc.qty || qty,
+									rate: me.doc.rate || rate,
+								});
+								dialog.fields_dict.trans_items.grid.refresh();
+							}
+						}
+					},
+				});
+			},
 		},
 		{
 			fieldtype: "Link",


### PR DESCRIPTION
Issue: [Support Ticket  - 28625](https://support.frappe.io/helpdesk/tickets/28625)

**Depends on Frappe Fix** : Currently, this.doc is not updating correctly after one update.
As Shown in screenshot on change of 3rd row this.doc contains value for last row that was added.
<img width="734" alt="Screenshot 2025-01-07 at 11 38 15 AM" src="https://github.com/user-attachments/assets/64903a84-55bc-48d8-992f-343ba7208812" />


**What This PR Does**
This PR addresses the support issue of updating the rate and other fields if they are already set for the items, but due to a Frappe bug where doc.idx does not update correctly for multiple rows, the functionality currently works for a single row only. Once the Frappe fix is implemented, it will work perfectly for all rows.

Additionally, due to this same bug, the UOM update functionality, which is already written, is also not functioning correctly for multiple rows.