### PR TITLE
fix: added item_group filter in item_code field in stock balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -41,8 +41,13 @@ frappe.query_reports["Stock Balance"] = {
 			width: "80",
 			options: "Item",
 			get_query: function () {
+				let item_group = frappe.query_report.get_filter_value("item_group");
+
 				return {
 					query: "erpnext.controllers.queries.item_query",
+					filters: {
+						...(item_group && { item_group }),
+					},
 				};
 			},
 		},

--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -47,6 +47,7 @@ frappe.query_reports["Stock Balance"] = {
 					query: "erpnext.controllers.queries.item_query",
 					filters: {
 						...(item_group && { item_group }),
+						is_stock_item: 1,
 					},
 				};
 			},


### PR DESCRIPTION
In response to support ticket [29705](https://support.frappe.io/helpdesk/tickets/29705)

Previous behaviour: In the Stock Balance Report, when selecting item_group filter, it was not being applied to the item_code filter.

New behaviour: Now if item_group is selected, the item_code field will be filtered according to it.

`no-docs`