### PR TITLE
fix: Show Credit Note amount in credit note column

### DIFF
--- a/erpnext/accounts/report/accounts_payable/test_accounts_payable.py
+++ b/erpnext/accounts/report/accounts_payable/test_accounts_payable.py
@@ -38,6 +38,23 @@ class TestAccountsPayable(AccountsTestMixin, IntegrationTestCase):
 		self.assertEqual(data[1][0].get("outstanding"), 300)
 		self.assertEqual(data[1][0].get("currency"), "USD")
 
+	def test_account_payable_for_debit_note(self):
+		pi = self.create_purchase_invoice(do_not_submit=True)
+		pi.is_return = 1
+		pi.items[0].qty = -1
+		pi = pi.save().submit()
+
+		filters = {
+			"company": self.company,
+			"party_type": "Supplier",
+			"party": [self.supplier],
+			"report_date": today(),
+			"range": "30, 60, 90, 120",
+		}
+
+		data = execute(filters)
+		self.assertEqual(data[1][0].get("invoiced"), 300)
+
 	def create_purchase_invoice(self, do_not_submit=False):
 		frappe.set_user("Administrator")
 		pi = make_purchase_invoice(

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -267,6 +267,18 @@ class ReceivablePayableReport:
 				row.invoiced_in_account_currency += amount_in_account_currency
 		else:
 			if self.is_invoice(ple):
+				# when invoice has is_return marked
+				if self.invoice_details.get(row.voucher_no, {}).get("is_return"):
+					# for Credit Note
+					if row.voucher_type == "Sales Invoice":
+						row.credit_note -= amount
+						row.credit_note_in_account_currency -= amount_in_account_currency
+					# for Debit Note
+					else:
+						row.invoiced -= amount
+						row.invoiced_in_account_currency -= amount_in_account_currency
+					return
+
 				if row.voucher_no == ple.voucher_no == ple.against_voucher_no:
 					row.paid -= amount
 					row.paid_in_account_currency -= amount_in_account_currency
@@ -421,7 +433,7 @@ class ReceivablePayableReport:
 			# nosemgrep
 			si_list = frappe.db.sql(
 				"""
-				select name, due_date, po_no
+				select name, due_date, po_no, is_return
 				from `tabSales Invoice`
 				where posting_date <= %s
 					and company = %s
@@ -453,7 +465,7 @@ class ReceivablePayableReport:
 			# nosemgrep
 			for pi in frappe.db.sql(
 				"""
-				select name, due_date, bill_no, bill_date
+				select name, due_date, bill_no, bill_date, is_return
 				from `tabPurchase Invoice`
 				where
 					posting_date <= %s

--- a/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
@@ -204,7 +204,7 @@ class TestAccountsReceivable(AccountsTestMixin, IntegrationTestCase):
 
 		expected_data_after_credit_note = [
 			[100.0, 100.0, 40.0, 0.0, 60.0, si.name],
-			[0, 0, 100.0, 0.0, -100.0, cr_note.name],
+			[0, 0, 0, 100.0, -100.0, cr_note.name],
 		]
 		self.assertEqual(len(report[1]), 2)
 		si_row = next(
@@ -478,13 +478,19 @@ class TestAccountsReceivable(AccountsTestMixin, IntegrationTestCase):
 		report = execute(filters)[1]
 		self.assertEqual(len(report), 2)
 
-		expected_data = {sr.name: [10.0, -10.0, 0.0, -10], si.name: [100.0, 100.0, 10.0, 90.0]}
+		expected_data = {sr.name: [0.0, 10.0, -10.0, 0.0, -10], si.name: [100.0, 0.0, 100.0, 10.0, 90.0]}
 
 		rows = report[:2]
 		for row in rows:
 			self.assertEqual(
 				expected_data[row.voucher_no],
-				[row.invoiced or row.paid, row.outstanding, row.remaining_balance, row.future_amount],
+				[
+					row.invoiced or row.paid,
+					row.credit_note,
+					row.outstanding,
+					row.remaining_balance,
+					row.future_amount,
+				],
 			)
 
 		pe.cancel()


### PR DESCRIPTION
Support ticket: [Support Ticket  - 32447](https://support.frappe.io/helpdesk/tickets/32447)

If the Sales Invoice has `is_return` marked, then show the value in the Credit Note, and 

Before:
<img width="908" alt="Screenshot 2025-02-27 at 1 22 02 PM" src="https://github.com/user-attachments/assets/2ab68d72-2d93-468e-a243-6ce173a964ed" />

After :
<img width="908" alt="Screenshot 2025-02-27 at 1 20 22 PM" src="https://github.com/user-attachments/assets/37c763b2-426c-42eb-a401-ed00ea390ac9" />

if the Purchase Invoice has `is_return` marked, then show the value in the Invoiced Amount.

Before : 
<img width="1091" alt="Screenshot 2025-02-27 at 1 30 06 PM" src="https://github.com/user-attachments/assets/de4f8251-6f7d-4aef-9dbd-68828314185f" />

After :
<img width="1091" alt="Screenshot 2025-02-27 at 1 29 15 PM" src="https://github.com/user-attachments/assets/3770a68d-0815-4f9a-a3e2-697ed59db297" />
