### PR TITLE
Fix validation mismatch in inventory dimension fields

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -397,6 +397,7 @@ def get_inventory_dimensions():
 			"Inventory Dimension",
 			fields=[
 				"distinct target_fieldname as fieldname",
+				"source_fieldname",
 				"reference_document as doctype",
 				"validate_negative_stock",
 				"name as dimension_name",

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -92,7 +92,7 @@ class StockReconciliation(StockController):
 		dimensions = get_inventory_dimensions()
 		for dimension in dimensions:
 			for row in self.items:
-				if not row.batch_no and row.current_qty and row.get(dimension.get("fieldname")):
+				if not row.batch_no and row.current_qty and row.get(dimension.get("source_fieldname")):
 					frappe.throw(
 						_(
 							"Row #{0}: You cannot use the inventory dimension '{1}' in Stock Reconciliation to modify the quantity or valuation rate. Stock reconciliation with inventory dimensions is intended solely for performing opening entries."


### PR DESCRIPTION
In the file [inventory_dimension.py](https://github.com/frappe/erpnext/blob/fcf374928f1d7e07b2f04598d973077573da3995/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py#L184), the inventory dimension fields were created using `source_fieldname`. However, in the [stock_reconciliation.py](https://github.com/frappe/erpnext/blob/fcf374928f1d7e07b2f04598d973077573da3995/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py#L95) file, the validation was performed against `target_fieldname` instead, leading to incorrect validation logic.

This pull request fixes the issue by ensuring that the validation is performed consistently with the fieldnames used during the creation of the inventory dimension fields.