### PR TITLE
feat: full screen on pos

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -204,14 +204,17 @@ erpnext.PointOfSale.Controller = class {
 	prepare_fullscreen_btn() {
 		this.page.page_actions.find(".custom-actions").empty();
 
-		this.page.add_button(__("Enable Full Screen"), (e) => {
+		let enable_full_screen = __("Enable Full Screen");
+		let exit_full_screen = __("Exit Full Screen");
+
+		this.page.add_button(enable_full_screen, (e) => {
 			if (!document.fullscreenElement) {
 				document.documentElement.requestFullscreen().then(() => {
-					e.target.innerHTML = __("Exit Full Screen");
+					e.target.innerHTML = exit_full_screen;
 				});
 			} else if (document.exitFullscreen) {
 				document.exitFullscreen().then(() => {
-					e.target.innerHTML = __("Enable Full Screen");
+					e.target.innerHTML = enable_full_screen;
 				});
 			}
 		});

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -204,20 +204,34 @@ erpnext.PointOfSale.Controller = class {
 	prepare_fullscreen_btn() {
 		this.page.page_actions.find(".custom-actions").empty();
 
-		let enable_full_screen = __("Enable Full Screen");
-		let exit_full_screen = __("Exit Full Screen");
+		this.page.add_button(__("Enable Full Screen"), null, { btn_class: "btn-default fullscreen-btn" });
 
-		this.page.add_button(enable_full_screen, (e) => {
+		this.bind_fullscreen_events();
+	}
+
+	bind_fullscreen_events() {
+		this.$fullscreen_btn = this.page.page_actions.find(".fullscreen-btn");
+
+		this.$fullscreen_btn.on("click", function () {
 			if (!document.fullscreenElement) {
-				document.documentElement.requestFullscreen().then(() => {
-					e.target.innerHTML = exit_full_screen;
-				});
+				document.documentElement.requestFullscreen();
 			} else if (document.exitFullscreen) {
-				document.exitFullscreen().then(() => {
-					e.target.innerHTML = enable_full_screen;
-				});
+				document.exitFullscreen();
 			}
 		});
+
+		$(document).on("fullscreenchange", this.handle_fullscreen_change_event.bind(this));
+	}
+
+	handle_fullscreen_change_event() {
+		let enable_fullscreen_label = __("Enable Full Screen");
+		let exit_fullscreen_label = __("Exit Full Screen");
+
+		if (document.fullscreenElement) {
+			this.$fullscreen_btn[0].innerText = exit_fullscreen_label;
+		} else {
+			this.$fullscreen_btn[0].innerText = enable_fullscreen_label;
+		}
 	}
 
 	open_form_view() {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -204,7 +204,7 @@ erpnext.PointOfSale.Controller = class {
 	prepare_fullscreen_btn() {
 		this.page.page_actions.find(".custom-actions").empty();
 
-		this.page.add_button(__("Enable Full Screen"), null, { btn_class: "btn-default fullscreen-btn" });
+		this.page.add_button(__("Full Screen"), null, { btn_class: "btn-default fullscreen-btn" });
 
 		this.bind_fullscreen_events();
 	}
@@ -224,7 +224,7 @@ erpnext.PointOfSale.Controller = class {
 	}
 
 	handle_fullscreen_change_event() {
-		let enable_fullscreen_label = __("Enable Full Screen");
+		let enable_fullscreen_label = __("Full Screen");
 		let exit_fullscreen_label = __("Exit Full Screen");
 
 		if (document.fullscreenElement) {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -165,6 +165,7 @@ erpnext.PointOfSale.Controller = class {
 		this.prepare_dom();
 		this.prepare_components();
 		this.prepare_menu();
+		this.prepare_fullscreen_btn();
 		this.make_new_invoice();
 	}
 
@@ -198,6 +199,22 @@ erpnext.PointOfSale.Controller = class {
 		this.page.add_menu_item(__("Save as Draft"), this.save_draft_invoice.bind(this), false, "Ctrl+S");
 
 		this.page.add_menu_item(__("Close the POS"), this.close_pos.bind(this), false, "Shift+Ctrl+C");
+	}
+
+	prepare_fullscreen_btn() {
+		this.page.page_actions.find(".custom-actions").empty();
+
+		this.page.add_button(__("Enable Full Screen"), (e) => {
+			if (!document.fullscreenElement) {
+				document.documentElement.requestFullscreen().then(() => {
+					e.target.innerHTML = __("Exit Full Screen");
+				});
+			} else if (document.exitFullscreen) {
+				document.exitFullscreen().then(() => {
+					e.target.innerHTML = __("Enable Full Screen");
+				});
+			}
+		});
 	}
 
 	open_form_view() {


### PR DESCRIPTION
In POS, the default keyboard shortcut for Full Screen is already assigned to 'Open Form View'. 

Added a separate button on the POS page to toggle Full Screen View, as the POS is better viewed in Full Screen Mode.

![image](https://github.com/user-attachments/assets/384ae88d-3b18-40d4-8bfb-5072ccd14790)
Non Full Screen Mode

![image](https://github.com/user-attachments/assets/790ecbc4-3100-43aa-a0dd-7cd72673fedc)
Full Screen Mode

This enhances the user experience since full-screen mode eliminates the need to scroll to click the checkout button.

no-docs