### PR TITLE
fix: do not include opening invoices in billed items to be received report

### DIFF
--- a/erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py
+++ b/erpnext/accounts/report/billed_items_to_be_received/billed_items_to_be_received.py
@@ -27,6 +27,7 @@ def get_report_filters(report_filters):
 		["Purchase Invoice", "docstatus", "=", 1],
 		["Purchase Invoice", "per_received", "<", 100],
 		["Purchase Invoice", "update_stock", "=", 0],
+		["Purchase Invoice", "is_opening", "!=", "Yes"],
 	]
 
 	if report_filters.get("purchase_invoice"):


### PR DESCRIPTION
Do not include opening invoices in billed items to be received report.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/33115



