### PR TITLE
fix: not able to see create Quality Inspection button

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -302,8 +302,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return;
 		}
 
+		let show_qc_button = true;
+		if (["Sales Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
+			show_qc_button = this.frm.doc.update_stock;
+		}
+
 		const me = this;
-		if (!this.frm.is_new() && this.frm.doc.docstatus === 0 && frappe.model.can_create("Quality Inspection") && this.frm.doc.update_stock) {
+		if (!this.frm.is_new() && this.frm.doc.docstatus === 0 && frappe.model.can_create("Quality Inspection") && show_qc_button) {
 			this.frm.add_custom_button(__("Quality Inspection(s)"), () => {
 				me.make_quality_inspection();
 			}, __("Create"));


### PR DESCRIPTION
Not able to see create Quality Inspection button in the purchase receipt

Regression https://github.com/frappe/erpnext/pull/45130/files#diff-d243a364bcb9beb99023ffabc45910291efeb15f16a9979abb782a3cad1f106cR306

![Screenshot 2025-01-09 at 2 31 33 PM](https://github.com/user-attachments/assets/89cca45d-ed5d-4bab-badf-4851852a1745)
