### PR TITLE
feat: Add first and last name fields to quick entry customer creation

### DIFF
--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -16,13 +16,13 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 	insert() {
 		/**
 		 * Using alias fieldnames because the doctype definition define "email_id" and "mobile_no" as readonly fields.
-		 * Therefor, resulting in the fields being "hidden".
+		 * This results in the fields being "hidden".
 		 */
 		const map_field_names = {
 			email_address: "email_id",
 			mobile_number: "mobile_no",
 			map_to_first_name : "first_name",
-			map_to_last_name: "last_name"
+			map_to_last_name: "last_name",
 		};
 
 		Object.entries(map_field_names).forEach(([fieldname, new_fieldname]) => {
@@ -44,13 +44,13 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 				label: __("First Name"),
 				fieldname: "map_to_first_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'"
+				depends_on: "eval:doc.customer_type=='Company'",
 			},
 			{
 				label: __("Last Name"),
 				fieldname: "map_to_last_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'"
+				depends_on: "eval:doc.customer_type=='Company'",
 			},
 
 			{

--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -21,6 +21,8 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 		const map_field_names = {
 			email_address: "email_id",
 			mobile_number: "mobile_no",
+			map_to_first_name : "first_name",
+			map_to_last_name: "last_name"
 		};
 
 		Object.entries(map_field_names).forEach(([fieldname, new_fieldname]) => {
@@ -39,13 +41,26 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 				collapsible: 1,
 			},
 			{
+				label: __("First Name"),
+				fieldname: "map_to_first_name",
+				fieldtype: "Data",
+				depends_on: "eval:doc.customer_type=='Company'"
+			},
+			{
+				label: __("Last Name"),
+				fieldname: "map_to_last_name",
+				fieldtype: "Data",
+				depends_on: "eval:doc.customer_type=='Company'"
+			},
+
+			{
+				fieldtype: "Column Break",
+			},
+			{
 				label: __("Email Id"),
 				fieldname: "email_address",
 				fieldtype: "Data",
 				options: "Email",
-			},
-			{
-				fieldtype: "Column Break",
 			},
 			{
 				label: __("Mobile Number"),

--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -21,7 +21,7 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 		const map_field_names = {
 			email_address: "email_id",
 			mobile_number: "mobile_no",
-			map_to_first_name : "first_name",
+			map_to_first_name: "first_name",
 			map_to_last_name: "last_name",
 		};
 

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -594,7 +594,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2024-06-17 03:24:59.612974",
+ "modified": "2025-03-04 15:24:57.292163",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",
@@ -672,6 +672,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "customer_group,territory, mobile_no,primary_address",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -56,6 +56,8 @@
   "customer_primary_contact",
   "mobile_no",
   "email_id",
+  "first_name",
+  "last_name",
   "tax_tab",
   "taxation_section",
   "tax_id",
@@ -581,6 +583,20 @@
    "no_copy": 1,
    "options": "Prospect",
    "print_hide": 1
+  },
+  {
+   "fetch_from": "customer_primary_contact.first_name",
+   "fieldname": "first_name",
+   "fieldtype": "Read Only",
+   "hidden": 1,
+   "label": "First Name"
+  },
+  {
+   "fetch_from": "customer_primary_contact.last_name",
+   "fieldname": "last_name",
+   "fieldtype": "Read Only",
+   "hidden": 1,
+   "label": "Last Name"
   }
  ],
  "icon": "fa fa-user",
@@ -594,7 +610,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-03-04 15:24:57.292163",
+ "modified": "2025-03-05 10:01:47.885574",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -248,7 +248,7 @@ class Customer(TransactionBase):
 
 	def create_primary_contact(self):
 		if not self.customer_primary_contact and not self.lead_name:
-			if self.mobile_no or self.email_id:
+			if self.mobile_no or self.email_id or self.first_name or self.last_name:
 				contact = make_contact(self)
 				self.db_set("customer_primary_contact", contact.name)
 				self.db_set("mobile_no", self.mobile_no)
@@ -723,6 +723,11 @@ def make_contact(args, is_primary_contact=1):
 		contact.add_email(args.get("email_id"), is_primary=True)
 	if args.get("mobile_no"):
 		contact.add_phone(args.get("mobile_no"), is_primary_mobile_no=True)
+	if args.get("first_name"):
+		contact.first_name = args.get("first_name")
+	if args.get("last_name"):
+		contact.last_name = args.get("last_name")
+
 
 	if flags := args.get("flags"):
 		contact.insert(ignore_permissions=flags.get("ignore_permissions"))

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -730,7 +730,6 @@ def make_contact(args, is_primary_contact=1):
 	if args.get("last_name"):
 		contact.last_name = args.get("last_name")
 
-
 	if flags := args.get("flags"):
 		contact.insert(ignore_permissions=flags.get("ignore_permissions"))
 	else:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -60,12 +60,14 @@ class Customer(TransactionBase):
 		disabled: DF.Check
 		dn_required: DF.Check
 		email_id: DF.ReadOnly | None
+		first_name: DF.ReadOnly | None
 		gender: DF.Link | None
 		image: DF.AttachImage | None
 		industry: DF.Link | None
 		is_frozen: DF.Check
 		is_internal_customer: DF.Check
 		language: DF.Link | None
+		last_name: DF.ReadOnly | None
 		lead_name: DF.Link | None
 		loyalty_program: DF.Link | None
 		loyalty_program_tier: DF.Data | None


### PR DESCRIPTION
## Problem
When creating a customer of type "Company", users cannot specify the primary contact's first and last name in the quick entry form. 
They must navigate to the contact, edit it, go back to the customer, and re-select the primary contact—a confusing and unintuitive process, especially for new users. Small businesses, which rarely need multiple contacts per customer, find this workflow unnecessarily cumbersome.

## Solution
This PR adds First Name and Last Name fields to the quick entry form. Users can now specify the primary contact’s name during customer creation, eliminating the need for any additional steps.
The additional fields only appear when the customer type is "Company".


## Demo
![pr_customer_quickentry](https://github.com/user-attachments/assets/731d804d-bf24-44e4-8ecf-684ee1ef376a)


## Key Changes
- Added first_name and last_name fields to the quick entry form.
- Updated contact_address_quick_entry.js, customer.py, and customer.json to support these fields.

## Benefits
- Simplified Workflow: No more navigating, editing, or re-selecting contacts.
- Improved Usability: Makes ERPNext more intuitive for new users and small businesses.


#no-docs