### PR TITLE
fix: incorrect taxable_amount on `other_charges_calculation`

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1103,11 +1103,8 @@ def get_itemised_tax_breakup_data(doc):
 	itemised_tax = get_itemised_tax(doc.taxes)
 	itemised_tax_data = []
 	for item_code, taxes in itemised_tax.items():
-		itemised_tax_data.append(
-			frappe._dict(
-				{"item": item_code, "taxable_amount": sum(tax.net_amount for tax in taxes.values()), **taxes}
-			)
-		)
+		taxable_amount = next(iter(taxes.values())).get("net_amount")
+		itemised_tax_data.append(frappe._dict({"item": item_code, "taxable_amount": taxable_amount, **taxes}))
 
 	return itemised_tax_data
 


### PR DESCRIPTION
On some Sales Invoice print formats, `other_charges_calculation` is used as source for the Item-wise breakdown of tax. After a recent change, print formats reported double the net total of each item.


This is caused by [summing of net_amount on all tax rows](https://github.com/frappe/erpnext/blob/110412d8ad6b01c5da9f56fb8eedf4bb01a3754d/erpnext/controllers/taxes_and_totals.py#L1108).

Since each tax row has the net total for that item, just pick the first one as taxable amount.

Example Itemised Tax details

```
{'Galaxy Ultra': {'SGST': {'tax_rate': 9.0,
                              'tax_amount': 2700.0,
                              'net_amount': 30000.0},
                     'CGST': {'tax_rate': 9.0,
                              'tax_amount': 2700.0,
                              'net_amount': 30000.0}},
 'iPhone': {'SGST': {'tax_rate': 9.0,
                       'tax_amount': 4500.0,
                       'net_amount': 50000.0},
              'CGST': {'tax_rate': 9.0,
                       'tax_amount': 4500.0,
                       'net_amount': 50000.0}}}
```

regression: https://github.com/frappe/erpnext/pull/43372