### PR TITLE
fix: JobCardTimeLog' object has no attribute 'remaining_time_in_mins'

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -344,8 +344,8 @@ class JobCard(Document):
 		return overlap
 
 	def get_time_logs(self, args, doctype, open_job_cards=None):
-		if get_datetime(args.from_time) >= get_datetime(args.to_time):
-			args.to_time = add_to_date(args.from_time, minutes=args.remaining_time_in_mins)
+		if args.get("remaining_time_in_mins") and get_datetime(args.from_time) >= get_datetime(args.to_time):
+			args.to_time = add_to_date(args.from_time, minutes=args.get("remaining_time_in_mins"))
 
 		jc = frappe.qb.DocType("Job Card")
 		jctl = frappe.qb.DocType(doctype)


### PR DESCRIPTION
**Issue**


<img width="847" alt="image" src="https://github.com/user-attachments/assets/f2afc579-4a17-4c39-895a-abfe0ff5c26d" />
