### PR TITLE
fix: respect user set account if not advance account for getting outsanding invoices in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1907,7 +1907,7 @@ class PaymentEntry(AccountsController):
 		paid_amount -= sum(flt(d.amount, precision) for d in self.deductions)
 
 		for ref in self.references:
-			reference_outstanding_amount = ref.outstanding_amount
+			reference_outstanding_amount = flt(ref.outstanding_amount)
 			abs_outstanding_amount = abs(reference_outstanding_amount)
 
 			if reference_outstanding_amount > 0:
@@ -2352,10 +2352,17 @@ def get_outstanding_reference_documents(args, validate=False):
 	outstanding_invoices = []
 	negative_outstanding_invoices = []
 
+	party_account = args.get("party_account")
+
+	# get party account if advance account is set.
 	if args.get("book_advance_payments_in_separate_party_account"):
-		party_account = get_party_account(args.get("party_type"), args.get("party"), args.get("company"))
-	else:
-		party_account = args.get("party_account")
+		accounts = get_party_account(
+			args.get("party_type"), args.get("party"), args.get("company"), include_advance=True
+		)
+		advnace_account = accounts[1] if len(accounts) >= 1 else None
+
+		if party_account == advnace_account:
+			party_account = accounts[0]
 
 	if args.get("get_outstanding_invoices"):
 		outstanding_invoices = get_outstanding_invoices(

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2359,9 +2359,9 @@ def get_outstanding_reference_documents(args, validate=False):
 		accounts = get_party_account(
 			args.get("party_type"), args.get("party"), args.get("company"), include_advance=True
 		)
-		advnace_account = accounts[1] if len(accounts) >= 1 else None
+		advance_account = accounts[1] if len(accounts) >= 1 else None
 
-		if party_account == advnace_account:
+		if party_account == advance_account:
 			party_account = accounts[0]
 
 	if args.get("get_outstanding_invoices"):


### PR DESCRIPTION
Issue: Outstanding Invoices for the incorrect account are being fetched in Payment Entry.

Steps to replicate:
- Enable "Book Advance in Separate Party Account in company settings".
- Create a receivable account B.
- Create two invoices for a customer one in default receivable and the other in B Account.
- Create a New Payment Entry for the customer.
- Set "Account Paid From" as B.
- Fetch Outstanding Invoices

Even though Account B is set, invoices for the default account will be fetched because the system reset the party account.

Solution: Reset party account only if an advance account is set.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/30383