### PR TITLE
fix: added debounce to prevent multiple clicks

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.js
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.js
@@ -34,6 +34,7 @@ frappe.ui.form.on("Depreciation Schedule", {
 					asset_depr_schedule_name: frm.doc.name,
 					date: row.schedule_date,
 				},
+				debounce:1000, 
 				callback: function (r) {
 					frappe.model.sync(r.message);
 					frm.refresh();

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.js
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.js
@@ -34,7 +34,7 @@ frappe.ui.form.on("Depreciation Schedule", {
 					asset_depr_schedule_name: frm.doc.name,
 					date: row.schedule_date,
 				},
-				debounce:1000, 
+				debounce: 1000,
 				callback: function (r) {
 					frappe.model.sync(r.message);
 					frm.refresh();


### PR DESCRIPTION
On clicking make depreciation entry more than 1 time, duplicate (triplicate) JVs for depreciation were posting against the same asset and same dep-schedule.

https://github.com/user-attachments/assets/ed605253-9115-4665-aad9-14d46cf069de

