### PR TITLE
fix: consolidate gl entries by project in General Ledger Report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -537,6 +537,7 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map, tot
 					for dim in accounting_dimensions:
 						keylist.append(gle.get(dim))
 					keylist.append(gle.get("cost_center"))
+					keylist.append(gle.get("project"))
 
 				key = tuple(keylist)
 				if key not in consolidated_gle:
@@ -682,10 +683,11 @@ def get_columns(filters):
 		{"label": _("Against Account"), "fieldname": "against", "width": 120},
 		{"label": _("Party Type"), "fieldname": "party_type", "width": 100},
 		{"label": _("Party"), "fieldname": "party", "width": 100},
-		{"label": _("Project"), "options": "Project", "fieldname": "project", "width": 100},
 	]
 
 	if filters.get("include_dimensions"):
+		columns.append({"label": _("Project"), "options": "Project", "fieldname": "project", "width": 100})
+
 		for dim in get_accounting_dimensions(as_list=False):
 			columns.append(
 				{"label": _(dim.label), "options": dim.label, "fieldname": dim.fieldname, "width": 100}


### PR DESCRIPTION
Project is also an accounting dimension just like Cost Center, GL entries should be consolidated based on the Project also.

Steps to replicate:
- Create a Journal Entry for Expense Payment for two projects.
- View General Ledger with "Group by voucher consolidated".

Entries are not getting bifurcated based on the project.

Before: 
![image](https://github.com/user-attachments/assets/8a34ed77-2450-4c5c-937f-e2ffb382bbe7)


After:
![image](https://github.com/user-attachments/assets/eda6e260-0483-4854-aa20-095c257201e2)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/31673
 