### PR TITLE
fix: attribute 'msgbox' not found in sales invoice.js

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -65,7 +65,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	refresh(doc, dt, dn) {
 		const me = this;
 		super.refresh();
-		if (this.frm.msgbox && this.frm.msgbox.$wrapper.is(":visible")) {
+		if (this.frm?.msgbox && this.frm.msgbox.$wrapper.is(":visible")) {
 			// hide new msgbox
 			this.frm.msgbox.hide();
 		}


### PR DESCRIPTION
Reference support ticket [30495](https://support.frappe.io/helpdesk/tickets/30495)

Simply added a null check

`no-docs`