### PR TITLE
fix: add condition to check if item is delivered by supplier in make_purchase_order_for_default_supplier()

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1044,7 +1044,8 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 					"postprocess": update_item,
 					"condition": lambda doc: doc.ordered_qty < doc.stock_qty
 					and doc.supplier == supplier
-					and doc.item_code in items_to_map,
+					and doc.item_code in items_to_map
+					and doc.delivered_by_supplier == 1,
 				},
 			},
 			target_doc,


### PR DESCRIPTION
Add condition to check if item is delivered by supplier in make_purchase_order_for_default_supplier()

This fix ensures that the make_purchase_order_for_default_supplier method only includes items marked as delivered_by_supplier = 1 when creating purchase orders. By adding this condition, the function now correctly filters out items intended for warehouse delivery, aligning with the intended behavior.

This change prevents the incorrect inclusion of warehouse-stock items in purchase orders, ensuring accurate order processing and better drop-ship management.

closes #45364

backport version-14