### PR TITLE
fix: improve pos return

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -173,7 +173,7 @@ class AccountsController(TransactionBase):
 			self.validate_qty_is_not_zero()
 
 		if (
-			self.doctype in ["Sales Invoice", "Purchase Invoice"]
+			self.doctype in ["Sales Invoice", "Purchase Invoice", "POS Invoice"]
 			and self.get("is_return")
 			and self.get("update_stock")
 		):

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -258,7 +258,7 @@ def get_already_returned_items(doc):
 
 	field = (
 		frappe.scrub(doc.doctype) + "_item"
-		if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Sales Invoice"]
+		if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Sales Invoice", "POS Invoice"]
 		else "dn_detail"
 	)
 	data = frappe.db.sql(
@@ -770,6 +770,7 @@ def get_return_against_item_fields(voucher_type):
 		"Delivery Note": "dn_detail",
 		"Sales Invoice": "sales_invoice_item",
 		"Subcontracting Receipt": "subcontracting_receipt_item",
+		"POS Invoice": "sales_invoice_item",
 	}
 	return return_against_item_fields[voucher_type]
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -1163,3 +1163,11 @@ def get_available_serial_nos(serial_nos, warehouse):
 def get_payment_data(invoice):
 	payment = frappe.db.get_all("Sales Invoice Payment", {"parent": invoice}, ["mode_of_payment", "amount"])
 	return payment
+
+
+@frappe.whitelist()
+def get_pos_inv_item_returned_qty(invoice, customer, item_name):
+	POS_INVOICE = "POS Invoice"
+	is_return, docstatus = frappe.db.get_value(POS_INVOICE, invoice, ["is_return", "docstatus"])
+	if not is_return and docstatus == 1:
+		return get_returned_qty_map_for_row(invoice, customer, item_name, POS_INVOICE)

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -1166,26 +1166,25 @@ def get_payment_data(invoice):
 
 
 @frappe.whitelist()
-def get_pos_inv_item_returned_qty(invoice, customer, item_name):
-	POS_INVOICE = "POS Invoice"
-	is_return, docstatus = frappe.db.get_value(POS_INVOICE, invoice, ["is_return", "docstatus"])
+def get_pos_invoice_item_returned_qty(pos_invoice, customer, item_row_name):
+	is_return, docstatus = frappe.db.get_value("POS Invoice", pos_invoice, ["is_return", "docstatus"])
 	if not is_return and docstatus == 1:
-		return get_returned_qty_map_for_row(invoice, customer, item_name, POS_INVOICE)
+		return get_returned_qty_map_for_row(pos_invoice, customer, item_row_name, "POS Invoice")
 
 
 @frappe.whitelist()
-def allow_pos_invoice_return(invoice):
-	POS_INVOICE = "POS Invoice"
-	is_return, docstatus = frappe.db.get_value(POS_INVOICE, invoice, ["is_return", "docstatus"])
+def is_pos_invoice_returnable(pos_invoice):
+	is_return, docstatus, customer = frappe.db.get_value(
+		"POS Invoice", pos_invoice, ["is_return", "docstatus", "customer"]
+	)
 	if is_return or docstatus == 0:
 		return False
 
-	customer = frappe.db.get_value(POS_INVOICE, invoice, "customer")
-	invoice_item_qty = frappe.db.get_all(f"{POS_INVOICE} Item", {"parent": invoice}, ["name", "qty"])
+	invoice_item_qty = frappe.db.get_all("POS Invoice Item", {"parent": pos_invoice}, ["name", "qty"])
 
 	already_full_returned = 0
 	for d in invoice_item_qty:
