### PR TITLE
fix: round sum amount in JE auditing PF

### DIFF
--- a/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
+++ b/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
@@ -44,7 +44,7 @@
             {% endfor %}
             <tr>
                     <td class="right" colspan="3" ><strong>Total (debit) </strong></td>
-                    <td class="left" >{{ gl | sum(attribute='debit') }}</td>
+                    <td class="left" >{{ gl | sum(attribute='debit') | round(2) }}</td>
             </tr>
             <tr>
                     <td class="top-bottom" colspan="5"><strong>Credit</strong></td>
@@ -61,7 +61,7 @@
             {% endfor %}
             <tr>
                 <td class="right" colspan="3"><strong>Total (credit) </strong></td>
-                <td class="left" >{{ gl | sum(attribute='credit') }}</td>
+                <td class="left" >{{ gl | sum(attribute='credit') | round(2) }}</td>
             </tr>
             <tr>
                 <td class="top-bottom" colspan="5"><b>Narration: </b>{{ gl[0].remarks }}</td>


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/helpdesk/tickets/32021

Updated the `Journal Auditing Voucher` Print format to round the total debit and credit values to 2 decimal places. Previously, the totals showed excessive decimals, making it harder to read.

> Screenshots/GIFs

- Before
![image](https://github.com/user-attachments/assets/23eb0a50-7f79-4cdf-b5c4-faad13089d33)


- After
![image](https://github.com/user-attachments/assets/35851ab3-5057-49c1-b5d5-dc0843bd822d)
