### PR TITLE
fix: validate items against selling settings

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3712,6 +3712,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 						).format(frappe.bold(parent.name))
 					)
 	else:  # Sales Order
+		parent.validate_for_duplicate_items()
 		parent.validate_warehouse()
 		parent.update_reserved_qty()
 		parent.update_project()


### PR DESCRIPTION
Issue: [Support Ticket  - 29465](https://support.frappe.io/helpdesk/tickets/29465)

Before:
It used to allow adding multiple identical items even if `Allow Item to be Added Multiple Times in a Transaction` in Selling Settings was unchecked.

After:
It validates items based on Selling Settings and checks for duplicate items.