### PR TITLE
fix: the project document timed out while opening

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -291,7 +291,8 @@
    "oldfieldname": "project_name",
    "oldfieldtype": "Link",
    "options": "Project",
-   "print_hide": 1
+   "print_hide": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -2210,7 +2211,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-01-14 11:38:30.446370",
+ "modified": "2025-02-06 15:59:54.636202",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -86,8 +86,6 @@ class Project(Document):
 			),
 		)
 
-		self.update_costing()
-
 	def before_print(self, settings=None):
 		self.onload()
 

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1142,7 +1142,8 @@
    "label": "Project",
    "oldfieldname": "project",
    "oldfieldtype": "Link",
-   "options": "Project"
+   "options": "Project",
+   "search_index": 1
   },
   {
    "fieldname": "party_account_currency",
@@ -1677,7 +1678,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-06 15:01:45.771616",
+ "modified": "2025-02-06 16:02:20.320877",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",


### PR DESCRIPTION
Project performance issue causes

- Update the cost of the project while opening the record
- Project field was not indexed in multiple documents 