### PR TITLE
fix: set stock adjustment account in difference account

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1634,6 +1634,7 @@ class StockEntry(StockController):
 				item.sample_quantity,
 				item.has_serial_no,
 				item.allow_alternative_item,
+				item_default.expense_account,
 				item_default.buying_cost_center,
 			)
 			.where(
@@ -1688,6 +1689,11 @@ class StockEntry(StockController):
 
 		if self.purpose == "Material Issue":
 			ret["expense_account"] = item.get("expense_account") or item_group_defaults.get("expense_account")
+
+		if self.purpose == "Manufacture":
+			ret["expense_account"] = frappe.get_cached_value(
+				"Company", self.company, "stock_adjustment_account"
+			)
 
 		for company_field, field in {
 			"stock_adjustment_account": "expense_account",


### PR DESCRIPTION
**Issue:** 
In the stock entry, while selecting the item, it fetches the default expense account from the item defaults as a different account
**ref:** [27927](https://support.frappe.io/helpdesk/tickets/27927)

**Before:**

https://github.com/user-attachments/assets/d2877e01-916d-4fe2-998c-78e4a1cecb7c

**After:**

https://github.com/user-attachments/assets/84dd7c5f-55df-4470-9882-dab80a1eb448

**Backport needed for v14 & v15**