### PR TITLE
fix: show only items with inspection enabled on create QI dialog

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1580,9 +1580,12 @@ def check_item_quality_inspection(doctype, items):
 		"Delivery Note": "inspection_required_before_delivery",
 	}
 
+	items_to_remove = []
 	for item in items:
 		if not frappe.db.get_value("Item", item.get("item_code"), inspection_fieldname_map.get(doctype)):
-			items.remove(item)
+			items_to_remove.append(item)
+	items = [item for item in items if item not in items_to_remove]
+
 	return items
 
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1568,6 +1568,25 @@ def repost_required_for_queue(doc: StockController) -> bool:
 
 
 @frappe.whitelist()
+def check_item_quality_inspection(doctype, items):
+	if isinstance(items, str):
+		items = json.loads(items)
+
+	inspection_fieldname_map = {
+		"Purchase Receipt": "inspection_required_before_purchase",
+		"Purchase Invoice": "inspection_required_before_purchase",
+		"Subcontracting Receipt": "inspection_required_before_purchase",
+		"Sales Invoice": "inspection_required_before_delivery",
+		"Delivery Note": "inspection_required_before_delivery",
+	}
+
+	for item in items:
+		if not frappe.db.get_value("Item", item.get("item_code"), inspection_fieldname_map.get(doctype)):
+			items.remove(item)
+	return items
+
+
+@frappe.whitelist()
 def make_quality_inspections(doctype, docname, items, inspection_type):
 	if isinstance(items, str):
 		items = json.loads(items)


### PR DESCRIPTION
Reference support ticket [30355](https://support.frappe.io/helpdesk/tickets/30355)

Dialog box when creating Quality Inspection will now show only those items which have Quality Inspection enabled in their masters

`no-docs`