### PR TITLE
fix: Batch Price gets updated only if it is a billed item

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1095,7 +1095,8 @@ def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code) -> fl
 	if not item_price:
 		item_price = get_item_price(pctx, item_code, ignore_party=True, force_batch_no=True)
 
-	if item_price and item_price[0].uom == pctx.uom and not pctx.get("items", [{}])[0].get("is_free_item", 0):
+
+	if item_price and item_price[0].uom == pctx.uom and params.get("is_free_item") == 0:
 		return item_price[0].price_list_rate
 
 	return 0.0

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1095,7 +1095,7 @@ def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code) -> fl
 	if not item_price:
 		item_price = get_item_price(pctx, item_code, ignore_party=True, force_batch_no=True)
 
-	is_free_item = pctx.get('items', [{}])[0].get('is_free_item')
+	is_free_item = pctx.get("items", [{}])[0].get("is_free_item")
 
 	if item_price and item_price[0].uom == pctx.uom and not is_free_item:
 		return item_price[0].price_list_rate

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1095,8 +1095,9 @@ def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code) -> fl
 	if not item_price:
 		item_price = get_item_price(pctx, item_code, ignore_party=True, force_batch_no=True)
 
+	is_free_item = pctx.get('items', [{}])[0].get('is_free_item')
 
-	if item_price and item_price[0].uom == pctx.uom and params.get("is_free_item") == 0:
+	if item_price and item_price[0].uom == pctx.uom and not is_free_item:
 		return item_price[0].price_list_rate
 
 	return 0.0


### PR DESCRIPTION
Currently the price is not updating for free item only after saving. But when the batch_no field is triggered for the free item, 
the price gets fetched and set in the field of the rate. But once if we save it, it changes to zero.



**Before Fix:**

https://github.com/user-attachments/assets/c0ef4406-1285-43d1-87f0-adfc17e015e0


**Fix:** 
While the batch_no field is triggered, this fix will not update the rate of the item even the batch_no is triggered.

https://github.com/user-attachments/assets/9758e681-ce9e-4ae9-90a9-5f3346141407



This helps in adding some Fixes to these PRs:

https://github.com/frappe/erpnext/pull/45692

https://github.com/frappe/erpnext/pull/45740