### PR TITLE
fix:[regional] Italian einvoice xml generated with wrong prices (#40254)

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -188,9 +188,9 @@
         <Descrizione>{{ html2text(item.description or '') or item.item_name }}</Descrizione>
         <Quantita>{{ format_float(item.qty) }}</Quantita>
         <UnitaMisura>{{ item.stock_uom }}</UnitaMisura>
-        <PrezzoUnitario>{{ format_float(item.price_list_rate or item.rate, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
+        <PrezzoUnitario>{{ format_float(item.net_rate or item.price_list_rate or item.rate, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
         {{ render_discount_or_margin(item) }}
-        <PrezzoTotale>{{ format_float(item.amount, item_meta.get_field("amount").precision) }}</PrezzoTotale>
+        <PrezzoTotale>{{ format_float(item.net_amount, item_meta.get_field("amount").precision) }}</PrezzoTotale>
         <AliquotaIVA>{{ format_float(item.tax_rate, item_meta.get_field("tax_rate").precision) }}</AliquotaIVA>
         {%- if item.tax_exemption_reason %}
         <Natura>{{ item.tax_exemption_reason.split("-")[0] }}</Natura>


### PR DESCRIPTION
As described in #40254 :
if "included_in_print_rate" is true xml output is not compliant and validation fails in italian system. In xml, and fields should be net price instead gross price is used this result in a wrong total price computation.
A backport to `version-15-hotfix` is kindly requested. 

Credits: @tamburro92
closes #40254 