### PR TITLE
fix: handling company in bank reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -19,9 +19,9 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 	},
 
 	onload: function (frm) {
-		// set default company
-		const default_company = frappe.defaults.get_default("company");
-		frm.set_value("company", default_company);
+		if (!frm.doc.company) {
+			frm.set_value("company", frappe.defaults.get_default("company"));
+		}
 
 		// Set default filter dates
 		let today = frappe.datetime.get_today();

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -19,10 +19,15 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 	},
 
 	onload: function (frm) {
+		// set default company
+		const default_company = frappe.defaults.get_default("company");
+		frm.set_value("company", default_company);
+
 		// Set default filter dates
 		let today = frappe.datetime.get_today();
 		frm.doc.bank_statement_from_date = frappe.datetime.add_months(today, -1);
 		frm.doc.bank_statement_to_date = today;
+
 		frm.trigger("bank_account");
 	},
 
@@ -98,7 +103,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 
 	make_reconciliation_tool(frm) {
 		frm.get_field("reconciliation_tool_cards").$wrapper.empty();
-		if (frm.doc.bank_account && frm.doc.bank_statement_to_date) {
+		if (frm.doc.company && frm.doc.bank_account && frm.doc.bank_statement_to_date) {
 			frm.trigger("get_cleared_balance").then(() => {
 				if (
 					frm.doc.bank_account &&
@@ -114,7 +119,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 	},
 
 	get_account_opening_balance(frm) {
-		if (frm.doc.bank_account && frm.doc.bank_statement_from_date) {
+		if (frm.doc.company && frm.doc.bank_account && frm.doc.bank_statement_from_date) {
 			frappe.call({
 				method: "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_account_balance",
 				args: {
@@ -130,7 +135,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 	},
 
 	get_cleared_balance(frm) {
-		if (frm.doc.bank_account && frm.doc.bank_statement_to_date) {
+		if (frm.doc.company && frm.doc.bank_account && frm.doc.bank_statement_to_date) {
 			return frappe.call({
 				method: "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_account_balance",
 				args: {


### PR DESCRIPTION
**Issue:**
In **Bank Reconciliation Tool**, `company`  field is not loaded with the default company value. 
So, API call made on selecting the `Bank Account` throws error for missing value of `company`.


![Screenshot from 2025-01-29 13-44-34](https://github.com/user-attachments/assets/8df17355-8624-468c-873e-1633207c2332)
*Default Company is not loaded when opening Bank Reconciliation Tool*

![Screenshot from 2025-01-29 13-46-20](https://github.com/user-attachments/assets/a6302c19-b08f-46df-aed2-6c1db0b7df9c)
*An error is thrown when selecting Bank Account*

**Reference:**
https://github.com/frappe/erpnext/blob/d748b491ee2bbb2967175f58e1b04f5c2eda4722/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js#L9


backport version-14
backport version-15