### PR TITLE
fix: pos accounting dimension fieldname error

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -263,7 +263,7 @@ def get_checks_for_pl_and_bs_accounts():
 		frappe.flags.accounting_dimensions_details = frappe.db.sql(
 			"""SELECT p.label, p.disabled, p.fieldname, c.default_dimension, c.company, c.mandatory_for_pl, c.mandatory_for_bs
 			FROM `tabAccounting Dimension`p ,`tabAccounting Dimension Detail` c
-			WHERE p.name = c.parent""",
+			WHERE p.name = c.parent AND p.disabled = 0""",
 			as_dict=1,
 		)
 

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -103,6 +103,7 @@ class AccountingDimension(Document):
 
 	def on_update(self):
 		frappe.flags.accounting_dimensions = None
+		frappe.flags.accounting_dimensions_details = None
 
 
 def make_dimension_in_accounting_doctypes(doc, doclist=None):

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -41,6 +41,11 @@ class AccountingDimension(Document):
 		self.set_fieldname_and_label()
 
 	def validate(self):
+		self.validate_doctype()
+		validate_column_name(self.fieldname)
+		self.validate_dimension_defaults()
+
+	def validate_doctype(self):
 		if self.document_type in (
 			*core_doctypes_list,
 			"Accounting Dimension",
@@ -61,9 +66,6 @@ class AccountingDimension(Document):
 
 		if not self.is_new():
 			self.validate_document_type_change()
-
-		validate_column_name(self.fieldname)
-		self.validate_dimension_defaults()
 
 	def validate_document_type_change(self):
 		doctype_before_save = frappe.db.get_value("Accounting Dimension", self.name, "document_type")

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -12,8 +12,8 @@ from frappe.utils import cint, flt, get_time, getdate, nowdate, nowtime
 from frappe.utils.background_jobs import enqueue, is_job_enqueued
 from frappe.utils.scheduler import is_scheduler_inactive
 
-from erpnext.accounts.doctype.pos_profile.pos_profile import (
-	get_enabled_accounting_dimensions_with_pl_bs_checks,
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_checks_for_pl_and_bs_accounts,
 )
 from erpnext.controllers.taxes_and_totals import ItemWiseTaxDetail
 
@@ -295,7 +295,7 @@ class POSInvoiceMergeLog(Document):
 		invoice.disable_rounded_total = cint(
 			frappe.db.get_value("POS Profile", invoice.pos_profile, "disable_rounded_total")
 		)
-		accounting_dimensions = get_enabled_accounting_dimensions_with_pl_bs_checks()
+		accounting_dimensions = get_checks_for_pl_and_bs_accounts()
 		accounting_dimensions_fields = [d.fieldname for d in accounting_dimensions]
 		dimension_values = frappe.db.get_value(
 			"POS Profile", {"name": invoice.pos_profile}, accounting_dimensions_fields, as_dict=1

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -12,8 +12,8 @@ from frappe.utils import cint, flt, get_time, getdate, nowdate, nowtime
 from frappe.utils.background_jobs import enqueue, is_job_enqueued
 from frappe.utils.scheduler import is_scheduler_inactive
 
-from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
-	get_checks_for_pl_and_bs_accounts,
+from erpnext.accounts.doctype.pos_profile.pos_profile import (
+	get_enabled_accounting_dimensions_with_pl_bs_checks,
 )
 from erpnext.controllers.taxes_and_totals import ItemWiseTaxDetail
 
@@ -295,7 +295,7 @@ class POSInvoiceMergeLog(Document):
 		invoice.disable_rounded_total = cint(
 			frappe.db.get_value("POS Profile", invoice.pos_profile, "disable_rounded_total")
 		)
-		accounting_dimensions = get_checks_for_pl_and_bs_accounts()
+		accounting_dimensions = get_enabled_accounting_dimensions_with_pl_bs_checks()
 		accounting_dimensions_fields = [d.fieldname for d in accounting_dimensions]
 		dimension_values = frappe.db.get_value(
 			"POS Profile", {"name": invoice.pos_profile}, accounting_dimensions_fields, as_dict=1

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -75,7 +75,7 @@ class POSProfile(Document):
 		self.validate_accounting_dimensions()
 
 	def validate_accounting_dimensions(self):
-		acc_dims = get_enabled_accounting_dimensions_with_pl_bs_checks()
+		acc_dims = get_checks_for_pl_and_bs_accounts()
 		for acc_dim in acc_dims:
 			if not self.get(acc_dim.fieldname) and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs):
 				frappe.throw(
@@ -219,11 +219,6 @@ def get_child_nodes(group_type, root):
 			lft >= {lft} and rgt <= {rgt} order by lft""",
 		as_dict=1,
 	)
