### PR TITLE
feat: add option to update modified on communication recieved

### DIFF
--- a/erpnext/crm/doctype/crm_settings/crm_settings.json
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.json
@@ -17,7 +17,9 @@
   "quotation_section",
   "default_valid_till",
   "section_break_13",
-  "carry_forward_communication_and_comments"
+  "carry_forward_communication_and_comments",
+  "column_break_junk",
+  "update_timestamp_on_new_communication"
  ],
  "fields": [
   {
@@ -77,7 +79,7 @@
   {
    "fieldname": "section_break_13",
    "fieldtype": "Section Break",
-   "label": "Other Settings"
+   "label": "Activity"
   },
   {
    "default": "0",
@@ -85,13 +87,24 @@
    "fieldname": "carry_forward_communication_and_comments",
    "fieldtype": "Check",
    "label": "Carry Forward Communication and Comments"
+  },
+  {
+   "fieldname": "column_break_junk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Update the modified timestamp on new communications received in Lead & Opportunity.",
+   "fieldname": "update_timestamp_on_new_communication",
+   "fieldtype": "Check",
+   "label": "Update timestamp on new communication"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:06:47.508534",
+ "modified": "2025-01-16 16:12:14.889455",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "CRM Settings",

--- a/erpnext/crm/doctype/crm_settings/crm_settings.py
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.py
@@ -20,6 +20,7 @@ class CRMSettings(Document):
 		carry_forward_communication_and_comments: DF.Check
 		close_opportunity_after_days: DF.Int
 		default_valid_till: DF.Data | None
+		update_timestamp_on_new_communication: DF.Check
 	# end: auto-generated types
 
 	def validate(self):

--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -84,6 +84,20 @@ def link_communications_with_prospect(communication, method):
 			row.db_update()
 
 
+def update_modified_timestamp(communication, method):
+	if communication.reference_doctype and communication.reference_name:
+		if communication.sent_or_received == "Received" and frappe.db.get_single_value(
+			"CRM Settings", "update_timestamp_on_new_communication"
+		):
+			frappe.db.set_value(
+				dt=communication.reference_doctype,
+				dn=communication.reference_name,
+				field="modified",
+				val=now(),
+				update_modified=False,
+			)
+
+
 def get_linked_prospect(reference_doctype, reference_name):
 	prospect = None
 	if reference_doctype == "Lead":

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -345,7 +345,10 @@ doc_events = {
 			"erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update",
 			"erpnext.support.doctype.issue.issue.set_first_response_time",
 		],
-		"after_insert": "erpnext.crm.utils.link_communications_with_prospect",
+		"after_insert": [
+			"erpnext.crm.utils.link_communications_with_prospect",
+			"erpnext.crm.utils.update_modified_timestamp",
+		],
 	},
 	"Event": {
 		"after_insert": "erpnext.crm.utils.link_events_with_prospect",


### PR DESCRIPTION
Closes #44330 

> Please provide enough information so that others can review your pull request:

Related to #43968 


- Add a field in CRM Settings to select whether to update the modified timestamp when new communication is received.
![image](https://github.com/user-attachments/assets/4b6cc858-94cf-4d23-a3f7-ea87eaab3263)

- Add a `doc` event of `after_insert` which updates the modified timestamp when a communication is received.


`no-docs`
