### PR TITLE
feat: BOM now explodes items based on both item_code AND item_name

### DIFF
--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -41,8 +41,9 @@ class TestBOM(IntegrationTestCase):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=0
 		)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
+		test_record = self.globalTestRecords["BOM"][2]["items"]
+		self.assertTrue((test_record[0]["item_code"], test_record[0]["item_code"]) in items_dict)
+		self.assertTrue((test_record[1]["item_code"], test_record[1]["item_code"]) in items_dict)
 		self.assertEqual(len(items_dict.values()), 2)
 
 	@timeout
@@ -52,10 +53,34 @@ class TestBOM(IntegrationTestCase):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=1
 		)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
-		self.assertFalse(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][1]["item_code"] in items_dict)
+		self.assertTrue(
+			(
+				self.globalTestRecords["BOM"][2]["items"][0]["item_code"],
+				self.globalTestRecords["BOM"][2]["items"][0]["item_code"],
+			)
+			in items_dict
+		)
+		self.assertFalse(
+			(
+				self.globalTestRecords["BOM"][2]["items"][1]["item_code"],
+				self.globalTestRecords["BOM"][2]["items"][1]["item_code"],
+			)
+			in items_dict
+		)
+		self.assertTrue(
+			(
+				self.globalTestRecords["BOM"][0]["items"][0]["item_code"],
+				self.globalTestRecords["BOM"][0]["items"][0]["item_code"],
+			)
+			in items_dict
+		)
+		self.assertTrue(
+			(
+				self.globalTestRecords["BOM"][0]["items"][1]["item_code"],
+				self.globalTestRecords["BOM"][0]["items"][1]["item_code"],
+			)
+			in items_dict
+		)
 		self.assertEqual(len(items_dict.values()), 3)
 
 	@timeout

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -765,7 +765,7 @@ class StockEntry(StockController):
 
 	def get_matched_items(self, item_code):
 		for row in self.items:
-			if row.item_code == item_code:
+			if (row.item_code, row.item_name) == item_code:
 				return row
 
 		return {}

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -448,7 +448,7 @@ class StockEntry(StockController):
 				for_update=True,
 			)
 
-			reset_fields = "stock_uom"
+			reset_fields = ["stock_uom"]
 			for field in reset_fields:
 				item.set(field, item_details.get(field))
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -448,7 +448,7 @@ class StockEntry(StockController):
 				for_update=True,
 			)
 
-			reset_fields = ("stock_uom", "item_name")
+			reset_fields = "stock_uom"
 			for field in reset_fields:
 				item.set(field, item_details.get(field))
 
@@ -2417,7 +2417,7 @@ class StockEntry(StockController):
 				if item_row["allow_alternative_item"]:
 					item_row["allow_alternative_item"] = work_order.allow_alternative_item
 
-				item_dict.setdefault(d.item_code, item_row)
+				item_dict.setdefault((d.item_code, d.item_name), item_row)
 
 		return item_dict
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -448,9 +448,9 @@ class StockEntry(StockController):
 				for_update=True,
 			)
 
-			reset_fields = ["stock_uom"]
-			for field in reset_fields:
-				item.set(field, item_details.get(field))
+			item.set("stock_uom", item_details.get("stock_uom"))
+			if not item.item_name:
+				item.set("item_name", item_details.get("item_name"))
 
 			update_fields = (
 				"uom",

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1453,11 +1453,9 @@ class TestStockEntry(IntegrationTestCase):
 		)
 
 		self.assertEqual(se.items[0].item_name, item.item_name)
-		se.items[0].item_name = "wat"
 		se.items[0].stock_uom = "Kg"
 		se.save()
 
-		self.assertEqual(se.items[0].item_name, item.item_name)
 		self.assertEqual(se.items[0].stock_uom, item.stock_uom)
 
 	@IntegrationTestCase.change_settings("Stock Reposting Settings", {"item_based_reposting": 0})


### PR DESCRIPTION
Reference issue: #44043 

Current behaviour:
Upon saving a BOM, exploded items were computed based on only the item_code. If 2 items with same item_code but different item_name were added, ERPNext would merge them into 1.

New behaviour:
Now when user saves a BOM, ERPNext will check if both item_code and item_name fields are same and only then merge them.

`no-docs`