### PR TITLE
fix: unable to remove image from employee

### DIFF
--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -182,8 +182,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "user_id.user_image",
-   "fetch_if_empty": 1,
    "fieldname": "image",
    "fieldtype": "Attach Image",
    "hidden": 1,
@@ -824,7 +822,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:09:36.900706",
+ "modified": "2025-02-07 13:54:40.122345",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -64,14 +64,12 @@ class Employee(NestedSet):
 
 	def validate_user_details(self):
 		if self.user_id:
-			data = frappe.db.get_value("User", self.user_id, ["enabled", "user_image"], as_dict=1)
+			data = frappe.db.get_value("User", self.user_id, ["enabled"], as_dict=1)
 
 			if not data:
 				self.user_id = None
 				return
 
-			if data.get("user_image") and self.image == "":
-				self.image = data.get("user_image")
 			self.validate_for_enabled_user_id(data.get("enabled", 0))
 			self.validate_duplicate_user_id()
 


### PR DESCRIPTION
#### Current Premise

1. Employee image is "fetched from" user doctype, with "Fetch on save if empty" checked, but this only works on server side. For example create an employee attach an image to it, don't link `user_id` just yet. Create a user, don't attach any image to it. Now from system console, link the user to the employee. The image won't be overwritten.
2. "Fetch on save if empty" isn't meant to work client side, as soon as you set a value in a linked field, for example user_id, all fields of employee that depend on user, in this case image, should be updated regardless of if they are empty or not. [This use-case explains why](https://github.com/frappe/frappe/pull/14516#issuecomment-2644740242)

#### The Problem
This, because the user is created after employee

https://github.com/user-attachments/assets/3f1c35e4-96b9-469c-88db-f58774707717

#### After

https://github.com/user-attachments/assets/34e3b39d-357f-4a2b-a643-c9d785f57b1c

Removing fetch from also solves the problem of not being able to remove image from employee, because it would be refetched as soon as it was removed.
fixes frappe/hrms#10