### PR TITLE
fix: Batch Rate in delivery note will be updated only for the billed item

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -823,7 +823,7 @@ class AccountsController(TransactionBase):
 									and item.get("use_serial_batch_fields")
 								)
 							):
-								if fieldname == "batch_no" and not item.batch_no:
+								if fieldname == "batch_no" and not item.batch_no and not item.is_free_item:
 									item.set("rate", ret.get("rate"))
 									item.set("price_list_rate", ret.get("price_list_rate"))
 								item.set(fieldname, value)


### PR DESCRIPTION
Fix: Currently Delivery note will be fetching the batch rate for all the items in the delivery note item. Now the rate of the batch will be updated only if it is billed item, not a free item.


Fixing these PRs:

https://github.com/frappe/erpnext/pull/45692

https://github.com/frappe/erpnext/pull/45740