### PR TITLE
fix(pos profile): check company while validating mandatory accounting dimension

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -78,7 +78,11 @@ class POSProfile(Document):
 	def validate_accounting_dimensions(self):
 		acc_dims = get_checks_for_pl_and_bs_accounts()
 		for acc_dim in acc_dims:
-			if not self.get(acc_dim.fieldname) and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs):
+			if (
+				self.company == acc_dim.company
+				and not self.get(acc_dim.fieldname)
+				and (acc_dim.mandatory_for_pl or acc_dim.mandatory_for_bs)
+			):
 				frappe.throw(
 					_(
 						"{0} is a mandatory Accounting Dimension. <br>"


### PR DESCRIPTION
**Issue:**
unable to save pos-profile, when the accounting dimension is mandatory on different company
**ref:** [30597](https://support.frappe.io/helpdesk/tickets/30597)

**Accounting Dimension:** 
![image](https://github.com/user-attachments/assets/7a202488-8b26-4fc5-b0f8-a21731b247c0)

**POS Profile:**
![image](https://github.com/user-attachments/assets/867f45b1-1356-4fef-9cad-f9722c54575a)

![image](https://github.com/user-attachments/assets/843e7f20-04bc-44bf-bdfb-dc1487071b60)

**Issue:**
![image](https://github.com/user-attachments/assets/6bea7c31-2287-4c38-8ba6-b26652cfb08a)


**Backport needed for v15**