### PR TITLE
fix: remove field from SLA fields if DocType already has that field

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -235,6 +235,15 @@ class ServiceLevelAgreement(Document):
 		service_level_agreement_fields = get_service_level_agreement_fields()
 		meta = frappe.get_meta(self.document_type, cached=False)
 
+		# remove fields if already exists
+		fields_to_remove = []
+		for field in service_level_agreement_fields:
+			if meta.has_field(field.get("fieldname")):
+				fields_to_remove.append(field)
+		service_level_agreement_fields = [
+			field for field in service_level_agreement_fields if field not in fields_to_remove
+		]
+
 		if meta.custom:
 			self.create_docfields(meta, service_level_agreement_fields)
 		else:


### PR DESCRIPTION
Reference support ticket [31052](https://support.frappe.io/helpdesk/tickets/31052)

Some DocTypes already have fields with the same name as SLA fields, causing errors such as in the support ticket above. This code will check if fields exist and remove them from SLA fields list, preventing the error.