### PR TITLE
fix: System was allowing to save payment schedule amount less than grand total

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2435,10 +2435,15 @@ class AccountsController(TransactionBase):
 					)
 
 			if (
-				abs(flt(total, self.precision("grand_total")) - flt(grand_total, self.precision("grand_total")))
+				abs(
+					flt(total, self.precision("grand_total"))
+					- flt(grand_total, self.precision("grand_total"))
+				)
 				> 0.1
-				or abs(flt(base_total, self.precision("base_grand_total"))
-				- flt(base_grand_total, self.precision("base_grand_total")))
+				or abs(
+					flt(base_total, self.precision("base_grand_total"))
+					- flt(base_grand_total, self.precision("base_grand_total"))
+				)
 				> 0.1
 			):
 				frappe.throw(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2435,10 +2435,10 @@ class AccountsController(TransactionBase):
 					)
 
 			if (
-				flt(total, self.precision("grand_total")) - flt(grand_total, self.precision("grand_total"))
+				abs(flt(total, self.precision("grand_total")) - flt(grand_total, self.precision("grand_total")))
 				> 0.1
-				or flt(base_total, self.precision("base_grand_total"))
-				- flt(base_grand_total, self.precision("base_grand_total"))
+				or abs(flt(base_total, self.precision("base_grand_total"))
+				- flt(base_grand_total, self.precision("base_grand_total")))
 				> 0.1
 			):
 				frappe.throw(


### PR DESCRIPTION
### Example about how to simulate

- [ ] Create a Sales Invoice with total 1000.00
![image](https://github.com/user-attachments/assets/e7163064-04ef-4a7b-a033-aed77d0820fc)

- [ ] In the Payment Therms, create a therm with amount 900.00 and try to save (and even submit)
![image](https://github.com/user-attachments/assets/3bb78102-908d-4bbc-9b78-b03986a53084)

You will see that the system will allow you to do that, but it should not, because the Payments total should be equal to the grand total of the invoice ([reference](https://github.com/frappe/erpnext/blob/97e37708728691f60f61789a131e567736040d2a/erpnext/controllers/accounts_controller.py#L2445)).

The validation that should block only works if the payments total is more than the grand total. This commit fixes that adding abs function to the validation.