### PR TITLE
fix: Set Taxes Before Calculating Taxes and Totals

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -197,6 +197,14 @@ class AccountsController(TransactionBase):
 		self.set_incoming_rate()
 		self.init_internal_values()
 
+		# Need to set taxes based on taxes_and_charges template
+		# before calculating taxes and totals
+		if self.meta.get_field("taxes_and_charges"):
+			self.validate_enabled_taxes_and_charges()
+			self.validate_tax_account_company()
+
+		self.set_taxes_and_charges()
+
 		if self.meta.get_field("currency"):
 			self.calculate_taxes_and_totals()
 
@@ -206,10 +214,6 @@ class AccountsController(TransactionBase):
 			validate_return(self)
 
 		self.validate_all_documents_schedule()
-
-		if self.meta.get_field("taxes_and_charges"):
-			self.validate_enabled_taxes_and_charges()
-			self.validate_tax_account_company()
 
 		self.validate_party()
 		self.validate_currency()
@@ -254,8 +258,6 @@ class AccountsController(TransactionBase):
 
 			self.validate_deferred_income_expense_account()
 			self.set_inter_company_account()
-
-		self.set_taxes_and_charges()
 
 		if self.doctype == "Purchase Invoice":
 			self.calculate_paid_amount()

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -935,6 +935,35 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertEqual(exc_je_for_si, [])
 		self.assertEqual(exc_je_for_pe, [])
 
+	@IntegrationTestCase.change_settings("Accounts Settings", {"add_taxes_from_item_tax_template": 1})
+	def test_18_fetch_taxes_based_on_taxes_and_charges_template(self):
+		# Create a Sales Taxes and Charges Template
+		if not frappe.db.exists("Sales Taxes and Charges Template", "_Test Tax - _TC"):
+			doc = frappe.new_doc("Sales Taxes and Charges Template")
+			doc.company = self.company
+			doc.title = "_Test Tax"
+			doc.append(
+				"taxes",
+				{
+					"charge_type": "On Net Total",
+					"account_head": "Sales Expenses - _TC",
+					"description": "Test taxes",
+					"rate": 9,
+				},
+			)
+			doc.insert()
+
+		# Create a Sales Invoice
+		sinv = frappe.new_doc("Sales Invoice")
+		sinv.customer = self.customer
+		sinv.company = self.company
+		sinv.currency = "INR"
+		sinv.taxes_and_charges = "_Test Tax - _TC"
+		sinv.append("items", {"item_code": "_Test Item", "qty": 1, "rate": 50})
+		sinv.insert()
+
+		self.assertEqual(sinv.total_taxes_and_charges, 4.5)
+
 	def test_20_journal_against_sales_invoice(self):
 		# Invoice in Foreign Currency
 		si = self.create_sales_invoice(qty=1, conversion_rate=80, rate=1)


### PR DESCRIPTION
Reference PR: https://github.com/frappe/erpnext/pull/45585

- In the reference PR, taxes are getting fetched based on the  `taxes_and_charges` template when transaction is made through api call. 
- But the problem is, it is getting fetched after calculating taxes and totals and because of it the taxes are not getting set.

<img width="1468" alt="Screenshot 2025-02-18 at 1 05 45 PM" src="https://github.com/user-attachments/assets/ab2e5216-5bc4-4498-82f6-6e6fe579a30c" />

- The above issue is solved in the current PR

<img width="1468" alt="Screenshot 2025-02-18 at 1 07 03 PM" src="https://github.com/user-attachments/assets/7d8f0f48-7e24-46de-afb3-085c6729755e" />