### PR TITLE
fix: validate payment request total of partly paid invoice

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -780,7 +780,10 @@ def get_existing_paid_amount(doctype, name):
 		frappe.qb.from_(PL)
 		.left_join(PER)
 		.on(
-			(PER.reference_doctype == PL.against_voucher_type) & (PER.reference_name == PL.against_voucher_no)
+			(PL.against_voucher_type == PER.reference_doctype)
+			& (PL.against_voucher_no == PER.reference_name)
+			& (PL.voucher_type == PER.parenttype)
+			& (PL.voucher_no == PER.parent)
 		)
 		.select(Abs(Sum(PL.amount)).as_("total_paid_amount"))
 		.where(PL.against_voucher_type.eq(doctype))


### PR DESCRIPTION
Issue:
When creating payment request for partly paid invoices with more than one payment entry, Amount value cannot be negative error occurred or amount value got doubled.

Before:

https://github.com/user-attachments/assets/b54b9e6f-369b-4451-b691-3fc47fce01e1


After:

https://github.com/user-attachments/assets/ed8ee2f0-b675-4353-8eb4-1869ee2364ef

Back port needed for v15