### PR TITLE
fix: broken image issue in BOM Tree

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom_item_preview.html
+++ b/erpnext/manufacturing/doctype/bom/bom_item_preview.html
@@ -1,7 +1,7 @@
 <div style="padding: 15px;">
 	<div class="row mb-5">
 		<div class="col-md-5" style="max-height: 500px">
-			{% if data.image %}
+			{% if data.image && (data.image).replace("''", "").length %}
 				<div class="border image-field " style="overflow: hidden;border-color:#e6e6e6">
 					<img class="responsive" style="width: 100%;" src={{ data.image }}>
 				</div>

--- a/erpnext/manufacturing/doctype/bom/bom_tree.js
+++ b/erpnext/manufacturing/doctype/bom/bom_tree.js
@@ -63,7 +63,7 @@ frappe.treeview_settings["BOM"] = {
 		if (node.is_root && node.data.value != "BOM") {
 			frappe.model.with_doc("BOM", node.data.value, function () {
 				var bom = frappe.model.get_doc("BOM", node.data.value);
-				node.data.image = escape(bom.image) || "";
+				node.data.image = bom.image || "";
 				node.data.description = bom.description || "";
 				node.data.item_code = bom.item || "";
 			});


### PR DESCRIPTION
Closes #45147 

> Screenshots/GIFs

- When Images are not set
![image](https://github.com/user-attachments/assets/30ca663d-2a62-4550-871e-10b039bd94f5)

- When Images are set
![image](https://github.com/user-attachments/assets/6bf903b5-a9c2-46d3-914e-5991dafb86f3)

