### PR TITLE
fix(report): Allow `Closed` Purchase Orders to be Visible in Purchase Order Analysis Report

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -52,9 +52,16 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			label: __("Status"),
 			fieldtype: "MultiSelectList",
 			width: "80",
-			options: ["To Pay", "To Bill", "To Receive", "To Receive and Bill", "Completed"],
+			options: ["To Pay", "To Bill", "To Receive", "To Receive and Bill", "Completed", "Closed"],
 			get_data: function (txt) {
-				let status = ["To Pay", "To Bill", "To Receive", "To Receive and Bill", "Completed"];
+				let status = [
+					"To Pay",
+					"To Bill",
+					"To Receive",
+					"To Receive and Bill",
+					"Completed",
+					"Closed",
+				];
 				let options = [];
 				for (let option of status) {
 					options.push({

--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -19,6 +19,10 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			reqd: 1,
 			default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
+			on_change: (report) => {
+				report.set_filter_value("name", []);
+				report.refresh();
+			},
 		},
 		{
 			fieldname: "to_date",
@@ -27,6 +31,10 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			reqd: 1,
 			default: frappe.datetime.get_today(),
+			on_change: (report) => {
+				report.set_filter_value("name", []);
+				report.refresh();
+			},
 		},
 		{
 			fieldname: "project",
@@ -38,13 +46,17 @@ frappe.query_reports["Purchase Order Analysis"] = {
 		{
 			fieldname: "name",
 			label: __("Purchase Order"),
-			fieldtype: "Link",
+			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Purchase Order",
-			get_query: () => {
-				return {
-					filters: { docstatus: 1 },
-				};
+			get_data: function (txt) {
+				let filters = { docstatus: 1 };
+
+				const from_date = frappe.query_report.get_filter_value("from_date");
+				const to_date = frappe.query_report.get_filter_value("to_date");
+				if (from_date && to_date) filters["transaction_date"] = ["between", [from_date, to_date]];
+
+				return frappe.db.get_link_options("Purchase Order", txt, filters);
 			},
 		},
 		{

--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -75,9 +75,11 @@ def get_data(filters):
 		.orderby(po.transaction_date)
 	)
 
-	for field in ("company", "name"):
-		if filters.get(field):
-			query = query.where(po[field] == filters.get(field))
+	if filters.get("company"):
+		query = query.where(po.company == filters.get("company"))
+
+	if filters.get("name"):
+		query = query.where(po.name.isin(filters.get("name")))
 
 	if filters.get("from_date") and filters.get("to_date"):
 		query = query.where(po.transaction_date.between(filters.get("from_date"), filters.get("to_date")))

--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -70,7 +70,7 @@ def get_data(filters):
 			po.company,
 			po_item.name,
 		)
-		.where((po_item.parent == po.name) & (po.status.notin(("Stopped", "Closed"))) & (po.docstatus == 1))
+		.where((po_item.parent == po.name) & (po.status.notin(("Stopped", "On Hold"))) & (po.docstatus == 1))
 		.groupby(po_item.name)
 		.orderby(po.transaction_date)
 	)

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
@@ -53,10 +53,17 @@ frappe.query_reports["Sales Order Analysis"] = {
 			fieldname: "status",
 			label: __("Status"),
 			fieldtype: "MultiSelectList",
-			options: ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed"],
+			options: ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed", "Closed"],
 			width: "80",
 			get_data: function (txt) {
-				let status = ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed"];
+				let status = [
+					"To Pay",
+					"To Bill",
+					"To Deliver",
+					"To Deliver and Bill",
+					"Completed",
+					"Closed",
+				];
 				let options = [];
 				for (let option of status) {
 					options.push({

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
@@ -19,6 +19,10 @@ frappe.query_reports["Sales Order Analysis"] = {
 			width: "80",
 			reqd: 1,
 			default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
+			on_change: (report) => {
+				report.set_filter_value("sales_order", []);
+				report.refresh();
+			},
 		},
 		{
 			fieldname: "to_date",
@@ -27,6 +31,10 @@ frappe.query_reports["Sales Order Analysis"] = {
 			width: "80",
 			reqd: 1,
 			default: frappe.datetime.get_today(),
+			on_change: (report) => {
+				report.set_filter_value("sales_order", []);
+				report.refresh();
+			},
 		},
 		{
 			fieldname: "sales_order",
@@ -35,12 +43,13 @@ frappe.query_reports["Sales Order Analysis"] = {
 			width: "80",
 			options: "Sales Order",
 			get_data: function (txt) {
-				return frappe.db.get_link_options("Sales Order", txt);
-			},
-			get_query: () => {
-				return {
-					filters: { docstatus: 1 },
-				};
+				let filters = { docstatus: 1 };
+
+				const from_date = frappe.query_report.get_filter_value("from_date");
+				const to_date = frappe.query_report.get_filter_value("to_date");
+				if (from_date && to_date) filters["transaction_date"] = ["between", [from_date, to_date]];
+
+				return frappe.db.get_link_options("Sales Order", txt, filters);
 			},
 		},
 		{

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -86,7 +86,7 @@ def get_data(conditions, filters):
 			ON sii.so_detail = soi.name and sii.docstatus = 1
 		WHERE
 			soi.parent = so.name
-			and so.status not in ('Stopped', 'Closed', 'On Hold')
+			and so.status not in ('Stopped', 'On Hold')
 			and so.docstatus = 1
 			{conditions}
 		GROUP BY soi.name


### PR DESCRIPTION
### Issue

1. Closed purchase orders are not visible in the **Purchase Order Analysis Report**.

- Example Scenario:
  - A purchase order is created for an item with a quantity of 2. However, only 1.8 is received due to adjustments, and the remaining 0.2 will not be received.
  - As a result, the purchase order is closed since no further receipts are expected.
  - Despite being closed, the purchase order should still be visible in the **Purchase Order Analysis Report**.

2. **On Hold** purchase orders are not filterable but visible in the Purchase Order Analysis report, and **On Hold** sales orders are already excluded from the Sales Order Analysis Report.

- For consistency, “On Hold” purchase orders should also be excluded from this Purchase Order Analysis report.
 
3. Closed sales orders are not visible in the **Sales Order Analysis Report**.

4. Filtering of Sales / Purchase Orders is not happening based on date filters.

5. **Sales Order** filter is a **MultiSelectList** in Sales Order Analysis Report whereas **Purchase Order** Filter is a **Link** in Purchase Order Analysis Report.
