### PR TITLE
fix: maintain unrounded value in company currency fields

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1012,7 +1012,7 @@ class PurchaseInvoice(BuyingController):
 									"cost_center": item.cost_center,
 									"project": item.project or self.project,
 									"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
-									"debit": -1 * flt(credit_amount, item.precision("base_net_amount")),
+									"debit": -1 * credit_amount,
 								},
 								warehouse_account[item.from_warehouse]["account_currency"],
 								item=item,
@@ -1026,7 +1026,7 @@ class PurchaseInvoice(BuyingController):
 									{
 										"account": item.expense_account,
 										"against": self.supplier,
-										"debit": flt(item.base_net_amount, item.precision("base_net_amount")),
+										"debit": item.base_net_amount,
 										"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
 										"cost_center": item.cost_center,
 										"project": item.project,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1775,10 +1775,7 @@ class AccountsController(TransactionBase):
 			and self.get("additional_discount_account")
 		):
 			amount += item.distributed_discount_amount
-			base_amount += flt(
-				item.distributed_discount_amount * self.get("conversion_rate"),
-				item.precision("distributed_discount_amount"),
-			)
+			base_amount += item.distributed_discount_amount * self.get("conversion_rate")
 
 		return amount, base_amount
 
@@ -2938,14 +2935,12 @@ def set_balance_in_account_currency(
 	# set debit/credit in account currency if not provided
 	if flt(gl_dict.debit) and not flt(gl_dict.debit_in_account_currency):
 		gl_dict.debit_in_account_currency = (
-			gl_dict.debit if account_currency == company_currency else flt(gl_dict.debit / conversion_rate, 2)
+			gl_dict.debit if account_currency == company_currency else (gl_dict.debit / conversion_rate)
 		)
 
 	if flt(gl_dict.credit) and not flt(gl_dict.credit_in_account_currency):
 		gl_dict.credit_in_account_currency = (
-			gl_dict.credit
-			if account_currency == company_currency
-			else flt(gl_dict.credit / conversion_rate, 2)
+			gl_dict.credit if account_currency == company_currency else (gl_dict.credit / conversion_rate)
 		)
 
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -309,7 +309,7 @@ class BuyingController(SubcontractingController):
 					)
 					valuation_amount_adjustment -= item.item_tax_amount
 
-				self.round_floats_in(item)
+				# self.round_floats_in(item)
 				if flt(item.conversion_factor) == 0.0:
 					item.conversion_factor = (
 						get_conversion_factor(item.item_code, item.uom).get("conversion_factor") or 1.0

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -243,9 +243,7 @@ class calculate_taxes_and_totals:
 	def _set_in_company_currency(self, doc, fields):
 		"""set values in base currency"""
 		for f in fields:
-			val = flt(
-				flt(doc.get(f), doc.precision(f)) * self.doc.conversion_rate, doc.precision("base_" + f)
-			)
+			val = doc.get(f) * self.doc.conversion_rate
 			doc.set("base_" + f, val)
 
 	def initialize_taxes(self):
@@ -370,7 +368,7 @@ class calculate_taxes_and_totals:
 			self.doc.net_total += item.net_amount
 			self.doc.base_net_total += item.base_net_amount
 
-		self.doc.round_floats_in(self.doc, ["total", "base_total", "net_total", "base_net_total"])
+		self.doc.round_floats_in(self.doc, ["total", "net_total"])
 
 	def calculate_shipping_charges(self):
 		# Do not apply shipping rule for POS
@@ -643,7 +641,7 @@ class calculate_taxes_and_totals:
 			"POS Invoice",
 		]:
 			self.doc.base_grand_total = (
-				flt(self.doc.grand_total * self.doc.conversion_rate, self.doc.precision("base_grand_total"))
+				(self.doc.grand_total * self.doc.conversion_rate)
 				if self.doc.total_taxes_and_charges
 				else self.doc.base_net_total
 			)
