### PR TITLE
feat(accounting/regional): allow chart_of_account.get_chart to be whilelist

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -116,6 +116,7 @@ def identify_is_group(child):
 	return is_group
 
 
+@frappe.whitelist()
 def get_chart(chart_template, existing_company=None):
 	chart = {}
 	if existing_company:


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Allow complete autonomy for external application to propose other charts of accounts than those already embeded in erpnext/accounts/doctype/account/chart_of_accounts/verified

> Explain the **details** for making this change. What existing problem does the pull request solve?

As erpnext.accounts.doctype.acount.chart_of_accounts.get_charts_for_country is already whilelist this is unfortunatly  the half of the needed process for customization done by external application (like regionnal application erpnext_france for exemple). 
Because select list of chart of account available in setup withard is provided by chart_of_accounts.get_charts_for_country, , so here an custom application can add other entry, but latter the install process use chart_of_accounts.get_chart to get the json chart_of_account.

>no-docs
