### PR TITLE
fix: add precision in serial_batch_bundle.py

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1080,6 +1080,7 @@ class SerialBatchCreation:
 	def set_serial_batch_entries(self, doc):
 		incoming_rate = self.get("incoming_rate")
 
+		precision = frappe.get_precision("Serial and Batch Entry", "qty")
 		if self.get("serial_nos"):
 			serial_no_wise_batch = frappe._dict({})
 			if self.has_batch_no:
@@ -1109,7 +1110,8 @@ class SerialBatchCreation:
 					"entries",
 					{
 						"batch_no": batch_no,
-						"qty": batch_qty * (-1 if self.type_of_transaction == "Outward" else 1),
+						"qty": flt(batch_qty, precision)
+						* (-1 if self.type_of_transaction == "Outward" else 1),
 						"incoming_rate": incoming_rate,
 					},
 				)


### PR DESCRIPTION
Made as per @rohitwaghchaure instructions

Explicit precision conversion was missing when setting qty of batch no in SABB.