### PR TITLE
fix: Allow return with partial amount in POS Sales Invoice

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1019,26 +1019,20 @@ class calculate_taxes_and_totals:
 				else payment.base_amount
 			)
 
-		pending_amount = total_amount_to_pay - total_paid_amount
+		if abs(total_paid_amount) <= abs(total_amount_to_pay):
+			return
 
-		if pending_amount > 0:
-			default_mode_of_payment = frappe.db.get_value(
-				"POS Payment Method",
-				{"parent": self.doc.pos_profile, "default": 1},
-				["mode_of_payment"],
-				as_dict=1,
-			)
+		payment_status = True
 
-			if default_mode_of_payment:
-				self.doc.payments = []
-				self.doc.append(
-					"payments",
-					{
-						"mode_of_payment": default_mode_of_payment.mode_of_payment,
-						"amount": pending_amount,
-						"default": 1,
-					},
-				)
+		for payment in self.doc.get("payments"):
+			if payment.default and payment_status:
+				payment.amount = total_amount_to_pay
+				payment_status = False
+			else:
+				payment.amount = 0
+
+		if self.doc.payments and payment_status:
+			self.doc.payments[0].amount = total_amount_to_pay
 
 
 def get_itemised_tax_breakup_html(doc):

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -64,7 +64,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			&& this.frm.doc.is_pos
 			&& this.frm.doc.is_return
 		) {
-			this.set_total_amount_to_default_mop();
+			this.set_total_amount_to_default_mop(update_paid_amount);
 			this.calculate_paid_amount();
 		}
 
@@ -838,7 +838,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 	}
 
-	set_total_amount_to_default_mop() {
+	set_total_amount_to_default_mop(update_paid_amount) {
+		if (update_paid_amount === false) return;
+
 		let grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 		let base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
@@ -860,15 +862,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		}
 
-		this.frm.doc.payments.find(payment => {
-			if (payment.default) {
-				payment.amount = total_amount_to_pay;
-			} else {
-				payment.amount = 0
-			}
-		});
-
-		this.frm.refresh_fields();
+		this.set_default_payment(total_amount_to_pay, update_paid_amount);
 	}
 
 	set_default_payment(total_amount_to_pay, update_paid_amount) {
@@ -898,6 +892,10 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					frappe.model.set_value(data.doctype, data.name, "amount", 0.0);
 				}
 			});
+
+			if (payment_status) {
+				frappe.model.set_value(this.frm.doc.payments[0].doctype, this.frm.doc.payments[0].name, "amount", total_amount_to_pay);
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/043475aa-c1da-40f1-9738-ea6693a676f8

https://github.com/user-attachments/assets/00e71ef9-f1a3-4142-b1f1-c78324a05c47

Issues:
1. Not able modify the amount in Payments Table in POS returns.
2. While creating a return from a Sales Invoice where there is no row with default mode of payment in Payments Table, the default amount set is 0 instead of the -ve of the amount in Sales Invoice. https://support.frappe.io/helpdesk/tickets/26583
