### PR TITLE
fix: pos item selection using serial no

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -609,6 +609,14 @@ erpnext.PointOfSale.Controller = class {
 
 				if (this.is_current_item_being_edited(item_row) || from_selector) {
 					await frappe.model.set_value(item_row.doctype, item_row.name, field, value);
+					if (item.serial_no && from_selector) {
+						await frappe.model.set_value(
+							item_row.doctype,
+							item_row.name,
+							"serial_no",
+							item_row.serial_no + `\n${item.serial_no}`
+						);
+					}
 					this.update_cart_html(item_row);
 				}
 			} else {


### PR DESCRIPTION
When an item with serial number tracking is added to the POS cart for the first time, the correct serial number is successfully retrieved. However, if the same item is added again with a different serial number, only the quantity increases, while the new serial number is not recorded. Instead, the serial number field gets overwritten with other serial numbers.

Before:

https://github.com/user-attachments/assets/6b3840d4-15bd-4ab4-98c3-d826094c109f

After:

https://github.com/user-attachments/assets/74fbde54-5c63-4139-aa18-b7ae147eba07
