### PR TITLE
perf: optimize DB calls with frappe.get_all

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -711,6 +711,12 @@ class SellingController(StockController):
 		if self.doctype == "POS Invoice":
 			return
 
+		items = [item.item_code for item in self.get("items")]
+		item_details = frappe.get_all(
+			"Item", filters={"item_code": ["in", items]}, fields=["is_stock_item", "item_code"]
+		)
+		item_stock_map = {item.item_code: item.is_stock_item for item in item_details}
+
 		for d in self.get("items"):
 			if self.doctype == "Sales Invoice":
 				stock_items = [
@@ -744,7 +750,7 @@ class SellingController(StockController):
 				frappe.bold(_("Allow Item to Be Added Multiple Times in a Transaction")),
 				get_link_to_form("Selling Settings", "Selling Settings"),
 			)
-			if frappe.db.get_value("Item", d.item_code, "is_stock_item") == 1:
+			if item_stock_map.get(d.item_code):
 				if stock_items in check_list:
 					frappe.throw(duplicate_items_msg)
 				else:

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -712,10 +712,14 @@ class SellingController(StockController):
 			return
 
 		items = [item.item_code for item in self.get("items")]
-		item_details = frappe.get_all(
-			"Item", filters={"item_code": ["in", items]}, fields=["is_stock_item", "item_code"]
+		item_stock_map = frappe._dict(
+			frappe.get_all(
+				"Item",
+				filters={"item_code": ["in", items]},
+				fields=["item_code", "is_stock_item"],
+				as_list=True,
+			)
 		)
-		item_stock_map = {item.item_code: item.is_stock_item for item in item_details}
 
 		for d in self.get("items"):
 			if self.doctype == "Sales Invoice":


### PR DESCRIPTION
Replaced multiple calls to frappe.db.get_value for fetching individual items with a single call to frappe.get_all.