### PR TITLE
fix: serial no status for internal transfer delivery note

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -593,12 +593,13 @@ class SellingController(StockController):
 			if not self.is_internal_transfer() or self.docstatus == 1
 			else None
 		)
-		if serial_and_batch_bundle and self.is_internal_transfer() and self.is_return:
-			if self.docstatus == 1:
+
+		if self.is_internal_transfer():
+			if serial_and_batch_bundle and self.docstatus == 1 and self.is_return:
 				serial_and_batch_bundle = self.make_package_for_transfer(
 					serial_and_batch_bundle, item_row.warehouse, type_of_transaction="Inward"
 				)
-			else:
+			elif not serial_and_batch_bundle:
 				serial_and_batch_bundle = frappe.db.get_value(
 					"Stock Ledger Entry",
 					{"voucher_detail_no": item_row.name, "warehouse": item_row.warehouse},


### PR DESCRIPTION
- Create delivery note for internal transfer with serial nos
- Cancel the delivery note and check the status of the serial nos
- The status will show as Inactive