### PR TITLE
fix: set sco_qty field of PO to non negative

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -937,6 +937,7 @@
    "fieldtype": "Float",
    "label": "Subcontracted Quantity",
    "no_copy": 1,
+   "non_negative": 1,
    "read_only": 1
   }
  ],
@@ -944,7 +945,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-10 12:11:18.536089",
+ "modified": "2025-02-18 12:35:04.432636",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",


### PR DESCRIPTION
Reference support ticket [32087](https://support.frappe.io/helpdesk/tickets/32087)

I don't know how it happened but sco_qty field value became negative which does not make sense. So adding non negative flag to the field.