### PR TITLE
fix: validate return invoice qty

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2558,6 +2558,30 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		item.reload()
 		self.assertEqual(item.last_purchase_rate, 0)
 
+	def test_return_qty_above_against_voucher_qty(self):
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		invoice = make_purchase_invoice(qty=10)
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -11
+
+		self.assertRaises(frappe.ValidationError, return_doc.save)
+
+	def test_return_qty_above_against_voucher_qty_with_multiple_return_invoices(self):
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		invoice = make_purchase_invoice(qty=10)
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -5
+		return_doc.save()
+		return_doc.submit()
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -6
+
+		self.assertRaises(frappe.ValidationError, return_doc.save)
+
 	def test_invoice_against_returned_pr(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -26,9 +26,52 @@ def validate_return(doc):
 		validate_return_against(doc)
 
 		if doc.doctype in ("Sales Invoice", "Purchase Invoice") and not doc.update_stock:
+			validate_returned_invoice_items_qty(doc)
 			return
 
 		validate_returned_items(doc)
+
+
+def validate_returned_invoice_items_qty(doc):
+	child_ref_field_name = "sales_invoice_item" if doc.doctype == "Sales Invoice" else "purchase_invoice_item"
+	for item in doc.get("items"):
+		if not item.get(child_ref_field_name):
+			# ignoring item without reference
+			return
+
+		against_voucher_item_qty = frappe.db.get_value(
+			f"{doc.doctype} Item",
+			item.get(child_ref_field_name),
+			"qty",
+		)
+
+		existing_returned_qty = (
+			frappe.db.get_values(
+				f"{doc.doctype} Item",
+				{
+					child_ref_field_name: item.get(child_ref_field_name),
+					"docstatus": 1,
+				},
+				"sum(qty)",
+			)[0][0]
+			or 0
+		)
+
+		if abs(existing_returned_qty) >= against_voucher_item_qty:
+			frappe.throw(
+				_("Row # {0}: Item {1} has already been returned").format(
+					frappe.bold(item.idx), frappe.bold(item.item_code)
+				)
+			)
+		elif item.qty and abs(existing_returned_qty + item.qty) > against_voucher_item_qty:
+			against_voucher_item_qty = against_voucher_item_qty - abs(existing_returned_qty)
+			frappe.throw(
+				_("Row # {0}: Cannot return more than {1} qty for Item {2}").format(
+					frappe.bold(item.idx),
+					frappe.bold(abs(against_voucher_item_qty)),
+					frappe.bold(item.item_code),
+				)
+			)
 
 
 def validate_return_against(doc):


### PR DESCRIPTION
1. A validation check to prevent the return invoice item quantity from exceeding the corresponding voucher item quantity.
2. A restriction to disallow zero-quantity returns when the invoice item is already fully returned.

Ref: [31768](https://support.frappe.io/helpdesk/tickets/31768)

**Before:**

[before.webm](https://github.com/user-attachments/assets/e39782c7-e8a3-44a6-bc50-fc85146bb6c1)


**After:**

[after.webm](https://github.com/user-attachments/assets/3968331b-e8b5-48c9-ad16-1db8bae16e4f)


Backport Needed: v15
