### PR TITLE
feat: added option to enforce free item qty in pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -646,7 +646,7 @@
    "label": "Has Priority"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval:doc.price_or_product_discount == 'Product'",
    "fieldname": "enforce_free_item_qty",
    "fieldtype": "Check",
@@ -656,7 +656,7 @@
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2025-02-05 18:05:03.886828",
+ "modified": "2025-02-05 21:03:22.103044",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -53,6 +53,7 @@
   "column_break_42",
   "free_item_uom",
   "round_free_qty",
+  "enforce_free_item_qty",
   "is_recursive",
   "recurse_for",
   "apply_recursion_over",
@@ -643,12 +644,19 @@
    "fieldname": "has_priority",
    "fieldtype": "Check",
    "label": "Has Priority"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.price_or_product_discount == 'Product'",
+   "fieldname": "enforce_free_item_qty",
+   "fieldtype": "Check",
+   "label": "Enforce Free Item Qty"
   }
  ],
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2024-09-16 18:14:51.314765",
+ "modified": "2025-02-05 18:05:03.886828",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -53,7 +53,7 @@
   "column_break_42",
   "free_item_uom",
   "round_free_qty",
-  "enforce_free_item_qty",
+  "dont_enforce_free_item_qty",
   "is_recursive",
   "recurse_for",
   "apply_recursion_over",
@@ -648,15 +648,15 @@
   {
    "default": "1",
    "depends_on": "eval:doc.price_or_product_discount == 'Product'",
-   "fieldname": "enforce_free_item_qty",
+   "fieldname": "dont_enforce_free_item_qty",
    "fieldtype": "Check",
-   "label": "Enforce Free Item Qty"
+   "label": "Don't Enforce Free Item Qty"
   }
  ],
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2025-02-05 21:03:22.103044",
+ "modified": "2025-02-17 18:15:39.824639",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -646,7 +646,7 @@
    "label": "Has Priority"
   },
   {
-   "default": "1",
+   "default": "0",
    "depends_on": "eval:doc.price_or_product_discount == 'Product'",
    "fieldname": "dont_enforce_free_item_qty",
    "fieldtype": "Check",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -60,6 +60,7 @@ class PricingRule(Document):
 		disable: DF.Check
 		discount_amount: DF.Currency
 		discount_percentage: DF.Float
+		enforce_free_item_qty: DF.Check
 		for_price_list: DF.Link | None
 		free_item: DF.Link | None
 		free_item_rate: DF.Currency

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -60,7 +60,7 @@ class PricingRule(Document):
 		disable: DF.Check
 		discount_amount: DF.Currency
 		discount_percentage: DF.Float
-		enforce_free_item_qty: DF.Check
+		dont_enforce_free_item_qty: DF.Check
 		for_price_list: DF.Link | None
 		free_item: DF.Link | None
 		free_item_rate: DF.Currency
@@ -646,7 +646,7 @@ def remove_pricing_rule_for_item(pricing_rules, item_details, item_code=None, ra
 			if pricing_rule.margin_type in ["Percentage", "Amount"]:
 				item_details.margin_rate_or_amount = 0.0
 				item_details.margin_type = None
-		elif pricing_rule.get("free_item") and pricing_rule.get("enforce_free_item_qty"):
+		elif pricing_rule.get("free_item") and not pricing_rule.get("dont_enforce_free_item_qty"):
 			item_details.remove_free_item = (
 				item_code if pricing_rule.get("same_item") else pricing_rule.get("free_item")
 			)

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -646,7 +646,7 @@ def remove_pricing_rule_for_item(pricing_rules, item_details, item_code=None, ra
 			if pricing_rule.margin_type in ["Percentage", "Amount"]:
 				item_details.margin_rate_or_amount = 0.0
 				item_details.margin_type = None
-		elif pricing_rule.get("free_item"):
+		elif pricing_rule.get("free_item") and pricing_rule.get("enforce_free_item_qty"):
 			item_details.remove_free_item = (
 				item_code if pricing_rule.get("same_item") else pricing_rule.get("free_item")
 			)

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -438,7 +438,7 @@ class TestPricingRule(IntegrationTestCase):
 		self.assertEqual(so.items[1].is_free_item, 1)
 		self.assertEqual(so.items[1].item_code, "_Test Item 2")
 
-	def test_enforce_free_item_qty(self):
+	def test_dont_enforce_free_item_qty(self):
 		# this test is only for testing non-enforcement as all other tests in this file already test with enforcement
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
 		test_record = {
@@ -477,10 +477,10 @@ class TestPricingRule(IntegrationTestCase):
 		self.assertEqual(len(so.items), 2)
 
 		# Without enforcement
-		pricing_rule.enforce_free_item_qty = 0
+		pricing_rule.dont_enforce_free_item_qty = 1
 		pricing_rule.save()
 
-		# Test 2 : Deleted free item will not be fetched again on save without enfrocement
+		# Test 2 : Deleted free item will not be fetched again on save without enforcement
 		so.items.pop(1)
 		so.save()
 		so.reload()
@@ -1509,7 +1509,7 @@ def make_pricing_rule(**args):
 			"discount_amount": args.discount_amount or 0.0,
 			"apply_multiple_pricing_rules": args.apply_multiple_pricing_rules or 0,
 			"has_priority": args.has_priority or 0,
-			"enforce_free_item_qty": args.enforce_free_item_qty or 1,
+			"enforce_free_item_qty": args.dont_enforce_free_item_qty or 0,
 		}
 	)
 

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -396,6 +396,7 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 1,
+			"enforce_free_item_qty": 1,
 			"company": "_Test Company",
 		}
 		frappe.get_doc(test_record.copy()).insert()
@@ -428,6 +429,7 @@ class TestPricingRule(IntegrationTestCase):
 			"same_item": 0,
 			"free_item": "_Test Item 2",
 			"free_qty": 1,
+			"enforce_free_item_qty": 1,
 			"company": "_Test Company",
 		}
 		frappe.get_doc(test_record.copy()).insert()
