### PR TITLE
fix: do not validate party against Receivable and Payable account for cancelled gl entries

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -129,7 +129,7 @@ class GLEntry(Document):
 			if not self.get(k):
 				frappe.throw(_("{0} is required").format(_(self.meta.get_label(k))))
 
-		if not (self.party_type and self.party):
+		if not self.is_cancelled and not (self.party_type and self.party):
 			account_type = frappe.get_cached_value("Account", self.account, "account_type")
 			if account_type == "Receivable":
 				frappe.throw(


### PR DESCRIPTION
Issue: Not able to update expense account in Purchase Invoice Item from Payable to expense Account.


![image](https://github.com/user-attachments/assets/ccb64a31-6e03-4f02-b869-539ae06388c8)



Frappe Support Issue:  https://support.frappe.io/app/hd-ticket/22249