-
-
-def get_enabled_accounting_dimensions_with_pl_bs_checks():
-	accounting_dimensions = [d for d in get_checks_for_pl_and_bs_accounts() if not d.disabled]
-	return accounting_dimensions
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -7,6 +7,10 @@ from frappe import _, msgprint, scrub, unscrub
 from frappe.model.document import Document
 from frappe.utils import get_link_to_form, now
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_checks_for_pl_and_bs_accounts,
+)
+
 
 class POSProfile(Document):
 	# begin: auto-generated types
@@ -71,15 +75,15 @@ class POSProfile(Document):
 		self.validate_accounting_dimensions()
 
 	def validate_accounting_dimensions(self):
-		acc_dim_names = required_accounting_dimensions()
-		for acc_dim in acc_dim_names:
-			if not self.get(acc_dim):
+		acc_dims = get_checks_for_pl_and_bs_accounts()
+		for acc_dim in acc_dims:
+			if not self.get(acc_dim.fieldname) and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs):
 				frappe.throw(
 					_(
 						"{0} is a mandatory Accounting Dimension. <br>"
 						"Please set a value for {0} in Accounting Dimensions section."
 					).format(
-						unscrub(frappe.bold(acc_dim)),
+						frappe.bold(acc_dim.label),
 					),
 					title=_("Mandatory Accounting Dimension"),
 				)
@@ -215,23 +219,6 @@ def get_child_nodes(group_type, root):
 			lft >= {lft} and rgt <= {rgt} order by lft""",
 		as_dict=1,
 	)
-
-
-def required_accounting_dimensions():
-	p = frappe.qb.DocType("Accounting Dimension")
-	c = frappe.qb.DocType("Accounting Dimension Detail")
-
-	acc_dim_doc = (
-		frappe.qb.from_(p)
-		.inner_join(c)
-		.on(p.name == c.parent)
-		.select(c.parent)
-		.where((c.mandatory_for_bs == 1) | (c.mandatory_for_pl == 1))
-		.where(p.disabled == 0)
-	).run(as_dict=1)
-
-	acc_dim_names = [scrub(d.parent) for d in acc_dim_doc]
-	return acc_dim_names
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -75,7 +75,7 @@ class POSProfile(Document):
 		self.validate_accounting_dimensions()
 
 	def validate_accounting_dimensions(self):
-		acc_dims = get_checks_for_pl_and_bs_accounts()
+		acc_dims = get_enabled_accounting_dimensions_with_pl_bs_checks()
 		for acc_dim in acc_dims:
 			if not self.get(acc_dim.fieldname) and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs):
 				frappe.throw(
@@ -219,6 +219,11 @@ def get_child_nodes(group_type, root):
 			lft >= {lft} and rgt <= {rgt} order by lft""",
 		as_dict=1,
 	)
+
+
+def get_enabled_accounting_dimensions_with_pl_bs_checks():
+	accounting_dimensions = [d for d in get_checks_for_pl_and_bs_accounts() if not d.disabled]
+	return accounting_dimensions
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Fixed [support ticket](https://support.frappe.io/helpdesk/tickets/31750)

During POS Invoice Consolidation, non-mandatory accounting dimensions were not being set.

Also replaced scrubbing and unscrubbing accounting dimension label with exact accounting dimension fieldname.