### PR TITLE
fix: subcontracting validation precision issue

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -113,11 +113,10 @@ class SubcontractingController(StockController):
 					)
 					item.sc_conversion_factor = service_item_qty / item.qty
 
-				if (
-					self.doctype not in "Subcontracting Receipt"
-					and item.qty
-					> flt(get_pending_sco_qty(self.purchase_order).get(item.purchase_order_item))
-					/ item.sc_conversion_factor
+				if self.doctype not in "Subcontracting Receipt" and item.qty > flt(
+					get_pending_sco_qty(self.purchase_order).get(item.purchase_order_item)
+					/ item.sc_conversion_factor,
+					frappe.get_precision("Purchase Order Item", "qty"),
 				):
 					frappe.throw(
 						_(


### PR DESCRIPTION
Reference support issue [30429](https://support.frappe.io/helpdesk/tickets/30429)

Added precision for validation logic in subcontracting controller. This was preventing submission of Subcontracting Order even when data in the document was valid.