### PR TITLE
fix: validation for subscription end date

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -345,9 +345,11 @@ class Subscription(Document):
 		billing_cycle_info = self.get_billing_cycle_data()
 		end_date = add_to_date(self.start_date, **billing_cycle_info)
 
-		if self.end_date and getdate(self.end_date) <= getdate(end_date):
+		if self.end_date and getdate(self.end_date) < getdate(end_date):
 			frappe.throw(
-				_("Subscription End Date must be after {0} as per the subscription plan").format(end_date)
+				_("Subscription End Date must be on or after {0} as per the subscription plan").format(
+					end_date
+				)
 			)
 
 	def validate_to_follow_calendar_months(self) -> None:


### PR DESCRIPTION
Support ticket : [18911](https://support.frappe.io/helpdesk/tickets/18911)

### Before

Previously, if you created a yearly subscription starting on 01/01/2025, the system incorrectly restricted setting the end date to 31/12/2025, even though it aligns with the plan duration.

### After

Now, you can create a yearly subscription starting on 01/01/2025 and set the end date to 31/12/2025. 
This ensures that the subscription period correctly reflects the chosen plan.

✅ This update also applies to weekly and monthly subscriptions, ensuring consistency across all plans.