### PR TITLE
fix: possible model sync issue

### DIFF
--- a/erpnext/patches/v15_0/sync_auto_reconcile_config.py
+++ b/erpnext/patches/v15_0/sync_auto_reconcile_config.py
@@ -11,16 +11,17 @@ def execute():
 	frappe.db.set_single_value("Accounts Settings", "reconciliation_queue_size", 5)
 
 	# Create Scheduler Event record if it doesn't exist
-	method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
-	if not frappe.db.get_all(
-		"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
-	):
-		frappe.get_doc(
-			{
-				"doctype": "Scheduler Event",
-				"scheduled_against": "Process Payment Reconciliation",
-				"method": method,
-			}
-		).save()
+	if frappe.reload_doc("core", "doctype", "scheduler_event"):
+		method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
+		if not frappe.db.get_all(
+			"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}
+		):
+			frappe.get_doc(
+				{
+					"doctype": "Scheduler Event",
+					"scheduled_against": "Process Payment Reconciliation",
+					"method": method,
+				}
+			).save()
 
-	sync_auto_reconcile_config(15)
+		sync_auto_reconcile_config(15)


### PR DESCRIPTION
Model sync issue on v14 -> v15 migration
```
Executing erpnext.patches.v15_0.sync_auto_reconcile_config in erpnutrich.frappe.cloud (_fce3f19821cef4ea)

	Set default Cron Interval and Queue size


Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 689, in migrate
    ).run(site=site)
      ^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 186, in run
    self.run_schema_updates()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 52, in wrapper
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 44, in wrapper
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 121, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v15_0/sync_auto_reconcile_config.py", line 15, in execute
    if not frappe.db.get_all(
           ^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 757, in get_all
    return frappe.get_all(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2015, in get_all
    return get_list(doctype, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1990, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 185, in execute
    self.columns = self.get_table_columns()
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 546, in get_table_columns
    return get_table_columns(self.doctype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 73, in get_table_columns
    return frappe.db.get_table_columns(doctype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 1326, in get_table_columns
    raise self.TableMissingError("DocType", doctype)
pymysql.err.ProgrammingError: ('DocType', 'Scheduler Event')
```