### PR TITLE
fix: validations and account type filter for `Tax Withholding Category`

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.js
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.js
@@ -10,6 +10,7 @@ frappe.ui.form.on("Tax Withholding Category", {
 					filters: {
 						company: child.company,
 						root_type: ["in", ["Asset", "Liability"]],
+						is_group: 0,
 					},
 				};
 			}


### PR DESCRIPTION
## Summary

This PR enhances validation logic to prevent overlapping date ranges and duplicate company entries in the system.

### Before
1.	Users could add multiple rate rows with overlapping date ranges.
	          • Example:
	              •	Row 1: From 01/04/2024 → To 31/03/2025
	              •	Row 2: From 01/05/2024 → To 31/05/2024
	          •The system previously allowed this, leading to incorrect data.

2.	A user could add the same company multiple times with different accounts, which caused redundancy and data inconsistencies.

### After

✅ Fixed Overlapping Date Validation
	•	The system now throws an error if a user tries to add a rate row with overlapping dates.

✅ Prevented Duplicate Company Entries
	•	A company can now only be added once.
