### PR TITLE
fix: get stock balance filtered by company for validating stock value in jv

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -154,10 +154,9 @@ class TestJournalEntry(IntegrationTestCase):
 				"credit_in_account_currency": 0 if diff > 0 else abs(diff),
 			},
 		)
-		jv.insert()
 
 		if account_bal == stock_bal:
-			self.assertRaises(StockAccountInvalidTransaction, jv.submit)
+			self.assertRaises(StockAccountInvalidTransaction, jv.save)
 			frappe.db.rollback()
 		else:
 			jv.submit()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1678,7 +1678,7 @@ def get_stock_and_account_balance(account=None, posting_date=None, company=None)
 			if wh_details.account == account and not wh_details.is_group
 		]
 
-	total_stock_value = get_stock_value_on(related_warehouses, posting_date)
+	total_stock_value = get_stock_value_on(related_warehouses, posting_date, company=company)
 
 	precision = frappe.get_precision("Journal Entry Account", "debit_in_account_currency")
 	return flt(account_balance, precision), flt(total_stock_value, precision), related_warehouses

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -58,7 +58,10 @@ def get_stock_value_from_bin(warehouse=None, item_code=None):
 
 
 def get_stock_value_on(
-	warehouses: list | str | None = None, posting_date: str | None = None, item_code: str | None = None
+	warehouses: list | str | None = None,
+	posting_date: str | None = None,
+	item_code: str | None = None,
+	company: str | None = None,
 ) -> float:
 	if not posting_date:
 		posting_date = nowdate()
@@ -83,6 +86,9 @@ def get_stock_value_on(
 
 	if item_code:
 		query = query.where(sle.item_code == item_code)
+
+	if company:
+		query = query.where(sle.company == company)
 
 	return query.run(as_list=True)[0][0]
 


### PR DESCRIPTION
Issue: stock account validation is not working in the Journal Voucher.

Steps to Replicate:
- Create two companies A and B with only a single stock account.
- Create a Stock Transaction in company A to change stock value.
- Create a Journal Entry in Company B with the stock account.

Validation will not be raised even though the stock account is used because the stock balance will be for all the companies.


Fix:
get stock balance filtered by company.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/29844

backport version-15
backport version-14





