### PR TITLE
fix: source warehouse not fetched in bom creator

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -28,6 +28,8 @@ BOM_ITEM_FIELDS = [
 	"stock_uom",
 	"conversion_factor",
 	"do_not_explode",
+	"source_warehouse",
+	"allow_alternative_item",
 ]
 
 
@@ -291,7 +293,6 @@ class BOMCreator(Document):
 				"item": row.item_code,
 				"bom_type": "Production",
 				"quantity": row.qty,
-				"allow_alternative_item": 1,
 				"bom_creator": self.name,
 				"bom_creator_item": bom_creator_item,
 			}
@@ -315,7 +316,6 @@ class BOMCreator(Document):
 			item_args.update(
 				{
 					"bom_no": bom_no,
-					"allow_alternative_item": 1,
 					"allow_scrap_items": 1,
 					"include_item_in_manufacturing": 1,
 				}
@@ -428,6 +428,7 @@ def add_sub_assembly(**kwargs):
 				"do_not_explode": 1,
 				"is_expandable": 1,
 				"stock_uom": item_info.stock_uom,
+				"allow_alternative_item": kwargs.allow_alternative_item,
 			},
 		)
 

--- a/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
+++ b/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -15,6 +15,7 @@
   "is_expandable",
   "sourced_by_supplier",
   "bom_created",
+  "allow_alternative_item",
   "description_section",
   "description",
   "quantity_and_rate_section",
@@ -225,12 +226,18 @@
    "label": "BOM Created",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_alternative_item",
+   "fieldtype": "Check",
+   "label": "Allow Alternative Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-03 18:45:24.339532",
+ "modified": "2025-02-19 13:25:15.732496",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Creator Item",

--- a/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.py
+++ b/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.py
@@ -14,6 +14,7 @@ class BOMCreatorItem(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		allow_alternative_item: DF.Check
 		amount: DF.Currency
 		base_amount: DF.Currency
 		base_rate: DF.Currency

--- a/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
+++ b/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
@@ -210,6 +210,13 @@ class BOMConfigurator {
 			[
 				{ label: __("Item"), fieldname: "item_code", fieldtype: "Link", options: "Item", reqd: 1 },
 				{ label: __("Qty"), fieldname: "qty", default: 1.0, fieldtype: "Float", reqd: 1 },
+				{
+					label: __("Allow Alternative Item"),
+					fieldname: "allow_alternative_item",
+					default: 1.0,
+					fieldtype: "Check",
+					reqd: 1,
+				},
 			],
 			(data) => {
 				if (!node.data.parent_id) {
@@ -224,6 +231,7 @@ class BOMConfigurator {
 						item_code: data.item_code,
 						fg_reference_id: node.data.name || this.frm.doc.name,
 						qty: data.qty,
+						allow_alternative_item: data.allow_alternative_item,
 					},
 					callback: (r) => {
 						view.events.load_tree(r, node);
@@ -258,6 +266,7 @@ class BOMConfigurator {
 					fg_item: node.data.value,
 					fg_reference_id: node.data.name || this.frm.doc.name,
 					bom_item: bom_item,
+					allow_alternative_item: bom_item.allow_alternative_item,
 				},
 				callback: (r) => {
 					view.events.load_tree(r, node);
@@ -275,6 +284,14 @@ class BOMConfigurator {
 				fieldname: "item_code",
 				fieldtype: "Link",
 				options: "Item",
+				reqd: 1,
+				read_only: read_only,
+			},
+			{
+				label: __("Allow Alternative Item"),
+				fieldname: "allow_alternative_item",
+				default: 1.0,
+				fieldtype: "Check",
 				reqd: 1,
 				read_only: read_only,
 			},


### PR DESCRIPTION
Reference support ticket [30783](https://support.frappe.io/helpdesk/tickets/30783)

In BOM Creator if Source Warehouse for the sub assemblies or raw materials was set, the BOM created would ignore that field. This PR fixes it.

It also now allows user to control the "Allow Alternative Item" field instead of it being hardcoded to 1