### PR TITLE
fix: resolved pos return setting to default mode of payment instead of user selection

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -877,3 +877,11 @@ def get_item_group(pos_profile):
 			item_groups.extend(get_descendants_of("Item Group", row.item_group))
 
 	return list(set(item_groups))
+
+
+@frappe.whitelist()
+def get_payment_data(pos_invoice):
+	payment = frappe.db.get_all(
+		"Sales Invoice Payment", {"parent": pos_invoice}, ["mode_of_payment", "amount"]
+	)
+	return payment

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -877,11 +877,3 @@ def get_item_group(pos_profile):
 			item_groups.extend(get_descendants_of("Item Group", row.item_group))
 
 	return list(set(item_groups))
-
-
-@frappe.whitelist()
-def get_payment_data(pos_invoice):
-	payment = frappe.db.get_all(
-		"Sales Invoice Payment", {"parent": pos_invoice}, ["mode_of_payment", "amount"]
-	)
-	return payment

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -1150,3 +1150,9 @@ def get_available_serial_nos(serial_nos, warehouse):
 	return frappe.get_all(
 		"Serial No", filters={"warehouse": warehouse, "name": ("in", serial_nos)}, pluck="name"
 	)
+
+
+@frappe.whitelist()
+def get_payment_data(invoice):
+	payment = frappe.db.get_all("Sales Invoice Payment", {"parent": invoice}, ["mode_of_payment", "amount"])
+	return payment

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -886,7 +886,6 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				pos_invoice: this.frm.doc.return_against
 			}
 		});
-		console.log(return_against_mop.message);
 
 		if (return_against_mop.message.length === 1) {
 			this.frm.doc.payments.forEach(payment => {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -838,7 +838,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 	}
 
-	set_total_amount_to_default_mop() {
+	async set_total_amount_to_default_mop() {
 		let grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 		let base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
@@ -858,6 +858,46 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				),
 				precision("base_grand_total")
 			);
+		}
+
+		/*
+		During returns, if an user select mode of payment other than
+		default mode of payment, it should retain the user selection
+		instead resetting it to default mode of payment.
+		*/
+
+		let payment_amount = 0;
+		this.frm.doc.payments.forEach(payment => {
+			payment_amount += payment.amount
+		});
+
+		if (payment_amount == total_amount_to_pay) {
+			return;
+		}
+
+		/*
+		For partial return, if the payment was made using single mode of payment
+		it should set the return to that mode of payment only.
+		*/
+
+		let return_against_mop = await frappe.call({
+			method: 'erpnext.accounts.doctype.pos_invoice.pos_invoice.get_payment_data',
+			args: {
+				pos_invoice: this.frm.doc.return_against
+			}
+		});
+		console.log(return_against_mop.message);
+
+		if (return_against_mop.message.length === 1) {
+			this.frm.doc.payments.forEach(payment => {
+				if (payment.mode_of_payment == return_against_mop.message[0].mode_of_payment) {
+					payment.amount = total_amount_to_pay;
+				} else {
+					payment.amount = 0;
+				}
+			});
+			this.frm.refresh_fields();
+			return;
 		}
 
 		this.frm.doc.payments.find(payment => {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -881,9 +881,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		*/
 
 		let return_against_mop = await frappe.call({
-			method: 'erpnext.accounts.doctype.pos_invoice.pos_invoice.get_payment_data',
+			method: 'erpnext.controllers.sales_and_purchase_return.get_payment_data',
 			args: {
-				pos_invoice: this.frm.doc.return_against
+				invoice: this.frm.doc.return_against
 			}
 		});
 


### PR DESCRIPTION
Resolved the issue where the POS system automatically selected the default payment method and paid amount during returns, despite the user choosing a different payment method.

Requires backport in both version-15 and version-14.