### PR TITLE
fix: Wrong bank_ac_no filter + simplify logic in automatch

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
+++ b/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.core.utils import find
 from frappe.utils import flt
 from rapidfuzz import fuzz, process
 
@@ -136,7 +135,7 @@ class AutoMatchbyPartyNameDescription:
 		skip = False
 		result = process.extract(
 			query=self.get(field),
-			choices=[name.get("party_name") for name in names],
+			choices={row.get("name"): row.get("party_name") for row in names},
 			scorer=fuzz.token_set_ratio,
 		)
 		party_name, skip = self.process_fuzzy_result(result)
@@ -144,8 +143,6 @@ class AutoMatchbyPartyNameDescription:
 		if not party_name:
 			return None, skip
 
-		# Get Party Docname from the list of dicts
-		party_name = find(names, lambda x: x["party_name"] == party_name).get("name")
 		return (
 			party,
 			party_name,
@@ -158,14 +155,14 @@ class AutoMatchbyPartyNameDescription:
 
 		Returns: Result, Skip (whether or not to discontinue matching)
 		"""
-		PARTY, SCORE, CUTOFF = 0, 1, 80
+		SCORE, PARTY_ID, CUTOFF = 1, 2, 80
 
 		if not result or not len(result):
 			return None, False
 
 		first_result = result[0]
 		if len(result) == 1:
-			return (first_result[PARTY] if first_result[SCORE] > CUTOFF else None), True
+			return (first_result[PARTY_ID] if first_result[SCORE] > CUTOFF else None), True
 
 		second_result = result[1]
 		if first_result[SCORE] > CUTOFF:
@@ -174,7 +171,7 @@ class AutoMatchbyPartyNameDescription:
 			if first_result[SCORE] == second_result[SCORE]:
 				return None, True
 
-			return first_result[PARTY], True
+			return first_result[PARTY_ID], True
 		else:
 			return None, False
 

--- a/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
+++ b/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.core.utils import find
 from frappe.utils import flt
 from rapidfuzz import fuzz, process
 
@@ -113,7 +114,8 @@ class AutoMatchbyPartyNameDescription:
 
 		for party in parties:
 			filters = {"status": "Active"} if party == "Employee" else {"disabled": 0}
-			names = frappe.get_all(party, filters=filters, pluck=party.lower() + "_name")
+			field = party.lower() + "_name"
+			names = frappe.get_all(party, filters=filters, fields=[f"{field} as party_name", "name"])
 
 			for field in ["bank_party_name", "description"]:
 				if not self.get(field):
@@ -132,12 +134,18 @@ class AutoMatchbyPartyNameDescription:
 
 	def fuzzy_search_and_return_result(self, party, names, field) -> tuple | None:
 		skip = False
-		result = process.extract(query=self.get(field), choices=names, scorer=fuzz.token_set_ratio)
+		result = process.extract(
+			query=self.get(field),
+			choices=[name.get("party_name") for name in names],
+			scorer=fuzz.token_set_ratio,
+		)
 		party_name, skip = self.process_fuzzy_result(result)
 
 		if not party_name:
 			return None, skip
 
+		# Get Party Docname from the list of dicts
+		party_name = find(names, lambda x: x["party_name"] == party_name).get("name")
 		return (
 			party,
 			party_name,


### PR DESCRIPTION
Backport of https://github.com/frappe/erpnext/pull/45129 and also backport missing https://github.com/frappe/erpnext/pull/37299 to version-15-hotfix

------------
## Issue
```
File "apps/erpnext/erpnext/accounts/doctype/bank_transaction/auto_match_party.py", line 58, in match_account_in_party
    party_result = frappe.db.get_all(
  File "apps/frappe/frappe/database/database.py", line 810, in get_all
    return frappe.get_all(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1938, in get_all
    return get_list(doctype, *args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1910, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "apps/frappe/frappe/model/db_query.py", line 190, in execute
    result = self.build_and_run()
  File "apps/frappe/frappe/model/db_query.py", line 231, in build_and_run
    return frappe.db.sql(
  File "apps/frappe/frappe/database/database.py", line 244, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'tabBank Account.bank_ac_no' in 'where clause'")
```
- `or_filters["bank_ac_no"]` gets set for "Employee" and then when the loop moves on to the next party type, this value persists, since or_filters is instantiated outside the loop and does not get refreshed
- The loop is unnecessary as Supplier and Customer do not have any data to extract and match here

## Fix
- Simplify the logic (Look in Bank Account first and then Employee) and remove the loop (we were checking in "Bank Account" in every loop which was plain ... futile)
- Return fast if filter data is unavailable
- Misc: Sourcery refactors

> Already has tests that should check correctness

## To Test

- Create a Bank account and an IBAN to it "DE123456789" and set a party and party type in it
- In Accounts Settings > Banking > enable automatic party matching
- Create a Bank Transaction and set the Party IBAN as "DE123456789" 
- Submit the transaction > The Party must be set
- The same thing can be achieved by setting the IBAN in the "Employee" doctype (remove party from bank account)<hr>This is an automatic backport of pull request #45129 done by [Mergify](https://mergify.com).