### PR TITLE
fix: incorrect stock value difference for adjustment entry

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -884,6 +884,10 @@ class update_entries_after:
 
 		if not sle.is_adjustment_entry:
 			sle.stock_value_difference = stock_value_difference
+		elif sle.is_adjustment_entry and not self.args.get("sle_id"):
+			sle.stock_value_difference = get_stock_value_difference(
+				sle.item_code, sle.warehouse, sle.posting_date, sle.posting_time, sle.voucher_no
+			)
 
 		sle.doctype = "Stock Ledger Entry"
 		frappe.get_doc(sle).db_update()


### PR DESCRIPTION
Fixed https://support.frappe.io/helpdesk/tickets/31874

During reposting system should recalculate the stock value difference