### PR TITLE
fix: use currency from opportunity while creating quotation

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -887,7 +887,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		var get_party_currency = function() {
-			if (me.is_a_mapped_document()) {
+			if (me.is_a_mapped_document() || me.frm.doc.__onload?.load_after_mapping) {
 				return;
 			}
 


### PR DESCRIPTION
Issue:
While creating Quotation from Opportunity, company currency is fetched instead of using the currency from Opportunity

ref: [30069](https://support.frappe.io/helpdesk/tickets/30069)

Before:

[party_currency_bfr.webm](https://github.com/user-attachments/assets/94a84f25-4c66-4cef-99fc-274064d75fb9)

After:

[party_currency_afr.webm](https://github.com/user-attachments/assets/2fb2c9b3-6f4c-48be-800d-6c3bc7d8942f)

