### PR TITLE
fix: validate address and contact related to party

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -466,9 +466,9 @@ class AccountsController(TransactionBase):
 				pluck="parent",
 			)
 			if billing_address and billing_address not in party_address:
-				frappe.throw(f"Billing Address does not belong to the {party}")
+				frappe.throw(_("Billing Address does not belong to the {0}").format(party))
 			elif shipping_address and shipping_address not in party_address:
-				frappe.throw(f"Shipping Address does not belong to the {party}")
+				frappe.throw(_("Shipping Address does not belong to the {0}").format(party))
 
 	def validate_party_contact(self, party, party_type):
 		if self.get("contact_person"):
@@ -478,7 +478,7 @@ class AccountsController(TransactionBase):
 				pluck="parent",
 			)
 			if self.contact_person and self.contact_person not in contact:
-				frappe.throw(f"Contact Person does not belong to the {party}")
+				frappe.throw(_("Contact Person does not belong to the {party}").format(party))
 
 	def validate_return_against_account(self):
 		if self.doctype in ["Sales Invoice", "Purchase Invoice"] and self.is_return and self.return_against:
@@ -3568,7 +3568,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 		1. Change rate of subcontracting - regardless of other changes.
 		2. Change qty and/or add new items and/or remove items
-		                Exception: Transfer/Consumption is already made, qty change not allowed.
+		        Exception: Transfer/Consumption is already made, qty change not allowed.
 		"""
 
 		supplied_items_processed = any(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -445,16 +445,17 @@ class AccountsController(TransactionBase):
 					)
 
 	def validate_party_address_and_contact(self):
+		party, party_type = None, None
 		if self.get("customer"):
 			party, party_type = self.customer, "Customer"
 			billing_address, shipping_address = self.get("customer_address"), self.get("shipping_address")
 			self.validate_party_address(party, party_type, billing_address, shipping_address)
-			self.validate_party_contact(party, party_type)
-
 		elif self.get("supplier"):
 			party, party_type = self.supplier, "Supplier"
 			billing_address = self.get("supplier_address")
 			self.validate_party_address(party, party_type, billing_address)
+
+		if party and party_type:
 			self.validate_party_contact(party, party_type)
 
 	def validate_party_address(self, party, party_type, billing_address, shipping_address=None):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -449,12 +449,13 @@ class AccountsController(TransactionBase):
 			party, party_type = self.customer, "Customer"
 			billing_address, shipping_address = self.get("customer_address"), self.get("shipping_address")
 			self.validate_party_address(party, party_type, billing_address, shipping_address)
+			self.validate_party_contact(party, party_type)
+
 		elif self.get("supplier"):
 			party, party_type = self.supplier, "Supplier"
 			billing_address = self.get("supplier_address")
 			self.validate_party_address(party, party_type, billing_address)
-
-		self.validate_party_contact(party, party_type)
+			self.validate_party_contact(party, party_type)
 
 	def validate_party_address(self, party, party_type, billing_address, shipping_address=None):
 		if billing_address or shipping_address:


### PR DESCRIPTION
**Issue:**
Able to set address and contact of different party in invoice, which sent email to different party.

**ref:** [31775](https://support.frappe.io/helpdesk/tickets/31775)

**Before:**

[validate_party_address_bfr.webm](https://github.com/user-attachments/assets/d958e611-00c6-48f4-8754-4a8835cc4eb5)

**After:**

[validate_party_address_afr.webm](https://github.com/user-attachments/assets/5e4df4b7-e60d-4f78-a7df-568c2b4d4bcc)

**Back port needed for v15**