### PR TITLE
fix: only include submitted docs for internal received quantity validation

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1237,7 +1237,7 @@ class StockController(AccountsController):
 				child_tab.item_code,
 				child_tab.qty,
 			)
-			.where(parent_tab.docstatus < 2)
+			.where(parent_tab.docstatus == 1)
 		)
 
 		if self.doctype == "Purchase Invoice":


### PR DESCRIPTION
Only include submitted invoices for internal transfer qty validation.
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/33165
