### PR TITLE
fix: Gross Profit Report with Correct Totals and Gross Margin

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.json
+++ b/erpnext/accounts/report/gross_profit/gross_profit.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 1,
+ "add_total_row": 0,
  "columns": [],
  "creation": "2013-02-25 17:03:34",
  "disable_prepared_report": 0,
@@ -9,7 +9,7 @@
  "filters": [],
  "idx": 3,
  "is_standard": "Yes",
- "modified": "2022-02-11 10:18:36.956558",
+ "modified": "2025-01-27 18:40:24.493829",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Gross Profit",

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -178,7 +178,13 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 	# removing Item Code and Item Name columns
 	del columns[4:6]
 
+	total_row = {"qty": 0.0, "base_amount": 0.0, "buying_amount": 0.0, "gross_profit": 0.0}
+
 	for src in gross_profit_data.si_list:
+		if src.indent == 1:
+			for key in total_row:
+				total_row[key] += src.get(key, 0.0)
+
 		row = frappe._dict()
 		row.indent = src.indent
 		row.parent_invoice = src.parent_invoice
@@ -188,6 +194,16 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 			row[column_names[col]] = src.get(col)
 
 		data.append(row)
+
+	total_row.update(
+		{
+			"sales_invoice": "Total",
+			"selling_amount": total_row["base_amount"],
+			"gross_profit_%": flt((total_row["gross_profit"] / total_row["base_amount"]) * 100.0, 3),
+		}
+	)
+
+	data.append(total_row)
 
 
 def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_columns, data):

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -178,12 +178,13 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 	# removing Item Code and Item Name columns
 	del columns[4:6]
 
-	total_row = {"qty": 0.0, "base_amount": 0.0, "buying_amount": 0.0, "gross_profit": 0.0}
+	total_base_amount = 0
+	total_buying_amount = 0
 
 	for src in gross_profit_data.si_list:
 		if src.indent == 1:
-			for key in total_row:
-				total_row[key] += src.get(key, 0.0)
+			total_base_amount += src.base_amount or 0.0
+			total_buying_amount += src.buying_amount or 0.0
 
 		row = frappe._dict()
 		row.indent = src.indent
@@ -195,15 +196,16 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 
 		data.append(row)
 
-	total_row.update(
+	total_gross_profit = total_base_amount - total_buying_amount
+	data.append(
 		{
 			"sales_invoice": "Total",
-			"selling_amount": total_row["base_amount"],
-			"gross_profit_%": flt((total_row["gross_profit"] / total_row["base_amount"]) * 100.0, 3),
+			"selling_amount": total_base_amount,
+			"buying_amount": total_buying_amount,
+			"gross_profit": total_gross_profit,
+			"gross_profit_%": flt((total_gross_profit / total_base_amount) * 100.0, 3),
 		}
 	)
-
-	data.append(total_row)
 
 
 def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_columns, data):

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -201,6 +201,9 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 		frappe._dict(
 			{
 				"sales_invoice": "Total",
+				"qty": None,
+				"avg._selling_rate": None,
+				"valuation_rate": None,
 				"selling_amount": total_base_amount,
 				"buying_amount": total_buying_amount,
 				"gross_profit": total_gross_profit,

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -207,7 +207,10 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 				"selling_amount": total_base_amount,
 				"buying_amount": total_buying_amount,
 				"gross_profit": total_gross_profit,
-				"gross_profit_%": flt((total_gross_profit / total_base_amount) * 100.0, 3)
+				"gross_profit_%": flt(
+					(total_gross_profit / total_base_amount) * 100.0,
+					cint(frappe.db.get_default("currency_precision")) or 3,
+				)
 				if total_base_amount
 				else 0,
 			}

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -198,13 +198,17 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 
 	total_gross_profit = total_base_amount - total_buying_amount
 	data.append(
-		{
-			"sales_invoice": "Total",
-			"selling_amount": total_base_amount,
-			"buying_amount": total_buying_amount,
-			"gross_profit": total_gross_profit,
-			"gross_profit_%": flt((total_gross_profit / total_base_amount) * 100.0, 3),
-		}
+		frappe._dict(
+			{
+				"sales_invoice": "Total",
+				"selling_amount": total_base_amount,
+				"buying_amount": total_buying_amount,
+				"gross_profit": total_gross_profit,
+				"gross_profit_%": flt((total_gross_profit / total_base_amount) * 100.0, 3)
+				if total_base_amount
+				else 0,
+			}
+		)
 	)
 
 

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -612,3 +612,33 @@ class TestGrossProfit(IntegrationTestCase):
 		item_from_sinv2 = [x for x in data if x.parent_invoice == sinv2.name]
 		self.assertEqual(len(item_from_sinv2), 1)
 		self.assertEqual(1800, item_from_sinv2[0].valuation_rate)
+
+	def test_gross_profit_groupby_invoices(self):
+		create_sales_invoice(
+			qty=1,
+			rate=100,
+			company=self.company,
+			customer=self.customer,
+			item_code=self.item,
+			item_name=self.item,
+			cost_center=self.cost_center,
+			warehouse=self.warehouse,
+			debit_to=self.debit_to,
+			parent_cost_center=self.cost_center,
+			update_stock=0,
+			currency="INR",
+			income_account=self.income_account,
+			expense_account=self.expense_account,
+		)
+
+		filters = frappe._dict(
+			company=self.company, from_date=nowdate(), to_date=nowdate(), group_by="Invoice"
+		)
+
+		_, data = execute(filters=filters)
+		total = data[-1]
+
+		self.assertEqual(total.selling_amount, 100.0)
+		self.assertEqual(total.buying_amount, 0.0)
+		self.assertEqual(total.gross_profit, 100.0)
+		self.assertEqual(total.get("gross_profit_%"), 100.0)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -399,3 +399,4 @@ erpnext.patches.v15_0.rename_manufacturing_settings_field
 erpnext.patches.v15_0.migrate_checkbox_to_select_for_reconciliation_effect
 erpnext.patches.v15_0.sync_auto_reconcile_config
 execute:frappe.db.set_single_value("Accounts Settings", "exchange_gain_loss_posting_date", "Payment")
+erpnext.patches.v14_0.disable_add_row_in_gross_profit

--- a/erpnext/patches/v14_0/disable_add_row_in_gross_profit.py
+++ b/erpnext/patches/v14_0/disable_add_row_in_gross_profit.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.db.set_value("Report", "Gross Profit", "add_total_row", 0)


### PR DESCRIPTION
Support ticket: [Support Ticket  - 30225](https://support.frappe.io/helpdesk/tickets/30225)
- closes : #35942

Before : 
The add_total_row option was checked, causing the subtotals to combine, which resulted in an incorrect **Selling Amount**, **Buying Amount**,  **Gross Profit**, **Gross Profit Percentage**.

<img width="847" alt="Screenshot 2025-01-27 at 6 55 10 PM" src="https://github.com/user-attachments/assets/374c917f-727b-4bdf-a93b-2dc548a440a9" />


After : 
The total Selling Amount and Buying Amount are now calculated correctly.
The total **Gross Profit** and **Gross Profit Percentage** is calculated using a formula.
The add_total_row option was disabled using a patch.

<img width="847" alt="Screenshot 2025-01-27 at 9 58 45 PM" src="https://github.com/user-attachments/assets/45151881-71a0-4ab1-a55b-15f42fc99321" />



