### PR TITLE
fix: delivered button of purchase order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -367,7 +367,11 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 				}
 
 				if (is_drop_ship && doc.status != "Delivered") {
-					this.frm.add_custom_button(__("Delivered"), this.delivered_by_supplier, __("Status"));
+					this.frm.add_custom_button(
+						__("Delivered"),
+						this.delivered_by_supplier.bind(this),
+						__("Status")
+					);
 
 					this.frm.page.set_inner_btn_group_as_primary(__("Status"));
 				}


### PR DESCRIPTION
No reference issue

Set status to `Delivered` button of Purchase Order was not working due to reference to `this` was lost when function was called. Fixed by binding `this` to function call explicitly.

`no-docs`