### PR TITLE
fix: Party name in Supplier Portal for Purchase Order

### DIFF
--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -72,8 +72,7 @@
 				</span>
 			</div>
 			<div class="text-right col-2">
-				{%- set party_name = doc.supplier_name if doc.doctype in ['Supplier Quotation', 'Purchase Invoice', 'Purchase
-				Order'] else doc.customer_name %}
+				{%- set party_name = doc.supplier_name if doc.doctype in ['Supplier Quotation', 'Purchase Invoice', 'Purchase Order'] else doc.customer_name %}
 				<b>{{ party_name }}</b>
 
 				{% if doc.contact_display and doc.contact_display != party_name %}


### PR DESCRIPTION
Closes: https://github.com/frappe/erpnext/issues/45749

Before:
![image](https://github.com/user-attachments/assets/c4489c33-69ca-4390-b65c-a10a72fa605a)


After:
![image](https://github.com/user-attachments/assets/9aa2f9a5-ed94-4030-b320-37ac2e2e7f48)
