### PR TITLE
refactor: Remove duplicate inherited method

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -765,27 +765,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		});
 	}
 
-	add_taxes_from_item_tax_template(item_tax_map) {
-		let me = this;
-
-		if(item_tax_map && cint(frappe.defaults.get_default("add_taxes_from_item_tax_template"))) {
-			if(typeof (item_tax_map) == "string") {
-				item_tax_map = JSON.parse(item_tax_map);
-			}
-
-			$.each(item_tax_map, function(tax, rate) {
-				let found = (me.frm.doc.taxes || []).find(d => d.account_head === tax);
-				if(!found) {
-					let child = frappe.model.add_child(me.frm.doc, "taxes");
-					child.charge_type = "On Net Total";
-					child.account_head = tax;
-					child.rate = 0;
-					child.set_by_item_tax_template = true;
-				}
-			});
-		}
-	}
-
 	serial_no(doc, cdt, cdn) {
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);


### PR DESCRIPTION
I would like a review from someone more knowledgeable than me on this code.

The method `add_taxes_from_item_tax_template` is defined identically in the `erpnext.taxes_and_totals` class, that `erpnext.TransactionController` extends. So it can be removed safely, it seems to me.

https://github.com/frappe/erpnext/blob/75379b79fca5890d7e62f5cbd6752f4bcc97c9d8/erpnext/public/js/controllers/transaction.js#L768-L787

https://github.com/frappe/erpnext/blob/75379b79fca5890d7e62f5cbd6752f4bcc97c9d8/erpnext/public/js/controllers/taxes_and_totals.js#L324-L343