### PR TITLE
fix: enable asset value editing for duplicate item code

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -652,7 +652,6 @@ frappe.ui.form.on("Asset", {
 					frm.set_value("purchase_amount", data.gross_purchase_amount);
 					frm.set_value("asset_quantity", data.asset_quantity);
 					frm.set_value("cost_center", data.cost_center);
-					frm.set_value("location", data.asset_location);
 
 					if (doctype === "Purchase Receipt") {
 						frm.set_value("purchase_receipt_item", data.purchase_receipt_item);

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -609,9 +609,7 @@ frappe.ui.form.on("Asset", {
 		frm.trigger("toggle_reference_doc");
 		if (frm.doc.purchase_receipt) {
 			if (frm.doc.item_code) {
-				frappe.db.get_doc("Purchase Receipt", frm.doc.purchase_receipt).then((pr_doc) => {
-					frm.events.set_values_from_purchase_doc(frm, "Purchase Receipt", pr_doc);
-				});
+				frm.events.set_values_from_purchase_doc(frm, "Purchase Receipt");
 			} else {
 				frm.set_value("purchase_receipt", "");
 				frappe.msgprint({
@@ -626,9 +624,7 @@ frappe.ui.form.on("Asset", {
 		frm.trigger("toggle_reference_doc");
 		if (frm.doc.purchase_invoice) {
 			if (frm.doc.item_code) {
-				frappe.db.get_doc("Purchase Invoice", frm.doc.purchase_invoice).then((pi_doc) => {
-					frm.events.set_values_from_purchase_doc(frm, "Purchase Invoice", pi_doc);
-				});
+				frm.events.set_values_from_purchase_doc(frm, "Purchase Invoice");
 			} else {
 				frm.set_value("purchase_invoice", "");
 				frappe.msgprint({
@@ -639,45 +635,36 @@ frappe.ui.form.on("Asset", {
 		}
 	},
 
-	set_values_from_purchase_doc: function (frm, doctype, purchase_doc) {
-		frm.set_value("company", purchase_doc.company);
-		if (purchase_doc.bill_date) {
-			frm.set_value("purchase_date", purchase_doc.bill_date);
-		} else {
-			frm.set_value("purchase_date", purchase_doc.posting_date);
-		}
-		if (!frm.doc.is_existing_asset && !frm.doc.available_for_use_date) {
-			frm.set_value("available_for_use_date", frm.doc.purchase_date);
-		}
-		const item = purchase_doc.items.find((item) => item.item_code === frm.doc.item_code);
-		if (!item) {
-			let doctype_field = frappe.scrub(doctype);
-			frm.set_value(doctype_field, "");
-			frappe.msgprint({
-				title: __("Invalid {0}", [__(doctype)]),
-				message: __("The selected {0} does not contain the selected Asset Item.", [__(doctype)]),
-				indicator: "red",
-			});
-		}
-		frappe.db.get_value("Item", item.item_code, "is_grouped_asset", (r) => {
-			var asset_quantity = r.is_grouped_asset ? item.qty : 1;
-			var purchase_amount = flt(
-				item.valuation_rate * asset_quantity,
-				precision("gross_purchase_amount")
-			);
+	set_values_from_purchase_doc: (frm, doctype) => {
+		frappe.call({
+			method: "erpnext.assets.doctype.asset.asset.get_values_from_purchase_doc",
+			args: {
+				purchase_doc_name: frm.doc.purchase_receipt || frm.doc.purchase_invoice,
+				item_code: frm.doc.item_code,
+				doctype: doctype,
+			},
+			callback: (r) => {
+				if (r.message) {
+					let data = r.message;
+					frm.set_value("company", data.company);
+					frm.set_value("purchase_date", data.purchase_date);
+					frm.set_value("gross_purchase_amount", data.gross_purchase_amount);
+					frm.set_value("purchase_amount", data.gross_purchase_amount);
+					frm.set_value("asset_quantity", data.asset_quantity);
+					frm.set_value("cost_center", data.cost_center);
+					frm.set_value("location", data.asset_location);
 
-			frm.set_value("gross_purchase_amount", purchase_amount);
-			frm.set_value("purchase_amount", purchase_amount);
-			frm.set_value("asset_quantity", asset_quantity);
-			frm.set_value("cost_center", item.cost_center || purchase_doc.cost_center);
-			if (item.asset_location) {
-				frm.set_value("location", item.asset_location);
-			}
-			if (doctype === "Purchase Receipt") {
-				frm.set_value("purchase_receipt_item", item.name);
-			} else if (doctype === "Purchase Invoice") {
-				frm.set_value("purchase_invoice_item", item.name);
-			}
+					if (doctype === "Purchase Receipt") {
+						frm.set_value("purchase_receipt_item", data.purchase_receipt_item);
+					} else {
+						frm.set_value("purchase_invoice_item", data.purchase_invoice_item);
+					}
+
+					let is_editable = !data.is_multiple_items; // if multiple items, then fields should not be read-only
+					frm.set_df_property("gross_purchase_amount", "read_only", is_editable);
+					frm.set_df_property("asset_quantity", "read_only", !is_editable);
+				}
+			},
 		});
 	},
 

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -660,9 +660,9 @@ frappe.ui.form.on("Asset", {
 						frm.set_value("purchase_invoice_item", data.purchase_invoice_item);
 					}
 
-					let is_editable = !data.is_multiple_items; // if multiple items, then fields should not be read-only
+					let is_editable = !data.is_multiple_items; // if multiple items, then fields should be read-only
 					frm.set_df_property("gross_purchase_amount", "read_only", is_editable);
-					frm.set_df_property("asset_quantity", "read_only", !is_editable);
+					frm.set_df_property("asset_quantity", "read_only", is_editable);
 				}
 			},
 		});

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -507,17 +507,15 @@
   },
   {
    "fieldname": "purchase_receipt_item",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "hidden": 1,
-   "label": "Purchase Receipt Item",
-   "options": "Purchase Receipt Item"
+   "label": "Purchase Receipt Item"
   },
   {
    "fieldname": "purchase_invoice_item",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "hidden": 1,
-   "label": "Purchase Invoice Item",
-   "options": "Purchase Invoice Item"
+   "label": "Purchase Invoice Item"
   },
   {
    "fieldname": "insurance_details_tab",
@@ -592,7 +590,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-12-26 14:23:20.968882",
+ "modified": "2025-02-11 16:01:56.140904",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -228,8 +228,7 @@
    "fieldtype": "Currency",
    "label": "Gross Purchase Amount",
    "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency",
-   "read_only_depends_on": "eval:!doc.is_existing_asset"
+   "options": "Company:company:default_currency"
   },
   {
    "fieldname": "available_for_use_date",
@@ -436,8 +435,7 @@
    "default": "1",
    "fieldname": "asset_quantity",
    "fieldtype": "Int",
-   "label": "Asset Quantity",
-   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
+   "label": "Asset Quantity"
   },
   {
    "fieldname": "depr_entry_posting_status",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -95,9 +95,9 @@ class Asset(AccountsController):
 		purchase_amount: DF.Currency
 		purchase_date: DF.Date | None
 		purchase_invoice: DF.Link | None
-		purchase_invoice_item: DF.Link | None
+		purchase_invoice_item: DF.Data | None
 		purchase_receipt: DF.Link | None
-		purchase_receipt_item: DF.Link | None
+		purchase_receipt_item: DF.Data | None
 		split_from: DF.Link | None
 		status: DF.Literal[
 			"Draft",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -233,14 +233,6 @@ class Asset(AccountsController):
 				if item.base_net_rate == self.gross_purchase_amount and item.qty == self.asset_quantity:
 					return item.name
 
-		# If no matching item found, raise validation error
-		frappe.throw(
-			_(
-				"No matching item found in {0} with item code {1}. "
-				"Please verify the purchase details and ensure the correct amount and quantity is recorded."
-			).format(purchase_doc_type, self.item_code)
-		)
-
 	def validate_asset_and_reference(self):
 		if self.purchase_invoice or self.purchase_receipt:
 			reference_doc = "Purchase Invoice" if self.purchase_invoice else "Purchase Receipt"


### PR DESCRIPTION
When creating an asset manually from a purchase invoice or purchase receipt that has multiple items with the same item code, the system always picks the first matching item's values. This makes it difficult to create an asset for the second item.

Solution:
- If a purchase invoice contains multiple items with the same item code, users can now update the asset gross purchase amount and asset quantity manually.
- Once updated, the system will verify if an item with the new values exists.
- If found, it will automatically set the corresponding Purchase Receipt Item and Purchase Invoice Item fields to the correct row from the respective documents.