### PR TITLE
fix(payment entry): fetch default bank account based on company

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2950,7 +2950,9 @@ def get_payment_entry(
 	pe.paid_amount = paid_amount
 	pe.received_amount = received_amount
 	pe.letter_head = doc.get("letter_head")
-	pe.bank_account = frappe.db.get_value("Bank Account", {"is_company_account": 1, "is_default": 1}, "name")
+	pe.bank_account = frappe.db.get_value(
+		"Bank Account", {"is_company_account": 1, "is_default": 1, "company": doc.company}, "name"
+	)
 
 	if dt in ["Purchase Order", "Sales Order", "Sales Invoice", "Purchase Invoice"]:
 		pe.project = doc.get("project") or reduce(


### PR DESCRIPTION
**Issue:**
Different company bank accounts are being fetched while creating Payment Entry from Sales Invoice
**ref:** [33189](https://support.frappe.io/helpdesk/tickets/33189)

**Steps to reproduce:**
- Create 2 companies Company A and Company B
- Create a default bank account for company Company A
- Default bank account and default cash account shouldn't be mentioned in Company B
- There should be 2 or more accounts with account type bank and cash.
- Create a sales invoice for Company B
- Create Payment Entry from sales invoice, Company A's bank and bank account will be fetched into Company B's Payment Entry

**Before:**

https://github.com/user-attachments/assets/4b93a26d-3b71-4cb6-8c43-71196e2d7cbf


**After:**

https://github.com/user-attachments/assets/117b7a3f-58f1-4ef3-869b-9d293f86af59



**Backport needed for v15 and v14**
