### PR TITLE
fix: pos return total amount using default mode of payment

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -385,8 +385,8 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 						{
 							"mode_of_payment": data.mode_of_payment,
 							"type": data.type,
-							"amount": -1 * paid_amount,
-							"base_amount": -1 * base_paid_amount,
+							"amount": -1 * (paid_amount - source.change_amount),
+							"base_amount": -1 * (base_paid_amount - source.base_paid_amount),
 							"account": data.account,
 							"default": data.default,
 						},

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -916,7 +916,6 @@ class calculate_taxes_and_totals:
 				and self.doc.get("is_return")
 				and not self.doc.get("is_consolidated")
 			):
-				self.set_total_amount_to_default_mop(total_amount_to_pay)
 				self.calculate_paid_amount()
 
 	def calculate_paid_amount(self):

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -64,7 +64,6 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			&& this.frm.doc.is_pos
 			&& this.frm.doc.is_return
 		) {
-			this.set_total_amount_to_default_mop();
 			this.calculate_paid_amount();
 		}
 


### PR DESCRIPTION
Resolved the issue where the POS system automatically selected the default payment method and paid amount during returns, despite the user choosing a different payment method.

Requires backport in both version-15 and version-14.