### PR TITLE
fix: pricing rule not ignored in Sales Order

### DIFF
--- a/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
+++ b/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
@@ -128,7 +128,7 @@ class TestCouponCode(IntegrationTestCase):
 			item_code="_Test Tesla Car",
 			rate=5000,
 			qty=1,
-			do_not_submit=True,
+			do_not_save=True,
 		)
 
 		self.assertEqual(so.items[0].rate, 5000)

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -454,8 +454,7 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 
 			if pricing_rule.coupon_code_based == 1:
 				if not args.coupon_code:
-					return item_details
-
+					continue
 				coupon_code = frappe.db.get_value(
 					doctype="Coupon Code", filters={"pricing_rule": pricing_rule.name}, fieldname="name"
 				)


### PR DESCRIPTION
**Issue:**
ignore_pricing_rule checkbox not working 

Steps to produce,
- First, create a coupon_code_based Pricing Rule for an item with "Apply Multiple Pricing Rules" enabled. 
- Create another Pricing Rule for the same item with "Apply Multiple Pricing Rules" enabled and without coupon_code_based.
- Create a Sales Order and verify that the Pricing Rule is applied.
- Check "Ignore Pricing Rule" in the Sales Order but Pricing Rule is still applied instead of being ignored.

**ref:** [32422](https://support.frappe.io/helpdesk/tickets/32422)

**Before:**

[ignoring_pricing_rule_bfr.webm](https://github.com/user-attachments/assets/bb35de16-ab98-46ee-b607-0af6c8d4ae8a)

**After:**

[ignoring_pricing_rule_afr.webm](https://github.com/user-attachments/assets/08827a56-017d-464f-870a-0c26a36f4529)

Back port needed for version-15