### PR TITLE
fix: add allow_on_submit for party_balance, paid_from_account_balance and paid_to_account_balance

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -224,6 +224,7 @@
    "label": "Accounts"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "party",
    "fieldname": "party_balance",
    "fieldtype": "Currency",
@@ -254,6 +255,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "paid_from",
    "fieldname": "paid_from_account_balance",
    "fieldtype": "Currency",
@@ -287,6 +289,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "paid_to",
    "fieldname": "paid_to_account_balance",
    "fieldtype": "Currency",
@@ -807,7 +810,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-01-13 16:03:47.169699",
+ "modified": "2025-01-31 17:27:28.555246",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",


### PR DESCRIPTION
Issue:
While updating accounting dimension after submission of Payment Entry, error was thrown that party balance can't be updated after submission.

Before:

[balance_allow_on_submit_bfr.webm](https://github.com/user-attachments/assets/96bc1088-7d4f-484d-bc50-493f7320a205)

After:

[balance_allow_on_submit_afr.webm](https://github.com/user-attachments/assets/aebf50c7-bb0d-4c80-a992-980ce4f7a355)

Back port needed for v15