### PR TITLE
feat: Prevent need for scrolling in lower screens (Point of Sale)

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -5,9 +5,9 @@
 	padding: 1%;
 
 	section {
-		min-height: 45rem;
-		height: calc(100vh - 200px);
-		max-height: calc(100vh - 200px);
+		min-height: 30rem;
+		height: calc(100vh - 125px);
+		max-height: calc(100vh - 125px);
 	}
 
 	.frappe-control {
@@ -373,6 +373,7 @@
 					flex-direction: column;
 					flex: 1 1 0%;
 					overflow-y: scroll;
+					min-height: 50px;
 
 					> .cart-item-wrapper {
 						@extend .pointer-no-select;
@@ -778,117 +779,131 @@
 			margin-bottom: var(--margin-md);
 		}
 
-		> .payment-modes {
+		> .payment-split-container {
 			display: flex;
-			padding-bottom: var(--padding-sm);
-			margin-bottom: var(--margin-sm);
-			overflow-x: scroll;
-			overflow-y: hidden;
-			flex-shrink: 0;
 
-			> .payment-mode-wrapper {
-				min-width: 40%;
-				padding: var(--padding-xs);
+			> .payment-container-left {
+				width: 50%;
+				margin-bottom: var(--margin-md);
 
-				> .mode-of-payment {
-					@extend .pos-card;
-					@extend .pointer-no-select;
-					padding: var(--padding-md) var(--padding-lg);
+				.payment-modes {
+					display: flex;
+					flex-direction: column;
+					padding-right: var(--padding-sm);
+					margin-right: var(--margin-sm);
+					min-height: 15rem;
+					overflow-x: scroll;
+					height: calc(100vh - 350px);
 
-					> .pay-amount {
-						display: inline;
-						float: right;
-						font-weight: 700;
-					}
+					> .payment-mode-wrapper {
+						min-width: 40%;
+						padding: var(--padding-xs);
 
-					> .mode-of-payment-control {
-						display: none;
-						align-items: center;
-						margin-top: var(--margin-sm);
-						margin-bottom: var(--margin-xs);
-					}
-
-					> .loyalty-amount-name {
-						display: none;
-						float: right;
-						font-weight: 700;
-						white-space: nowrap;
-						overflow: hidden;
-						text-overflow: ellipsis;
-					}
-
-					> .cash-shortcuts {
-						display: none;
-						grid-template-columns: repeat(3, minmax(0, 1fr));
-						gap: var(--margin-sm);
-						font-size: var(--text-sm);
-						text-align: center;
-
-						> .shortcut {
+						> .mode-of-payment {
+							@extend .pos-card;
 							@extend .pointer-no-select;
-							border-radius: var(--border-radius-sm);
-							background-color: var(--control-bg);
-							font-weight: 500;
-							padding: var(--padding-xs) var(--padding-sm);
-							transition: all 0.15s ease-in-out;
+							padding: var(--padding-md) var(--padding-lg);
 
-							&:hover {
-								background-color: var(--control-bg);
+							> .pay-amount {
+								display: inline;
+								float: right;
+								font-weight: 700;
 							}
+
+							> .mode-of-payment-control {
+								display: none;
+								align-items: center;
+								margin-top: var(--margin-sm);
+								margin-bottom: var(--margin-xs);
+							}
+
+							> .loyalty-amount-name {
+								display: none;
+								float: right;
+								font-weight: 700;
+								white-space: nowrap;
+								overflow: hidden;
+								text-overflow: ellipsis;
+							}
+
+							> .cash-shortcuts {
+								display: none;
+								grid-template-columns: repeat(3, minmax(0, 1fr));
+								gap: var(--margin-sm);
+								font-size: var(--text-sm);
+								text-align: center;
+
+								> .shortcut {
+									@extend .pointer-no-select;
+									border-radius: var(--border-radius-sm);
+									background-color: var(--control-bg);
+									font-weight: 500;
+									padding: var(--padding-xs) var(--padding-sm);
+									transition: all 0.15s ease-in-out;
+
+									&:hover {
+										background-color: var(--control-bg);
+									}
+								}
+							}
+						}
+
+						> .loyalty-card {
+							display: flex;
+							flex-direction: column;
 						}
 					}
 				}
-
-				> .loyalty-card {
-					display: flex;
-					flex-direction: column;
-				}
 			}
-		}
 
-		> .fields-numpad-container {
-			display: flex;
-			flex: 1;
-			height: 100%;
-			position: relative;
-			justify-content: flex-end;
-
-			> .fields-section {
-				flex: 1;
+			> .payment-container-right {
 				display: flex;
 				flex-direction: column;
 				width: 50%;
-				height: 100%;
-				padding-bottom: var(--margin-md);
 
-				.invoice-fields {
-					overflow-y: scroll;
+				.fields-numpad-container {
+					display: flex;
+					flex-direction: column;
+					flex: 1;
 					height: 100%;
-					padding-right: var(--padding-sm);
-				}
-			}
+					position: relative;
+					justify-content: flex-end;
 
-			> .number-pad {
-				flex: 1;
-				display: flex;
-				justify-content: flex-end;
-				align-items: flex-end;
-				max-width: 50%;
-
-				.numpad-container {
-					display: grid;
-					grid-template-columns: repeat(3, minmax(0, 1fr));
-					gap: var(--margin-md);
-					margin-bottom: var(--margin-md);
-
-					> .numpad-btn {
-						@extend .pointer-no-select;
-						border-radius: var(--border-radius-md);
+					> .fields-section {
+						flex: 1;
 						display: flex;
-						align-items: center;
-						justify-content: center;
-						padding: var(--padding-md);
-						box-shadow: var(--shadow-sm);
+						flex-direction: column;
+						padding-left: var(--margin-md);
+
+						.invoice-fields {
+							overflow-y: scroll;
+							height: 100%;
+							padding-right: var(--padding-sm);
+						}
+					}
+
+					> .number-pad {
+						flex: 1;
+						display: flex;
+						justify-content: flex-end;
+						align-items: flex-end;
+
+						.numpad-container {
+							display: grid;
+							grid-template-columns: repeat(3, minmax(0, 1fr));
+							gap: var(--margin-md);
+							margin-bottom: var(--margin-md);
+
+							> .numpad-btn {
+								@extend .pointer-no-select;
+								border-radius: var(--border-radius-md);
+								display: flex;
+								align-items: center;
+								justify-content: center;
+								padding: var(--padding-md);
+								box-shadow: var(--shadow-sm);
+							}
+						}
 					}
 				}
 			}

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -17,14 +17,20 @@ erpnext.PointOfSale.Payment = class {
 	prepare_dom() {
 		this.wrapper.append(
 			`<section class="payment-container">
-				<div class="section-label payment-section">${__("Payment Method")}</div>
-				<div class="payment-modes"></div>
-				<div class="fields-numpad-container">
-					<div class="fields-section">
-						<div class="section-label">${__("Additional Information")}</div>
-						<div class="invoice-fields"></div>
+				<div class="payment-split-container">
+					<div class="payment-container-left">
+						<div class="section-label payment-section">${__("Payment Method")}</div>
+						<div class="payment-modes"></div>
 					</div>
-					<div class="number-pad"></div>
+					<div class="payment-container-right">
+						<div class="fields-numpad-container">
+							<div class="fields-section">
+								<div class="section-label">${__("Additional Information")}</div>
+								<div class="invoice-fields"></div>
+							</div>
+							<div class="number-pad"></div>
+						</div>
+					</div>
 				</div>
 				<div class="totals-section">
 					<div class="totals"></div>


### PR DESCRIPTION
I screens lower than 814px, the browser creates a scroll in the window, that is inconvenient if the user are using a touch screen, for example, as the user already needs to scroll the items section. This pull-requests improves it, preventing the user of scrolling window till a lowest limit.

### Cart - Before:
![image](https://github.com/user-attachments/assets/ec6fed91-68bc-4ce3-84e4-3caf6754dfea)

### Cart - After:
![image](https://github.com/user-attachments/assets/5a086574-890e-40a5-984c-b51875cfbdbe)

### Payment - Before
![image](https://github.com/user-attachments/assets/2a1ad504-4dc4-4d7d-a9ee-6d922e70417d)

### Payment - After
![image](https://github.com/user-attachments/assets/7567d2a7-e925-4d1a-a9d3-97084f7195da)


no-docs
