### PR TITLE
fix: add accounting dimensions section in sales order item

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -107,7 +107,11 @@
   "purchase_order",
   "column_break_89",
   "material_request_item",
-  "purchase_order_item"
+  "purchase_order_item",
+  "accounting_dimensions_section",
+  "cost_center",
+  "column_break_ihdh",
+  "project"
  ],
  "fields": [
   {
@@ -932,12 +936,42 @@
    "fieldname": "available_quantity_section",
    "fieldtype": "Section Break",
    "label": "Available Quantity"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": ":Company",
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center",
+   "print_hide": 1,
+   "print_width": "120px",
+   "reqd": 1,
+   "width": "120px"
+  },
+  {
+   "fieldname": "column_break_ihdh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project",
+   "search_index": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-09 15:34:47.768457",
+ "modified": "2025-02-06 13:29:24.619850",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -32,6 +32,7 @@ class SalesOrderItem(Document):
 		brand: DF.Link | None
 		company_total_stock: DF.Float
 		conversion_factor: DF.Float
+		cost_center: DF.Link
 		customer_item_code: DF.Data | None
 		delivered_by_supplier: DF.Check
 		delivered_qty: DF.Float
@@ -69,6 +70,7 @@ class SalesOrderItem(Document):
 		pricing_rules: DF.SmallText | None
 		produced_qty: DF.Float
 		production_plan_qty: DF.Float
+		project: DF.Link | None
 		projected_qty: DF.Float
 		purchase_order: DF.Link | None
 		purchase_order_item: DF.Data | None


### PR DESCRIPTION
**Issue:**
Unable to create a Sales Invoice with multiple Sales Orders with different Accounting Dimensions.

**ref:** [29679](https://support.frappe.io/helpdesk/tickets/29679)

**Before:**

[dimension_order_item_bfr.webm](https://github.com/user-attachments/assets/d184e567-54d7-48e9-bc14-1d8c8ebd9eb3)

**After:**


https://github.com/user-attachments/assets/2537fbcb-1bf2-4ef2-86d7-eb6c8fb36025

**Back port needed for v15**
