### PR TITLE
fix: set asset value correctly after cancelling value adjustment

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -1069,7 +1069,7 @@ def make_new_active_asset_depr_schedules_and_cancel_current_ones(
 
 		new_asset_depr_schedule_doc = frappe.copy_doc(current_asset_depr_schedule_doc)
 		if asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment and not value_after_depreciation:
-			value_after_depreciation = row.value_after_depreciation + difference_amount
+			value_after_depreciation = row.value_after_depreciation - difference_amount
 
 		if asset_doc.flags.increase_in_asset_value_due_to_repair and row.depreciation_method in (
 			"Written Down Value",


### PR DESCRIPTION
When cancelling the asset value adjustment for any asset, `value_after_depreciation` was not setting correctly.
Internal support issue: https://support.frappe.io/helpdesk/tickets/30904