### PR TITLE
fix: Skip WIP Warehouse transfer

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -884,9 +884,9 @@ class TestProductionPlan(IntegrationTestCase):
 		"""
 		from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 
-		make_stock_entry(item_code="_Test Item", target="Work In Progress - _TC", qty=2, basic_rate=100)
+		make_stock_entry(item_code="_Test Item", target="_Test Warehouse - _TC", qty=2, basic_rate=100)
 		make_stock_entry(
-			item_code="_Test Item Home Desktop 100", target="Work In Progress - _TC", qty=4, basic_rate=100
+			item_code="_Test Item Home Desktop 100", target="_Test Warehouse - _TC", qty=4, basic_rate=100
 		)
 
 		item = "_Test FG Item"
@@ -934,10 +934,10 @@ class TestProductionPlan(IntegrationTestCase):
 		from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 
 		make_stock_entry(
-			item_code="Raw Material Item 1", target="Work In Progress - _TC", qty=2, basic_rate=100
+			item_code="Raw Material Item 1", target="_Test Warehouse - _TC", qty=2, basic_rate=100
 		)
 		make_stock_entry(
-			item_code="Raw Material Item 2", target="Work In Progress - _TC", qty=2, basic_rate=100
+			item_code="Raw Material Item 2", target="_Test Warehouse - _TC", qty=2, basic_rate=100
 		)
 
 		pln = create_production_plan(item_code="Test Production Item 1", skip_getting_mr_items=True)
@@ -1634,7 +1634,6 @@ class TestProductionPlan(IntegrationTestCase):
 		for d in work_orders:
 			wo_doc = frappe.get_doc("Work Order", d.name)
 			wo_doc.skip_transfer = 1
-			wo_doc.from_wip_warehouse = 1
 
 			wo_doc.wip_warehouse = (
 				warehouse

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -724,7 +724,12 @@ class TestWorkOrder(IntegrationTestCase):
 				self.assertEqual(row.item_code, fg_item)
 
 		work_order = make_wo_order_test_record(
-			item=fg_item, skip_transfer=True, planned_start_date=now(), qty=30, do_not_save=True
+			item=fg_item,
+			skip_transfer=True,
+			source_warehouse="_Test Warehouse - _TC",
+			planned_start_date=now(),
+			qty=30,
+			do_not_save=True,
 		)
 		work_order.batch_size = 10
 		work_order.insert()
@@ -940,7 +945,6 @@ class TestWorkOrder(IntegrationTestCase):
 			bom_no=bom_no,
 			wip_warehouse=wip_warehouse,
 			qty=qty,
-			skip_transfer=1,
 			stock_uom=fg_item_non_whole.stock_uom,
 		)
 
@@ -2059,6 +2063,7 @@ class TestWorkOrder(IntegrationTestCase):
 		wo = make_wo_order_test_record(
 			production_item=fg_item,
 			bom_no=bom_doc.name,
+			source_warehouse="_Test Warehouse - _TC",
 			qty=1,
 			skip_transfer=1,
 		)
@@ -2112,6 +2117,7 @@ class TestWorkOrder(IntegrationTestCase):
 			production_item="Test Final FG Item",
 			qty=10,
 			use_multi_level_bom=1,
+			source_warehouse="_Test Warehouse - _TC",
 			skip_transfer=1,
 			from_wip_warehouse=1,
 		)

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -552,6 +552,13 @@ frappe.ui.form.on("Work Order", {
 		erpnext.work_order.calculate_cost(frm.doc);
 		erpnext.work_order.calculate_total_cost(frm);
 	},
+
+	skip_transfer: function (frm) {
+		if (frm.doc.skip_transfer) {
+			frm.set_value("wip_warehouse", null);
+			frm.refresh_field("wip_warehouse");
+		}
+	},
 });
 
 frappe.ui.form.on("Work Order Item", {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -168,6 +168,7 @@ class WorkOrder(Document):
 			validate_bom_no(self.production_item, self.bom_no)
 
 		self.validate_sales_order()
+		self.check_wip_warehouse_skip()
 		self.set_default_warehouse()
 		self.validate_warehouse_belongs_to_company()
 		self.calculate_operating_cost()
@@ -268,6 +269,10 @@ class WorkOrder(Document):
 			self.wip_warehouse = frappe.db.get_single_value("Manufacturing Settings", "default_wip_warehouse")
 		if not self.fg_warehouse:
 			self.fg_warehouse = frappe.db.get_single_value("Manufacturing Settings", "default_fg_warehouse")
+
+	def check_wip_warehouse_skip(self):
+		if self.skip_transfer:
+			self.wip_warehouse = None
 
 	def validate_warehouse_belongs_to_company(self):
 		warehouses = [self.fg_warehouse, self.wip_warehouse]

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1465,7 +1465,9 @@ def make_stock_entry(work_order_id, purpose, qty=None, target_warehouse=None):
 		stock_entry.to_warehouse = wip_warehouse
 		stock_entry.project = work_order.project
 	else:
-		stock_entry.from_warehouse = wip_warehouse
+		stock_entry.from_warehouse = (
+			wip_warehouse if not work_order.skip_transfer else work_order.source_warehouse
+		)
 		stock_entry.to_warehouse = work_order.fg_warehouse
 		stock_entry.project = work_order.project
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1704,7 +1704,6 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		wo_name = raise_work_orders(mr.name)[0]
 		wo = frappe.get_doc("Work Order", wo_name)
 		wo.wip_warehouse = "Work In Progress - _TC"
-		wo.skip_transfer = True
 
 		self.assertEqual(wo.sales_order, so.name)
 		self.assertEqual(wo.sales_order_item, so.items[0].name)


### PR DESCRIPTION
Reference support ticket: [29053](https://support.frappe.io/helpdesk/tickets/29053)

WIP warehouse field was not being removed even when "Skip Material Transfer to WIP Warehouse" was enabled. This simple PR fixes that.

`no-docs`