### PR TITLE
fix: use value from currency exchange when exchange api is disabled

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -66,9 +66,6 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 	if not transaction_date:
 		transaction_date = nowdate()
 
-	if rate := get_pegged_rate(from_currency, to_currency, transaction_date):
-		return rate
-
 	currency_settings = frappe.get_doc("Accounts Settings").as_dict()
 	allow_stale_rates = currency_settings.get("allow_stale")
 
@@ -97,6 +94,9 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 
 	if frappe.get_cached_value("Currency Exchange Settings", "Currency Exchange Settings", "disabled"):
 		return 0.00
+
+	if rate := get_pegged_rate(from_currency, to_currency, transaction_date):
+		return rate
 
 	try:
 		cache = frappe.cache()


### PR DESCRIPTION
**Issue:**
exchange rate not fetching from the currency exchange when exchange API setting is disabled.
**ref:** [32635](https://support.frappe.io/helpdesk/tickets/32635)

**Steps to reproduce:**
 - Create company with Currency AED
 - Disable exchange API setting
 - Create a currency exchange with From currency USD, To currency AED and exchange rate as 3.67.
 - Create a Invoice with party currency as USD
 - Exchange rate will be fetched as 3.6725 instead of 3.67.

**Before:**

https://github.com/user-attachments/assets/0f95ab80-1c99-4c78-a620-70154b268d56

**After:**

https://github.com/user-attachments/assets/a4683b58-7825-4702-bf86-3bc4b323f7ee


**Back port needed for v15**