### PR TITLE
fix: Wrong Overdue Status in Sales Invoices (Floating-point arithmetic)

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1934,13 +1934,13 @@ def is_overdue(doc, total):
 		"base_payment_amount" if doc.party_account_currency != doc.currency else "payment_amount"
 	)
 
-	payable_amount = sum(
+	payable_amount = flt(sum(
 		payment.get(payment_amount_field)
 		for payment in doc.payment_schedule
 		if getdate(payment.due_date) < today
-	)
+	), doc.precision("outstanding_amount"))
 
-	return (total - outstanding_amount) < payable_amount
+	return flt(total - outstanding_amount, doc.precision("outstanding_amount")) < payable_amount
 
 
 def get_discounting_status(sales_invoice):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1934,11 +1934,14 @@ def is_overdue(doc, total):
 		"base_payment_amount" if doc.party_account_currency != doc.currency else "payment_amount"
 	)
 
-	payable_amount = flt(sum(
-		payment.get(payment_amount_field)
-		for payment in doc.payment_schedule
-		if getdate(payment.due_date) < today
-	), doc.precision("outstanding_amount"))
+	payable_amount = flt(
+		sum(
+			payment.get(payment_amount_field)
+			for payment in doc.payment_schedule
+			if getdate(payment.due_date) < today
+		),
+		doc.precision("outstanding_amount"),
+	)
 
 	return flt(total - outstanding_amount, doc.precision("outstanding_amount")) < payable_amount
 


### PR DESCRIPTION
We need to use flt in this kind of math account for prevent float-point arithmetic problems.

If we have for example, two schedules with values 1.55 and 1.85, the sum will be 3.4000000000000004, instead of 3.40.

It could do the is_overdue function returns wrong boolean, causing for example, a wrong overdue status in a Sales Invoice that should be Partly Paid.