### PR TITLE
fix: not able to save work order with alternative item

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -92,7 +92,7 @@ class WorkOrder(Document):
 		if self.source_warehouse:
 			self.set_warehouses()
 
-		validate_uom_is_integer(self, "stock_uom", ["qty", "produced_qty"])
+		validate_uom_is_integer(self, "stock_uom", ["required_qty"])
 
 		self.set_required_items(reset_only_qty=len(self.get("required_items")))
 


### PR DESCRIPTION
**Issue**

Qty field not exists in the child doctype Work Order Item

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 97, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1619, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 31, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 310, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 345, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1061, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 931, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1283, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1265, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 928, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 95, in validate
    validate_uom_is_integer(self, "stock_uom", ["qty", "produced_qty"])
  File "apps/erpnext/erpnext/utilities/transaction_base.py", line 213, in validate_uom_is_integer
    precision = d.precision(f)
  File "apps/frappe/frappe/model/base_document.py", line 1123, in precision
    if df.fieldtype in ("Currency", "Float", "Percent"):
AttributeError: 'NoneType' object has no attribute 'fieldtype'
```