### PR TITLE
fix: renamed Comments Tab to Notes tab in Lead doctype

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -366,7 +366,7 @@
    "depends_on": "eval:!doc.__islocal",
    "fieldname": "notes_tab",
    "fieldtype": "Tab Break",
-   "label": "Comments"
+   "label": "Notes"
   },
   {
    "collapsible": 1,
@@ -510,9 +510,9 @@
   },
   {
    "fieldname": "utm_content",
-   "print_hide": 1,
    "fieldtype": "Data",
-   "label": "Content"
+   "label": "Content",
+   "print_hide": 1
   },
   {
    "fieldname": "utm_source",
@@ -546,7 +546,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2024-06-28 10:29:32.676323",
+ "modified": "2025-01-31 13:40:08.094759",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",


### PR DESCRIPTION
Before:
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/aed8747f-c9ef-48d7-bb8e-a2423ca7bdd6" />
After:
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/5852ae4e-5fba-4676-846d-29efe9c73900" />
