### PR TITLE
fix: dont update rate of free item on save

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -823,7 +823,7 @@ class AccountsController(TransactionBase):
 									and item.get("use_serial_batch_fields")
 								)
 							):
-								if fieldname == "batch_no" and not item.batch_no:
+								if fieldname == "batch_no" and not item.batch_no and not item.is_free_item:
 									item.set("rate", ret.get("rate"))
 									item.set("price_list_rate", ret.get("price_list_rate"))
 								item.set(fieldname, value)


### PR DESCRIPTION
Related to PR [45692](https://github.com/frappe/erpnext/pull/45692)

The old PR did not check if item is free item or not and updated the price anyway, even of free items (which is wrong). This PR fixes that by simply adding `and not item.is_free_item`