### PR TITLE
fix: correctly change from and to amount during cross currency Payment Entry (Internal Transfer)

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -811,12 +811,14 @@ frappe.ui.form.on("Payment Entry", {
 	},
 
 	paid_amount: function (frm) {
+		frm.set_value("received_amount", frm.doc.paid_amount / frm.doc.target_exchange_rate);
 		frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 		frm.trigger("reset_received_amount");
 		frm.events.hide_unhide_fields(frm);
 	},
 
 	received_amount: function (frm) {
+		frm.set_value("paid_amount", frm.doc.received_amount * frm.doc.target_exchange_rate);
 		frm.set_paid_amount_based_on_received_amount = true;
 
 		if (!frm.doc.paid_amount && frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -163,6 +163,7 @@ class PaymentEntry(AccountsController):
 			self.party_account_currency = self.paid_to_account_currency
 
 	def validate(self):
+		self.validate_amounts_if_currency_exchange()
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
@@ -195,7 +196,6 @@ class PaymentEntry(AccountsController):
 	def on_submit(self):
 		if self.difference_amount:
 			frappe.throw(_("Difference Amount must be zero"))
-		self.validate_amounts_if_currency_exchnage()
 		self.make_gl_entries()
 		self.update_outstanding_amounts()
 		self.update_payment_schedule()
@@ -204,7 +204,7 @@ class PaymentEntry(AccountsController):
 		self.update_advance_paid()  # advance_paid_status depends on the payment request amount
 		self.set_status()
 
-	def validate_amounts_if_currency_exchnage(self):
+	def validate_amounts_if_currency_exchange(self):
 		if self.paid_from_account_currency != self.paid_to_account_currency:
 			self.paid_amount = self.received_amount * self.target_exchange_rate
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -163,7 +163,6 @@ class PaymentEntry(AccountsController):
 			self.party_account_currency = self.paid_to_account_currency
 
 	def validate(self):
-		self.validate_amounts_if_currency_exchange()
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
@@ -203,10 +202,6 @@ class PaymentEntry(AccountsController):
 		self.make_advance_payment_ledger_entries()
 		self.update_advance_paid()  # advance_paid_status depends on the payment request amount
 		self.set_status()
-
-	def validate_amounts_if_currency_exchange(self):
-		if self.paid_from_account_currency != self.paid_to_account_currency:
-			self.paid_amount = self.received_amount * self.target_exchange_rate
 
 	def set_liability_account(self):
 		# Auto setting liability account should only be done during 'draft' status

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -195,6 +195,7 @@ class PaymentEntry(AccountsController):
 	def on_submit(self):
 		if self.difference_amount:
 			frappe.throw(_("Difference Amount must be zero"))
+		self.validate_amounts_if_currency_exchnage()
 		self.make_gl_entries()
 		self.update_outstanding_amounts()
 		self.update_payment_schedule()
@@ -202,6 +203,10 @@ class PaymentEntry(AccountsController):
 		self.make_advance_payment_ledger_entries()
 		self.update_advance_paid()  # advance_paid_status depends on the payment request amount
 		self.set_status()
+
+	def validate_amounts_if_currency_exchnage(self):
+		if self.paid_from_account_currency != self.paid_to_account_currency:
+			self.paid_amount = self.received_amount * self.target_exchange_rate
 
 	def set_liability_account(self):
 		# Auto setting liability account should only be done during 'draft' status


### PR DESCRIPTION
Reference issue #45543 

Previous behaviour: From and To amounts for Internal Transfer Payment Entries were not being updated when any of the 3 values (3rd being Exchange Rate) were being modified.

New behaviour: To system will now auto compute from and to amounts based on other 2 fields and exchange rate

`no-docs`