### PR TITLE
refactor: allow users to configure interval for Semi-Auto payment reconciliation

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -47,6 +47,7 @@
   "exchange_gain_loss_posting_date",
   "column_break_resa",
   "cron_interval",
+  "queue_size",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -515,6 +516,13 @@
    "fieldname": "cron_interval",
    "fieldtype": "Int",
    "label": "Cron Interval"
+  },
+  {
+   "default": "5",
+   "description": "Queue Size should be between 5 and 100",
+   "fieldname": "queue_size",
+   "fieldtype": "Int",
+   "label": "Queue Size"
   }
  ],
  "icon": "icon-cog",
@@ -522,7 +530,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-08 20:34:23.362588",
+ "modified": "2025-01-08 20:51:39.882648",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -46,8 +46,8 @@
   "auto_reconcile_payments",
   "exchange_gain_loss_posting_date",
   "column_break_resa",
-  "cron_interval",
-  "queue_size",
+  "auto_reconciliation_job_trigger",
+  "reconciliation_queue_size",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -513,16 +513,16 @@
   {
    "default": "15",
    "description": "Interval should be between 1 to 59 MInutes",
-   "fieldname": "cron_interval",
+   "fieldname": "auto_reconciliation_job_trigger",
    "fieldtype": "Int",
-   "label": "Cron Interval"
+   "label": "Auto Reconciliation Job Trigger"
   },
   {
    "default": "5",
-   "description": "Queue Size should be between 5 and 100",
-   "fieldname": "queue_size",
+   "description": "Documents Processed on each trigger. Queue Size should be between 5 and 100",
+   "fieldname": "reconciliation_queue_size",
    "fieldtype": "Int",
-   "label": "Queue Size"
+   "label": "Reconciliation Queue Size"
   }
  ],
  "icon": "icon-cog",
@@ -530,7 +530,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-08 20:51:39.882648",
+ "modified": "2025-01-13 17:25:24.690593",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -40,9 +40,13 @@
   "show_payment_schedule_in_print",
   "currency_exchange_section",
   "allow_stale",
+  "column_break_yuug",
+  "stale_days",
   "section_break_jpd0",
   "auto_reconcile_payments",
-  "stale_days",
+  "exchange_gain_loss_posting_date",
+  "column_break_resa",
+  "cron_interval",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -489,6 +493,28 @@
    "fieldname": "create_pr_in_draft_status",
    "fieldtype": "Check",
    "label": "Create in Draft Status"
+  },
+  {
+   "fieldname": "column_break_yuug",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Payment",
+   "fieldname": "exchange_gain_loss_posting_date",
+   "fieldtype": "Select",
+   "label": "Posting Date Inheritance for Exchange Gain / Loss",
+   "options": "Invoice\nPayment"
+  },
+  {
+   "fieldname": "column_break_resa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "15",
+   "description": "Interval should be between 1 to 59 MInutes",
+   "fieldname": "cron_interval",
+   "fieldtype": "Int",
+   "label": "Cron Interval"
   }
  ],
  "icon": "icon-cog",
@@ -496,7 +522,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-26 06:48:52.714630",
+ "modified": "2025-01-08 20:34:23.362588",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -44,10 +44,9 @@
   "stale_days",
   "section_break_jpd0",
   "auto_reconcile_payments",
-  "exchange_gain_loss_posting_date",
-  "column_break_resa",
   "auto_reconciliation_job_trigger",
   "reconciliation_queue_size",
+  "column_break_resa",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -500,13 +499,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "Payment",
-   "fieldname": "exchange_gain_loss_posting_date",
-   "fieldtype": "Select",
-   "label": "Posting Date Inheritance for Exchange Gain / Loss",
-   "options": "Invoice\nPayment"
-  },
-  {
    "fieldname": "column_break_resa",
    "fieldtype": "Column Break"
   },
@@ -530,7 +522,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-13 17:25:24.690593",
+ "modified": "2025-01-13 17:38:39.661320",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -52,6 +52,7 @@ class AccountsSettings(Document):
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
 		post_change_gl_entries: DF.Check
+		queue_size: DF.Int
 		receivable_payable_remarks_length: DF.Int
 		role_allowed_to_over_bill: DF.Link | None
 		round_row_wise_tax: DF.Check
@@ -118,6 +119,9 @@ class AccountsSettings(Document):
 			check_pending_reposting(self.acc_frozen_upto)
 
 	def before_save(self):
