### PR TITLE
perf: don't track seen for POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -1625,6 +1625,5 @@
  "states": [],
  "timeline_field": "customer",
  "title_field": "customer_name",
- "track_changes": 1,
- "track_seen": 1
+ "track_changes": 1
 }


### PR DESCRIPTION
This is a fast moving doctype. Do people even browse the list view? 

It doesn't make much sense either. POS Invoices are rarely "reviewed" by multiple users.