### PR TITLE
fix: don't update party-type on change of cost center in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -430,12 +430,6 @@ frappe.ui.form.on("Journal Entry Account", {
 			});
 		}
 	},
-	cost_center: function (frm, dt, dn) {
-		// Don't reset for Gain/Loss type journals, as it will make Debit and Credit values '0'
-		if (frm.doc.voucher_type != "Exchange Gain Or Loss") {
-			erpnext.journal_entry.set_account_details(frm, dt, dn);
-		}
-	},
 
 	account: function (frm, dt, dn) {
 		erpnext.journal_entry.set_account_details(frm, dt, dn);


### PR DESCRIPTION
Issue: [Support Ticket - 29524](https://support.frappe.io/helpdesk/tickets/29524)

Before https://github.com/frappe/erpnext/pull/37477, the balance was updating based on the cost center. However, after https://github.com/frappe/erpnext/pull/37477, the cost center is not required in that function, and changing the cost center does not require a function call anymore.