### PR TITLE
fix: copy correct uom from delivery note when creating packing list

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1127,7 +1127,7 @@ def make_packing_slip(source_name, target_doc=None):
 					"batch_no": "batch_no",
 					"description": "description",
 					"qty": "qty",
-					"stock_uom": "stock_uom",
+					"uom": "stock_uom",
 					"name": "dn_detail",
 				},
 				"postprocess": update_item,

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -159,11 +159,10 @@ class PackingSlip(StatusUpdater):
 			self.from_case_no = self.get_recommended_case_no()
 
 		for item in self.items:
-			stock_uom, weight_per_unit, weight_uom = frappe.db.get_value(
-				"Item", item.item_code, ["stock_uom", "weight_per_unit", "weight_uom"]
+			weight_per_unit, weight_uom = frappe.db.get_value(
+				"Item", item.item_code, ["weight_per_unit", "weight_uom"]
 			)
 
-			item.stock_uom = stock_uom
 			if weight_per_unit and not item.net_weight:
 				item.net_weight = weight_per_unit
 			if weight_uom and not item.weight_uom:


### PR DESCRIPTION
Reference issue #45572 

Old behaviour: System was ignoring UOM from Delivery Note line item causing incorrect data
New behaviour: System will now fetch the correct UOM from Delivery Note line item