### PR TITLE
feat: disable auto setting grand total to default mode of payment

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -31,6 +31,7 @@
   "ignore_pricing_rule",
   "allow_rate_change",
   "allow_discount_change",
+  "disable_grand_total_to_default_mop",
   "section_break_23",
   "item_groups",
   "column_break_25",
@@ -399,6 +400,12 @@
    "fieldname": "print_receipt_on_order_complete",
    "fieldtype": "Check",
    "label": "Print Receipt on Order Complete"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_grand_total_to_default_mop",
+   "fieldtype": "Check",
+   "label": "Disable auto setting Grand Total to default Payment Mode"
   }
  ],
  "icon": "icon-cog",
@@ -426,7 +433,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-01-01 11:07:03.161950",
+ "modified": "2025-01-29 13:12:30.796630",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -35,6 +35,7 @@ class POSProfile(Document):
 		currency: DF.Link
 		customer: DF.Link | None
 		customer_groups: DF.Table[POSCustomerGroup]
+		disable_grand_total_to_default_mop: DF.Check
 		disable_rounded_total: DF.Check
 		disabled: DF.Check
 		expense_account: DF.Link | None

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -910,10 +910,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		this.frm.refresh_fields();
 	}
 
-	set_default_payment(total_amount_to_pay, update_paid_amount) {
+	async set_default_payment(total_amount_to_pay, update_paid_amount) {
 		var me = this;
 		var payment_status = true;
 		if(this.frm.doc.is_pos && (update_paid_amount===undefined || update_paid_amount)) {
+			let r = await frappe.db.get_value("POS Profile", this.frm.doc.pos_profile, "disable_grand_total_to_default_mop");
+
+			if (r.message.disable_grand_total_to_default_mop) {
+				return;
+			}
+
 			$.each(this.frm.doc['payments'] || [], function(index, data) {
 				if(data.default && payment_status && total_amount_to_pay > 0) {
 					let base_amount, amount;

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -332,11 +332,19 @@ erpnext.PointOfSale.Payment = class {
 		// pass
 	}
 
-	render_payment_section() {
+	async render_payment_section() {
 		this.render_payment_mode_dom();
 		this.make_invoice_fields_control();
 		this.update_totals_section();
-		this.focus_on_default_mop();
+		let r = await frappe.db.get_value(
+			"POS Profile",
+			this.frm.doc.pos_profile,
+			"disable_grand_total_to_default_mop"
+		);
+
+		if (!r.message.disable_grand_total_to_default_mop) {
+			this.focus_on_default_mop();
+		}
 	}
 
 	after_render() {


### PR DESCRIPTION
Added a POS Profile Configuration, where users can disable auto-setting the Grand Total to the default Mode of Payment. 

![image](https://github.com/user-attachments/assets/13327596-833a-4db5-a068-118d3f543e9f)

Before:

https://github.com/user-attachments/assets/4e0496fa-283d-4d54-ae6f-c267cd2a25aa

After the configuration is enabled, users can manually select the mode of payment while checking out from POS.

https://github.com/user-attachments/assets/2daaf84d-bf79-4612-ad31-d868e07ac896


no-docs