### PR TITLE
refactor: validate due date code and message according to doctype

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -621,34 +621,41 @@ def get_due_date_from_template(template_name, posting_date, bill_date):
 	return due_date
 
 
-def validate_due_date(posting_date, due_date, bill_date=None, template_name=None):
+def validate_due_date(posting_date, due_date, bill_date=None, template_name=None, doctype=None):
 	if getdate(due_date) < getdate(posting_date):
-		frappe.throw(_("Due Date cannot be before Posting / Supplier Invoice Date"))
+		doctype_date = "Date"
+		if doctype == "Purchase Invoice":
+			doctype_date = "Supplier Invoice Date"
+
+		if doctype == "Sales Invoice":
+			doctype_date = "Posting Date"
+
+		frappe.throw(_("Due Date cannot be before {0}").format(doctype_date))
 	else:
-		if not template_name:
-			return
+		validate_due_date_with_template(posting_date, due_date, bill_date, template_name)
 
-		default_due_date = get_due_date_from_template(template_name, posting_date, bill_date).strftime(
-			"%Y-%m-%d"
+
+def validate_due_date_with_template(posting_date, due_date, bill_date, template_name):
+	if not template_name:
+		return
+
+	default_due_date = format(get_due_date_from_template(template_name, posting_date, bill_date))
+
+	if not default_due_date:
+		return
+
+	if default_due_date != posting_date and getdate(due_date) > getdate(default_due_date):
+		is_credit_controller = (
+			frappe.db.get_single_value("Accounts Settings", "credit_controller") in frappe.get_roles()
 		)
-
-		if not default_due_date:
-			return
-
-		if default_due_date != posting_date and getdate(due_date) > getdate(default_due_date):
-			is_credit_controller = (
-				frappe.db.get_single_value("Accounts Settings", "credit_controller") in frappe.get_roles()
+		if is_credit_controller:
+			msgprint(
+				_("Note: Due Date exceeds allowed customer credit days by {0} day(s)").format(
+					date_diff(due_date, default_due_date)
+				)
 			)
-			if is_credit_controller:
-				msgprint(
-					_("Note: Due / Reference Date exceeds allowed customer credit days by {0} day(s)").format(
-						date_diff(due_date, default_due_date)
-					)
-				)
-			else:
-				frappe.throw(
-					_("Due / Reference Date cannot be after {0}").format(formatdate(default_due_date))
-				)
+		else:
+			frappe.throw(_("Due Date cannot be after {0}").format(formatdate(default_due_date)))
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -672,9 +672,6 @@ class AccountsController(TransactionBase):
 			self.due_date = posting_date
 
 		elif self.doctype in ["Sales Invoice", "Purchase Invoice"]:
-			if self.doctype == "Sales Invoice" and not self.due_date:
-				frappe.throw(_("Due Date is mandatory"))
-
 			bill_date = self.bill_date if self.doctype == "Purchase Invoice" else None
 
 			validate_due_date(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -676,16 +676,18 @@ class AccountsController(TransactionBase):
 				frappe.throw(_("Due Date is mandatory"))
 
 			validate_due_date(
-				posting_date,
-				self.due_date,
-				self.payment_terms_template,
+				posting_date=posting_date,
+				due_date=self.due_date,
+				template_name=self.payment_terms_template,
+				doctype=self.doctype,
 			)
 		elif self.doctype == "Purchase Invoice":
 			validate_due_date(
-				posting_date,
-				self.due_date,
-				self.bill_date,
-				self.payment_terms_template,
+				posting_date=posting_date,
+				due_date=self.due_date,
+				bill_date=self.bill_date,
+				template_name=self.payment_terms_template,
+				doctype=self.doctype,
 			)
 
 	def set_price_list_currency(self, buying_or_selling):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -671,21 +671,16 @@ class AccountsController(TransactionBase):
 		if frappe.flags.in_import and getdate(self.due_date) < getdate(posting_date):
 			self.due_date = posting_date
 
-		elif self.doctype == "Sales Invoice":
-			if not self.due_date:
+		elif self.doctype in ["Sales Invoice", "Purchase Invoice"]:
+			if self.doctype == "Sales Invoice" and not self.due_date:
 				frappe.throw(_("Due Date is mandatory"))
+
+			bill_date = self.bill_date if self.doctype == "Purchase Invoice" else None
 
 			validate_due_date(
 				posting_date=posting_date,
 				due_date=self.due_date,
-				template_name=self.payment_terms_template,
-				doctype=self.doctype,
-			)
-		elif self.doctype == "Purchase Invoice":
-			validate_due_date(
-				posting_date=posting_date,
-				due_date=self.due_date,
-				bill_date=self.bill_date,
+				bill_date=bill_date,
 				template_name=self.payment_terms_template,
 				doctype=self.doctype,
 			)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1040,6 +1040,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	due_date() {
 		// due_date is to be changed, payment terms template and/or payment schedule must
 		// be removed as due_date is automatically changed based on payment terms
+
+		// if there is only one row in payment schedule child table, set its due date as the due date
+		if (this.frm.doc.payment_schedule.length == 1){
+			this.frm.doc.payment_schedule[0].due_date = this.frm.doc.due_date;
+			this.frm.refresh_field("payment_schedule");
+			return
+		}
+
 		if (
 			this.frm.doc.due_date &&
 			!this.frm.updating_party_details &&


### PR DESCRIPTION
Closes #44998 

> Changes in PR:

- Changed function arguments to named arguments.
- Added a doctype parameter and displayed a message based on the doctype.
- If there is only one row in the payment schedule child table, set its due date to the parent due date

> Screenshots/GIFs

- Sales Invoice
![image](https://github.com/user-attachments/assets/f419a3b7-177d-472c-abef-00a42b27bd4f)

- Purchase Invoice
![image](https://github.com/user-attachments/assets/2e27bc87-afaf-4b97-b330-3d5605b94f31)
