### PR TITLE
fix: change fieldname for cash_flow to export

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -630,7 +630,7 @@ def get_cost_centers_with_children(cost_centers):
 def get_columns(periodicity, period_list, accumulated_values=1, company=None, cash_flow=False):
 	columns = [
 		{
-			"fieldname": "account",
+			"fieldname": "account" if not cash_flow else "section",
 			"label": _("Account") if not cash_flow else _("Section"),
 			"fieldtype": "Link",
 			"options": "Account",


### PR DESCRIPTION
Support ticket: [Support Ticket  - 33305](https://support.frappe.io/helpdesk/tickets/33305)

During the export process, there is a mismatch between the column field names and the data field names. 

The column is assigned `account` as the field name, while the data contains `section` as the field name. As a result, the Section column appears empty in the exported XLSX or CSV file, except for `Profit of the Year` where the field name is already `account`, as shown in the before screenshot.

To resolve this, if the export is related to cash flow, I am using `section` as the field name. This ensures that the data is displayed correctly in the exported file.

**Before**
<img width="374" alt="Screenshot 2025-03-06 at 12 07 20 PM" src="https://github.com/user-attachments/assets/5ea173bf-9774-40c6-8d32-f742a6cd1cbe" />


**After**
<img width="374" alt="Screenshot 2025-03-06 at 12 06 35 PM" src="https://github.com/user-attachments/assets/2009b94d-a747-4ece-9fe2-fea551404f38" />
