### PR TITLE
fix: include missing payment_gateway parameter in Payment Request URL

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -300,6 +300,7 @@ class PaymentRequest(Document):
 				"payer_name": data.customer_name,
 				"order_id": self.name,
 				"currency": self.currency,
+				"payment_gateway": self.payment_gateway,
 			}
 		)
 


### PR DESCRIPTION
Resolves the following issue:

https://github.com/frappe/payments/issues/124

Solution:

The issue was caused by a missing payment_gateway parameter, leading to an incomplete URL error during Stripe payments. The fix involved adding this parameter in the get_payment_url function, ensuring expected arguments are passed correctly for proper gateway processing.