### PR TITLE
feat: add company level validation for accounting dimension

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.json
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.json
@@ -31,7 +31,8 @@
    "label": "Reference Document Type",
    "options": "DocType",
    "read_only_depends_on": "eval:!doc.__islocal",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -49,7 +50,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:05:56.890002",
+ "modified": "2025-01-09 11:27:24.617307",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounting Dimension",

--- a/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
@@ -8,6 +8,8 @@ from frappe.tests import IntegrationTestCase
 
 from erpnext.accounts.doctype.gl_entry.gl_entry import rename_gle_sle_docs
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.projects.doctype.project.test_project import make_project
 
 
 class TestGLEntry(IntegrationTestCase):
@@ -123,3 +125,15 @@ class TestGLEntry(IntegrationTestCase):
 				str(e),
 				"Party Type and Party can only be set for Receivable / Payable account_Test Account Cost for Goods Sold - _TC",
 			)
+
+	def test_company_validation_in_dimension(self):
+		si = create_sales_invoice(do_not_submit=True)
+		project = make_project({"project_name": "_Test Demo Project1", "company": "_Test Company 1"})
+		si.project = project.name
+		si.save()
+		self.assertRaises(frappe.ValidationError, si.submit)
+
+		si_1 = create_sales_invoice(do_not_submit=True)
+		si_1.items[0].project = project.name
+		si_1.save()
+		self.assertRaises(frappe.ValidationError, si_1.submit)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4294,6 +4294,7 @@ class TestSalesInvoice(IntegrationTestCase):
 		si = create_sales_invoice(do_not_submit=True)
 
 		project = frappe.new_doc("Project")
+		project.company = "_Test Company"
 		project.project_name = "Test Total Billed Amount"
 		project.save()
 

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -1472,32 +1472,32 @@ class TestAccountsController(IntegrationTestCase):
 
 		# Invoices
 		si1 = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_submit=True)
-		si1.department = "Management"
+		si1.department = "Management - _TC"
 		si1.save().submit()
 
 		si2 = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_submit=True)
-		si2.department = "Operations"
+		si2.department = "Operations - _TC"
 		si2.save().submit()
 
 		# Payments
 		cr_note1 = self.create_sales_invoice(qty=-1, conversion_rate=75, rate=1, do_not_save=True)
-		cr_note1.department = "Management"
+		cr_note1.department = "Management - _TC"
 		cr_note1.is_return = 1
 		cr_note1.save().submit()
 
 		cr_note2 = self.create_sales_invoice(qty=-1, conversion_rate=75, rate=1, do_not_save=True)
-		cr_note2.department = "Legal"
+		cr_note2.department = "Legal - _TC"
 		cr_note2.is_return = 1
 		cr_note2.save().submit()
 
 		pe1 = get_payment_entry(si1.doctype, si1.name)
 		pe1.references = []
-		pe1.department = "Research & Development"
+		pe1.department = "Research & Development - _TC"
 		pe1.save().submit()
 
 		pe2 = get_payment_entry(si1.doctype, si1.name)
 		pe2.references = []
-		pe2.department = "Management"
+		pe2.department = "Management - _TC"
 		pe2.save().submit()
 
 		je1 = self.create_journal_entry(
@@ -1510,7 +1510,7 @@ class TestAccountsController(IntegrationTestCase):
 		)
 		je1.accounts[0].party_type = "Customer"
 		je1.accounts[0].party = self.customer
-		je1.accounts[0].department = "Management"
+		je1.accounts[0].department = "Management - _TC"
 		je1.save().submit()
 
 		# assert dimension filter's result
@@ -1519,17 +1519,17 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertEqual(len(pr.invoices), 2)
 		self.assertEqual(len(pr.payments), 5)
 
-		pr.department = "Legal"
+		pr.department = "Legal - _TC"
 		pr.get_unreconciled_entries()
 		self.assertEqual(len(pr.invoices), 0)
 		self.assertEqual(len(pr.payments), 1)
 
-		pr.department = "Management"
+		pr.department = "Management - _TC"
 		pr.get_unreconciled_entries()
 		self.assertEqual(len(pr.invoices), 1)
 		self.assertEqual(len(pr.payments), 3)
 
-		pr.department = "Research & Development"
+		pr.department = "Research & Development - _TC"
 		pr.get_unreconciled_entries()
 		self.assertEqual(len(pr.invoices), 0)
 		self.assertEqual(len(pr.payments), 1)
@@ -1540,17 +1540,17 @@ class TestAccountsController(IntegrationTestCase):
 
 		# Invoice
 		si = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_submit=True)
-		si.department = "Management"
+		si.department = "Management - _TC"
 		si.save().submit()
 
 		# Payment
 		cr_note = self.create_sales_invoice(qty=-1, conversion_rate=75, rate=1, do_not_save=True)
-		cr_note.department = "Management"
+		cr_note.department = "Management - _TC"
 		cr_note.is_return = 1
 		cr_note.save().submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.department = "Management"
+		pr.department = "Management - _TC"
 		pr.get_unreconciled_entries()
 		self.assertEqual(len(pr.invoices), 1)
 		self.assertEqual(len(pr.payments), 1)
@@ -1582,7 +1582,7 @@ class TestAccountsController(IntegrationTestCase):
 		# Sales Invoice in Foreign Currency
 		self.setup_dimensions()
 		rate_in_account_currency = 1
-		dpt = "Research & Development"
+		dpt = "Research & Development - _TC"
 
 		si = self.create_sales_invoice(qty=1, rate=rate_in_account_currency, do_not_save=True)
 		si.department = dpt
@@ -1617,7 +1617,7 @@ class TestAccountsController(IntegrationTestCase):
 
 	def test_93_dimension_inheritance_on_advance(self):
 		self.setup_dimensions()
-		dpt = "Research & Development"
+		dpt = "Research & Development - _TC"
 
 		adv = self.create_payment_entry(amount=1, source_exc_rate=85)
 		adv.department = dpt

--- a/erpnext/projects/doctype/project/test_records.toml
+++ b/erpnext/projects/doctype/project/test_records.toml
@@ -1,4 +1,4 @@
 [[Project]]
 project_name = "_Test Project"
 status = "Open"
-
+company = "_Test Company"


### PR DESCRIPTION
Issue:
Accounting Dimension Validations are not happening as per Company

ref: [22387](https://support.frappe.io/helpdesk/tickets/22387)

Before:

[company_validation_bfr.webm](https://github.com/user-attachments/assets/abf8faa6-07a7-4d7a-8c89-4107765f202a)

After:

[company_validation_af.webm](https://github.com/user-attachments/assets/6badece1-449a-4e92-91d4-922765705eeb)

no-docs