### PR TITLE
fix: improve loyalty points amount precision calculation

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -1,12 +1,10 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, today
-
+from frappe.utils import flt, today, cint
 
 class LoyaltyProgram(Document):
 	# begin: auto-generated types
@@ -166,7 +164,8 @@ def validate_loyalty_points(ref_doc, points_to_redeem):
 		if points_to_redeem > loyalty_program_details.loyalty_points:
 			frappe.throw(_("You don't have enough Loyalty Points to redeem"))
 
-		loyalty_amount = flt(points_to_redeem * loyalty_program_details.conversion_factor)
+		float_precision = cint(frappe.db.get_default("float_precision")) or 2
+		loyalty_amount = flt(points_to_redeem * loyalty_program_details.conversion_factor, float_precision)
 
 		if loyalty_amount > ref_doc.rounded_total:
 			frappe.throw(_("You can't redeem Loyalty Points having more value than the Rounded Total."))


### PR DESCRIPTION
- Add system float precision configuration for loyalty amount calculation
- Fix precision issues with loyalty points conversion (e.g., 290 points with 0.1 conversion factor = 29.90)
- Use system default float precision or fallback to 2 decimal places

### Details for making this change

**Current Problem:**
When converting loyalty points to amount using a conversion factor, the system doesn't respect the configured float precision. This leads to inconsistent decimal places in monetary calculations.

**Example of the issue:**
Converting 290 points with 0.1 conversion factor should result in exactly 29.90, but the current implementation might show varying decimal places depending on floating-point arithmetic.

**Solution:**
1. Retrieve system's float precision configuration
2. Apply consistent decimal precision using `flt()` with the system's configuration
3. Provide a fallback to 2 decimal places if no system configuration is found

### Technical Implementation
```python
float_precision = cint(frappe.db.get_default("float_precision")) or 2
loyalty_amount = flt(points_to_redeem * loyalty_program_details.conversion_factor, float_precision)