### PR TITLE
fix: prevent unnecessary db.commit for contact insert

### DIFF
--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -185,7 +185,7 @@ def link_existing_conversations(doc, state):
 				""",
 				dict(phone_number=f"%{number}", docname=doc.name, doctype=doc.doctype),
 			)
-			if logs: 
+			if logs:
 				for log in logs:
 					call_log = frappe.get_doc("Call Log", log)
 					call_log.add_link(link_type=doc.doctype, link_name=doc.name)

--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -157,6 +157,8 @@ def link_existing_conversations(doc, state):
 	"""
 	Called from hooks on creation of Contact or Lead to link all the existing conversations.
 	"""
+	if doc.flags.ignore_auto_link_call_log:
+		return
 	if doc.doctype != "Contact":
 		return
 	try:
@@ -183,12 +185,12 @@ def link_existing_conversations(doc, state):
 				""",
 				dict(phone_number=f"%{number}", docname=doc.name, doctype=doc.doctype),
 			)
-
-			for log in logs:
-				call_log = frappe.get_doc("Call Log", log)
-				call_log.add_link(link_type=doc.doctype, link_name=doc.name)
-				call_log.save(ignore_permissions=True)
-			frappe.db.commit()
+			if logs: 
+				for log in logs:
+					call_log = frappe.get_doc("Call Log", log)
+					call_log.add_link(link_type=doc.doctype, link_name=doc.name)
+					call_log.save(ignore_permissions=True)
+				frappe.db.commit()
 	except Exception:
 		frappe.log_error(title=_("Error during caller information update"))
 


### PR DESCRIPTION
We have ERPNext integrated with another system, when retrieving data from the other system, the following is created:
Customer
Addresses
Contacts
The link between the two systems has been created

When we synchronize, a for loop is performed and the customer, address and contact are inserted, but there may be errors in the process...

When there are errors, a rollback must be performed, but when inserting the contact, ERPNext executes an "after_insert" hook event calling the erpnext.telephony.doctype.call_log.call_log.link_existing_conversations method
thus executing frappe.db.commit()

Two improvements were made:
1. Only perform frappe.db.commit if there is an impact record returned by the select above.

2. Created an "ignore_auto_link_call_log" flag to ignore this method when we do not want it to execute, as this commit may break the code.