### PR TITLE
fix: validate advance amount in company currency

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -800,21 +800,11 @@ class calculate_taxes_and_totals:
 
 			self.doc.total_advance = flt(total_allocated_amount, self.doc.precision("total_advance"))
 
-			grand_total = self.doc.rounded_total or self.doc.grand_total
+			grand_total = self.doc.base_rounded_total or self.doc.base_grand_total
 
-			if self.doc.party_account_currency == self.doc.currency:
-				invoice_total = flt(
-					grand_total - flt(self.doc.write_off_amount), self.doc.precision("grand_total")
-				)
-			else:
-				base_write_off_amount = flt(
-					flt(self.doc.write_off_amount) * self.doc.conversion_rate,
-					self.doc.precision("base_write_off_amount"),
-				)
-				invoice_total = (
-					flt(grand_total * self.doc.conversion_rate, self.doc.precision("grand_total"))
-					- base_write_off_amount
-				)
+			invoice_total = flt(
+				grand_total - flt(self.doc.base_write_off_amount), self.doc.precision("grand_total")
+			)
 
 			if invoice_total > 0 and self.doc.total_advance > invoice_total:
 				frappe.throw(


### PR DESCRIPTION
Issue:
Unable to create purchase invoice with the advance amount in foreign currency due to minor precision loss

Ref: [26967](https://support.frappe.io/helpdesk/tickets/26967)

Payment:

![purchase_advance_payment](https://github.com/user-attachments/assets/80291704-886c-47ff-8790-59557cb0a51a)

Invoice:

![purchase_invoice_v](https://github.com/user-attachments/assets/d30c5b56-c036-4bf1-92e2-73af65349b37)

Error:

![purchase_error](https://github.com/user-attachments/assets/944ecf13-3695-4b7d-98a2-016e85f80b36)

invoice amount - 80.445
exchange rate - 0.104950000

80.445/0.104950000 = 766.5078608861362
766.5078608861362 * 0.104950000 = 80.445

but since it is being rounded with field precision 766.50 * 0.104950000 = 80.444175
so the condition 80.445 > 80.444175 is passed

Back-port needed for v15