### PR TITLE
fix: remove tds account in taxes table on change of Tax Withholding C…

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -372,6 +372,18 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		}
 	}
 
+	tax_withholding_category(frm) {
+		var me = this;
+		let filtered_taxes = (me.frm.doc.taxes || []).filter((row) => !row.is_tax_withholding_account);
+		me.frm.clear_table("taxes");
+
+		filtered_taxes.forEach((row) => {
+			me.frm.add_child("taxes", row);
+		});
+
+		me.frm.refresh_field("taxes");
+	}
+
 	credit_to() {
 		var me = this;
 		if (this.frm.doc.credit_to) {


### PR DESCRIPTION
Issue: On changing the Tax Withholding Category, the account in the taxes table is not being removed and continues to accumulate.

Solution: Added a JS validation on the change of Tax Withholding Category

Before:

[tax_withholding_category_removal_before.webm](https://github.com/user-attachments/assets/99a980f6-709d-4240-a3c4-a9e06b29b134)


After:

[tax_withholding_category_removal_after.webm](https://github.com/user-attachments/assets/589f31ff-a617-43bd-be6b-936cfcb824f7)

Backport needed: Version15
