### PR TITLE
fix: make 'company_tax_id' and 'company_fiscal_code' as mandatory

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -262,12 +262,17 @@ def sales_invoice_validate(doc):
 
 	doc.company_tax_id = frappe.get_cached_value("Company", doc.company, "tax_id")
 	doc.company_fiscal_code = frappe.get_cached_value("Company", doc.company, "fiscal_code")
-	if not doc.company_tax_id and not doc.company_fiscal_code:
+	if not doc.company_tax_id or not doc.company_fiscal_code:
+		msg = "Please set the Tax ID and Fiscal Code on Company '%s'" % doc.company
+		if doc.company_tax_id and not doc.company_fiscal_code:
+			msg = "Please set Fiscal Code on Company '%s'" % doc.company
+		elif doc.company_fiscal_code and not doc.company_tax_id:
+			msg = "Please set Tax ID on Company '%s'" % doc.company
+
 		frappe.throw(
-			_("Please set either the Tax ID or Fiscal Code on Company '%s'" % doc.company),
+			_(msg),
 			title=_("E-Invoicing Information Missing"),
 		)
-
 	# Validate customer details
 	customer = frappe.get_doc("Customer", doc.customer)
 

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -264,7 +264,7 @@ def sales_invoice_validate(doc):
 	doc.company_fiscal_code = frappe.get_cached_value("Company", doc.company, "fiscal_code")
 	if not (doc.company_tax_id or doc.company_fiscal_code):
 		frappe.throw(
-			_("Please set both the Tax ID and Fiscal Code on Company {0}".format(doc.company)),
+			_(f"Please set both the Tax ID and Fiscal Code on Company {doc.company}"),
 			title=_("E-Invoicing Information Missing"),
 		)
 	# Validate customer details

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -263,14 +263,14 @@ def sales_invoice_validate(doc):
 	doc.company_tax_id = frappe.get_cached_value("Company", doc.company, "tax_id")
 	doc.company_fiscal_code = frappe.get_cached_value("Company", doc.company, "fiscal_code")
 	if not doc.company_tax_id or not doc.company_fiscal_code:
-		msg = "Please set the Tax ID and Fiscal Code on Company '%s'" % doc.company
+		msg = _("Please set the Tax ID and Fiscal Code on Company '%s'" % doc.company)
 		if doc.company_tax_id and not doc.company_fiscal_code:
-			msg = "Please set Fiscal Code on Company '%s'" % doc.company
+			msg = _("Please set Fiscal Code on Company '%s'" % doc.company)
 		elif doc.company_fiscal_code and not doc.company_tax_id:
-			msg = "Please set Tax ID on Company '%s'" % doc.company
+			msg = _("Please set Tax ID on Company '%s'" % doc.company)
 
 		frappe.throw(
-			_(msg),
+			msg,
 			title=_("E-Invoicing Information Missing"),
 		)
 	# Validate customer details

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -263,11 +263,11 @@ def sales_invoice_validate(doc):
 	doc.company_tax_id = frappe.get_cached_value("Company", doc.company, "tax_id")
 	doc.company_fiscal_code = frappe.get_cached_value("Company", doc.company, "fiscal_code")
 	if not doc.company_tax_id or not doc.company_fiscal_code:
-		msg = _("Please set the Tax ID and Fiscal Code on Company '%s'" % doc.company)
+		msg = _("Please set the Tax ID and Fiscal Code on Company '%s'") % doc.company
 		if doc.company_tax_id and not doc.company_fiscal_code:
-			msg = _("Please set Fiscal Code on Company '%s'" % doc.company)
+			msg = _("Please set Fiscal Code on Company '%s'") % doc.company
 		elif doc.company_fiscal_code and not doc.company_tax_id:
-			msg = _("Please set Tax ID on Company '%s'" % doc.company)
+			msg = _("Please set Tax ID on Company '%s'") % doc.company
 
 		frappe.throw(
 			msg,

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -262,15 +262,9 @@ def sales_invoice_validate(doc):
 
 	doc.company_tax_id = frappe.get_cached_value("Company", doc.company, "tax_id")
 	doc.company_fiscal_code = frappe.get_cached_value("Company", doc.company, "fiscal_code")
-	if not doc.company_tax_id or not doc.company_fiscal_code:
-		msg = _("Please set the Tax ID and Fiscal Code on Company '%s'") % doc.company
-		if doc.company_tax_id and not doc.company_fiscal_code:
-			msg = _("Please set Fiscal Code on Company '%s'") % doc.company
-		elif doc.company_fiscal_code and not doc.company_tax_id:
-			msg = _("Please set Tax ID on Company '%s'") % doc.company
-
+	if not (doc.company_tax_id or doc.company_fiscal_code):
 		frappe.throw(
-			msg,
+			_("Please set both the Tax ID and Fiscal Code on Company {0}".format(doc.company)),
 			title=_("E-Invoicing Information Missing"),
 		)
 	# Validate customer details


### PR DESCRIPTION
**Issue:**
When the company country is Italy, the existing validation validates the company tax ID or fiscal code to be mandatory.
As the Company Tax ID is used as [e-invoice naming](https://github.com/frappe/erpnext/blob/987a95d2b5e20773059845f283ca102aa6491ab2/erpnext/regional/italy/utils.py#L416), error occurs when company tax id is not set

Ref: [31829](https://support.frappe.io/helpdesk/tickets/31829)

**Before:**

[before.webm](https://github.com/user-attachments/assets/f28ee2e3-4f19-4685-99dd-8e91f75d9961)

**After:**

[after.webm](https://github.com/user-attachments/assets/19433a67-0cf0-433e-b53c-e514eee4859d)

Backport Needed: v15
