### PR TITLE
fix: auto email report creation

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -247,6 +247,7 @@ function get_filters() {
 					company: frappe.query_report.get_filter_value("company"),
 				});
 			},
+			options: "Cost Center"
 		},
 		{
 			fieldname: "project",
@@ -257,6 +258,7 @@ function get_filters() {
 					company: frappe.query_report.get_filter_value("company"),
 				});
 			},
+			options: "Project"
 		},
 	];
 

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -189,15 +189,15 @@ function get_filters() {
 			fieldname: "period_start_date",
 			label: __("Start Date"),
 			fieldtype: "Date",
-			reqd: 1,
 			depends_on: "eval:doc.filter_based_on == 'Date Range'",
+			mandatory_depends_on: "eval:doc.filter_based_on == 'Date Range'",
 		},
 		{
 			fieldname: "period_end_date",
 			label: __("End Date"),
 			fieldtype: "Date",
-			reqd: 1,
 			depends_on: "eval:doc.filter_based_on == 'Date Range'",
+			mandatory_depends_on: "eval:doc.filter_based_on == 'Date Range'",
 		},
 		{
 			fieldname: "from_fiscal_year",


### PR DESCRIPTION
**Issue:**
1. When creating Auto Email Report with report Profit and Loss Statement. It requires `Start Date` and `End Date` even though the `Filter Based On` drop-down is equals  to 'Fiscal Year'

**Issue Demo:**
![start_date_issue](https://github.com/user-attachments/assets/7731444b-a96f-4eb3-a671-184b781cc274)

2. When creating Auto Email Report with report Profit and Loss Statement. Project and Cost Center is not fetched

**Issue Demo:**
![project_cost_not_showing](https://github.com/user-attachments/assets/0f9d82eb-9e9c-4632-b943-b2a159028c3d)


**Investigation:**
- Filters data is fetched from financial_statement.js. There `period_start_date` and `period_end_date` is required always. Another thing is in Auto Email Report, MultiSelectList fieldtype returns empty array if val.options is not set.  
![Screenshot from 2025-03-05 20-59-32](https://github.com/user-attachments/assets/52c4fdf0-f1dc-4706-a586-cddcc27957b0)

**Proposed Solution**
- Use mandatory_depends_on for period dates.
- Add options for filters Cost Center and Project in financial_statement.js.

**Solution Demo:**
![sol-1](https://github.com/user-attachments/assets/fb598adb-00b0-4dbe-b073-1e948e801820)
