### PR TITLE
fix: check if employee is currently working on another workstation

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -296,7 +296,8 @@ class JobCard(Document):
 			frappe.throw(
 				_(
 					"Employee {0} is currently working on another workstation. Please assign another employee."
-				).format(args.get("employee"))
+				).format(args.get("employee")),
+				OverlapError,
 			)
 
 		if not self.has_overlap(production_capacity, time_logs):


### PR DESCRIPTION
Reference support ticket [31872](https://support.frappe.io/helpdesk/tickets/31872)

If employee was set on Job Card Time Log child table of Job Card, no check was being made if employee is already working on another workstation.

Instead, if employee was simply set to the Time Log, production capacity was set to 1, which made no logical sense.