### PR TITLE
fix: do not allow "Finance Book" in Accounting Dimensions

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -49,6 +49,7 @@ class AccountingDimension(Document):
 			"Accounting Dimension Detail",
 			"Company",
 			"Account",
+			"Finance Book",
 		):
 			msg = _("Not allowed to create accounting dimension for {0}").format(self.document_type)
 			frappe.throw(msg)


### PR DESCRIPTION
Issue: The user created the Finance book as Accounting Dimensions which is already a default dimension causing errors in the report because the accounting dimension is multi-select and the finance book field is a Link field.

### App Versions
```
{
	"erpnext": "15.35.1",
	"frappe": "15.40.6",
	"hrms": "15.28.3",
	"lending": "0.0.1",
	"ls_treso": "0.0.1",
	"paie": "0.0.1",
	"print_designer": "1.4.2"
}
```
### Route
```
query-report/Trial Balance
```
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1775, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 928, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 223, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 928, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 84, in generate_report_result
    res = get_report_result(report, filters) or []
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 65, in get_report_result
    res = report.execute_script_report(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 163, in execute_script_report
    res = self.execute_module(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 180, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 34, in execute
    data = get_data(filters)
           ^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 105, in get_data
    opening_balances = get_opening_balances(filters)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 135, in get_opening_balances
    balance_sheet_opening = get_rootwise_opening_balances(filters, "Balance Sheet")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 177, in get_rootwise_opening_balances
    gle = get_opening_balance("GL Entry", filters, report_type, accounting_dimensions)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 295, in get_opening_balance
    opening_balance = opening_balance.where(
                      ^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/utils.py", line 50, in _copy
    result = func(self_copy, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/queries.py", line 930, in where
    if not self._validate_table(criterion):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/queries.py", line 1155, in _validate_table
    for field in term.fields_():
                 ^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 57, in fields_
    return set(self.find_(Field))
               ^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 37, in find_
    return [node for node in self.nodes_() if isinstance(node, type)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 37, in <listcomp>
    return [node for node in self.nodes_() if isinstance(node, type)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pypika/terms.py", line 795, in nodes_
    yield from self.container.nodes_()
               ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'nodes_'

```
### Request Data
```
{
	"type": "GET",
	"args": {
		"report_name": "Trial Balance",
		"filters": "{\"company\":\"Institut Congolais pour la Conservation de la Nature (ICCN)\",\"fiscal_year\":\"2024\",\"from_date\":\"2024-01-01\",\"to_date\":\"2024-12-31\",\"programme\":[],\"imputation_analytique_2\":[],\"branch\":[],\"finance_book\":\"311OD1\",\"with_period_closing_entry_for_opening\":1,\"with_period_closing_entry_for_current_period\":1,\"include_default_book_entries\":1,\"show_net_values\":1}",
		"ignore_prepared_report": false,
		"is_tree": true,
		"parent_field": "parent_account",
		"are_default_filters": false
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.query_report.run",
	"request_id": "fcd87219-a9a7-4054-be8a-d13140a4826f"
}
```
### Response Data
```
{
	"exception": "AttributeError: 'str' object has no attribute 'nodes_'",
	"exc_type": "AttributeError",
	"_exc_source": "erpnext (app)"
}
```


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/27798

