### PR TITLE
fix: use stock qty in packing slip

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1108,7 +1108,10 @@ def make_packing_slip(source_name, target_doc=None):
 		target.run_method("set_missing_values")
 
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.stock_qty) - flt(obj.packed_qty)
+		if obj.get("stock_qty") is not None:
+			target.qty = flt(obj.stock_qty) - flt(obj.packed_qty)
+		else:
+			target.qty = flt(obj.qty) - flt(obj.packed_qty)
 
 	doclist = get_mapped_doc(
 		"Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -720,7 +720,7 @@ class DeliveryNote(SellingController):
 				if (
 					item.item_code not in product_bundle_list
 					and flt(item.packed_qty)
-					and flt(item.packed_qty) != flt(item.qty)
+					and flt(item.packed_qty) != flt(item.stock_qty)
 				):
 					frappe.throw(
 						_("Row {0}: Packed Qty must be equal to {1} Qty.").format(
@@ -808,7 +808,7 @@ class DeliveryNote(SellingController):
 		product_bundle_list = self.get_product_bundle_list()
 
 		for item in self.items + self.packed_items:
-			if item.item_code not in product_bundle_list and flt(item.packed_qty) < flt(item.qty):
+			if item.item_code not in product_bundle_list and flt(item.packed_qty) < flt(item.stock_qty):
 				return True
 
 		return False
@@ -1108,7 +1108,7 @@ def make_packing_slip(source_name, target_doc=None):
 		target.run_method("set_missing_values")
 
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.qty) - flt(obj.packed_qty)
+		target.qty = flt(obj.stock_qty) - flt(obj.packed_qty)
 
 	doclist = get_mapped_doc(
 		"Delivery Note",
@@ -1126,7 +1126,7 @@ def make_packing_slip(source_name, target_doc=None):
 					"item_name": "item_name",
 					"batch_no": "batch_no",
 					"description": "description",
-					"qty": "qty",
+					"stock_qty": "qty",
 					"stock_uom": "stock_uom",
 					"name": "dn_detail",
 				},

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -41,7 +41,7 @@ class PackingSlip(StatusUpdater):
 				"join_field": "dn_detail",
 				"target_field": "packed_qty",
 				"target_parent_dt": "Delivery Note",
-				"target_ref_field": "qty",
+				"target_ref_field": "stock_qty",
 				"source_dt": "Packing Slip Item",
 				"source_field": "qty",
 			},
@@ -132,7 +132,7 @@ class PackingSlip(StatusUpdater):
 			remaining_qty = frappe.db.get_value(
 				"Delivery Note Item" if item.dn_detail else "Packed Item",
 				{"name": item.dn_detail or item.pi_detail, "docstatus": 0},
-				["sum(qty - packed_qty)"],
+				[f"sum({'stock_qty' if item.dn_detail else 'qty'} - packed_qty)"],
 			)
 
 			if remaining_qty is None:


### PR DESCRIPTION
**Issue:**
When the delivery note is created with a different uom for an item, the packing slip is always made with the stock uom. So there is a difference in qty
ref: [30145](https://support.frappe.io/helpdesk/tickets/30145)

**Item:**
![Image](https://github.com/user-attachments/assets/b94ea292-f1aa-415d-8657-dfdb033b96f5)

![Image](https://github.com/user-attachments/assets/8ecbe572-c804-42ce-8936-a12fcd022754)

**Delivery Note:**
![Image](https://github.com/user-attachments/assets/e8899c6d-12d9-4116-90e5-2ec96f615190)

**Before:**
![Image](https://github.com/user-attachments/assets/7e2f0fe1-5ab0-4ad2-bf70-814dee2079d3)

**After:**
![image](https://github.com/user-attachments/assets/d6a032d6-c8fe-4263-ba0a-bd1c08c25af8)


Backport needed for v15