### PR TITLE
fix: set preferred email in Employee via backend controller

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -41,6 +41,7 @@ class Employee(NestedSet):
 		self.validate_email()
 		self.validate_status()
 		self.validate_reports_to()
+		self.set_preferred_email()
 		self.validate_preferred_email()
 
 		if self.user_id:
@@ -160,9 +161,7 @@ class Employee(NestedSet):
 
 	def set_preferred_email(self):
 		preferred_email_field = frappe.scrub(self.prefered_contact_email)
-		if preferred_email_field:
-			preferred_email = self.get(preferred_email_field)
-			self.prefered_email = preferred_email
+		self.prefered_email = self.get(preferred_email_field) if preferred_email_field else None
 
 	def validate_status(self):
 		if self.status == "Left":


### PR DESCRIPTION
> Noticed when Employee was bulk updated from list view for `prefered_contact_email` to "Company Email" did not set the appropriate values under `preferred_email` because the respective code was in the desk script 😄

Set "Preferred Email" for Employee via validate based on "Preferred Contact Email" value which can be either "Company Email", "Personal Email" or "User ID".

Additional change to note: Unset `preferred_email` when `prefered_contact_email` is also unset.