+		self.validate_auto_reconcile_config()
+
+	def validate_auto_reconcile_config(self):
 		doc_before_save = self.get_doc_before_save()
 		if doc_before_save.cron_interval != self.cron_interval:
 			if self.cron_interval > 0 and self.cron_interval < 60:
@@ -130,3 +134,7 @@ class AccountsSettings(Document):
 				doc.update({"cron_format": f"0/{self.cron_interval} * * * *"}).save()
 			else:
 				frappe.throw(_("Cron Interval should be between 1 and 59 Min"))
+
+		if doc_before_save.queue_size != self.queue_sizel:
+			if self.queue_size < 5 or self.queue_size > 100:
+				frappe.throw(_("Queue Size should be between 5 and 100"))

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -124,7 +124,7 @@ class AccountsSettings(Document):
 
 	def validate_and_sync_auto_reconcile_config(self):
 		if self.has_value_changed("cron_interval"):
-			if self.cron_interval > 0 and self.cron_interval < 60:
+			if int(self.cron_interval) > 0 and int(self.cron_interval) < 60:
 				sync_auto_reconcile_config()
 			else:
 				frappe.throw(_("Cron Interval should be between 1 and 59 Min"))

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -45,7 +45,6 @@ class AccountsSettings(Document):
 		enable_fuzzy_matching: DF.Check
 		enable_immutable_ledger: DF.Check
 		enable_party_matching: DF.Check
-		exchange_gain_loss_posting_date: DF.Literal["Invoice", "Payment"]
 		frozen_accounts_modifier: DF.Link | None
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -125,7 +125,7 @@ class AccountsSettings(Document):
 	def validate_and_sync_auto_reconcile_config(self):
 		if self.has_value_changed("cron_interval"):
 			if self.cron_interval > 0 and self.cron_interval < 60:
-				sync_auto_reconcile_config(self.cron_interval)
+				sync_auto_reconcile_config()
 			else:
 				frappe.throw(_("Cron Interval should be between 1 and 59 Min"))
 

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -37,12 +37,14 @@ class AccountsSettings(Document):
 		check_supplier_invoice_uniqueness: DF.Check
 		create_pr_in_draft_status: DF.Check
 		credit_controller: DF.Link | None
+		cron_interval: DF.Int
 		delete_linked_ledger_entries: DF.Check
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]
 		enable_common_party_accounting: DF.Check
 		enable_fuzzy_matching: DF.Check
 		enable_immutable_ledger: DF.Check
 		enable_party_matching: DF.Check
+		exchange_gain_loss_posting_date: DF.Literal["Invoice", "Payment"]
 		frozen_accounts_modifier: DF.Link | None
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -94,6 +94,8 @@ class AccountsSettings(Document):
 		if clear_cache:
 			frappe.clear_cache()
 
+		self.validate_and_sync_auto_reconcile_config()
+
 	def validate_stale_days(self):
 		if not self.allow_stale and cint(self.stale_days) <= 0:
 			frappe.msgprint(
@@ -119,16 +121,13 @@ class AccountsSettings(Document):
 		if self.acc_frozen_upto:
 			check_pending_reposting(self.acc_frozen_upto)
 
-	def before_save(self):
-		self.validate_and_sync_auto_reconcile_config()
-
 	def validate_and_sync_auto_reconcile_config(self):
 		if self.has_value_changed("cron_interval"):
-			if int(self.cron_interval) > 0 and int(self.cron_interval) < 60:
-				sync_auto_reconcile_config()
+			if cint(self.cron_interval) > 0 and cint(self.cron_interval) < 60:
+				sync_auto_reconcile_config(self.cron_interval)
 			else:
 				frappe.throw(_("Cron Interval should be between 1 and 59 Min"))
 
 		if self.has_value_changed("queue_size"):
-			if self.queue_size < 5 or self.queue_size > 100:
+			if cint(self.queue_size) < 5 or cint(self.queue_size) > 100:
 				frappe.throw(_("Queue Size should be between 5 and 100"))

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -210,7 +210,7 @@ def trigger_reconciliation_for_queued_docs():
 
 		docs_to_trigger = []
 		unique_filters = set()
-		queue_size = 5
+		queue_size = frappe.db.get_single_value("Accounts Settings", "reconciliation_queue_size") or 5
 
 		fields = ["company", "party_type", "party", "receivable_payable_account", "default_advance_account"]
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2284,3 +2284,26 @@ def run_ledger_health_checks():
 					doc.general_and_payment_ledger_mismatch = True
 					doc.checked_on = run_date
 					doc.save()
+
+
+def sync_auto_reconcile_config(cron_interval: int = 15):
+	if cron_interval:
+		method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
+		if frappe.db.get_value("Scheduled Job Type", {"method": method}):
+			frappe.get_doc(
+				"Scheduled Job Type",
+				{
+					"method": method,
+				},
+			).update({"cron_format": f"0/{cron_interval} * * * *"}).save()
+		else:
+			frappe.get_doc(
+				{
+					"doctype": "Scheduled Job Type",
+					"method": method,
+					"cron_format": f"0/{cron_interval} * * * *",
+					"create_log": True,
+					"stopped": False,
+					"frequency": "Cron",
+				}
+			).save()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2286,8 +2286,10 @@ def run_ledger_health_checks():
 					doc.save()
 
 
-def sync_auto_reconcile_config(cron_interval: int = 15):
-	cron_interval = cron_interval or frappe.db.get_single_value("Accounts Settings", "cron_interval")
+def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
+	auto_reconciliation_job_trigger = auto_reconciliation_job_trigger or frappe.db.get_single_value(
+		"Accounts Settings", "auto_reconciliation_job_trigger"
+	)
 	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
 
 	sch_event = frappe.get_doc(
@@ -2301,7 +2303,7 @@ def sync_auto_reconcile_config(cron_interval: int = 15):
 			},
 		).update(
 			{
-				"cron_format": f"0/{cron_interval} * * * *",
+				"cron_format": f"0/{auto_reconciliation_job_trigger} * * * *",
 				"scheduler_event": sch_event.name,
 			}
 		).save()
