### PR TITLE
chore: rename print and stationery account

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/in_standard_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/in_standard_chart_of_accounts.json
@@ -98,7 +98,7 @@
                 "Office Maintenance Expenses": {},
                 "Office Rent": {},
                 "Postal Expenses": {},
-                "Print and Stationary": {},
+                "Print and Stationery": {},
                 "Rounded Off": {
                     "account_type": "Round Off"
                 },


### PR DESCRIPTION
**Issue:**
Typo in Indian Chart of Accounts

**Reference:** #46361 

**Solution:**
Renamed 'Print and Stationary' account to 'Print and Stationery' account in Chart of Accounts

**Before:**

![photo_6224054851046852018_w](https://github.com/user-attachments/assets/6d994f95-4b95-4348-a1ba-823ea622c566)

**After:**

![photo_6224054851046852031_w](https://github.com/user-attachments/assets/86929899-b2ed-48d5-9ad7-3918178a5330)


**Backport needed for version-15, version-14**