### PR TITLE
feat(projects): add option to hide timesheets for project users

### DIFF
--- a/erpnext/projects/doctype/project_user/project_user.json
+++ b/erpnext/projects/doctype/project_user/project_user.json
@@ -12,6 +12,7 @@
   "full_name",
   "welcome_email_sent",
   "view_attachments",
+  "hide_timesheets",
   "section_break_5",
   "project_status"
  ],
@@ -63,6 +64,13 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "View attachments"
+  },
+  {
+   "columns": 2,
+   "default": "0",
+   "fieldname": "hide_timesheets",
+   "fieldtype": "Check",
+   "label": "Hide timesheets"
   },
   {
    "fieldname": "section_break_5",

--- a/erpnext/templates/pages/projects.html
+++ b/erpnext/templates/pages/projects.html
@@ -56,25 +56,27 @@
     {{ empty_state(_("Task")) }}
   {% endif %}
 
-  <h4 class="my-account-header">{{ _("Timesheets") }}</h4>
   {% if doc.timesheets %}
-    <div class="website-list">
-      <div class="result">
-        <div class="web-list-item transaction-list-item">
-          <div class="row align-items-center">
-            <div class="col-xs-2"><b>{{ _("Timesheet") }}</b></div>
-            <div class="col-xs-2"><b>{{ _("Status") }}</b></div>
-            <div class="col-xs-2"><b>{{ _("From") }}</b></div>
-            <div class="col-xs-2"><b>{{ _("To") }}</b></div>
-            <div class="col-xs-2"><b>{{ _("Modified By") }}</b></div>
-            <div class="col-xs-2"><b>{{ _("Modified On") }}</b></div>
+    <h4 class="my-account-header">{{ _("Timesheets") }}</h4>
+    {% if doc.timesheets %}
+      <div class="website-list">
+        <div class="result">
+          <div class="web-list-item transaction-list-item">
+            <div class="row align-items-center">
+              <div class="col-xs-2"><b>{{ _("Timesheet") }}</b></div>
+              <div class="col-xs-2"><b>{{ _("Status") }}</b></div>
+              <div class="col-xs-2"><b>{{ _("From") }}</b></div>
+              <div class="col-xs-2"><b>{{ _("To") }}</b></div>
+              <div class="col-xs-2"><b>{{ _("Modified By") }}</b></div>
+              <div class="col-xs-2"><b>{{ _("Modified On") }}</b></div>
+            </div>
           </div>
+        {% include "erpnext/templates/includes/projects/project_timesheets.html" %}
         </div>
-      {% include "erpnext/templates/includes/projects/project_timesheets.html" %}
       </div>
-    </div>
-  {% else %}
-    {{ empty_state(_("Timesheet")) }}
+    {% else %}
+      {{ empty_state(_("Timesheet")) }}
+    {% endif %}
   {% endif %}
 
   {% if doc.attachments %}

--- a/erpnext/templates/pages/projects.html
+++ b/erpnext/templates/pages/projects.html
@@ -58,25 +58,21 @@
 
   {% if doc.timesheets %}
     <h4 class="my-account-header">{{ _("Timesheets") }}</h4>
-    {% if doc.timesheets %}
-      <div class="website-list">
-        <div class="result">
-          <div class="web-list-item transaction-list-item">
-            <div class="row align-items-center">
-              <div class="col-xs-2"><b>{{ _("Timesheet") }}</b></div>
-              <div class="col-xs-2"><b>{{ _("Status") }}</b></div>
-              <div class="col-xs-2"><b>{{ _("From") }}</b></div>
-              <div class="col-xs-2"><b>{{ _("To") }}</b></div>
-              <div class="col-xs-2"><b>{{ _("Modified By") }}</b></div>
-              <div class="col-xs-2"><b>{{ _("Modified On") }}</b></div>
-            </div>
+    <div class="website-list">
+      <div class="result">
+        <div class="web-list-item transaction-list-item">
+          <div class="row align-items-center">
+            <div class="col-xs-2"><b>{{ _("Timesheet") }}</b></div>
+            <div class="col-xs-2"><b>{{ _("Status") }}</b></div>
+            <div class="col-xs-2"><b>{{ _("From") }}</b></div>
+            <div class="col-xs-2"><b>{{ _("To") }}</b></div>
+            <div class="col-xs-2"><b>{{ _("Modified By") }}</b></div>
+            <div class="col-xs-2"><b>{{ _("Modified On") }}</b></div>
           </div>
-        {% include "erpnext/templates/includes/projects/project_timesheets.html" %}
         </div>
+      {% include "erpnext/templates/includes/projects/project_timesheets.html" %}
       </div>
-    {% else %}
-      {{ empty_state(_("Timesheet")) }}
-    {% endif %}
+    </div>
   {% endif %}
 
   {% if doc.attachments %}

--- a/erpnext/templates/pages/projects.py
+++ b/erpnext/templates/pages/projects.py
@@ -9,7 +9,7 @@ def get_context(context):
 	project_user = frappe.db.get_value(
 		"Project User",
 		{"parent": frappe.form_dict.project, "user": frappe.session.user},
-		["user", "view_attachments"],
+		["user", "view_attachments", "hide_timesheets"],
 		as_dict=True,
 	)
 	if frappe.session.user != "Administrator" and (not project_user or frappe.session.user == "Guest"):
@@ -25,7 +25,8 @@ def get_context(context):
 		project.name, start=0, item_status="open", search=frappe.form_dict.get("search")
 	)
 
-	project.timesheets = get_timesheets(project.name, start=0, search=frappe.form_dict.get("search"))
+	if project_user and not project_user.hide_timesheets:
+		project.timesheets = get_timesheets(project.name, start=0, search=frappe.form_dict.get("search"))
 
 	if project_user and project_user.view_attachments:
 		project.attachments = get_attachments(project.name)


### PR DESCRIPTION
Add a new "Hide timesheets" checkbox field to Project User doctype that controls 
timesheet visibility on the project page. When enabled, the timesheets section 
will not be displayed for that specific user.

Select which branch should this PR be merged in?
At least version 15


`no-docs`