### PR TITLE
fix: fix creating documents from sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -16,6 +16,10 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	setup(doc) {
 		this.setup_posting_date_time_check();
 		super.setup(doc);
+		this.frm.make_methods = {
+			Dunning: this.make_dunning.bind(this),
+			"Invoice Discounting": this.make_invoice_discounting.bind(this),
+		};
 	}
 	company() {
 		super.company();
@@ -125,12 +129,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					},
 					__("Create")
 				);
-
 				this.frm.add_custom_button(
 					__("Invoice Discounting"),
-					function () {
-						this.frm.events.create_invoice_discounting(this.frm);
-					},
+					this.make_invoice_discounting.bind(this),
 					__("Create")
 				);
 
@@ -139,22 +140,14 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					.reduce((prev, current) => prev || current, false);
 
 				if (payment_is_overdue) {
-					this.frm.add_custom_button(
-						__("Dunning"),
-						() => {
-							this.frm.events.create_dunning(this.frm);
-						},
-						__("Create")
-					);
+					this.frm.add_custom_button(__("Dunning"), this.make_dunning.bind(this), __("Create"));
 				}
 			}
 
 			if (doc.docstatus === 1) {
 				this.frm.add_custom_button(
 					__("Maintenance Schedule"),
-					function () {
-						this.frm.cscript.make_maintenance_schedule();
-					},
+					this.make_maintenance_schedule.bind(this),
 					__("Create")
 				);
 			}
@@ -187,6 +180,20 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 		}
 
 		erpnext.accounts.unreconcile_payment.add_unreconcile_btn(me.frm);
+	}
+
+	make_invoice_discounting() {
+		frappe.model.open_mapped_doc({
+			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.create_invoice_discounting",
+			frm: this.frm,
+		});
+	}
+
+	make_dunning() {
+		frappe.model.open_mapped_doc({
+			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.create_dunning",
+			frm: this.frm,
+		});
 	}
 
 	make_maintenance_schedule() {
@@ -1043,20 +1050,6 @@ frappe.ui.form.on("Sales Invoice", {
 		if (frm.doc.is_debit_note) {
 			frm.set_df_property("return_against", "label", __("Adjustment Against"));
 		}
-	},
-
-	create_invoice_discounting: function (frm) {
-		frappe.model.open_mapped_doc({
-			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.create_invoice_discounting",
-			frm: frm,
-		});
-	},
-
-	create_dunning: function (frm) {
-		frappe.model.open_mapped_doc({
-			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.create_dunning",
-			frm: frm,
-		});
 	},
 });
 


### PR DESCRIPTION
Hello everyone :)

there are some bugs when creating documents from sales invoice:

1. create dunning with + button in tab Connections -> doesn't add the sales invoice in the sales invoice table in dunning doc
2. Button Create -> Invoice Discounting does nothing
3. Button Create -> Maintenance Schedule does nothing

I also added a before video and a after video with the fixed bugs for a better understanding.

Before (current develop branch)
[before.webm](https://github.com/user-attachments/assets/d367e6ab-d199-4996-b3ee-93b0f17966cf)

After (with my code changes)
[after.webm](https://github.com/user-attachments/assets/ca4a94ce-9202-40fd-9e1e-23960cc0f679)

And please backport to v15 and v14 if possible.

Best regards
Meike
