### PR TITLE
fix: check if tds deducted based on Purchase Taxes and Charges

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -71,6 +71,49 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		for d in reversed(invoices):
 			d.cancel()
 
+	def test_tds_with_account_changed(self):
+		frappe.db.set_value(
+			"Supplier", "Test TDS Supplier", "tax_withholding_category", "Multi Account TDS Category"
+		)
+		invoices = []
+
+		# create invoices for lower than single threshold tax rate
+		for _ in range(2):
+			pi = create_purchase_invoice(supplier="Test TDS Supplier")
+			pi.submit()
+			invoices.append(pi)
+
+		# create another invoice whose total when added to previously created invoice,
+		# surpasses cumulative threshhold
+		pi = create_purchase_invoice(supplier="Test TDS Supplier")
+		pi.submit()
+
+		# assert equal tax deduction on total invoice amount until now
+		self.assertEqual(pi.taxes_and_charges_deducted, 3000)
+		self.assertEqual(pi.grand_total, 7000)
+		invoices.append(pi)
+
+		# account changed
+
+		frappe.db.set_value(
+			"Tax Withholding Account",
+			{"parent": "Multi Account TDS Category"},
+			"account",
+			"_Test Account VAT - _TC",
+		)
+
+		# TDS should be on invoice only even thpugh account is changed
+		pi = create_purchase_invoice(supplier="Test TDS Supplier", rate=5000)
+		pi.submit()
+
+		# assert equal tax deduction on total invoice amount until now
+		self.assertEqual(pi.taxes_and_charges_deducted, 500)
+		invoices.append(pi)
+
+		# delete invoices to avoid clashing
+		for d in reversed(invoices):
+			d.cancel()
+
 	def test_single_threshold_tds(self):
 		invoices = []
 		frappe.db.set_value(
@@ -1069,6 +1112,16 @@ def create_tax_withholding_category_records():
 		single_threshold=5000,
 		cumulative_threshold=10000,
 		consider_party_ledger_amount=1,
+	)
+
+	create_tax_withholding_category(
+		category_name="Multi Account TDS Category",
+		rate=10,
+		from_date=from_date,
+		to_date=to_date,
+		account="TDS - _TC",
+		single_threshold=0,
+		cumulative_threshold=30000,
 	)
 
 

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -102,7 +102,7 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 			"_Test Account VAT - _TC",
 		)
 
-		# TDS should be on invoice only even thpugh account is changed
+		# TDS should be on invoice only even though account is changed
 		pi = create_purchase_invoice(supplier="Test TDS Supplier", rate=5000)
 		pi.submit()
 


### PR DESCRIPTION
Issue: When an account is changed in a Tax withholding account in the middle of period, Tax Deducted at Source (TDS) is deducted on all invoices, including those on which TDS has already been deducted.

Steps to Replicate:
- Create a Tax Withholding Category with a limit of 10,000 and rate = 10%.
- Create a supplier with the same Tax Withholding Category.
- Create a Purchase Invoice with an amount of ₹15,000. The expected TDS is ₹1,500 (calculated as ₹15,000 * 10%).
- Change the TDS Account in the Tax Withholding Category.
-  Create another Purchase Invoice with an amount of ₹10,000.

The TDS for the second invoice should be ₹1,000 (calculated as ₹10,000 * 10%). However, due to the current system logic, TDS is recalculated based on the new account change, resulting in a total deduction of ₹2,500 (calculated as (₹15,000 + ₹10,000) * 10%).


Proposed Solution:

- Utilize the "is_tax_withholding_account" checkbox in the Purchase Taxes and Charges table to determine if TDS has already been deducted.


Note: This field is only available in Purchase Taxes and Charges Table

Frappe Support Issue: 
https://support.frappe.io/app/hd-ticket/28665
https://support.frappe.io/app/hd-ticket/28660

backport-version-14
backport-version-15



