### PR TITLE
fix: millisecond issue for posting datetime

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -400,3 +400,4 @@ erpnext.patches.v15_0.migrate_checkbox_to_select_for_reconciliation_effect
 erpnext.patches.v15_0.sync_auto_reconcile_config
 execute:frappe.db.set_single_value("Accounts Settings", "exchange_gain_loss_posting_date", "Payment")
 erpnext.patches.v14_0.disable_add_row_in_gross_profit
+erpnext.patches.v14_0.update_posting_datetime

--- a/erpnext/patches/v14_0/update_posting_datetime.py
+++ b/erpnext/patches/v14_0/update_posting_datetime.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""
+		UPDATE `tabStock Ledger Entry`
+			SET posting_datetime = timestamp(posting_date, posting_time)
+	"""
+	)

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -663,7 +663,7 @@ def get_combine_datetime(posting_date, posting_time):
 	if isinstance(posting_time, datetime.timedelta):
 		posting_time = (datetime.datetime.min + posting_time).time()
 
-	return datetime.datetime.combine(posting_date, posting_time).replace(microsecond=0)
+	return datetime.datetime.combine(posting_date, posting_time)
 
 
 @frappe.request_cache


### PR DESCRIPTION
Consider milliseconds in the posting datetime to get the correct precious stock ledger entry