### PR TITLE
fix: pos item detail serial no field

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -187,6 +187,7 @@ erpnext.PointOfSale.ItemDetails = class {
 			this[`${fieldname}_control`].set_value(item[fieldname]);
 		});
 
+		this.resize_serial_control(item);
 		this.make_auto_serial_selection_btn(item);
 
 		this.bind_custom_control_change_event();
@@ -203,9 +204,15 @@ erpnext.PointOfSale.ItemDetails = class {
 			"actual_qty",
 			"price_list_rate",
 		];
-		if (item.has_serial_no) fields.push("serial_no");
-		if (item.has_batch_no) fields.push("batch_no");
+		if (item.has_serial_no || item.serial_no) fields.push("serial_no");
+		if (item.has_batch_no || item.batch_no) fields.push("batch_no");
 		return fields;
+	}
+
+	resize_serial_control(item) {
+		if (item.has_serial_no || item.serial_no) {
+			this.$form_container.find(".serial_no-control").find("textarea").css("height", "6rem");
+		}
 	}
 
 	make_auto_serial_selection_btn(item) {
@@ -225,7 +232,6 @@ erpnext.PointOfSale.ItemDetails = class {
 						`<div class="btn btn-sm btn-secondary auto-fetch-btn" style="margin-top: 6px">${label}</div>`
 					);
 			}
-			this.$form_container.find(".serial_no-control").find("textarea").css("height", "6rem");
 		}
 	}
 


### PR DESCRIPTION
In the POS Item Details, the visibility of the Serial Number and Batch Number fields depends on the attributes `has_serial_no` and `has_batch_no`, respectively. However, these attributes are not present in the POS Invoice Item, causing the Serial Number and Batch Number fields to be skipped while rendering the form fields during Return or navigating back to Item Selection from Checkout.

To address this, added additional conditions to check for `serial_no` and `batch_no` instead of relying only on `has_serial_no` and `has_batch_no`.

Before:

https://github.com/user-attachments/assets/ae68bc39-974a-4eb2-8f46-57105e8b19c8

After:

https://github.com/user-attachments/assets/69ef757f-0f31-45cc-a1e5-7d6a3934fcf6
