### PR TITLE
fix: reset location only if there is value in row item location field

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -652,6 +652,9 @@ frappe.ui.form.on("Asset", {
 					frm.set_value("purchase_amount", data.gross_purchase_amount);
 					frm.set_value("asset_quantity", data.asset_quantity);
 					frm.set_value("cost_center", data.cost_center);
+					if (data.asset_location) {
+						frm.set_value("location", data.asset_location);
+					}
 
 					if (doctype === "Purchase Receipt") {
 						frm.set_value("purchase_receipt_item", data.purchase_receipt_item);


### PR DESCRIPTION
Reset asset location only if there is a value in the row item location field.