### PR TITLE
fix: batch number search on pos

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -74,15 +74,25 @@ def search_by_term(search_term, warehouse, price_list):
 
 	def __sort(p):
 		p_uom = p.get("uom")
+		p_batch = p.get("batch_no")
+		batch_no = item.get("batch_no")
+
+		if batch_no and p_batch and p_batch == batch_no:
+			if p_uom == item.get("uom"):
+				return 0
+			elif p_uom == item.get("stock_uom"):
+				return 1
+			else:
+				return 2
 
 		if p_uom == item.get("uom"):
-			return 0
+			return 3
 		elif p_uom == item.get("stock_uom"):
-			return 1
+			return 4
 		else:
-			return 2
+			return 5
 
-	# sort by fallback preference. always pick exact uom match if available
+	# sort by fallback preference. always pick exact uom and batch number match if available
 	price = sorted(price, key=__sort)
 
 	if len(price) > 0:

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -64,7 +64,7 @@ def search_by_term(search_term, warehouse, price_list):
 	}
 
 	if batch_no:
-		price_filters["batch_no"] = batch_no
+		price_filters["batch_no"] = ["in", [batch_no, ""]]
 
 	price = frappe.get_list(
 		doctype="Item Price",


### PR DESCRIPTION
Fixed the issue related to items having batch numbers but no separate item price list for each batch number. 

Before: If a separate price list was not set for each batch number, the price set to 0 would be shown if searched with the batch number on POS.

![image](https://github.com/user-attachments/assets/ae3aabac-16b5-4a0f-b2a7-de212eb02936)

In the above screenshot, the item price with batch number "BRE0002" does not exist.

After: The Price is automatically set to the default Item Price (Item Price where no Batch Number is set).

![image](https://github.com/user-attachments/assets/1414f588-ee6b-4ce8-a3a1-db0326966c84)

![image](https://github.com/user-attachments/assets/79c19869-471a-4126-845e-81da8cb9ed3f)


