### PR TITLE
fix: prevent duplicate pos fields in pos settings

### DIFF
--- a/erpnext/accounts/doctype/pos_settings/pos_settings.py
+++ b/erpnext/accounts/doctype/pos_settings/pos_settings.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from collections import Counter
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -22,4 +25,14 @@ class POSSettings(Document):
 	# end: auto-generated types
 
 	def validate(self):
-		pass
+		self.validate_invoice_fields()
+
+	def validate_invoice_fields(self):
+		invoice_fields = [field.fieldname for field in self.invoice_fields]
+		duplicate_invoice_fields = {key for key, value in Counter(invoice_fields).items() if value > 1}
+
+		if len(duplicate_invoice_fields):
+			for field in duplicate_invoice_fields:
+				frappe.throw(
+					title=_("Duplicate POS Fields"), msg=_("'{0}' has been already added.").format(field)
+				)


### PR DESCRIPTION
Preventing duplicate POS Fields in POS Settings

Before:

https://github.com/user-attachments/assets/08fefd2a-4067-49f9-88de-a2bdb2af2ded

After:

https://github.com/user-attachments/assets/1054e0aa-e4cf-4035-86e6-9561ff3fdae3
