### PR TITLE
fix: do not add ordered items from Quotation to new Sales Order

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -413,7 +413,11 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 		2. If selections: Is Alternative Item/Has Alternative Item: Map if selected and adequate qty
 		3. If selections: Simple row: Map if adequate qty
 		"""
-		has_qty = item.qty > 0
+		balance_qty = item.qty - ordered_items.get(item.item_code, 0.0)
+		if balance_qty <= 0:
+			return False
+
+		has_qty = balance_qty
 
 		if not selected_rows:
 			return not item.is_alternative

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -51,6 +51,38 @@ class TestQuotation(IntegrationTestCase):
 
 		self.assertTrue(sales_order.get("payment_schedule"))
 
+	def test_do_not_add_ordered_items_in_new_sales_order(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item = make_item("_Test Item for Quotation for SO", {"is_stock_item": 1})
+
+		quotation = make_quotation(qty=5, do_not_submit=True)
+		quotation.append(
+			"items",
+			{
+				"item_code": item.name,
+				"qty": 5,
+				"rate": 100,
+				"conversion_factor": 1,
+				"uom": item.stock_uom,
+				"warehouse": "_Test Warehouse - _TC",
+				"stock_uom": item.stock_uom,
+			},
+		)
+		quotation.submit()
+
+		sales_order = make_sales_order(quotation.name)
+		sales_order.delivery_date = nowdate()
+		self.assertEqual(len(sales_order.items), 2)
+		sales_order.remove(sales_order.items[1])
+		sales_order.submit()
+
+		sales_order = make_sales_order(quotation.name)
+		self.assertEqual(len(sales_order.items), 1)
+		self.assertEqual(sales_order.items[0].item_code, item.name)
+		self.assertEqual(sales_order.items[0].qty, 5.0)
+
 	def test_gross_profit(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry


### PR DESCRIPTION
**Issue**

- Create the sales Quotation with 2 line items 
- Create the sales order and remove the second line item
- Create another the sales order, here the 1st items should not add because against that item the sales order already created
- But system adds the already ordered items with zero quantity


https://github.com/user-attachments/assets/b7efd326-f634-458c-9346-04763df9c753





**After Fix**

https://github.com/user-attachments/assets/b68b19e5-bd77-4a1f-a5b8-05b61700a546


