### PR TITLE
fix: show remaining qty on 'Complete Job' button instead of full qty

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -217,7 +217,7 @@ frappe.ui.form.on("Job Card", {
 				label: __("Completed Quantity"),
 				fieldname: "qty",
 				reqd: 1,
-				default: frm.doc.for_quantity - frm.doc.manufactured_qty,
+				default: frm.doc.for_quantity - frm.doc.total_completed_qty,
 			},
 			{
 				fieldtype: "Datetime",


### PR DESCRIPTION
fixes #45440 