### PR TITLE
fix: Ensure new line is added regardless of postal code presence

### DIFF
--- a/erpnext/regional/address_template/templates/united_states.html
+++ b/erpnext/regional/address_template/templates/united_states.html
@@ -1,4 +1,4 @@
 {{ address_line1 }}<br>
 {% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
-{{ city }}, {% if state %}{{ state }}{% endif -%}{% if pincode %} {{ pincode }}<br>{% endif -%}
+{{ city }}, {% if state %}{{ state }}{% endif -%}{% if pincode %} {{ pincode }}{% endif -%}<br>
 {% if country != "United States" %}{{ country }}{% endif -%}


### PR DESCRIPTION
Support ticket: [Support Ticket  - 32261](https://support.frappe.io/helpdesk/tickets/32261)

**Before**
If the postal code is not present, the state and country appear on the same line without any space between them 
(e.g., MaharashtraIndia).
<img width="476" alt="Screenshot 2025-02-20 at 4 37 11 PM" src="https://github.com/user-attachments/assets/7b59deba-3878-495a-8295-ff15e328779d" />

**After**
Now, the country will appear on a new line, regardless of whether the postal code is present or not.
<img width="476" alt="Screenshot 2025-02-20 at 4 38 08 PM" src="https://github.com/user-attachments/assets/190e1591-190a-44af-8cac-ab1e5f5e8f71" />
