### PR TITLE
fix: removed mandatory property for the cost center field

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -952,7 +952,6 @@
    "options": "Cost Center",
    "print_hide": 1,
    "print_width": "120px",
-   "reqd": 1,
    "width": "120px"
   },
   {
@@ -971,7 +970,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-06 13:29:24.619850",
+ "modified": "2025-02-28 09:45:43.934947",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -32,7 +32,7 @@ class SalesOrderItem(Document):
 		brand: DF.Link | None
 		company_total_stock: DF.Float
 		conversion_factor: DF.Float
-		cost_center: DF.Link
+		cost_center: DF.Link | None
 		customer_item_code: DF.Data | None
 		delivered_by_supplier: DF.Check
 		delivered_qty: DF.Float


### PR DESCRIPTION
Fixed [32566](https://support.frappe.io/helpdesk/my-tickets/32566)