### PR TITLE
feat: combined production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -592,7 +592,7 @@ frappe.tour["Production Plan"] = [
 		fieldname: "get_items_from",
 		title: "Get Items From",
 		description: __(
-			"Select whether to get items from a Sales Order or a Material Request. For now select <b>Sales Order</b>.\n A Production Plan can also be created manually where you can select the Items to manufacture."
+			"Select whether to get items from a Sales Order or a Material Request or Both. For now select <b>Sales Order</b>.\n A Production Plan can also be created manually where you can select the Items to manufacture."
 		),
 	},
 	{

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -86,7 +86,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Get Items From",
-   "options": "\nSales Order\nMaterial Request"
+   "options": "\nSales Order\nMaterial Request\nBoth"
   },
   {
    "fieldname": "column_break1",
@@ -155,7 +155,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "eval: doc.__islocal",
-   "depends_on": "eval: doc.get_items_from == \"Sales Order\"",
+   "depends_on": "eval: [\"Sales Order\", \"Both\"].includes(doc.get_items_from)",
    "fieldname": "sales_orders_detail",
    "fieldtype": "Section Break",
    "label": "Sales Orders"
@@ -175,7 +175,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "eval: doc.__islocal",
-   "depends_on": "eval: doc.get_items_from == \"Material Request\"",
+   "depends_on": "eval: [\"Material Request\", \"Both\"].includes(doc.get_items_from)",
    "fieldname": "material_request_detail",
    "fieldtype": "Section Break",
    "label": "Material Request Detail"
@@ -440,7 +440,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-10 17:47:52.207209",
+ "modified": "2025-02-14 12:07:16.079109",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",


### PR DESCRIPTION
Currently, production plan allowed only Sales Order or Material Request at a time.
Added provision so that both documents can be listed in a single Production Plan.