### PR TITLE
fix: unused field ignore_default_payment_terms_template stopping paym…

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2308,8 +2308,6 @@ class AccountsController(TransactionBase):
 				and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 			):
 				self.fetch_payment_terms_from_order(po_or_so, doctype)
-				if self.get("payment_terms_template"):
-					self.ignore_default_payment_terms_template = 1
 			elif self.get("payment_terms_template"):
 				data = get_payment_terms(
 					self.payment_terms_template, posting_date, grand_total, base_grand_total
@@ -2349,7 +2347,6 @@ class AccountsController(TransactionBase):
 					)
 		else:
 			self.fetch_payment_terms_from_order(po_or_so, doctype)
-			self.ignore_default_payment_terms_template = 1
 
 	def get_order_details(self):
 		if not self.get("items"):


### PR DESCRIPTION
fixes #46392 

@ruthra-kumar this field is not being set anywhere in the code base as far as I can tell so I have removed the hard code to 1. Please check and help me out here!