### PR TITLE
fix(workspace): enable is_query_report on purchase reports

### DIFF
--- a/erpnext/accounts/workspace/payables/payables.json
+++ b/erpnext/accounts/workspace/payables/payables.json
@@ -93,7 +93,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Accounts Payable",
    "link_count": 0,
    "link_to": "Accounts Payable",
@@ -103,7 +103,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Accounts Payable Summary",
    "link_count": 0,
    "link_to": "Accounts Payable Summary",
@@ -113,7 +113,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Purchase Register",
    "link_count": 0,
    "link_to": "Purchase Register",
@@ -123,7 +123,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Item-wise Purchase Register",
    "link_count": 0,
    "link_to": "Item-wise Purchase Register",
@@ -133,7 +133,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Purchase Order Analysis",
    "link_count": 0,
    "link_to": "Purchase Order Analysis",
@@ -143,7 +143,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Received Items To Be Billed",
    "link_count": 0,
    "link_to": "Received Items To Be Billed",
@@ -153,7 +153,7 @@
   },
   {
    "hidden": 0,
-   "is_query_report": 0,
+   "is_query_report": 1,
    "label": "Supplier Ledger Summary",
    "link_count": 0,
    "link_to": "Supplier Ledger Summary",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -401,3 +401,4 @@ erpnext.patches.v15_0.sync_auto_reconcile_config
 execute:frappe.db.set_single_value("Accounts Settings", "exchange_gain_loss_posting_date", "Payment")
 erpnext.patches.v14_0.disable_add_row_in_gross_profit
 erpnext.patches.v14_0.update_posting_datetime
+erpnext.patches.v15_0.update_query_report

--- a/erpnext/patches/v15_0/update_query_report.py
+++ b/erpnext/patches/v15_0/update_query_report.py
@@ -1,0 +1,25 @@
+import frappe
+
+
+def execute():
+	reports = [
+		"Accounts Payable",
+		"Accounts Payable Summary",
+		"Purchase Register",
+		"Item-wise Purchase Register",
+		"Purchase Order Analysis",
+		"Received Items To Be Billed",
+		"Supplier Ledger Summary",
+	]
+	frappe.db.set_value(
+		"Workspace Link",
+		{
+			"parent": "Payables",
+			"link_type": "Report",
+			"type": "Link",
+			"link_to": ["in", reports],
+			"is_query_report": 0,
+		},
+		"is_query_report",
+		1,
+	)


### PR DESCRIPTION
**Issue:**
unable to navigate to purchase reports from the workspace
**ref:** [31299](https://support.frappe.io/helpdesk/tickets/31299)

**Before:**

https://github.com/user-attachments/assets/2f5ac284-53ca-47b8-97cc-2fc2a5e4abcc

**After:**

https://github.com/user-attachments/assets/ad8c350e-9948-4155-abc1-a29aa0656d7f


**Backport needed for v15**