### PR TITLE
fix: clear cashe on employee hierarchy change

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -80,6 +80,7 @@ class Employee(NestedSet):
 
 	def on_update(self):
 		self.update_nsm_model()
+		frappe.clear_cache()
 		if self.user_id:
 			self.update_user()
 			self.update_user_permissions()


### PR DESCRIPTION
### Problem
Old incorrect doc permissions remain cashed even after changing employee hierarchy

https://github.com/user-attachments/assets/781a3dbb-2a3a-4454-b425-acf515a1a4a3

### After

https://github.com/user-attachments/assets/e4dcd31a-e87d-4e83-9ef3-59dae757d393



