### PR TITLE
fix(Employee): remove User Permissions if create_user_permission is unchecked

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -84,9 +84,8 @@ class Employee(NestedSet):
 		self.reset_employee_emails_cache()
 
 	def update_user_permissions(self):
-		if (
-			not has_permission("User Permission", ptype="write", print_logs=False)
-			or (not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"))
+		if not has_permission("User Permission", ptype="write", print_logs=False) or (
+			not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission")
 		):
 			return
 

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -84,7 +84,10 @@ class Employee(NestedSet):
 		self.reset_employee_emails_cache()
 
 	def update_user_permissions(self):
-		if not has_permission("User Permission", ptype="write", print_logs=False):
+		if (
+			not has_permission("User Permission", ptype="write", print_logs=False)
+			or (not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"))
+		):
 			return
 
 		employee_user_permission_exists = frappe.db.exists(

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -5,7 +5,6 @@ from frappe import _, scrub, throw
 from frappe.model.naming import set_name_by_naming_series
 from frappe.permissions import (
 	add_user_permission,
-	delete_user_permission,
 	get_doc_permissions,
 	has_permission,
 	remove_user_permission,
@@ -93,8 +92,8 @@ class Employee(NestedSet):
 		)
 
 		if employee_user_permission_exists and not self.create_user_permission:
-			delete_user_permission("Employee", self.name, self.user_id)
-			delete_user_permission("Company", self.company, self.user_id)
+			remove_user_permission("Employee", self.name, self.user_id)
+			remove_user_permission("Company", self.company, self.user_id)
 		elif not employee_user_permission_exists and self.create_user_permission:
 			add_user_permission("Employee", self.name, self.user_id)
 			add_user_permission("Company", self.company, self.user_id)

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -5,6 +5,7 @@ from frappe import _, scrub, throw
 from frappe.model.naming import set_name_by_naming_series
 from frappe.permissions import (
 	add_user_permission,
+	delete_user_permission,
 	get_doc_permissions,
 	has_permission,
 	remove_user_permission,
@@ -84,8 +85,6 @@ class Employee(NestedSet):
 		self.reset_employee_emails_cache()
 
 	def update_user_permissions(self):
-		if not self.create_user_permission:
-			return
 		if not has_permission("User Permission", ptype="write", print_logs=False):
 			return
 
@@ -93,11 +92,12 @@ class Employee(NestedSet):
 			"User Permission", {"allow": "Employee", "for_value": self.name, "user": self.user_id}
 		)
 
-		if employee_user_permission_exists:
-			return
-
-		add_user_permission("Employee", self.name, self.user_id)
-		add_user_permission("Company", self.company, self.user_id)
+		if employee_user_permission_exists and not self.create_user_permission:
+			delete_user_permission("Employee", self.name, self.user_id)
+			delete_user_permission("Company", self.company, self.user_id)
+		elif not employee_user_permission_exists and self.create_user_permission:
+			add_user_permission("Employee", self.name, self.user_id)
+			add_user_permission("Company", self.company, self.user_id)
 
 	def update_user(self):
 		# add employee role if missing


### PR DESCRIPTION
**Scenario:**
A supervisor wants to extend the permissions of a certain **Employee** by removing the **User Permissions**.

**Expected Solution:**
For this, they expect to un-check _Create User Permission_, since this was responsible for creating the **User Permissions** in the first place.
![image](https://github.com/user-attachments/assets/f17dcfaa-68d6-45f0-85ef-982efabe23ee)

**Problem:** 
The checkbox can be un-checked, without any further consequences (**User Permissions** are not removed and there is no transparency about the inconsistency).
