### PR TITLE
fix(projects settings): add checkbox to auto fetch timesheet in sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -896,7 +896,7 @@ frappe.ui.form.on("Sales Invoice", {
 	project: function (frm) {
 		if (frm.doc.project) {
 			frappe.db.get_value("Projects Settings", {}, "fetch_timesheet_in_sales_invoice", (r) => {
-				if (r.fetch_timesheet_in_sales_invoice) {
+				if (cint(r.fetch_timesheet_in_sales_invoice)) {
 					frm.events.add_timesheet_data(frm, {
 						project: frm.doc.project,
 					});

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -895,8 +895,12 @@ frappe.ui.form.on("Sales Invoice", {
 
 	project: function (frm) {
 		if (frm.doc.project) {
-			frm.events.add_timesheet_data(frm, {
-				project: frm.doc.project,
+			frappe.db.get_value("Projects Settings", {}, "fetch_timesheet_in_sales_invoice", (r) => {
+				if (r.fetch_timesheet_in_sales_invoice) {
+					frm.events.add_timesheet_data(frm, {
+						project: frm.doc.project,
+					});
+				}
 			});
 		}
 	},

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1096,16 +1096,17 @@ class SalesInvoice(SellingController):
 					timesheet.billing_amount = ts_doc.total_billable_amount
 
 	def update_timesheet_billing_for_project(self):
-		if self.timesheets:
+		if (
+			not self.timesheets
+			and self.project
+			and frappe.db.get_single_value("Projects Settings", "fetch_timesheet_in_sales_invoice")
+		):
+			self.add_timesheet_data()
+		else:
 			self.calculate_billing_amount_for_timesheet()
 
-	@frappe.whitelist(methods=["PUT"])
+	@frappe.whitelist()
 	def add_timesheet_data(self):
-		if not self.timesheets and self.project:
-			self._add_timesheet_data()
-			self.save()
-
-	def _add_timesheet_data(self):
 		self.set("timesheets", [])
 		if self.project:
 			for data in get_projectwise_timesheet_data(self.project):

--- a/erpnext/projects/doctype/projects_settings/projects_settings.json
+++ b/erpnext/projects/doctype/projects_settings/projects_settings.json
@@ -8,7 +8,8 @@
   "timesheet_sb",
   "ignore_workstation_time_overlap",
   "ignore_user_time_overlap",
-  "ignore_employee_time_overlap"
+  "ignore_employee_time_overlap",
+  "fetch_timesheet_in_sales_invoice"
  ],
  "fields": [
   {
@@ -33,11 +34,18 @@
    "fieldname": "ignore_employee_time_overlap",
    "fieldtype": "Check",
    "label": "Ignore Employee Time Overlap"
+  },
+  {
+   "default": "0",
+   "description": "Enabling the check box will fetch timesheet on select of a Project in Sales Invoice",
+   "fieldname": "fetch_timesheet_in_sales_invoice",
+   "fieldtype": "Check",
+   "label": "Fetch Timesheet in Sales Invoice"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:21.984404",
+ "modified": "2025-02-13 23:01:27.321902",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Projects Settings",

--- a/erpnext/projects/doctype/projects_settings/projects_settings.py
+++ b/erpnext/projects/doctype/projects_settings/projects_settings.py
@@ -14,6 +14,7 @@ class ProjectsSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		fetch_timesheet_in_sales_invoice: DF.Check
 		ignore_employee_time_overlap: DF.Check
 		ignore_user_time_overlap: DF.Check
 		ignore_workstation_time_overlap: DF.Check

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -53,6 +53,7 @@ class TestTimesheet(IntegrationTestCase):
 		self.assertEqual(item.qty, 2.00)
 		self.assertEqual(item.rate, 50.00)
 
+	@IntegrationTestCase.change_settings("Projects Settings", {"fetch_timesheet_in_sales_invoice": 1})
 	def test_timesheet_billing_based_on_project(self):
 		emp = make_employee("test_employee_6@salary.com")
 		project = frappe.get_value("Project", {"project_name": "_Test Project"})
@@ -62,7 +63,7 @@ class TestTimesheet(IntegrationTestCase):
 		)
 		sales_invoice = create_sales_invoice(do_not_save=True)
 		sales_invoice.project = project
-		sales_invoice._add_timesheet_data()
+		sales_invoice.add_timesheet_data()
 		sales_invoice.submit()
 
 		ts = frappe.get_doc("Timesheet", timesheet.name)


### PR DESCRIPTION
**Issue:**
Unable to link project without fetching the timesheet in the sales invoice.
**ref:** [31312](https://support.frappe.io/helpdesk/tickets/31312)

**Before:**

https://github.com/user-attachments/assets/f35916f9-6a46-42f2-a83c-49f810af2562


**After:**

https://github.com/user-attachments/assets/e5aa49cd-0b4d-4ef7-b9c2-e12aa1b9868c


**Backport needed for v15**