### PR TITLE
fix: include pos invoice in modifing key for returned item validation

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -110,7 +110,7 @@ def validate_returned_items(doc):
 	for d in doc.get("items"):
 		key = d.item_code
 		raise_exception = False
-		if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Sales Invoice"]:
+		if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Sales Invoice", "POS Invoice"]:
 			field = frappe.scrub(doc.doctype) + "_item"
 			if d.get(field):
 				key = (d.item_code, d.get(field))


### PR DESCRIPTION
**Issue:**
 get_ref_item_dict return key in `(item_code, name)` format, but since the POS Invoice is not part of the validation, `item_code` is compared with `(item_code, name)`
**ref:** [29094](https://support.frappe.io/helpdesk/tickets/29094)

**Before:**

https://github.com/user-attachments/assets/3b0ec642-807e-4c66-a90c-3e5147e95010

**After:**

https://github.com/user-attachments/assets/7790d998-537f-4c6f-8ec4-aa52f02966d8

**Backport needed for v14 & v15**