### PR TITLE
fix: use translated value of `Meter` UOM

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -43,11 +43,16 @@ class DeliveryTrip(Document):
 		super().__init__(*args, **kwargs)
 
 		# Google Maps returns distances in meters by default
+		# TODO: needs validation or fallback, the translated version of "Meter" may not exist as UOM
+		meter_uom = _("Meter")
+
 		self.default_distance_uom = (
-			frappe.db.get_single_value("Global Defaults", "default_distance_unit") or "Meter"
+			frappe.db.get_single_value("Global Defaults", "default_distance_unit") or meter_uom
 		)
+
+		# TODO: needs validation or fallback, the UOM Conversion Factor may not exist
 		self.uom_conversion_factor = frappe.db.get_value(
-			"UOM Conversion Factor", {"from_uom": "Meter", "to_uom": self.default_distance_uom}, "value"
+			"UOM Conversion Factor", {"from_uom": meter_uom, "to_uom": self.default_distance_uom}, "value"
 		)
 
 	def validate(self):


### PR DESCRIPTION
- Because UOMs are translated during initial creation, they should also be translated during subsequent use. There are cases where the UOM will not exist due to any number of reasons, but I think this is better than current hardcoded English UOM.
- Added a couple of TODOs about edge cases that need to be handled