### PR TITLE
fix: allow scrap item with zero qty

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2552,7 +2552,7 @@ class StockEntry(StockController):
 			item_row = item_dict[d]
 
 			child_qty = flt(item_row["qty"], precision)
-			if not self.is_return and child_qty <= 0:
+			if not self.is_return and child_qty <= 0 and not item_row.get("is_scrap_item"):
 				continue
 
 			se_child = self.append("items")


### PR DESCRIPTION
**Issue**

If scrap item has zero qty in the BOM then while making manufacturing entry against the work order, the system was 
skipping the scrap item