### PR TITLE
fix(asset depreciation schedules): enable auto commit

### DIFF
--- a/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
+++ b/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
@@ -82,6 +82,9 @@ def get_asset_depreciation_schedules_map():
 		.orderby(ds.idx)
 	).run(as_dict=True)
 
+	if len(records) > 20000:
+		frappe.db.auto_commit_on_many_writes = True
+
 	asset_depreciation_schedules_map = frappe._dict()
 	for d in records:
 		asset_depreciation_schedules_map.setdefault((d.asset_name, cstr(d.finance_book)), []).append(d)


### PR DESCRIPTION
**Issue:**
patch `erpnext.patches.v15_0.create_asset_depreciation_schedules_from_assets` fails when there are lots of asset depreciation schedule
**ref:** [31365](https://support.frappe.io/helpdesk/tickets/31365)

![asset-Issue](https://github.com/user-attachments/assets/73fab78d-dfdf-4023-8010-b38e2402b2b1)


**backport needed for v15**