### PR TITLE
fix: Convert tuple of tuples to list of dicts for dot notation access

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -436,6 +436,7 @@ def get_invoice_vouchers(parties, tax_details, company, party_type="Supplier"):
 			tax_details.get("tax_withholding_category"),
 			company,
 		),
+		as_dict=1,
 	)
 
 	for d in journal_entries_details:


### PR DESCRIPTION
Support ticket: [Support Ticket  - 32320](https://support.frappe.io/helpdesk/tickets/32320)

- closes : https://github.com/frappe/erpnext/issues/46050

Previously, the data was a tuple of tuples, preventing access using d.name. 
Now, it has been converted into a list of dictionaries, allowing dot notation access (d.name).