### PR TITLE
fix: Handle Empty JSON in Report Parsing

### DIFF
--- a/erpnext/patches/v14_0/update_reports_with_range.py
+++ b/erpnext/patches/v14_0/update_reports_with_range.py
@@ -27,7 +27,7 @@ def update_reference_reports(reference_report):
 
 
 def update_report_json(report):
-	report_json = json.loads(report.json)
+	report_json = json.loads(report.json) if report.get("json") else {}
 	report_filter = report_json.get("filters")
 
 	if not report_filter:


### PR DESCRIPTION
Support ticket: [Support Ticket  - 30983](https://support.frappe.io/helpdesk/tickets/30983)

Handle cases where the json is None in the report.

backport version-15