### PR TITLE
feat: added ability to use custom html format for process statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -173,15 +173,14 @@ def get_ar_filters(doc, entry):
 
 def get_html(doc, filters, entry, col, res, ageing):
 	base_template_path = "frappe/www/printview.html"
+	template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
+	if doc.report == "General Ledger":
+		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"	
 
 	process_soa_html = frappe.get_hooks("process_soa_html")
-	# fetching custom print format of Process Statement of Accounts
-	if process_soa_html.get(doc.report):
+	# fetching custom print format for Process Statement of Accounts
+	if process_soa_html and process_soa_html.get(doc.report):
 		template_path = process_soa_html[doc.report][-1]
-	elif doc.report == "General Ledger":
-		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"	
-	else:
-		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
 
 	if doc.letter_head:
 		from frappe.www.printview import get_letter_head

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -175,7 +175,9 @@ def get_html(doc, filters, entry, col, res, ageing):
 	base_template_path = "frappe/www/printview.html"
 	template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
 	if doc.report == "General Ledger":
-		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"	
+		template_path = (
+			"erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"
+		)
 
 	process_soa_html = frappe.get_hooks("process_soa_html")
 	# fetching custom print format for Process Statement of Accounts

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -173,17 +173,20 @@ def get_ar_filters(doc, entry):
 
 def get_html(doc, filters, entry, col, res, ageing):
 	base_template_path = "frappe/www/printview.html"
-	template_path = (
-		"erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"
-		if doc.report == "General Ledger"
-		else "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
-	)
+
+	process_soa_html = frappe.get_hooks("process_soa_html")
+	# fetching custom print format of Process Statement of Accounts
+	if process_soa_html.get(doc.report):
+		template_path = process_soa_html[doc.report][-1]
+	elif doc.report == "General Ledger":
+		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"	
+	else:
+		template_path = "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
 
 	if doc.letter_head:
 		from frappe.www.printview import get_letter_head
 
 		letter_head = get_letter_head(doc, 0)
-
 	html = frappe.render_template(
 		template_path,
 		{
@@ -199,7 +202,6 @@ def get_html(doc, filters, entry, col, res, ageing):
 			else None,
 		},
 	)
-
 	html = frappe.render_template(
 		base_template_path,
 		{"body": html, "css": get_print_style(), "title": "Statement For " + entry.customer},


### PR DESCRIPTION
Added code to process_statement_of_accounts.py.
The added code accepts the path to a custom html format of General Ledger and Accounts Receivable through a hook.
This path to custom html format is then used to build pdf to either download or send email.

`no-docs`