### PR TITLE
fix: resolved pos return setting to default mode of payment instead of user selection (#45377)

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -806,7 +806,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 	}
 
-	set_total_amount_to_default_mop() {
+	async set_total_amount_to_default_mop() {
 		let grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 		let base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
@@ -826,6 +826,45 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				),
 				precision("base_grand_total")
 			);
+		}
+
+		/*
+		During returns, if an user select mode of payment other than
+		default mode of payment, it should retain the user selection
+		instead resetting it to default mode of payment.
+		*/
+
+		let payment_amount = 0;
+		this.frm.doc.payments.forEach(payment => {
+			payment_amount += payment.amount
+		});
+
+		if (payment_amount == total_amount_to_pay) {
+			return;
+		}
+
+		/*
+		For partial return, if the payment was made using single mode of payment
+		it should set the return to that mode of payment only.
+		*/
+
+		let return_against_mop = await frappe.call({
+			method: 'erpnext.controllers.sales_and_purchase_return.get_payment_data',
+			args: {
+				invoice: this.frm.doc.return_against
+			}
+		});
+
+		if (return_against_mop.message.length === 1) {
+			this.frm.doc.payments.forEach(payment => {
+				if (payment.mode_of_payment == return_against_mop.message[0].mode_of_payment) {
+					payment.amount = total_amount_to_pay;
+				} else {
+					payment.amount = 0;
+				}
+			});
+			this.frm.refresh_fields();
+			return;
 		}
 
 		this.frm.doc.payments.find(payment => {


### PR DESCRIPTION
* fix: resolved pos return setting to default mode of payment instead of user selection

* refactor: removed console log statement

* refactor: moved get_payment_data to sales_and_purchase_return.py