### PR TITLE
fix: validate accounting dimension company in Journal Entry & Stock Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -141,6 +141,7 @@ class JournalEntry(AccountsController):
 		self.validate_empty_accounts_table()
 		self.validate_inter_company_accounts()
 		self.validate_depr_entry_voucher_type()
+		self.validate_company_in_accounting_dimension()
 		self.validate_advance_accounts()
 
 		if self.docstatus == 0:

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -599,13 +599,14 @@ def make_journal_entry(
 	save=True,
 	submit=False,
 	project=None,
+	company=None,
 ):
 	if not cost_center:
 		cost_center = "_Test Cost Center - _TC"
 
 	jv = frappe.new_doc("Journal Entry")
 	jv.posting_date = posting_date or nowdate()
-	jv.company = "_Test Company"
+	jv.company = company or "_Test Company"
 	jv.user_remark = "test"
 	jv.multi_currency = 1
 	jv.set(

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -26,6 +26,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cash - TPC",
 			account2="Sales - TPC",
 			cost_center=cost_center,
+			company=company,
 			save=False,
 		)
 		jv1.company = company
@@ -38,6 +39,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cost of Goods Sold - TPC",
 			account2="Cash - TPC",
 			cost_center=cost_center,
+			company=company,
 			save=False,
 		)
 		jv2.company = company
@@ -155,6 +157,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			amount=400,
 			cost_center=cost_center,
 			posting_date="2021-03-15",
+			company=company,
 		)
 		jv.company = company
 		jv.finance_book = create_finance_book().name
@@ -197,6 +200,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cash - TPC",
 			account2="Sales - TPC",
 			cost_center=cost_center,
+			company=company,
 			save=False,
 		)
 		jv1.company = company
@@ -219,6 +223,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cash - TPC",
 			account2="Sales - TPC",
 			cost_center=cost_center1,
+			company=company,
 			save=False,
 		)
 		jv1.company = company
@@ -231,6 +236,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cash - TPC",
 			account2="Sales - TPC",
 			cost_center=cost_center2,
+			company=company,
 			save=False,
 		)
 		jv2.company = company
@@ -260,6 +266,7 @@ class TestPeriodClosingVoucher(IntegrationTestCase):
 			account1="Cash - TPC",
 			account2="Sales - TPC",
 			cost_center=cost_center2,
+			company=company,
 			save=False,
 		)
 

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -941,6 +941,7 @@ class TestPurchaseOrder(IntegrationTestCase):
 		automatically_fetch_payment_terms(enable=0)
 
 	def test_internal_transfer_flow(self):
+		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 			make_inter_company_purchase_invoice,
 		)
@@ -956,8 +957,16 @@ class TestPurchaseOrder(IntegrationTestCase):
 		prepare_data_for_internal_transfer()
 		supplier = "_Test Internal Supplier 2"
 
+		create_cost_center(
+			cost_center_name="_Test Cost Center for perpetual inventory Account",
+			company="_Test Company with perpetual inventory",
+		)
+
 		mr = make_material_request(
-			qty=2, company="_Test Company with perpetual inventory", warehouse="Stores - TCP1"
+			qty=2,
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			cost_center="_Test Cost Center for perpetual inventory Account - TCP1",
 		)
 
 		po = create_purchase_order(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -421,7 +421,7 @@ class AccountsController(TransactionBase):
 			.where(doc_field.fieldname == "company")
 		).run(as_list=True)
 
-		dimension_list = sum(dimension_list, ["Project"])
+		dimension_list = sum(dimension_list, ["Project", "Cost Center"])
 		self.validate_company(dimension_list)
 
 		for child in self.get_all_children() or []:

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -10,6 +10,7 @@ from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.utils import add_days, cstr, flt, getdate, nowdate, nowtime, today
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
+from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 from erpnext.accounts.utils import get_balance_on
 from erpnext.controllers.accounts_controller import InvalidQtyError
 from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
@@ -1436,6 +1437,7 @@ class TestDeliveryNote(IntegrationTestCase):
 		warehouse = "Stores - TCP1"
 		target = "Finished Goods - TCP1"
 		customer = create_internal_customer(represents_company=company)
+		create_cost_center(cost_center_name="_Test Cost Center", company=company)
 
 		# average rate = 128.015
 		rates = [101.45, 150.46, 138.25, 121.9]
@@ -1450,6 +1452,7 @@ class TestDeliveryNote(IntegrationTestCase):
 			qty=4,
 			warehouse=warehouse,
 			target_warehouse=target,
+			cost_center="_Test Cost Center - TCP1",
 		)
 		self.assertFalse(frappe.db.exists("GL Entry", {"voucher_no": dn.name, "voucher_type": dn.doctype}))
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1135,6 +1135,7 @@ def create_delivery_note(source_name, target_doc=None):
 
 def create_dn_wo_so(pick_list):
 	delivery_note = frappe.new_doc("Delivery Note")
+	delivery_note.company = pick_list.company
 
 	item_table_mapper_without_so = {
 		"doctype": "Delivery Note Item",

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -34,16 +34,6 @@ class UnitTestSerialNo(UnitTestCase):
 
 
 class TestSerialNo(IntegrationTestCase):
-	def setUp(self):
-		self.create_currency_exchange()
-
-	def create_currency_exchange(self):
-		c_doc = frappe.new_doc("Currency Exchange")
-		c_doc.from_currency = "INR"
-		c_doc.to_currency = "USD"
-		c_doc.exchange_rate = 87.33
-		c_doc.insert()
-
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -34,6 +34,16 @@ class UnitTestSerialNo(UnitTestCase):
 
 
 class TestSerialNo(IntegrationTestCase):
+	def setUp(self):
+		self.create_currency_exchange()
+
+	def create_currency_exchange(self):
+		c_doc = frappe.new_doc("Currency Exchange")
+		c_doc.from_currency = "INR"
+		c_doc.to_currency = "USD"
+		c_doc.exchange_rate = 87.33
+		c_doc.insert()
+
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -127,6 +137,7 @@ class TestSerialNo(IntegrationTestCase):
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
 			warehouse=wh,
+			cost_center="_Test Company 1 - _TC1",
 		)
 		sn_doc.reload()
 
@@ -162,6 +173,7 @@ class TestSerialNo(IntegrationTestCase):
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
 			warehouse=wh,
+			cost_center="_Test Company 1 - _TC1",
 		)
 
 		# Delivery from second company
@@ -171,6 +183,7 @@ class TestSerialNo(IntegrationTestCase):
 			serial_no=[serial_nos[0]],
 			company="_Test Company 1",
 			warehouse=wh,
+			cost_center="_Test Company 1 - _TC1",
 		)
 		sn_doc.reload()
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -210,6 +210,7 @@ class StockEntry(StockController):
 		self.validate_bom()
 		self.set_process_loss_qty()
 		self.validate_purchase_order()
+		self.validate_company_in_accounting_dimension()
 
 		if self.purpose in ("Manufacture", "Repack"):
 			self.mark_finished_and_scrap_items()


### PR DESCRIPTION
**Issue**: Journal Entry and Stock Entry were not validating the accounting dimension for the company.

**ref: [31652](https://support.frappe.io/helpdesk/tickets/31652)**


**Before**

[1.issue.webm](https://github.com/user-attachments/assets/b46b8b31-fe51-409b-b335-a50d5adc657b)


**After**

[2.fix.webm](https://github.com/user-attachments/assets/06ea9d2b-e5a1-4df6-9a1c-b68686ab0e12)

**Backport Needed: v15 & v14**
