### PR TITLE
fix: add multiple item issue in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -906,7 +906,12 @@ frappe.ui.form.on("Stock Entry Detail", {
 						var d = locals[cdt][cdn];
 						$.each(r.message, function (k, v) {
 							if (v) {
-								frappe.model.set_value(cdt, cdn, k, v); // qty and it's subsequent fields weren't triggered
+								// set_value trigger barcode function and barcode set qty to 1 in stock_controller.js, to avoid this set value manually instead of set value.
+								if (k != "barcode") {
+									frappe.model.set_value(cdt, cdn, k, v); // qty and it's subsequent fields weren't triggered
+								} else {
+									d.barcode = v;
+								}
 							}
 						});
 						refresh_field("items");


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/helpdesk/tickets/28771

When a barcode is set for an item, adding multiple items sets the item quantity to 1 in the Stock Entry.

> Screenshots/GIFs

Before

https://github.com/user-attachments/assets/c8e7703c-2226-42e7-9e47-3427f0edfe0f


After

https://github.com/user-attachments/assets/8c4e19c1-ad0c-4a30-a4f4-4252b8c8d201