@@ -2311,7 +2313,7 @@ def sync_auto_reconcile_config(cron_interval: int = 15):
 				"doctype": "Scheduled Job Type",
 				"method": method,
 				"scheduler_event": sch_event.name,
-				"cron_format": f"0/{cron_interval} * * * *",
+				"cron_format": f"0/{auto_reconciliation_job_trigger} * * * *",
 				"create_log": True,
 				"stopped": False,
 				"frequency": "Cron",

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2286,24 +2286,25 @@ def run_ledger_health_checks():
 					doc.save()
 
 
-def sync_auto_reconcile_config(cron_interval: int = 15):
-	if cron_interval:
-		method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
-		if frappe.db.get_value("Scheduled Job Type", {"method": method}):
-			frappe.get_doc(
-				"Scheduled Job Type",
-				{
-					"method": method,
-				},
-			).update({"cron_format": f"0/{cron_interval} * * * *"}).save()
-		else:
-			frappe.get_doc(
-				{
-					"doctype": "Scheduled Job Type",
-					"method": method,
-					"cron_format": f"0/{cron_interval} * * * *",
-					"create_log": True,
-					"stopped": False,
-					"frequency": "Cron",
-				}
-			).save()
+def sync_auto_reconcile_config():
+	cron_interval = frappe.db.get_single_value("Accounts Settings", "cron_interval") or 15
+	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
+
+	if frappe.db.get_value("Scheduled Job Type", {"method": method}):
+		frappe.get_doc(
+			"Scheduled Job Type",
+			{
+				"method": method,
+			},
+		).update({"cron_format": f"0/{cron_interval} * * * *"}).save()
+	else:
+		frappe.get_doc(
+			{
+				"doctype": "Scheduled Job Type",
+				"method": method,
+				"cron_format": f"0/{cron_interval} * * * *",
+				"create_log": True,
+				"stopped": False,
+				"frequency": "Cron",
+			}
+		).save()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2286,22 +2286,31 @@ def run_ledger_health_checks():
 					doc.save()
 
 
-def sync_auto_reconcile_config():
-	cron_interval = frappe.db.get_single_value("Accounts Settings", "cron_interval") or 15
+def sync_auto_reconcile_config(cron_interval: int = 15):
+	cron_interval = cron_interval or frappe.db.get_single_value("Accounts Settings", "cron_interval")
 	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
 
