### PR TITLE
fix: if condition in service_level_agreement.py

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
@@ -192,7 +192,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:39.518860",
+ "modified": "2025-02-10 12:46:56.287574",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Service Level Agreement",

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -236,9 +236,9 @@ class ServiceLevelAgreement(Document):
 		meta = frappe.get_meta(self.document_type, cached=False)
 
 		if meta.custom:
-			self.create_docfields(meta, service_level_agreement_fields)
-		else:
 			self.create_custom_fields(meta, service_level_agreement_fields)
+		else:
+			self.create_docfields(meta, service_level_agreement_fields)
 
 	def on_trash(self):
 		set_documents_with_active_service_level_agreement()

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.json
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.json
@@ -379,7 +379,7 @@
  "icon": "fa fa-bug",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:59.601423",
+ "modified": "2025-02-10 12:50:06.307081",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Warranty Claim",


### PR DESCRIPTION
Reference support ticket [31052](https://support.frappe.io/helpdesk/tickets/31052)

For some reason the if condition was in reverse, this simply fixes that if condition, fixing the problem in the support ticket

`no-docs`