### PR TITLE
fix: set max_date range for date of birth to today in employee

### DIFF
--- a/erpnext/setup/doctype/employee/employee.js
+++ b/erpnext/setup/doctype/employee/employee.js
@@ -30,6 +30,11 @@ frappe.ui.form.on("Employee", {
 			};
 		});
 	},
+
+	refresh: function (frm) {
+		frm.fields_dict.date_of_birth.datepicker.update({ maxDate: new Date() });
+	},
+
 	prefered_contact_email: function (frm) {
 		frm.events.update_contact(frm);
 	},


### PR DESCRIPTION
It doesn't allow user to select the date of birth after Today.
backport to 15 and 14
![image](https://github.com/user-attachments/assets/95a19814-31fa-4f10-bac8-413649fdfab2)
