### PR TITLE
fix: correct amount in transaction currency for reverse gl entries

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -681,11 +681,15 @@ def make_reverse_gl_entries(
 
 			debit_in_account_currency = new_gle.get("debit_in_account_currency", 0)
 			credit_in_account_currency = new_gle.get("credit_in_account_currency", 0)
+			debit_in_transaction_currency = new_gle.get("debit_in_transaction_currency", 0)
+			credit_in_transaction_currency = new_gle.get("credit_in_transaction_currency", 0)
 
 			new_gle["debit"] = credit
 			new_gle["credit"] = debit
 			new_gle["debit_in_account_currency"] = credit_in_account_currency
 			new_gle["credit_in_account_currency"] = debit_in_account_currency
+			new_gle["debit_in_transaction_currency"] = credit_in_transaction_currency
+			new_gle["credit_in_transaction_currency"] = debit_in_transaction_currency
 
 			new_gle["remarks"] = "On cancellation of " + new_gle["voucher_no"]
 			new_gle["is_cancelled"] = 1


### PR DESCRIPTION
Steps to replicate:  Cancel a Purchase Invoice and check reverse gl entries
Before: 
![image](https://github.com/user-attachments/assets/eaf06543-8fa2-4f00-91fd-9686818c7bd9)



After:
![image](https://github.com/user-attachments/assets/4bd8bd8c-8181-4b04-9fad-be0f78cdee71)
