### PR TITLE
fix: added correct options for incoming_rate field of delivery note item

### DIFF
--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -757,6 +757,7 @@
    "fieldtype": "Currency",
    "label": "Incoming Rate",
    "no_copy": 1,
+   "options": "Company:company:default_currency",
    "precision": "6",
    "print_hide": 1,
    "read_only": 1
@@ -940,7 +941,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-21 16:37:37.441498",
+ "modified": "2025-02-05 14:27:32.322181",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",


### PR DESCRIPTION
For some reason, incoming_rate field of Delivery Note Item DocType did not have the correct options set for the Currency type of the field. This sometimes caused issues like [this](https://support.frappe.io/helpdesk/tickets/31003).

This PR sets the options field to "Company:company:default_currency"