### PR TITLE
fix: `base_net_rate` Required to Check Valid Range

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3312,6 +3312,7 @@ def set_child_tax_template_and_map(item, child_item, parent_doc):
 			"posting_date": parent_doc.transaction_date,
 			"tax_category": parent_doc.get("tax_category"),
 			"company": parent_doc.get("company"),
+			"base_net_rate": item.get("base_net_rate"),
 		}
 	)
 

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -843,6 +843,7 @@ def get_tax_template(doctype, txt, searchfield, start, page_len, filters):
 				"posting_date": valid_from,
 				"tax_category": filters.get("tax_category"),
 				"company": company,
+				"base_net_rate": filters.get("base_net_rate"),
 			}
 		)
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2503,6 +2503,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				'item_code': item.item_code,
 				'valid_from': ["<=", doc.transaction_date || doc.bill_date || doc.posting_date],
 				'item_group': item.item_group,
+				"base_net_rate": item.base_net_rate,
 			}
 
 			if (doc.tax_category)


### PR DESCRIPTION

- `base_net_rate` is required [here](https://github.com/frappe/erpnext/blob/0a2193e4589a9e748041001a8eb592be2bf091ce/erpnext/stock/get_item_details.py#L709) to check the valid range for `Net Rate`.

![Screenshot 2025-03-05 at 4 35 40 PM](https://github.com/user-attachments/assets/39a9c935-9878-4b19-8f1c-5c92cafbce80)
