### PR TITLE
feat: Options for asset depreciation start and end of the month

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -61,6 +61,8 @@
   "assets_tab",
   "asset_settings_section",
   "calculate_depr_using_total_days",
+  "calculate_depr_using_first_day_of_month",
+  "calculate_depr_using_last_day_of_month",
   "column_break_gjcc",
   "book_asset_depreciation_entry_automatically",
   "closing_settings_tab",
@@ -532,6 +534,22 @@
    "fieldtype": "Select",
    "label": "Posting Date Inheritance for Exchange Gain / Loss",
    "options": "Invoice\nPayment\nReconciliation Date"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.calculate_depr_using_total_days",
+   "description": "Only active if depreciation starts in the same month. Cannot be combined with pro rata calculation.",
+   "fieldname": "calculate_depr_using_first_day_of_month",
+   "fieldtype": "Check",
+   "label": "Calculate depreciation using the first day of the available-of-use month"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.calculate_depr_using_total_days",
+   "description": "Only active if depreciation starts in the same month. Overrides the selected depreciation start date and selects the end of the month for calculation. Depreciation will be booked on selected date.\nCannot be combined with pro rata calculation.",
+   "fieldname": "calculate_depr_using_last_day_of_month",
+   "fieldtype": "Check",
+   "label": "Calculate depreciation using the last day of the start-of-depreciation month"
   }
  ],
  "icon": "icon-cog",
@@ -539,7 +557,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-23 13:15:44.077853",
+ "modified": "2025-02-17 14:24:11.417864",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -35,6 +35,8 @@ class AccountsSettings(Document):
 		book_deferred_entries_based_on: DF.Literal["Days", "Months"]
 		book_deferred_entries_via_journal_entry: DF.Check
 		book_tax_discount_loss: DF.Check
+		calculate_depr_using_first_day_of_month: DF.Check
+		calculate_depr_using_last_day_of_month: DF.Check
 		calculate_depr_using_total_days: DF.Check
 		check_supplier_invoice_uniqueness: DF.Check
 		create_pr_in_draft_status: DF.Check

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -358,12 +358,21 @@ class AssetDepreciationSchedule(Document):
 				and not self.opening_accumulated_depreciation
 				and not self.flags.wdv_it_act_applied
 			):
-				if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_first_day_of_month")) and not has_wdv_or_dd_non_yearly_pro_rata:
+				if (
+					cint(
+						frappe.db.get_single_value(
+							"Accounts Settings", "calculate_depr_using_first_day_of_month"
+						)
+					)
+					and not has_wdv_or_dd_non_yearly_pro_rata
+				):
 					from_date = get_first_day(asset_doc.available_for_use_date)
 				else:
 					from_date = asset_doc.available_for_use_date
 				
-				if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_last_day_of_month")):
+				if cint(
+					frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_last_day_of_month")
+				):
 					to_date = get_last_day(row.depreciation_start_date)
 				else:
 					to_date = row.depreciation_start_date		

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -358,13 +358,21 @@ class AssetDepreciationSchedule(Document):
 				and not self.opening_accumulated_depreciation
 				and not self.flags.wdv_it_act_applied
 			):
-				from_date = asset_doc.available_for_use_date
+				if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_first_day_of_month")) and not has_wdv_or_dd_non_yearly_pro_rata:
+					from_date = get_first_day(asset_doc.available_for_use_date)
+				else:
+					from_date = asset_doc.available_for_use_date
+				
+				if cint(frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_last_day_of_month")):
+					to_date = get_last_day(row.depreciation_start_date)
+				else:
+					to_date = row.depreciation_start_date		
 				# needed to calc depr amount for available_for_use_date too
 				depreciation_amount, days, months = _get_pro_rata_amt(
 					row,
 					depreciation_amount,
 					from_date,
-					row.depreciation_start_date,
+					to_date,
 					has_wdv_or_dd_non_yearly_pro_rata,
 				)
 				if flt(depreciation_amount, asset_doc.precision("gross_purchase_amount")) <= 0:

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -369,13 +369,13 @@ class AssetDepreciationSchedule(Document):
 					from_date = get_first_day(asset_doc.available_for_use_date)
 				else:
 					from_date = asset_doc.available_for_use_date
-				
+
 				if cint(
 					frappe.db.get_single_value("Accounts Settings", "calculate_depr_using_last_day_of_month")
 				):
 					to_date = get_last_day(row.depreciation_start_date)
 				else:
-					to_date = row.depreciation_start_date		
+					to_date = row.depreciation_start_date
 				# needed to calc depr amount for available_for_use_date too
 				depreciation_amount, days, months = _get_pro_rata_amt(
 					row,


### PR DESCRIPTION
Feature allows for more flexible asset depreciation options.

Please backport to v15

**Option 1:**
Calculate depreciation using the first day of the available-of-use month

Function:
Setting this option allows for example linear depreciation to start in the beginning of the month independent of the available for use date. This is standard procedure required by law for example in Germany.
Applies of course only if the start date for depreciation and the available-for-use date are in the same month.

**Option 2:**
Calculate depreciation using the last day of the start-of-depreciation month

Function:
For the rather lazy book keeper (or as backup). This option always selects the end of the month for calculation. It is useful if depreciations always have to be booked with the value of the full month independent of the selected date for booking. Basically, even if the accountant selectes another date for the start of depreciation, it will always calculate for the full month.
Applies of course only if the start date for depreciation and the available-for-use date are in the same month. 