### PR TITLE
fix: auto allocation for negative amount outstanding for Customers in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1952,7 +1952,7 @@ class PaymentEntry(AccountsController):
 
 			allocated_positive_outstanding = paid_amount + allocated_negative_outstanding
 
-		elif self.party_type in ("Supplier", "Employee"):
+		elif self.party_type in ("Supplier", "Customer"):
 			if paid_amount > total_negative_outstanding:
 				if total_negative_outstanding == 0:
 					frappe.msgprint(


### PR DESCRIPTION
Issue: Auto allocation of paid amount for negative outstanding for Customers not working on change of paid amount.

Steps to replicate :
- Create a Payment Entry to receive from the customer against a Sales Return.
- Change the paid amount.

On change of paid amount, the allocation should also be changed.
regression: https://github.com/frappe/erpnext/pull/42427

Previously it was done for Suppliers and Customers but in the mentioned PR it was changed to handle Suppliers and Employees.


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/31719








