### PR TITLE
feat: Add corrective job card operating cost as additional costs in s…

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1470,7 +1470,15 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 		)
 		return query.run(as_dict=True)[0].amount or 0
 
-	if work_order and work_order.corrective_operation_cost:
+	if (
+		work_order
+		and work_order.corrective_operation_cost
+		and cint(
+			frappe.db.get_single_value(
+				"Manufacturing Settings", "add_corrective_operation_cost_in_finished_good_valuation"
+			)
+		)
+	):
 		max_qty = get_max_op_qty() - work_order.produced_qty
 		remaining_cc = work_order.corrective_operation_cost - get_utilised_cc()
 		stock_entry.append(

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1466,7 +1466,7 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 		query = (
 			frappe.qb.from_(table)
 			.select(Sum(table.amount).as_("amount"))
-			.where(table.parent.isin(subquery) & (table.description == "Corrective Operation Cost"))
+			.where(table.parent.isin(subquery) & (table.has_corrective_cost == 1))
 		)
 		return query.run(as_dict=True)[0].amount or 0
 
@@ -1486,6 +1486,7 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 			{
 				"expense_account": expense_account,
 				"description": "Corrective Operation Cost",
+				"has_corrective_cost": 1,
 				"amount": remaining_cc / max_qty * flt(stock_entry.fg_completed_qty),
 			},
 		)

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -670,7 +670,11 @@ class JobCard(Document):
 					)
 				)
 
-			if self.get("operation") == d.operation or self.operation_row_id == d.operation_row_id:
+			if (
+				self.get("operation") == d.operation
+				or self.operation_row_id == d.operation_row_id
+				or self.is_corrective_job_card
+			):
 				self.append(
 					"items",
 					{

--- a/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.json
+++ b/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.json
@@ -11,7 +11,8 @@
   "description",
   "col_break3",
   "amount",
-  "base_amount"
+  "base_amount",
+  "has_corrective_cost"
  ],
  "fields": [
   {
@@ -62,12 +63,19 @@
    "label": "Amount (Company Currency)",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "has_corrective_cost",
+   "fieldtype": "Check",
+   "label": "Has Corrective Cost",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:59.493991",
+ "modified": "2025-01-20 12:22:03.455762",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Taxes and Charges",

--- a/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.py
+++ b/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.py
@@ -20,6 +20,7 @@ class LandedCostTaxesandCharges(Document):
 		description: DF.SmallText
 		exchange_rate: DF.Float
 		expense_account: DF.Link | None
+		has_corrective_cost: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2892,17 +2892,6 @@ def get_operating_cost_per_unit(work_order=None, bom_no=None):
 		if bom.quantity:
 			operating_cost_per_unit = flt(bom.operating_cost) / flt(bom.quantity)
 
-	if (
-		work_order
-		and work_order.produced_qty
-		and cint(
-			frappe.db.get_single_value(
-				"Manufacturing Settings", "add_corrective_operation_cost_in_finished_good_valuation"
-			)
-		)
-	):
-		operating_cost_per_unit += flt(work_order.corrective_operation_cost) / flt(work_order.produced_qty)
-
 	return operating_cost_per_unit
 
 


### PR DESCRIPTION
Reference issue #44976 

This PR does two new things:

The operating cost of corrective job cards will now be added to the additional costs table of Manufacture Stock Entry.
Newly created corrective job cards will now have raw materials table pre-filled based on the job card it is being created from.

`no-docs`