### PR TITLE
fix: no permission to get project settings in sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -895,12 +895,16 @@ frappe.ui.form.on("Sales Invoice", {
 
 	project: function (frm) {
 		if (frm.doc.project) {
-			frappe.db.get_value("Projects Settings", {}, "fetch_timesheet_in_sales_invoice", (r) => {
-				if (cint(r.fetch_timesheet_in_sales_invoice)) {
-					frm.events.add_timesheet_data(frm, {
-						project: frm.doc.project,
-					});
-				}
+			frappe.call({
+				method: "is_auto_fetch_timesheet_enabled",
+				doc: frm.doc,
+				callback: function (r) {
+					if (cint(r.message)) {
+						frm.events.add_timesheet_data(frm, {
+							project: frm.doc.project,
+						});
+					}
+				},
 			});
 		}
 	},

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1096,14 +1096,14 @@ class SalesInvoice(SellingController):
 					timesheet.billing_amount = ts_doc.total_billable_amount
 
 	def update_timesheet_billing_for_project(self):
-		if (
-			not self.timesheets
-			and self.project
-			and frappe.db.get_single_value("Projects Settings", "fetch_timesheet_in_sales_invoice")
-		):
+		if not self.timesheets and self.project and self.is_auto_fetch_timesheet_enabled():
 			self.add_timesheet_data()
 		else:
 			self.calculate_billing_amount_for_timesheet()
+
+	@frappe.whitelist()
+	def is_auto_fetch_timesheet_enabled(self):
+		return frappe.db.get_single_value("Projects Settings", "fetch_timesheet_in_sales_invoice")
 
 	@frappe.whitelist()
 	def add_timesheet_data(self):


### PR DESCRIPTION
**Issue:**
As the user didn't have permission to get value from project settings, unable to create a sales invoice.


**Before:**

https://github.com/user-attachments/assets/80179d39-bd11-4a05-8775-68377331b6e0


**After:**

https://github.com/user-attachments/assets/dabbed38-acf9-4f0e-88fc-4877a16ebdc1



**Backport needed for v15**