### PR TITLE
fix: allow variant uom to differ from template uom

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -896,13 +896,17 @@ class Item(Document):
 			for d in frappe.db.get_all("Item", filters={"variant_of": self.name}):
 				check_stock_uom_with_bin(d.name, self.stock_uom)
 		if self.variant_of:
-			template_uom = frappe.db.get_value("Item", self.variant_of, "stock_uom")
-			if template_uom != self.stock_uom:
-				frappe.throw(
-					_("Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'").format(
-						self.stock_uom, template_uom
+			allow_different_uom = frappe.get_cached_value(
+				"Item Variant Settings", "Item Variant Settings", "allow_different_uom"
+			)
+			if not allow_different_uom:
+				template_uom = frappe.db.get_value("Item", self.variant_of, "stock_uom")
+				if template_uom != self.stock_uom:
+					frappe.throw(
+						_(
+							"Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
+						).format(self.stock_uom, template_uom)
 					)
-				)
 
 	def validate_uom_conversion_factor(self):
 		if self.uoms:

--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.json
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.json
@@ -8,6 +8,7 @@
   "section_break_3",
   "do_not_update_variants",
   "allow_rename_attribute_value",
+  "allow_different_uom",
   "copy_fields_to_variant",
   "fields"
  ],
@@ -40,11 +41,17 @@
    "fieldtype": "Table",
    "label": "Fields",
    "options": "Variant Field"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_different_uom",
+   "fieldtype": "Check",
+   "label": "Allow Variant UOM to be different from Template UOM"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:09:56.095684",
+ "modified": "2025-02-10 16:13:47.435148",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Variant Settings",

--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.py
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.py
@@ -18,6 +18,7 @@ class ItemVariantSettings(Document):
 
 		from erpnext.stock.doctype.variant_field.variant_field import VariantField
 
+		allow_different_uom: DF.Check
 		allow_rename_attribute_value: DF.Check
 		do_not_update_variants: DF.Check
 		fields: DF.Table[VariantField]


### PR DESCRIPTION
This PR introduces a new setting in **Item Variant Settings** to allow Item Variants to have a different Unit of Measure (UOM) from their Template Item, providing more flexibility.

![image](https://github.com/user-attachments/assets/601e51c3-31e3-4601-8188-a2f6acf9d4bf)


