### PR TITLE
ci: dont lock really old pull requests

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -19,3 +19,4 @@ jobs:
           github-token: ${{ github.token }}
           issue-inactive-days: 14
           pr-inactive-days: 14
+	  exclude-pr-created-before: 2025-01-01


### PR DESCRIPTION
Mergify incorrectly creates backport for really old PR's if their conversion is getting locked. This is a temporary change until the old PR's are locked manually. 