### PR TITLE
Fix: add parenttype condition to payment schedule query in accounts receivable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -498,7 +498,7 @@ class ReceivablePayableReport:
 				ps.description, ps.paid_amount, ps.discounted_amount
 			from `tab{row.voucher_type}` si, `tabPayment Schedule` ps
 			where
-				si.name = ps.parent and
+				si.name = ps.parent and ps.parenttype = '{row.voucher_type}' and
 				si.name = %s and
 				si.is_return = 0
 			order by ps.paid_amount desc, due_date


### PR DESCRIPTION
This fix ensures that the `get_payment_terms` function correctly filters records by adding the missing condition:

```sql
si.name = ps.parent and ps.parenttype = '{row.voucher_type}'
```

By including `ps.parenttype = '{row.voucher_type}'`, the function properly associates payment terms with the correct document type, preventing incorrect outstanding amount calculations.

#### Impact of the Fix
- Ensures that the **Accounts Receivable Report - Outstanding Amount** is accurately computed when the **Based On Payment Terms** filter is applied.
- Prevents incorrect doubling of outstanding amounts, improving financial accuracy in reporting.

closes #46367

backport version-14
backport version-15
