### PR TITLE
fix: pos print receipt on submit

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -485,6 +485,7 @@ erpnext.PointOfSale.Controller = class {
 					]);
 				},
 			},
+			pos_profile: this.pos_profile,
 		});
 	}
 


### PR DESCRIPTION
`pos_profile` was not initialized while initializing `order_summary` in `pos_controller.js`, breaking the "Print Receipt on Order Complete" feature.