### PR TITLE
fix: correct amt in account currency for lcv with manually distributed charges.

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1385,26 +1385,25 @@ def get_item_account_wise_additional_cost(purchase_document):
 		for item in landed_cost_voucher_doc.items:
 			if item.receipt_document == purchase_document:
 				for account in landed_cost_voucher_doc.taxes:
+					exchange_rate = account.exchange_rate or 1
 					item_account_wise_cost.setdefault((item.item_code, item.purchase_receipt_item), {})
 					item_account_wise_cost[(item.item_code, item.purchase_receipt_item)].setdefault(
 						account.expense_account, {"amount": 0.0, "base_amount": 0.0}
 					)
 
-					if total_item_cost > 0:
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["amount"] += account.amount * item.get(based_on_field) / total_item_cost
+					item_row = item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
+						account.expense_account
+					]
 
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["base_amount"] += account.base_amount * item.get(based_on_field) / total_item_cost
+					if total_item_cost > 0:
+						item_row["amount"] += account.amount * item.get(based_on_field) / total_item_cost
+
+						item_row["base_amount"] += (
+							account.base_amount * item.get(based_on_field) / total_item_cost
+						)
 					else:
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["amount"] += item.applicable_charges
-						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
-							account.expense_account
-						]["base_amount"] += item.applicable_charges
+						item_row["amount"] += item.applicable_charges / exchange_rate
+						item_row["base_amount"] += item.applicable_charges
 
 	return item_account_wise_cost
 


### PR DESCRIPTION
Issue: When a landed cost voucher is created with an account other than company currency and the amount is manually distributed gl entry is submitted with an incorrect Amount in Account Currency.

Steps to Replicate:
- Create a Purchase Receipt
- Create a Landed Cost Voucher with an Expense Account in USD currency and distribution as Manually Distributed.
- Check GL Entry for Expense Account

Amount in Account currency will be same as Amount in Company Currency.

Before:
![image](https://github.com/user-attachments/assets/0b5aa4c4-2424-4570-9f98-a3a79a39e19b)

After:
![image](https://github.com/user-attachments/assets/fa5c5ad6-cb5c-4b99-804e-795cf108a8c6)


Closes: https://github.com/frappe/erpnext/issues/44688
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/29828

backport version-15
backport version-14








