### PR TITLE
fix: pos numpad editable action buttons

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -748,6 +748,7 @@ erpnext.PointOfSale.ItemCart = class {
 				frappe.utils.play_sound("error");
 				return;
 			}
+			this.highlight_numpad_btn($btn, current_action);
 
 			if (first_click_event || field_to_edit_changed) {
 				this.prev_action = current_action;
@@ -793,7 +794,6 @@ erpnext.PointOfSale.ItemCart = class {
 			this.numpad_value = current_action;
 		}
 
-		this.highlight_numpad_btn($btn, current_action);
 		this.events.numpad_event(this.numpad_value, this.prev_action);
 	}
 


### PR DESCRIPTION
The Editable Action Buttons in Item Cart Numpad were not working as intended.

Before:

https://github.com/user-attachments/assets/e87d0a50-055f-4c36-bffa-a7683964abf4

After:

https://github.com/user-attachments/assets/8c00e530-bebc-47d0-9c8c-fff020ca32ee

