### PR TITLE
refactor: remove redundant balance fields from Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -472,9 +472,7 @@ frappe.ui.form.on("Payment Entry", {
 					"paid_from",
 					"paid_to",
 					"paid_from_account_currency",
-					"paid_from_account_balance",
 					"paid_to_account_currency",
-					"paid_to_account_balance",
 					"references",
 					"total_allocated_amount",
 				],
@@ -519,7 +517,6 @@ frappe.ui.form.on("Payment Entry", {
 										"paid_from_account_currency",
 										r.message.party_account_currency
 									);
-									frm.set_value("paid_from_account_balance", r.message.account_balance);
 								} else if (frm.doc.payment_type == "Pay") {
 									frm.set_value("paid_to", r.message.party_account);
 									frm.set_value(
@@ -580,7 +577,6 @@ frappe.ui.form.on("Payment Entry", {
 			frm,
 			frm.doc.paid_from,
 			"paid_from_account_currency",
-			"paid_from_account_balance",
 			function (frm) {
 				if (frm.doc.payment_type == "Pay") {
 					frm.events.paid_amount(frm);
@@ -612,13 +608,7 @@ frappe.ui.form.on("Payment Entry", {
 		);
 	},
 
-	set_account_currency_and_balance: function (
-		frm,
-		account,
-		currency_field,
-		balance_field,
-		callback_function
-	) {
+	set_account_currency_and_balance: function (frm, account, currency_field, callback_function) {
 		var company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 		if (frm.doc.posting_date && account) {
 			frappe.call({
@@ -633,8 +623,6 @@ frappe.ui.form.on("Payment Entry", {
 						frappe.run_serially([
 							() => frm.set_value(currency_field, r.message["account_currency"]),
 							() => {
-								frm.set_value(balance_field, r.message["account_balance"]);
-
 								if (
 									frm.doc.payment_type == "Receive" &&
 									currency_field == "paid_to_account_currency"
@@ -1676,10 +1664,6 @@ frappe.ui.form.on("Payment Entry", {
 					if (r.message) {
 						frappe.run_serially([
 							() => {
-								frm.set_value(
-									"paid_from_account_balance",
-									r.message.paid_from_account_balance
-								);
 								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
 							},
 						]);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -523,7 +523,6 @@ frappe.ui.form.on("Payment Entry", {
 										"paid_to_account_currency",
 										r.message.party_account_currency
 									);
-									frm.set_value("paid_to_account_balance", r.message.account_balance);
 								}
 							},
 							() => frm.set_value("party_name", r.message.party_name),
@@ -592,7 +591,6 @@ frappe.ui.form.on("Payment Entry", {
 			frm,
 			frm.doc.paid_to,
 			"paid_to_account_currency",
-			"paid_to_account_balance",
 			function (frm) {
 				if (frm.doc.payment_type == "Receive") {
 					if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
@@ -1645,32 +1643,6 @@ frappe.ui.form.on("Payment Entry", {
 		}
 
 		return current_tax_amount;
-	},
-
-	cost_center: function (frm) {
-		if (frm.doc.posting_date && (frm.doc.paid_from || frm.doc.paid_to)) {
-			return frappe.call({
-				method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_party_and_account_balance",
-				args: {
-					company: frm.doc.company,
-					date: frm.doc.posting_date,
-					paid_from: frm.doc.paid_from,
-					paid_to: frm.doc.paid_to,
-					ptype: frm.doc.party_type,
-					pty: frm.doc.party,
-					cost_center: frm.doc.cost_center,
-				},
-				callback: function (r, rt) {
-					if (r.message) {
-						frappe.run_serially([
-							() => {
-								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
-							},
-						]);
-					}
-				},
-			});
-		}
 	},
 
 	after_save: function (frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -374,7 +374,6 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_df_property("total_allocated_amount", "options", currency_field);
 		frm.set_df_property("unallocated_amount", "options", currency_field);
 		frm.set_df_property("total_taxes_and_charges", "options", currency_field);
-		frm.set_df_property("party_balance", "options", currency_field);
 
 		frm.set_currency_labels(
 			["total_amount", "outstanding_amount", "allocated_amount"],
@@ -422,15 +421,7 @@ frappe.ui.form.on("Payment Entry", {
 
 		if (frm.doc.payment_type == "Internal Transfer") {
 			$.each(
-				[
-					"party",
-					"party_type",
-					"party_balance",
-					"paid_from",
-					"paid_to",
-					"references",
-					"total_allocated_amount",
-				],
+				["party", "party_type", "paid_from", "paid_to", "references", "total_allocated_amount"],
 				function (i, field) {
 					frm.set_value(field, null);
 				}
@@ -478,7 +469,6 @@ frappe.ui.form.on("Payment Entry", {
 			$.each(
 				[
 					"party",
-					"party_balance",
 					"paid_from",
 					"paid_to",
 					"paid_from_account_currency",
@@ -539,7 +529,6 @@ frappe.ui.form.on("Payment Entry", {
 									frm.set_value("paid_to_account_balance", r.message.account_balance);
 								}
 							},
-							() => frm.set_value("party_balance", r.message.party_balance),
 							() => frm.set_value("party_name", r.message.party_name),
 							() => frm.clear_table("references"),
 							() => frm.events.hide_unhide_fields(frm),
@@ -1692,7 +1681,6 @@ frappe.ui.form.on("Payment Entry", {
 									r.message.paid_from_account_balance
 								);
 								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
-								frm.set_value("party_balance", r.message.party_balance);
 							},
 						]);
 					}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -35,7 +35,6 @@
   "paid_to",
   "paid_to_account_type",
   "paid_to_account_currency",
-  "paid_to_account_balance",
   "payment_amounts_section",
   "paid_amount",
   "paid_amount_after_tax",
@@ -265,16 +264,6 @@
    "print_hide": 1,
    "read_only": 1,
    "reqd": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "depends_on": "paid_to",
-   "fieldname": "paid_to_account_balance",
-   "fieldtype": "Currency",
-   "label": "Account Balance (To)",
-   "options": "paid_to_account_currency",
-   "print_hide": 1,
-   "read_only": 1
   },
   {
    "depends_on": "eval:(doc.paid_to && doc.paid_from)",
@@ -788,7 +777,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-01-31 11:17:52.292641",
+ "modified": "2025-01-31 11:24:58.076393",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -31,7 +31,6 @@
   "paid_from",
   "paid_from_account_type",
   "paid_from_account_currency",
-  "paid_from_account_balance",
   "column_break_18",
   "paid_to",
   "paid_to_account_type",
@@ -242,16 +241,6 @@
    "print_hide": 1,
    "read_only": 1,
    "reqd": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "depends_on": "paid_from",
-   "fieldname": "paid_from_account_balance",
-   "fieldtype": "Currency",
-   "label": "Account Balance (From)",
-   "options": "paid_from_account_currency",
-   "print_hide": 1,
-   "read_only": 1
   },
   {
    "fieldname": "column_break_18",
@@ -799,7 +788,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-01-31 11:05:51.703592",
+ "modified": "2025-01-31 11:17:52.292641",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -28,7 +28,6 @@
   "contact_person",
   "contact_email",
   "payment_accounts_section",
-  "party_balance",
   "paid_from",
   "paid_from_account_type",
   "paid_from_account_currency",
@@ -222,16 +221,6 @@
    "fieldname": "payment_accounts_section",
    "fieldtype": "Section Break",
    "label": "Accounts"
-  },
-  {
-   "allow_on_submit": 1,
-   "depends_on": "party",
-   "fieldname": "party_balance",
-   "fieldtype": "Currency",
-   "label": "Party Balance",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
   },
   {
    "bold": 1,
@@ -810,7 +799,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-01-31 17:27:28.555246",
+ "modified": "2025-01-31 11:05:51.703592",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -116,7 +116,6 @@ class PaymentEntry(AccountsController):
 		paid_to_account_currency: DF.Link
 		paid_to_account_type: DF.Data | None
 		party: DF.DynamicLink | None
-		party_balance: DF.Currency
 		party_bank_account: DF.Link | None
 		party_name: DF.Data | None
 		party_type: DF.Link | None
@@ -506,7 +505,6 @@ class PaymentEntry(AccountsController):
 		if self.payment_type == "Internal Transfer":
 			for field in (
 				"party",
-				"party_balance",
 				"total_allocated_amount",
 				"base_total_allocated_amount",
 				"unallocated_amount",
@@ -534,10 +532,6 @@ class PaymentEntry(AccountsController):
 				)
 			else:
 				complete_contact_details(self)
-			if not self.party_balance:
-				self.party_balance = get_balance_on(
-					party_type=self.party_type, party=self.party, date=self.posting_date, company=self.company
-				)
 
 			if not self.party_account:
 				party_account = get_party_account(self.party_type, self.party, self.company)
@@ -2721,9 +2715,7 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 	account_balance = get_balance_on(party_account, date, cost_center=cost_center)
 	_party_name = "title" if party_type == "Shareholder" else party_type.lower() + "_name"
 	party_name = frappe.db.get_value(party_type, party, _party_name)
-	party_balance = get_balance_on(
-		party_type=party_type, party=party, company=company, cost_center=cost_center
-	)
+
 	if party_type in ["Customer", "Supplier"]:
 		party_bank_account = get_party_bank_account(party_type, party)
 		bank_account = get_default_company_bank_account(company, party_type, party)
@@ -2732,7 +2724,6 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 		"party_account": party_account,
 		"party_name": party_name,
 		"party_account_currency": account_currency,
-		"party_balance": party_balance,
 		"account_balance": account_balance,
 		"party_bank_account": party_bank_account,
 		"bank_account": bank_account,
@@ -3564,7 +3555,6 @@ def get_party_and_account_balance(
 ):
 	return frappe._dict(
 		{
-			"party_balance": get_balance_on(party_type=ptype, party=pty, cost_center=cost_center),
 			"paid_from_account_balance": get_balance_on(paid_from, date, cost_center=cost_center),
 			"paid_to_account_balance": get_balance_on(paid_to, date=date, cost_center=cost_center),
 		}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -108,7 +108,6 @@ class PaymentEntry(AccountsController):
 		paid_amount: DF.Currency
 		paid_amount_after_tax: DF.Currency
 		paid_from: DF.Link
-		paid_from_account_balance: DF.Currency
 		paid_from_account_currency: DF.Link
 		paid_from_account_type: DF.Data | None
 		paid_to: DF.Link
@@ -538,10 +537,9 @@ class PaymentEntry(AccountsController):
 				self.set(self.party_account_field, party_account)
 				self.party_account = party_account
 
-		if self.paid_from and not self.paid_from_account_currency and not self.paid_from_account_balance:
+		if self.paid_from and not self.paid_from_account_currency:
 			acc = get_account_details(self.paid_from, self.posting_date, self.cost_center)
 			self.paid_from_account_currency = acc.account_currency
-			self.paid_from_account_balance = acc.account_balance
 
 		if self.paid_to and not self.paid_to_account_currency and not self.paid_to_account_balance:
 			acc = get_account_details(self.paid_to, self.posting_date, self.cost_center)
@@ -3555,7 +3553,6 @@ def get_party_and_account_balance(
 ):
 	return frappe._dict(
 		{
-			"paid_from_account_balance": get_balance_on(paid_from, date, cost_center=cost_center),
 			"paid_to_account_balance": get_balance_on(paid_to, date=date, cost_center=cost_center),
 		}
 	)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -111,7 +111,6 @@ class PaymentEntry(AccountsController):
 		paid_from_account_currency: DF.Link
 		paid_from_account_type: DF.Data | None
 		paid_to: DF.Link
-		paid_to_account_balance: DF.Currency
 		paid_to_account_currency: DF.Link
 		paid_to_account_type: DF.Data | None
 		party: DF.DynamicLink | None
@@ -541,10 +540,9 @@ class PaymentEntry(AccountsController):
 			acc = get_account_details(self.paid_from, self.posting_date, self.cost_center)
 			self.paid_from_account_currency = acc.account_currency
 
-		if self.paid_to and not self.paid_to_account_currency and not self.paid_to_account_balance:
+		if self.paid_to and not self.paid_to_account_currency:
 			acc = get_account_details(self.paid_to, self.posting_date, self.cost_center)
 			self.paid_to_account_currency = acc.account_currency
-			self.paid_to_account_balance = acc.account_balance
 
 		self.party_account_currency = (
 			self.paid_from_account_currency
@@ -3545,17 +3543,6 @@ def get_paid_amount(dt, dn, party_type, party, account, due_date):
 	)
 
 	return paid_amount[0][0] if paid_amount else 0
-
-
-@frappe.whitelist()
-def get_party_and_account_balance(
-	company, date, paid_from=None, paid_to=None, ptype=None, pty=None, cost_center=None
-):
-	return frappe._dict(
-		{
-			"paid_to_account_balance": get_balance_on(paid_to, date=date, cost_center=cost_center),
-		}
-	)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
1. Party Balance
2. Account Balance (From)
3. Account Balance (To)

Above fields query General Ledger on each new Payment Entry creation and cause significant DB load [^1] on large sites. As the balance information is purely for user interpretation and technically redundant in nature, removing it makes sense.

## Before
<img width="1552" alt="Screenshot 2025-01-31 at 1 00 14 PM" src="https://github.com/user-attachments/assets/327ddf6a-fa24-4159-9475-62d1159f7c55" />


## After
<img width="1552" alt="Screenshot 2025-01-31 at 11 34 27 AM" src="https://github.com/user-attachments/assets/8fe40d09-833f-4d08-aeba-ec47a76a97cb" />



[^1]: <img width="1009" alt="Screenshot 2025-01-31 at 11 49 26 AM" src="https://github.com/user-attachments/assets/112d8453-e5e4-400c-bdc1-d08fa4d08ea6" />
