### PR TITLE
fix: pos payment cash shortcut decimal

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -462,7 +462,7 @@ erpnext.PointOfSale.Payment = class {
 		this.$payment_modes.find(".cash-shortcuts").remove();
 		let shortcuts_html = shortcuts
 			.map((s) => {
-				return `<div class="shortcut" data-value="${s}">${format_currency(s, currency, 0)}</div>`;
+				return `<div class="shortcut" data-value="${s}">${format_currency(s, currency)}</div>`;
 			})
 			.join("");
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/8ed1ea9e-3036-4991-a5c0-c2795ea5e5e2)

After:

![image](https://github.com/user-attachments/assets/73e1b614-5863-4ca6-9501-19bb85dc700d)