@@ -1121,6 +1123,7 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 1,
+			"enforce_free_item_qty": 1,
 			"round_free_qty": 1,
 			"is_recursive": 1,
 			"recurse_for": 2,
@@ -1166,6 +1169,7 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 10,
+			"enforce_free_item_qty": 1,
 			"round_free_qty": 1,
 			"is_recursive": 1,
 			"recurse_for": 100,
@@ -1461,6 +1465,7 @@ def make_pricing_rule(**args):
 			"discount_amount": args.discount_amount or 0.0,
 			"apply_multiple_pricing_rules": args.apply_multiple_pricing_rules or 0,
 			"has_priority": args.has_priority or 0,
+			"enforce_free_item_qty": args.enforce_free_item_qty or 1,
 		}
 	)
 

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -396,7 +396,6 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 1,
-			"enforce_free_item_qty": 1,
 			"company": "_Test Company",
 		}
 		frappe.get_doc(test_record.copy()).insert()
@@ -429,7 +428,6 @@ class TestPricingRule(IntegrationTestCase):
 			"same_item": 0,
 			"free_item": "_Test Item 2",
 			"free_qty": 1,
-			"enforce_free_item_qty": 1,
 			"company": "_Test Company",
 		}
 		frappe.get_doc(test_record.copy()).insert()
@@ -439,6 +437,54 @@ class TestPricingRule(IntegrationTestCase):
 		so.load_from_db()
 		self.assertEqual(so.items[1].is_free_item, 1)
 		self.assertEqual(so.items[1].item_code, "_Test Item 2")
+
+	def test_enforce_free_item_qty(self):
+		# this test is only for testing non-enforcement as all other tests in this file already test with enforcement
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
+		test_record = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Pricing Rule",
+			"apply_on": "Item Code",
+			"currency": "USD",
+			"items": [
+				{
+					"item_code": "_Test Item",
+				}
+			],
+			"selling": 1,
+			"rate_or_discount": "Discount Percentage",
+			"rate": 0,
+			"min_qty": 0,
+			"max_qty": 7,
+			"discount_percentage": 17.5,
+			"price_or_product_discount": "Product",
+			"same_item": 0,
+			"free_item": "_Test Item 2",
+			"free_qty": 1,
+			"company": "_Test Company",
+		}
+		pricing_rule = frappe.get_doc(test_record.copy()).insert()
+
+		# With enforcement
+		so = make_sales_order(item_code="_Test Item", qty=1, do_not_submit=True)
+		self.assertEqual(so.items[1].is_free_item, 1)
+		self.assertEqual(so.items[1].item_code, "_Test Item 2")
+
+		# Test 1 : Saving a document with an item with pricing list without it's corresponding free item will cause it the free item to be refetched on save
+		so.items.pop(1)
+		so.save()
+		so.reload()
+		self.assertEqual(len(so.items), 2)
+
+		# Without enforcement
+		pricing_rule.enforce_free_item_qty = 0
+		pricing_rule.save()
+
+		# Test 2 : Deleted free item will not be fetched again on save without enfrocement
+		so.items.pop(1)
+		so.save()
+		so.reload()
+		self.assertEqual(len(so.items), 1)
 
 	def test_cumulative_pricing_rule(self):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Cumulative Pricing Rule")
