### PR TITLE
fix: packing slip now copies stock_qty instead of qty

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1108,7 +1108,7 @@ def make_packing_slip(source_name, target_doc=None):
 		target.run_method("set_missing_values")
 
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.stock_qty) - flt(obj.packed_qty)
+		target.qty = flt(obj.get("stock_qty") or obj.qty) - flt(obj.packed_qty)
 
 	doclist = get_mapped_doc(
 		"Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1108,7 +1108,7 @@ def make_packing_slip(source_name, target_doc=None):
 		target.run_method("set_missing_values")
 
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.qty) - flt(obj.packed_qty)
+		target.qty = flt(obj.stock_qty) - flt(obj.packed_qty)
 
 	doclist = get_mapped_doc(
 		"Delivery Note",
@@ -1126,7 +1126,6 @@ def make_packing_slip(source_name, target_doc=None):
 					"item_name": "item_name",
 					"batch_no": "batch_no",
 					"description": "description",
-					"qty": "qty",
 					"stock_uom": "stock_uom",
 					"name": "dn_detail",
 				},
@@ -1143,7 +1142,6 @@ def make_packing_slip(source_name, target_doc=None):
 					"item_name": "item_name",
 					"batch_no": "batch_no",
 					"description": "description",
-					"qty": "qty",
 					"name": "pi_detail",
 				},
 				"postprocess": update_item,


### PR DESCRIPTION
Reference issue #45572 

Packing slip's UOM field is read only and is `Nos` by default (stock UOM). If UOM used in Delivery Note is different than `Nos`, packing slip created would have that quantity instead of stock_qty

For example:
Item has an extra UOM `Box` with conversion factor of 0.5. User creates Delivery Note of Item with Quantity 10 and UOM as `Box`. Now stock_qty (Nos) is 5 (10 * 0.5). When user creates a Packing Slip from this DN, they will have quantity as 10 for UOM `Nos` which is wrong. It should be 5.

`no-docs`