### PR TITLE
fix: round off tax withholding amount

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -156,6 +156,9 @@ def get_party_tax_withholding_details(inv, tax_withholding_category=None):
 		}
 	)
 
+	if cint(tax_details.round_off_tax_amount):
+		inv.round_off_applicable_accounts_for_tax_withholding = tax_details.account_head
+
 	if inv.doctype == "Purchase Invoice":
 		return tax_row, tax_deducted_on_advances, voucher_wise_amount
 	else:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -34,6 +34,11 @@ class calculate_taxes_and_totals:
 			"Accounts Settings", "round_row_wise_tax"
 		)
 
+		if doc.get("round_off_applicable_accounts_for_tax_withholding"):
+			frappe.flags.round_off_applicable_accounts.append(
+				doc.round_off_applicable_accounts_for_tax_withholding
+			)
+
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
 
 		get_round_off_applicable_accounts(self.doc.company, frappe.flags.round_off_applicable_accounts)


### PR DESCRIPTION
Issue - The TCS Amount is not getting rounded off even though *round_off_tax_amount* is checked when the Charge Type is "On Net Total" or  "On Previous Row Total".

Steps to Replicate:

- Create a Tax withholding category with "round_off_tax_amount" as checked and threshold limit as 1.
- Create a Customer and set the tax withholding category.
- Now create a Sales Invoice. TCS will be deducted as Actual.
- Now create a Second Sales Invoice, TCS will be deducted from the Net Total but the amount will not be rounded off.

Note: Currently it is required only for Sales Invoice(TCS).

backport-version-14
backport-version-15

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/28906


Note: Currently it is required only for Sales Invoice(TCS).
