### PR TITLE
fix: ui issues across multiple pages

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -199,9 +199,10 @@
   },
   {
    "depends_on": "eval:doc.get_items_from && doc.docstatus == 0",
+   "description": "Get Finished Goods for Manufacture",
    "fieldname": "get_items",
    "fieldtype": "Button",
-   "label": "Get Finished Goods for Manufacture"
+   "label": "Get Finished Goods"
   },
   {
    "fieldname": "po_items",
@@ -439,7 +440,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-04 11:55:03.108971",
+ "modified": "2025-01-10 17:47:52.207209",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -717,7 +717,6 @@ erpnext.work_order = {
 									);
 								}
 							);
-							consumption_btn.addClass("btn-primary");
 						}
 					}
 				}

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -254,13 +254,13 @@ erpnext.buying.SubcontractingOrderController = class SubcontractingOrderControll
 		if (doc.docstatus == 1) {
 			if (!["Closed", "Completed"].includes(doc.status)) {
 				if (flt(doc.per_received) < 100) {
-					cur_frm.add_custom_button(
+					this.frm.add_custom_button(
 						__("Subcontracting Receipt"),
 						this.make_subcontracting_receipt,
 						__("Create")
 					);
 					if (me.has_unsupplied_items()) {
-						cur_frm.add_custom_button(
+						this.frm.add_custom_button(
 							__("Material to Supplier"),
 							this.make_stock_entry,
 							__("Transfer")
@@ -268,9 +268,9 @@ erpnext.buying.SubcontractingOrderController = class SubcontractingOrderControll
 					}
 				}
 				if (flt(doc.per_received) < 100 && me.has_unsupplied_items()) {
-					cur_frm.page.set_inner_btn_group_as_primary(__("Transfer"));
+					this.frm.page.set_inner_btn_group_as_primary(__("Transfer"));
 				} else {
-					cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+					this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 				}
 			}
 		}

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -267,7 +267,11 @@ erpnext.buying.SubcontractingOrderController = class SubcontractingOrderControll
 						);
 					}
 				}
-				cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+				if (flt(doc.per_received) < 100 && me.has_unsupplied_items()) {
+					cur_frm.page.set_inner_btn_group_as_primary(__("Transfer"));
+				} else {
+					cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #44659 

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Change Material Consumption button to secondary button as it is rarely used feature.
- In Subcontracting, if transfer isn't done, then it is Primary. If transfer is done, then Create is Primary. 

> Screenshots/GIFs

![image](https://github.com/user-attachments/assets/67fc5b54-7d47-45e1-bcc6-283d511c6fdd)

