### PR TITLE
fix(regional): removed payment schedule validation in sales invoice for italy

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -332,22 +332,19 @@ def sales_invoice_on_submit(doc, method):
 	]:
 		return
 
-	if not len(doc.payment_schedule):
-		frappe.throw(_("Please set the Payment Schedule"), title=_("E-Invoicing Information Missing"))
-	else:
-		for schedule in doc.payment_schedule:
-			if not schedule.mode_of_payment:
-				frappe.throw(
-					_("Row {0}: Please set the Mode of Payment in Payment Schedule").format(schedule.idx),
-					title=_("E-Invoicing Information Missing"),
-				)
-			elif not frappe.db.get_value("Mode of Payment", schedule.mode_of_payment, "mode_of_payment_code"):
-				frappe.throw(
-					_("Row {0}: Please set the correct code on Mode of Payment {1}").format(
-						schedule.idx, schedule.mode_of_payment
-					),
-					title=_("E-Invoicing Information Missing"),
-				)
+	for schedule in doc.payment_schedule:
+		if not schedule.mode_of_payment:
+			frappe.throw(
+				_("Row {0}: Please set the Mode of Payment in Payment Schedule").format(schedule.idx),
+				title=_("E-Invoicing Information Missing"),
+			)
+		elif not frappe.db.get_value("Mode of Payment", schedule.mode_of_payment, "mode_of_payment_code"):
+			frappe.throw(
+				_("Row {0}: Please set the correct code on Mode of Payment {1}").format(
+					schedule.idx, schedule.mode_of_payment
+				),
+				title=_("E-Invoicing Information Missing"),
+			)
 
 	prepare_and_attach_invoice(doc)
 


### PR DESCRIPTION
Issue: Payment Details are not mandatory for Italy e-Invoicing.

If Sales Return is created, the system automatically removes Payment Schedule rows causing the error.
![image](https://github.com/user-attachments/assets/f1a6d741-c85d-4307-a6a3-df861f85f711)

<details>
 <summary>Traceback</summary>

 ```
Traceback (most recent call last):

File "apps/frappe/frappe/[app.py](http://app.py/)", line 114, in application

response = frappe.api.handle(request)

^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/api/__init__.py", line 49, in handle

data = endpoint(**arguments)

^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/api/[v1.py](http://v1.py/)", line 36, in handle_rpc_call

return frappe.handler.handle()

^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/[handler.py](http://handler.py/)", line 50, in handle

data = execute_cmd(cmd)

^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/[handler.py](http://handler.py/)", line 86, in execute_cmd

return [frappe.call](http://frappe.call/)(method, **frappe.form_dict)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/__init__.py", line 1726, in call

return fn(*args, **newargs)

^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/utils/typing_[validations.py](http://validations.py/)", line 31, in wrapper

return func(*args, **kwargs)

^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/desk/form/[save.py](http://save.py/)", line 37, in savedocs

doc.submit()

File "apps/frappe/frappe/utils/typing_[validations.py](http://validations.py/)", line 31, in wrapper

return func(*args, **kwargs)

^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 1060, in submit

return self._submit()

^^^^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 1043, in _submit

return [self.save](http://self.save/)()

^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 342, in save

return self._save(*args, **kwargs)

^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 395, in _save

[self.run](http://self.run/)_post_save_methods()

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 1143, in run_post_save_methods

[self.run](http://self.run/)_method("on_submit")

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 974, in run_method

out = Document.hook(fn)(self, args, *kwargs)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 1334, in composer

return composed(self, method, args, *kwargs)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 1318, in runner

add_to_return_value(self, f(self, method, args, *kwargs))

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "apps/erpnext/erpnext/regional/italy/[utils.py](http://utils.py/)", line 335, in sales_invoice_on_submit

frappe.throw(_("Please set the Payment Schedule"), title=_("E-Invoicing Information Missing"))

File "apps/frappe/frappe/__init__.py", line 603, in throw

msgprint(

File "apps/frappe/frappe/__init__.py", line 568, in msgprint

raiseexception()

File "apps/frappe/frappe/__init__.py", line 519, in raiseexception

raise exc

frappe.exceptions.ValidationError: Please set the Payment Schedule
 ```
 </details>

We are modifiying "DatiPagamento" in xml.
Documentation: https://www.fatturapa.gov.it/export/documenti/Specifiche_tecniche_del_formato_FatturaPA_V1.3.2.pdf
![image](https://github.com/user-attachments/assets/5425b51f-4b3f-42ad-bd18-9c672b06d37e)



Closes: https://github.com/frappe/erpnext/issues/44658
Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/29505


