### PR TITLE
fix: Payment Entry fixes

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -258,6 +258,10 @@ frappe.ui.form.on("Payment Entry", {
 		frappe.flags.allocate_payment_amount = true;
 	},
 
+	validate: async function (frm) {
+		await frm.events.set_exchange_gain_loss_deduction(frm);
+	},
+
 	validate_company: (frm) => {
 		if (!frm.doc.company) {
 			frappe.throw({ message: __("Please select a Company first."), title: __("Mandatory") });
@@ -1837,8 +1841,6 @@ function prompt_for_missing_account(frm, account) {
 			(values) => resolve(values?.[account]),
 			__("Please Specify Account")
 		);
-
-		dialog.on_hide = () => resolve("");
 	});
 }
 


### PR DESCRIPTION
Issues Fixed:
- Add **Exchange Gain / Loss** Row on validate on client side
- **Write Off Difference Amount** button was not working properly when no Default Write-Off Account.

Support Ticket: https://support.frappe.io/helpdesk/tickets/31940