### PR TITLE
fix: alternate item not getting updated in work order

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -568,7 +568,7 @@ erpnext.utils.select_alternate_items = function (opts) {
 					qty = row.qty;
 				}
 				row[item_field] = d.alternate_item;
-				frappe.model.set_value(row.doctype, row.name, "qty", qty);
+				frappe.model.set_value(row.doctype, row.name, "required_qty", qty);
 				frappe.model.set_value(row.doctype, row.name, opts.original_item_field, d.item_code);
 				frm.trigger(item_field, row.doctype, row.name);
 			});


### PR DESCRIPTION
Incorrect field referred in the update qty in snot present in work order item

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