+	sch_event = frappe.get_doc(
+		"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
+	)
 	if frappe.db.get_value("Scheduled Job Type", {"method": method}):
 		frappe.get_doc(
 			"Scheduled Job Type",
 			{
 				"method": method,
 			},
-		).update({"cron_format": f"0/{cron_interval} * * * *"}).save()
+		).update(
+			{
+				"cron_format": f"0/{cron_interval} * * * *",
+				"scheduler_event": sch_event.name,
+			}
+		).save()
 	else:
 		frappe.get_doc(
 			{
 				"doctype": "Scheduled Job Type",
 				"method": method,
+				"scheduler_event": sch_event.name,
 				"cron_format": f"0/{cron_interval} * * * *",
 				"create_log": True,
 				"stopped": False,

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -660,5 +660,3 @@ default_log_clearing_doctypes = {
 export_python_type_annotations = True
 
 fields_for_group_similar_items = ["qty", "amount"]
-
-after_migrate = "erpnext.accounts.utils.sync_auto_reconcile_config"

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -407,7 +407,6 @@ scheduler_events = {
 	"cron": {
 		"0/15 * * * *": [
 			"erpnext.manufacturing.doctype.bom_update_log.bom_update_log.resume_bom_cost_update_jobs",
-			"erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs",
 		],
 		"0/30 * * * *": [
 			"erpnext.utilities.doctype.video.video.update_youtube_data",
@@ -661,3 +660,5 @@ default_log_clearing_doctypes = {
 export_python_type_annotations = True
 
 fields_for_group_similar_items = ["qty", "amount"]
+
+after_migrate = "erpnext.accounts.utils.sync_auto_reconcile_config"

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -396,5 +396,4 @@ erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts
 erpnext.patches.v15_0.refactor_closing_stock_balance #5
 erpnext.patches.v15_0.update_asset_status_to_work_in_progress
 erpnext.patches.v15_0.migrate_checkbox_to_select_for_reconciliation_effect
-execute:frappe.db.set_single_value("Accounts Settings", "cron_interval", 15)
-execute:frappe.db.set_single_value("Accounts Settings", "queue_size", 5)
+erpnext.patches.v15_0.sync_auto_reconcile_config

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -396,3 +396,5 @@ erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts
 erpnext.patches.v15_0.refactor_closing_stock_balance #5
 erpnext.patches.v15_0.update_asset_status_to_work_in_progress
 erpnext.patches.v15_0.migrate_checkbox_to_select_for_reconciliation_effect
+execute:frappe.db.set_single_value("Accounts Settings", "cron_interval", 15)
+execute:frappe.db.set_single_value("Accounts Settings", "queue_size", 5)

--- a/erpnext/patches/v15_0/sync_auto_reconcile_config.py
+++ b/erpnext/patches/v15_0/sync_auto_reconcile_config.py
@@ -9,4 +9,18 @@ def execute():
 	"""
 	frappe.db.set_single_value("Accounts Settings", "cron_interval", 15)
 	frappe.db.set_single_value("Accounts Settings", "queue_size", 5)
-	sync_auto_reconcile_config()
+
+	# Create Scheduler Event record if it doesn't exist
+	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
+	if not frappe.db.get_all(
+		"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
+	):
+		frappe.get_doc(
+			{
+				"doctype": "Scheduler Event",
+				"scheduled_against": "Process Payment Reconciliation",
+				"method": method,
+			}
+		).save()
+
+	sync_auto_reconcile_config(15)

--- a/erpnext/patches/v15_0/sync_auto_reconcile_config.py
+++ b/erpnext/patches/v15_0/sync_auto_reconcile_config.py
@@ -7,8 +7,8 @@ def execute():
 	"""
 	Set default Cron Interval and Queue size
 	"""
-	frappe.db.set_single_value("Accounts Settings", "cron_interval", 15)
-	frappe.db.set_single_value("Accounts Settings", "queue_size", 5)
+	frappe.db.set_single_value("Accounts Settings", "auto_reconciliation_job_trigger", 15)
+	frappe.db.set_single_value("Accounts Settings", "reconciliation_queue_size", 5)
 
 	# Create Scheduler Event record if it doesn't exist
 	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"

--- a/erpnext/patches/v15_0/sync_auto_reconcile_config.py
+++ b/erpnext/patches/v15_0/sync_auto_reconcile_config.py
@@ -1,0 +1,12 @@
+import frappe
+
+from erpnext.accounts.utils import sync_auto_reconcile_config
+
+
+def execute():
+	"""
+	Set default Cron Interval and Queue size
+	"""
+	frappe.db.set_single_value("Accounts Settings", "cron_interval", 15)
+	frappe.db.set_single_value("Accounts Settings", "queue_size", 5)
+	sync_auto_reconcile_config()


### PR DESCRIPTION
# Limitation
Semi-Auto Payment Reconciliation was hard coded to run every 15 min processing only 5 unique `Process Payment Reconciliation` documents. Initial requirement was to handle small number of parties will large volume of unreconciled invoices.

But, for the inverse scenario - thousands of parties but only a dozen or so unreconciled invoices, this interval and queue size is not ideal.

# Solution
Making Trigger interval and Queue size configurable.

ToDo:
- [x] better field names(?)


upstream dependency: https://github.com/frappe/frappe/pull/29122