### PR TITLE
fix: get invoice without apply_tds when Consider Entire Party Ledger Amount is enabled

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -352,7 +352,7 @@ def get_invoice_vouchers(parties, tax_details, company, party_type="Supplier"):
 		"docstatus": 1,
 	}
 
-	if doctype != "Sales Invoice":
+	if doctype != "Sales Invoice" and not cint(tax_details.consider_party_ledger_amount):
 		filters.update(
 			{"apply_tds": 1, "tax_withholding_category": tax_details.get("tax_withholding_category")}
 		)


### PR DESCRIPTION
**Issue:**
when Consider Entire Party Ledger Amount is ticked in the tds category, invoices without apply_tds are not fetched
**ref:** [29142](https://support.frappe.io/helpdesk/tickets/29142)

**Tax Withholding Category:**
![image](https://github.com/user-attachments/assets/669de45a-2836-4c5f-9954-9af34c8ade23)

**Before:**

https://github.com/user-attachments/assets/adeba8b0-7298-4506-83ba-3e5615a90d60

**After:** 

https://github.com/user-attachments/assets/b9205b80-74c7-4096-b9d7-10abe260b146

**Backport needed for v14 & v15**