### PR TITLE
fix: timeout error for work order

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -344,6 +344,9 @@ class JobCard(Document):
 		return overlap
 
 	def get_time_logs(self, args, doctype, open_job_cards=None):
+		if get_datetime(args.from_time) >= get_datetime(args.to_time):
+			args.to_time = add_to_date(args.from_time, minutes=args.remaining_time_in_mins)
+
 		jc = frappe.qb.DocType("Job Card")
 		jctl = frappe.qb.DocType(doctype)
 
@@ -389,8 +392,10 @@ class JobCard(Document):
 			else:
 				query = query.where(jc.name.isin(open_job_cards))
 
-		if doctype != "Job Card Time Log":
-			query = query.where(jc.total_time_in_mins == 0)
+		if doctype == "Job Card Time Log":
+			query = query.where(jc.docstatus < 2)
+		else:
+			query = query.where((jc.docstatus == 0) & (jc.total_time_in_mins == 0))
 
 		time_logs = query.run(as_dict=True)
 
@@ -447,7 +452,13 @@ class JobCard(Document):
 	def schedule_time_logs(self, row):
 		row.remaining_time_in_mins = row.time_in_mins
 		while row.remaining_time_in_mins > 0:
-			args = frappe._dict({"from_time": row.planned_start_time, "to_time": row.planned_end_time})
+			args = frappe._dict(
+				{
+					"from_time": row.planned_start_time,
+					"to_time": row.planned_end_time,
+					"remaining_time_in_mins": row.remaining_time_in_mins,
+				}
+			)
 
 			self.validate_overlap_for_workstation(args, row)
 			self.check_workstation_time(row)


### PR DESCRIPTION
Wrong picked time log for checking overlap causing the recursion due to which time out error was coming on submission of work order

<img width="773" alt="image" src="https://github.com/user-attachments/assets/ab8ed50f-1f6b-488c-98c3-8ff72cd9597f" />
