### PR TITLE
fix: create job card with wip warehouse set to source warehouse if material transfer to wip warehouse is skipped in work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2013,7 +2013,9 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 			"time_required": row.get("time_in_mins"),
 			"source_warehouse": row.get("source_warehouse"),
 			"target_warehouse": row.get("fg_warehouse"),
-			"wip_warehouse": work_order.wip_warehouse or row.get("wip_warehouse"),
+			"wip_warehouse": work_order.wip_warehouse or row.get("wip_warehouse")
+			if not work_order.skip_transfer or work_order.from_wip_warehouse
+			else work_order.source_warehouse or row.get("source_warehouse"),
 			"skip_material_transfer": row.get("skip_material_transfer"),
 			"backflush_from_wip_warehouse": row.get("backflush_from_wip_warehouse"),
 			"finished_good": row.get("finished_good"),


### PR DESCRIPTION
Reference support ticket [30984](https://support.frappe.io/helpdesk/tickets/30984)

Previous behaviour: If skip_transfer is enabled in work order, job card created won't have wip_warehouse set to source_warehouse by default, it remains empty for the user to fill

New behaviour: If skip_transfer is enabled, wip_warehouse in job card will be set to source_warehouse from work order by default