### PR TITLE
Update outstanding for self

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4329,6 +4329,35 @@ class TestSalesInvoice(IntegrationTestCase):
 		pos_return = make_sales_return(pos.name)
 		self.assertEqual(abs(pos_return.payments[0].amount), pos.payments[0].amount)
 
+	def test_create_return_invoice_for_self_update(self):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		invoice = create_sales_invoice()
+
+		payment_entry = get_payment_entry(dt=invoice.doctype, dn=invoice.name)
+		payment_entry.reference_no = "test001"
+		payment_entry.reference_date = getdate()
+
+		payment_entry.save()
+		payment_entry.submit()
+
+		r_invoice = make_return_doc(invoice.doctype, invoice.name)
+
+		r_invoice.update_outstanding_for_self = 0
+		r_invoice.save()
+
+		self.assertEqual(r_invoice.update_outstanding_for_self, 1)
+
+		r_invoice.submit()
+
+		self.assertNotEqual(r_invoice.outstanding_amount, 0)
+
+		invoice.reload()
+
+		self.assertEqual(invoice.outstanding_amount, 0)
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -553,7 +553,7 @@ class AccountsController(TransactionBase):
 				)
 
 			if msg:
-				msg += " you can use {0} tool to reconcile against {1} later.".format(
+				msg += " you can use {} tool to reconcile against {} later.".format(
 					get_link_to_form("Payment Reconciliation"),
 					get_link_to_form(self.doctype, self.get("return_against")),
 				)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -545,7 +545,7 @@ class AccountsController(TransactionBase):
 			):
 				self.update_outstanding_for_self = 1
 				msg = (
-					"The outstanding amount {0} in {1} is lesser than {2}. Updating the outstanding to this invoice. <br><br>And"
+					"The outstanding amount {} in {} is lesser than {}. Updating the outstanding to this invoice. <br><br>And"
 				).format(
 					against_voucher_outstanding,
 					get_link_to_form(self.doctype, self.get("return_against")),

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -851,6 +851,7 @@ class calculate_taxes_and_totals:
 		if (
 			self.doc.is_return
 			and self.doc.return_against
+			and not self.doc.update_outstanding_for_self
 			and not self.doc.get("is_pos")
 			or self.is_internal_invoice()
 		):


### PR DESCRIPTION
**ref: [26385](https://support.frappe.io/helpdesk/tickets/26385)**

**Issues:**

1) While making a return for a fully paid invoice with `update outstanding for self` disabled, the outstanding of the return against invoice goes to negative. As it isn't a return invoice, we are unable to reconcile it in Payment Reconciliation

**Before:**

[issue_party.webm](https://github.com/user-attachments/assets/a6c1e816-6eb6-4a55-a6dd-08ef7fe5a82c)

**After:**

[fix_party.webm](https://github.com/user-attachments/assets/507eba06-2458-4bae-a890-197fc8e341af)


____
2) While making return invoice for a common party with `update outstanding for self` disabled, the outstanding of the return against the invoice goes to negative and didn't post the reversal JV

**Before:**

[issue_c_party.webm](https://github.com/user-attachments/assets/07f987c0-c823-47e0-9593-75a9ef7c6436)

**After:**

[fix_c_party.webm](https://github.com/user-attachments/assets/2b7ad5b2-49fb-4ac2-890c-95d513ca385d)


**Backport Needed: v15 & v14**