### PR TITLE
refactor: change sales invoice button position

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -993,47 +993,51 @@ frappe.ui.form.on("Sales Invoice", {
 
 	refresh: function (frm) {
 		if (frm.doc.docstatus === 0 && !frm.doc.is_return) {
-			frm.add_custom_button(__("Fetch Timesheet"), function () {
-				let d = new frappe.ui.Dialog({
-					title: __("Fetch Timesheet"),
-					fields: [
-						{
-							label: __("From"),
-							fieldname: "from_time",
-							fieldtype: "Date",
-							reqd: 1,
+			frm.add_custom_button(
+				__("Timesheet"),
+				function () {
+					let d = new frappe.ui.Dialog({
+						title: __("Fetch Timesheet"),
+						fields: [
+							{
+								label: __("From"),
+								fieldname: "from_time",
+								fieldtype: "Date",
+								reqd: 1,
+							},
+							{
+								fieldtype: "Column Break",
+								fieldname: "col_break_1",
+							},
+							{
+								label: __("To"),
+								fieldname: "to_time",
+								fieldtype: "Date",
+								reqd: 1,
+							},
+							{
+								label: __("Project"),
+								fieldname: "project",
+								fieldtype: "Link",
+								options: "Project",
+								default: frm.doc.project,
+							},
+						],
+						primary_action: function () {
+							const data = d.get_values();
+							frm.events.add_timesheet_data(frm, {
+								from_time: data.from_time,
+								to_time: data.to_time,
+								project: data.project,
+							});
+							d.hide();
 						},
-						{
-							fieldtype: "Column Break",
-							fieldname: "col_break_1",
-						},
-						{
-							label: __("To"),
-							fieldname: "to_time",
-							fieldtype: "Date",
-							reqd: 1,
-						},
-						{
-							label: __("Project"),
-							fieldname: "project",
-							fieldtype: "Link",
-							options: "Project",
-							default: frm.doc.project,
-						},
-					],
-					primary_action: function () {
-						const data = d.get_values();
-						frm.events.add_timesheet_data(frm, {
-							from_time: data.from_time,
-							to_time: data.to_time,
-							project: data.project,
-						});
-						d.hide();
-					},
-					primary_action_label: __("Get Timesheets"),
-				});
-				d.show();
-			});
+						primary_action_label: __("Get Timesheets"),
+					});
+					d.show();
+				},
+				__("Get Items From")
+			);
 		}
 
 		if (frm.doc.is_debit_note) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -303,11 +303,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		const me = this;
-		if (!this.frm.is_new() && this.frm.doc.docstatus === 0 && frappe.model.can_create("Quality Inspection")) {
+		if (!this.frm.is_new() && this.frm.doc.docstatus === 0 && frappe.model.can_create("Quality Inspection") && this.frm.doc.update_stock) {
 			this.frm.add_custom_button(__("Quality Inspection(s)"), () => {
 				me.make_quality_inspection();
 			}, __("Create"));
-			this.frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
 
 		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)


### PR DESCRIPTION
Closes #44995 

## Change in PR

- Move the "Timesheet" button inside "Get Items From".
![image](https://github.com/user-attachments/assets/43bf4e46-dcd3-44f1-bec3-582e521f683b)

- Change the Create button from primary to secondary, as there is already a primary button when the form is not submitted, and show the "Quality Inspection" button only when "Update Stock" is checked.
![image](https://github.com/user-attachments/assets/f21466c7-4ff6-4f1e-90d7-76da96db23f7)