@@ -659,14 +657,14 @@ class calculate_taxes_and_totals:
 			self.doc.round_floats_in(self.doc, ["taxes_and_charges_added", "taxes_and_charges_deducted"])
 
 			self.doc.base_grand_total = (
-				flt(self.doc.grand_total * self.doc.conversion_rate)
+				(self.doc.grand_total * self.doc.conversion_rate)
 				if (self.doc.taxes_and_charges_added or self.doc.taxes_and_charges_deducted)
 				else self.doc.base_net_total
 			)
 
 			self._set_in_company_currency(self.doc, ["taxes_and_charges_added", "taxes_and_charges_deducted"])
 
-		self.doc.round_floats_in(self.doc, ["grand_total", "base_grand_total"])
+		self.doc.round_floats_in(self.doc, ["grand_total"])
 
 		self.set_rounded_total()
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -161,7 +161,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	set_in_company_currency(doc, fields) {
 		var me = this;
 		$.each(fields, function(i, f) {
-			doc["base_"+f] = flt(flt(doc[f], precision(f, doc)) * me.frm.doc.conversion_rate, precision("base_" + f, doc));
+			doc["base_"+f] = (flt(doc[f], precision(f, doc)) * me.frm.doc.conversion_rate);
 		});
 	}
 
@@ -306,7 +306,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			me.frm.doc.base_net_total += item.base_net_amount;
 		});
 
-		frappe.model.round_floats_in(this.frm.doc, ["total", "base_total", "net_total", "base_net_total"]);
+		frappe.model.round_floats_in(this.frm.doc, ["total", "net_total"]);
 	}
 
 	calculate_shipping_charges() {
@@ -315,7 +315,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			return;
 		}
 
-		frappe.model.round_floats_in(this.frm.doc, ["total", "base_total", "net_total", "base_net_total"]);
+		frappe.model.round_floats_in(this.frm.doc, ["total", "net_total"]);
 		if (frappe.meta.get_docfield(this.frm.doc.doctype, "shipping_rule", this.frm.doc.name)) {
 			return this.shipping_rule();
 		}
@@ -594,7 +594,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		if(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
 			this.frm.doc.base_grand_total = (this.frm.doc.total_taxes_and_charges) ?
-				flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total;
+				(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total;
 		} else {
 			// other charges added/deducted
 			this.frm.doc.taxes_and_charges_added = this.frm.doc.taxes_and_charges_deducted = 0.0;
@@ -613,8 +613,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					["taxes_and_charges_added", "taxes_and_charges_deducted"]);
 			}
 
-			this.frm.doc.base_grand_total = flt((this.frm.doc.taxes_and_charges_added || this.frm.doc.taxes_and_charges_deducted) ?
-				flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total);
+			this.frm.doc.base_grand_total = ((this.frm.doc.taxes_and_charges_added || this.frm.doc.taxes_and_charges_deducted) ?
+				(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total);
 
 			this.set_in_company_currency(this.frm.doc,
 				["taxes_and_charges_added", "taxes_and_charges_deducted"]);
@@ -982,8 +982,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total,
 					precision("change_amount"));
 
-				this.frm.doc.base_change_amount = flt(this.frm.doc.base_paid_amount -
-					base_grand_total, precision("base_change_amount"));
+					this.frm.doc.base_change_amount = (this.frm.doc.base_paid_amount - base_grand_total);
 			}
 		}
 	}


### PR DESCRIPTION
**Issue:**
Transaction currency precision mismatch between debit and credit when exchange rate: 0.737517516 is used.

**Solution:**
Tried to maintain the unrounded value in the company currency fields in Purchase Invoice (experimental fix, kindly advise if there are any other better ways)

**ref:** [29752](https://support.frappe.io/helpdesk/tickets/29752)

**Before:**
![image](https://github.com/user-attachments/assets/8272d175-2079-4dde-87c9-560c245c8837)


**After:**
![image](https://github.com/user-attachments/assets/3e5e1ede-e031-4d23-9966-7a5933c0c13f)
