### PR TITLE
feat: show item name alongside item code in the update items dialog

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -622,6 +622,7 @@ erpnext.utils.update_child_items = function (opts) {
 			docname: d.name,
 			name: d.name,
 			item_code: d.item_code,
+			item_name: d.item_name,
 			delivery_date: d.delivery_date,
 			schedule_date: d.schedule_date,
 			conversion_factor: d.conversion_factor,
@@ -723,7 +724,30 @@ erpnext.utils.update_child_items = function (opts) {
 						}
 					},
 				});
+
+				const item_code = this.value;
+				if (item_code) {
+					frappe.db.get_value("Item", item_code, "item_name", (r) => {
+						if (r && r.item_name) {
+							const idx = this.doc.idx;
+							dialog.fields_dict.trans_items.df.data.some((doc) => {
+								if (doc.idx === idx) {
+									doc.item_name = r.item_name;
+									dialog.fields_dict.trans_items.grid.refresh();
+									return true;
+								}
+							});
+						}
+					});
+				}
 			},
+
+		},
+		{
+			fieldtype: "Data",
+			fieldname: "item_name",
+			label: __("Item Name"),
+			read_only: 1,
 		},
 		{
 			fieldtype: "Link",

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -707,7 +707,13 @@ erpnext.utils.update_child_items = function (opts) {
 					},
 					callback: function (r) {
 						if (r.message) {
-							const { qty, price_list_rate: rate, uom, conversion_factor } = r.message;
+							const {
+								qty,
+								price_list_rate: rate,
+								uom,
+								conversion_factor,
+								item_name,
+							} = r.message;
 
 							const row = dialog.fields_dict.trans_items.df.data.find(
 								(doc) => doc.idx == me.doc.idx
@@ -718,30 +724,14 @@ erpnext.utils.update_child_items = function (opts) {
 									uom: me.doc.uom || uom,
 									qty: me.doc.qty || qty,
 									rate: me.doc.rate || rate,
+									item_name: item_name,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}
 						}
 					},
 				});
-
-				const item_code = this.value;
-				if (item_code) {
-					frappe.db.get_value("Item", item_code, "item_name", (r) => {
-						if (r && r.item_name) {
-							const idx = this.doc.idx;
-							dialog.fields_dict.trans_items.df.data.some((doc) => {
-								if (doc.idx === idx) {
-									doc.item_name = r.item_name;
-									dialog.fields_dict.trans_items.grid.refresh();
-									return true;
-								}
-							});
-						}
-					});
-				}
 			},
-
 		},
 		{
 			fieldtype: "Data",


### PR DESCRIPTION

### PR Description:
This update addresses the ux issue by displaying the item name next to the item code in the "update items" dialog. users no longer need to hover over the item code to see the name.


fixes #45245  (Partially resolved for the Update Items dialog)
### **Demo Video**

[Screencast from 13-01-25 08:22:32 PM IST.webm](https://github.com/user-attachments/assets/2a503438-34a7-4096-85b2-4cd68431b8e4)

`no-docs`