-		returned_qty = get_returned_qty_map_for_row(invoice, customer, d.name, POS_INVOICE)
+		returned_qty = get_returned_qty_map_for_row(pos_invoice, customer, d.name, "POS Invoice")
 		if returned_qty.qty == d.qty:
 			already_full_returned += 1
 

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -1086,34 +1086,49 @@
 
 					> .item-row-wrapper {
 						display: flex;
-						align-items: center;
+						gap: 2px;
+						flex-direction: column;
 						padding: var(--padding-sm) var(--padding-md);
+						border: 1px solid lightgray;
+						border-radius: 10px;
+						background: var(--bg-light-gray);
 
-						> .item-name {
-							@extend .nowrap;
-							font-weight: 500;
-							margin-right: var(--margin-md);
-						}
-
-						> .item-qty {
-							font-weight: 500;
-							margin-left: auto;
-						}
-
-						> .item-rate-disc {
+						> .item-row-data {
 							display: flex;
-							text-align: right;
-							margin-left: var(--margin-md);
-							justify-content: flex-end;
+							align-items: center;
 
-							> .item-disc {
-								color: var(--dark-green-500);
-							}
-
-							> .item-rate {
+							> .item-name {
+								@extend .nowrap;
 								font-weight: 500;
-								margin-left: var(--margin-md);
+								margin-right: var(--margin-md);
 							}
+
+							> .item-qty {
+								font-weight: 500;
+								margin-left: auto;
+								font-size: small;
+							}
+
+							> .item-rate-disc {
+								display: flex;
+								text-align: right;
+								margin-left: var(--margin-md);
+								justify-content: flex-end;
+								font-size: small;
+
+								> .item-disc {
+									color: var(--dark-green-500);
+								}
+
+								> .item-rate {
+									font-weight: 500;
+									margin-left: var(--margin-md);
+								}
+							}
+						}
+
+						> .item-row-refund {
+							font-size: x-small;
 						}
 					}
 
@@ -1124,6 +1139,12 @@
 					> .payments {
 						font-weight: 700;
 					}
+				}
+
+				> .order-summary-container {
+					display: flex;
+					background: white;
+					gap: 8px;
 				}
 
 				> .summary-btns {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -459,6 +459,8 @@ erpnext.PointOfSale.Controller = class {
 							() => this.make_return_invoice(doc),
 							() => this.cart.load_invoice(),
 							() => this.item_selector.toggle_component(true),
+							() => this.item_selector.resize_selector(false),
+							() => this.item_details.toggle_component(false),
 						]);
 					});
 				},

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -471,6 +471,8 @@ erpnext.PointOfSale.Controller = class {
 						() => this.frm.call("reset_mode_of_payments"),
 						() => this.cart.load_invoice(),
 						() => this.item_selector.toggle_component(true),
+						() => this.item_selector.resize_selector(false),
+						() => this.item_details.toggle_component(false),
 					]);
 				},
 				delete_order: (name) => {

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -117,11 +117,11 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 		async function get_returned_qty() {
 			const r = await frappe.call({
-				method: "erpnext.controllers.sales_and_purchase_return.get_pos_inv_item_returned_qty",
+				method: "erpnext.controllers.sales_and_purchase_return.get_pos_invoice_item_returned_qty",
 				args: {
-					invoice: doc.name,
+					pos_invoice: doc.name,
 					customer: doc.customer,
-					item_name: item_data.name,
+					item_row_name: item_data.name,
 				},
 			});
 
@@ -130,7 +130,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 			}
 
 			return `<div class="item-row-refund">
-				<strong>${r.message.qty}</strong> Returned
+				<strong>${r.message.qty}</strong> ${__("Returned")}
 			</div>`;
 		}
 	}
@@ -192,7 +192,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 	bind_events() {
 		this.$summary_container.on("click", ".return-btn", async () => {
-			const r = await this.allow_return(this.doc.name);
+			const r = await this.is_pos_invoice_returnable(this.doc.name);
 			if (!r) {
 				frappe.msgprint({
 					title: __("Invalid Return"),
@@ -473,11 +473,11 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		}
 	}
 
-	async allow_return(invoice) {
+	async is_pos_invoice_returnable(invoice) {
 		const r = await frappe.call({
-			method: "erpnext.controllers.sales_and_purchase_return.allow_pos_invoice_return",
+			method: "erpnext.controllers.sales_and_purchase_return.is_pos_invoice_returnable",
 			args: {
-				invoice: invoice,
+				pos_invoice: invoice,
 			},
 		});
 		return r.message;

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -191,7 +191,16 @@ erpnext.PointOfSale.PastOrderSummary = class {
 	}
 
 	bind_events() {
-		this.$summary_container.on("click", ".return-btn", () => {
+		this.$summary_container.on("click", ".return-btn", async () => {
+			const r = await this.allow_return(this.doc.name);
+			if (!r) {
+				frappe.msgprint({
+					title: __("Invalid Return"),
+					indicator: "orange",
+					message: __("All the items have been already returned."),
+				});
+				return;
+			}
 			this.events.process_return(this.doc.name);
 			this.toggle_component(false);
 			this.$component.find(".no-summary-placeholder").css("display", "flex");
@@ -462,5 +471,15 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		if (res.message.print_receipt_on_order_complete) {
 			this.print_receipt();
 		}
+	}
+
+	async allow_return(invoice) {
+		const r = await frappe.call({
+			method: "erpnext.controllers.sales_and_purchase_return.allow_pos_invoice_return",
+			args: {
+				invoice: invoice,
+			},
+		});
+		return r.message;
 	}
 };

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -125,8 +125,6 @@ erpnext.PointOfSale.PastOrderSummary = class {
 				},
 			});
 
-			console.log(doc.name, doc.customer, item_data.name);
-
 			if (!r.message.qty) {
 				return "";
 			}

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -130,7 +130,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 			}
 
 			return `<div class="item-row-refund">
-				<strong>${r.message.qty}</strong> Refunded
+				<strong>${r.message.qty}</strong> Returned
 			</div>`;
 		}
 	}


### PR DESCRIPTION
* Added validation during return in POS Invoice.
   Before (the item "Apple" has been returned):

https://github.com/user-attachments/assets/8150f696-e22c-43ee-8257-ebcca88f4275

   After:


https://github.com/user-attachments/assets/f0f21288-a25f-44ec-ab19-25b208369f47


* Fixed UI in POS Item Cart, while loading Return Invoice / Draft Invoice.
   Before:

https://github.com/user-attachments/assets/0404e087-9c1b-4c3d-aaef-857f8a18a645

  After:

https://github.com/user-attachments/assets/7f8aef36-b94c-405e-b289-6122f3d7ed94

* Added returned quantity for the items returned in the Paid Invoice Item list (need feedback)

![image](https://github.com/user-attachments/assets/ddc7b0ef-291d-4ed4-9f51-740d897aee87)

* Disable loading return invoices on POS for the invoices where all the items have already been returned.

https://github.com/user-attachments/assets/8623433e-6246-4cde-a6dd-d9a12f2314af