@@ -1123,7 +1169,6 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 1,
-			"enforce_free_item_qty": 1,
 			"round_free_qty": 1,
 			"is_recursive": 1,
 			"recurse_for": 2,
@@ -1169,7 +1214,6 @@ class TestPricingRule(IntegrationTestCase):
 			"price_or_product_discount": "Product",
 			"same_item": 1,
 			"free_qty": 10,
-			"enforce_free_item_qty": 1,
 			"round_free_qty": 1,
 			"is_recursive": 1,
 			"recurse_for": 100,

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -713,8 +713,8 @@ def apply_pricing_rule_for_free_items(doc, pricing_rule_args):
 				args.pop((item.item_code, item.pricing_rules))
 
 		for free_item in args.values():
-			if doc.is_new() or frappe.get_value(
-				"Pricing Rule", free_item["pricing_rules"], "enforce_free_item_qty"
+			if doc.is_new() or not frappe.get_value(
+				"Pricing Rule", free_item["pricing_rules"], "dont_enforce_free_item_qty"
 			):
 				doc.append("items", free_item)
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -713,7 +713,9 @@ def apply_pricing_rule_for_free_items(doc, pricing_rule_args):
 				args.pop((item.item_code, item.pricing_rules))
 
 		for free_item in args.values():
-			if frappe.get_value("Pricing Rule", free_item["pricing_rules"], "enforce_free_item_qty"):
+			if doc.is_new() or frappe.get_value(
+				"Pricing Rule", free_item["pricing_rules"], "enforce_free_item_qty"
+			):
 				doc.append("items", free_item)
 
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -713,7 +713,8 @@ def apply_pricing_rule_for_free_items(doc, pricing_rule_args):
 				args.pop((item.item_code, item.pricing_rules))
 
 		for free_item in args.values():
-			doc.append("items", free_item)
+			if frappe.get_value("Pricing Rule", free_item["pricing_rules"], "enforce_free_item_qty"):
+				doc.append("items", free_item)
 
 
 def get_pricing_rule_items(pr_doc, other_items=False) -> list:

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1251,7 +1251,7 @@ class TestPickList(IntegrationTestCase):
 				"is_recursive": 1,
 				"recurse_for": 2,
 				"free_qty": 1,
-				"enforce_free_item_qty": 1,
+				"dont_enforce_free_item_qty": 0,
 				"company": "_Test Company",
 				"customer": "_Test Customer",
 			}

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1251,6 +1251,7 @@ class TestPickList(IntegrationTestCase):
 				"is_recursive": 1,
 				"recurse_for": 2,
 				"free_qty": 1,
+				"enforce_free_item_qty": 1,
 				"company": "_Test Company",
 				"customer": "_Test Customer",
 			}


### PR DESCRIPTION
Reference support ticket [20447](https://support.frappe.io/helpdesk/tickets/20447)

Currently ERPNext forces user to mandatorily supply free items from pricing rule. This is done by fetching free items and adding it into child table whenever a document with pricing rule is saved. Normally, free items are at discretion of seller.

This PR adds a new option in Pricing Rule called `Don't Enforce Free Item Qty` which will keep the behavior same as before. However, upon enabling this checkbox, free items won't be fetched when document is saved.

Free items will now only be fetched when user adds an item with a free items pricing rule in the child table, not when document is saved, allowing the user to delete the free item as they wish.

https://docs.frappe.io/erpnext/user/manual/en/pricing-rule (scroll to the bottom)