### PR TITLE
fix(quotation): fetch exchange rate on currency change

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -353,6 +353,26 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 		);
 		dialog.show();
 	}
+
+	currency() {
+		super.currency();
+		let me = this;
+		const company_currency = this.get_company_currency();
+		if (this.frm.doc.currency && this.frm.doc.currency !== company_currency) {
+			this.get_exchange_rate(
+				this.frm.doc.transaction_date,
+				this.frm.doc.currency,
+				company_currency,
+				function (exchange_rate) {
+					if (exchange_rate != me.frm.doc.conversion_rate) {
+						me.set_margin_amount_based_on_currency(exchange_rate);
+						me.set_actual_charges_based_on_currency(exchange_rate);
+						me.frm.set_value("conversion_rate", exchange_rate);
+					}
+				}
+			);
+		}
+	}
 };
 
 cur_frm.script_manager.make(erpnext.selling.QuotationController);


### PR DESCRIPTION
**Issue:**
On changing the currency, the exchange rate is not fetching while creating a quotation from the opportunity
**ref:** [31271](https://support.frappe.io/helpdesk/tickets/31271)

**Before:**

https://github.com/user-attachments/assets/7228cc50-250c-4038-8946-dcf1966a6a3a


**After:**

https://github.com/user-attachments/assets/3132f369-68a6-441d-87de-6fa911727789



Backport needed for v15