### PR TITLE
fix: incorrect batch picked

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -540,6 +540,8 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 					has_batch_no: this.item.has_batch_no,
 					qty: qty,
 					based_on: based_on,
+					posting_date: this.frm.doc.posting_date,
+					posting_time: this.frm.doc.posting_time,
 				},
 				callback: (r) => {
 					if (r.message) {

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1006,6 +1006,10 @@ class SerialBatchCreation:
 		elif self.has_serial_no and not self.get("serial_nos"):
 			self.serial_nos = get_serial_nos_for_outward(kwargs)
 		elif not self.has_serial_no and self.has_batch_no and not self.get("batches"):
+			if self.get("posting_date"):
+				kwargs["posting_date"] = self.get("posting_date")
+				kwargs["posting_time"] = self.get("posting_time")
+
 			self.batches = get_available_batches(kwargs)
 
 	def set_auto_serial_batch_entries_for_inward(self):


### PR DESCRIPTION
- Make item ABC with batch
- In Stock Settings, enabled "Auto Create Serial and Batch Bundle For Outward" and set "Pick Serial / Batch Based On" as "LIFO"
- Make Purchase Receipt on 1st Jan 2025 for 10 qty with batch Batch-001
- Make Delivery Note on 2nd Jan 2025 for 5 qty with batch Batch-001
- Make Purchase Receipt on 4th Jan 2025 for 10 qty with batch Batch-002
- Make Delivery Note on 3rd Jan 2025, system will pick the batch as "Batch-002" as per LIFO and throws the negative stock validation.