### PR TITLE
fix: change voucher_type and voucher_name field type to data

### DIFF
--- a/erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
+++ b/erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
@@ -13,17 +13,15 @@
  "fields": [
   {
    "fieldname": "voucher_type",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Voucher Type",
-   "options": "DocType"
+   "label": "Voucher Type"
   },
   {
    "fieldname": "voucher_name",
-   "fieldtype": "Dynamic Link",
+   "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Voucher Name",
-   "options": "voucher_type"
+   "label": "Voucher Name"
   },
   {
    "fieldname": "taxable_amount",
@@ -36,7 +34,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:52.307012",
+ "modified": "2025-02-05 16:39:14.863698",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withheld Vouchers",

--- a/erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.py
+++ b/erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.py
@@ -18,8 +18,8 @@ class TaxWithheldVouchers(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		taxable_amount: DF.Currency
-		voucher_name: DF.DynamicLink | None
-		voucher_type: DF.Link | None
+		voucher_name: DF.Data | None
+		voucher_type: DF.Data | None
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
**Issue:**
While updating the cost center after the document was submitted, getting an error as one of the invoices from the tax_withheld_vouchers was cancelled.

**ref:** [30104](https://support.frappe.io/helpdesk/tickets/30104)

**Steps to reproduce:**
- Create a Purchase Invoice with TDS.
- Cancel one of the invoices from the Tax Withheld Vouchers table.
- Change any accounting dimension and update it.

![image](https://github.com/user-attachments/assets/3b0dfab8-ccf6-482c-9957-097dadb1335a)

![image](https://github.com/user-attachments/assets/c5707c6b-6655-4b60-b0b0-32a01e143b25)

![image](https://github.com/user-attachments/assets/293f34ef-37ce-4a8f-b3cc-c53ce1d49ce8)

**Back port needed for v14 and v15**