### PR TITLE
fix: ignore crm deal in tax_rule search filter

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -681,7 +681,7 @@ def set_taxes(
 ):
 	from erpnext.accounts.doctype.tax_rule.tax_rule import get_party_details, get_tax_template
 
-	args = {party_type.lower(): party, "company": company}
+	args = {frappe.scrub(party_type): party, "company": company}
 
 	if tax_category:
 		args["tax_category"] = tax_category
@@ -701,10 +701,10 @@ def set_taxes(
 	else:
 		args.update(get_party_details(party, party_type))
 
-	if party_type in ("Customer", "Lead", "Prospect"):
+	if party_type in ("Customer", "Lead", "Prospect", "CRM Deal"):
 		args.update({"tax_type": "Sales"})
 
-		if party_type in ["Lead", "Prospect"]:
+		if party_type in ["Lead", "Prospect", "CRM Deal"]:
 			args["customer"] = None
 			del args[frappe.scrub(party_type)]
 	else:


### PR DESCRIPTION
**Issue:**
unable to create a quotation for CRM Deal
**ref:** [28505](https://support.frappe.io/helpdesk/tickets/28505)

**Before:**

https://github.com/user-attachments/assets/4c922650-b596-45cd-aca6-a119c1d17a52


**After:**

https://github.com/user-attachments/assets/0218f569-fa6c-4ae1-ba44-2576bbff1db0


**Backport needed for v15**