### PR TITLE
fix: disable load_after_mapping when purchase order created from sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1523,6 +1523,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 	)
 
 	set_delivery_date(doc.items, source_name)
+	doc.set_onload("load_after_mapping", False)
 
 	return doc
 


### PR DESCRIPTION
**Issue:**
When the purchase order is created from the sales order for a foreign supplier, the exchange rate is not fetching because of load_after_mapping
**ref:** [29786](https://support.frappe.io/helpdesk/tickets/29786)

**Before:**

https://github.com/user-attachments/assets/462490c0-c200-47fc-862f-cb78887fad4f


**After**

https://github.com/user-attachments/assets/8b56115d-d567-42c8-b41d-fb5b44af6159


Backport needed for v15