### PR TITLE
fix: currency decimal on POS Past Order List

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_past_order_list.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_list.js
@@ -110,7 +110,7 @@ erpnext.PointOfSale.PastOrderList = class {
 					</div>
 				</div>
 				<div class="invoice-total-status">
-					<div class="invoice-total">${format_currency(invoice.grand_total, invoice.currency, 0) || 0}</div>
+					<div class="invoice-total">${format_currency(invoice.grand_total, invoice.currency, 2) || 0}</div>
 					<div class="invoice-date">${posting_datetime}</div>
 				</div>
 			</div>

--- a/erpnext/selling/page/point_of_sale/pos_past_order_list.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_list.js
@@ -110,7 +110,7 @@ erpnext.PointOfSale.PastOrderList = class {
 					</div>
 				</div>
 				<div class="invoice-total-status">
-					<div class="invoice-total">${format_currency(invoice.grand_total, invoice.currency, 2) || 0}</div>
+					<div class="invoice-total">${format_currency(invoice.grand_total, invoice.currency) || 0}</div>
 					<div class="invoice-date">${posting_datetime}</div>
 				</div>
 			</div>


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/0d462996-4660-43c9-b186-506f0ce38df3)

after:

![image](https://github.com/user-attachments/assets/e3c3a25d-95b2-4452-9584-f6a2cd3b3f62)
