### PR TITLE
feat(Sales Invoice): add items row via "Fetch Timesheet"

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -912,7 +912,23 @@ frappe.ui.form.on("Sales Invoice", {
 		}
 
 		const timesheets = await frm.events.get_timesheet_data(frm, kwargs);
+
+		if (kwargs.item_code) {
+			frm.events.add_timesheet_item(frm, kwargs.item_code, timesheets);
+		}
+
 		return frm.events.set_timesheet_data(frm, timesheets);
+	},
+
+	add_timesheet_item: function (frm, item_code, timesheets) {
+		const row = frm.add_child("items");
+		frappe.model.set_value(row.doctype, row.name, "item_code", item_code);
+		frappe.model.set_value(
+			row.doctype,
+			row.name,
+			"qty",
+			timesheets.reduce((a, b) => a + (b["billing_hours"] || 0.0), 0.0)
+		);
 	},
 
 	async get_timesheet_data(frm, kwargs) {
@@ -1013,6 +1029,22 @@ frappe.ui.form.on("Sales Invoice", {
 								reqd: 1,
 							},
 							{
+								label: __("Item Code"),
+								fieldname: "item_code",
+								fieldtype: "Link",
+								options: "Item",
+								get_query: () => {
+									return {
+										query: "erpnext.controllers.queries.item_query",
+										filters: {
+											is_sales_item: 1,
+											customer: frm.doc.customer,
+											has_variants: 0,
+										},
+									};
+								},
+							},
+							{
 								fieldtype: "Column Break",
 								fieldname: "col_break_1",
 							},
@@ -1036,6 +1068,7 @@ frappe.ui.form.on("Sales Invoice", {
 								from_time: data.from_time,
 								to_time: data.to_time,
 								project: data.project,
+								item_code: data.item_code,
 							});
 							d.hide();
 						},


### PR DESCRIPTION
Extends the "Fetch Timesheet" dialog in **Sales Invoice**.
Allows the optional specification of an _Item Code_. If set, a row is added to the _Items_ table with the quantity equal to the total billable hours of the timesheets. If not, everything works as before (no item added).

![Bildschirmfoto 2025-02-21 um 20 17 30](https://github.com/user-attachments/assets/d8761551-f0e5-4744-aec9-3c86a1f4abdc)

Partial solution for #26794

Ref: ABI-8

> no-docs
