### PR TITLE
fix: AttributeError in `get_item_details` when selecting/scanning batch in Delivery Note

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -213,7 +213,7 @@ def update_stock(ctx, out, doc=None):
 
 			for batch_no, batch_qty in batches.items():
 				rate = get_batch_based_item_price(
-					{"price_list": doc.selling_price_list, "uom": out.uom, "batch_no": batch_no},
+					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
 					out.item_code,
 				)
 				if batch_qty >= qty:


### PR DESCRIPTION
**Issue**

While selecting or scanning a batch in the Delivery Note, an AttributeError was raised:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/_init_.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 50, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/_init_.py", line 1726, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 123, in get_item_details
    update_stock(args, out, doc)
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 210, in update_stock
    {"price_list": doc.selling_price_list, "uom": out.uom, "batch_no": batch_no},
                   ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'selling_price_list'
```

This occurred because doc was being treated as an object but was actually a dictionary.

**Fix**
Updated the relevant code in `update_stock` to correctly access `selling_price_list` from doc.


Closes: #45768