### PR TITLE
fix: Correct Party Bank Account mapping in `Payment Entry` from Transactional Doctypes

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2918,7 +2918,7 @@ def get_payment_entry(
 
 	if pe.party_type in ["Customer", "Supplier"]:
 		bank_account = get_party_bank_account(pe.party_type, pe.party)
-		pe.set("bank_account", bank_account)
+		pe.set("party_bank_account", bank_account)
 		pe.set_bank_account_data()
 
 	# only Purchase Invoice can be blocked individually


### PR DESCRIPTION
This PR addresses an issue where, during the creation of a Payment Entry from transactional doctypes like Purchase Order or Purchase Invoice, the Party Bank Account was incorrectly being mapped to the `bank_account` field instead of the `party_bank_account` field.

**Before**

https://github.com/user-attachments/assets/77264fb4-afac-4c38-90db-94b48f333290

**After**

https://github.com/user-attachments/assets/f72c704b-2843-4111-b783-e6801bf00eea


