### PR TITLE
fix(selling): assign sales order item delivery date to materials request item required by field

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -884,7 +884,8 @@ def make_material_request(source_name, target_doc=None):
 			},
 			"Sales Order Item": {
 				"doctype": "Material Request Item",
-				"field_map": {"name": "sales_order_item", "parent": "sales_order"},
+				"field_map": {"name": "sales_order_item", "parent": "sales_order",
+							  "delivery_date": "required_by"},
 				"condition": lambda item: not frappe.db.exists(
 					"Product Bundle", {"name": item.item_code, "disabled": 0}
 				)


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/45225

When a Material Request is created from a Sales Order, Sales Order Item Delivery Date is not passed onto the Material Request Item Required By

User needs to manually update these values and therefore is an added feature.