### PR TITLE
fix: check payment overdue

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -134,9 +134,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					this.make_invoice_discounting.bind(this),
 					__("Create")
 				);
-
+				const date_now = frappe.datetime.now_date();
 				const payment_is_overdue = doc.payment_schedule
-					.map((row) => Date.parse(row.due_date) < Date.now())
+					.map((row) => row.due_date < date_now)
 					.reduce((prev, current) => prev || current, false);
 
 				if (payment_is_overdue) {


### PR DESCRIPTION
**Issue :** 
Dunning should not be created for unpaid sales invoices when the payment due date is today.

**Before :**

![Sales Invoice Dashboard](https://github.com/user-attachments/assets/c0db5dea-d224-4943-8f8c-ab9b0ef4d6a1)

![Sales Invoice  Dunning ](https://github.com/user-attachments/assets/1813a20b-4498-4b53-9546-550af0916d90)

**After :** 

![After fix](https://github.com/user-attachments/assets/99d4ed0f-dd6a-49f7-a1eb-063b9c0144b6)

**Backport needed for v15**
