### PR TITLE
fix: calculate due date based on payment term

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -679,7 +679,13 @@ class SalesInvoice(SellingController):
 				"Account", self.debit_to, "account_currency", cache=True
 			)
 		if not self.due_date and self.customer:
-			self.due_date = get_due_date(self.posting_date, "Customer", self.customer, self.company)
+			self.due_date = get_due_date(
+				self.posting_date,
+				"Customer",
+				self.customer,
+				self.company,
+				template_name=self.payment_terms_template,
+			)
 
 		super().set_missing_values(for_validate)
 

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -577,12 +577,13 @@ def validate_party_accounts(doc):
 
 
 @frappe.whitelist()
-def get_due_date(posting_date, party_type, party, company=None, bill_date=None):
+def get_due_date(posting_date, party_type, party, company=None, bill_date=None, template_name=None):
 	"""Get due date from `Payment Terms Template`"""
 	due_date = None
 	if (bill_date or posting_date) and party:
 		due_date = bill_date or posting_date
-		template_name = get_payment_terms_template(party, party_type, company)
+		if not template_name:
+			template_name = get_payment_terms_template(party, party_type, company)
 
 		if template_name:
 			due_date = get_due_date_from_template(template_name, posting_date, bill_date).strftime("%Y-%m-%d")


### PR DESCRIPTION
**Issue:**
The due date doesn't match the payment term while creating an invoice from a sales order.

**Ref:** [33110](https://support.frappe.io/helpdesk/tickets/33110), #46218 

**Before:**

https://github.com/user-attachments/assets/35d98678-73be-4df7-b399-36004447cfef

**After:**

https://github.com/user-attachments/assets/36b0385f-ef19-4202-8996-23c056c4920b

**Backport needed for v14 & v15**

