### PR TITLE
fix: add base_outstanding and base_paid_amount in payment schedule table

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -7,6 +7,7 @@ from functools import reduce
 
 import frappe
 from frappe import ValidationError, _, qb, scrub, throw
+from frappe.model.meta import get_field_precision
 from frappe.query_builder import Tuple
 from frappe.query_builder.functions import Count
 from frappe.utils import cint, comma_or, flt, getdate, nowdate
@@ -825,16 +826,39 @@ class PaymentEntry(AccountsController):
 			outstanding = flt(invoice_paid_amount_map.get(key, {}).get("outstanding"))
 			discounted_amt = flt(invoice_paid_amount_map.get(key, {}).get("discounted_amt"))
 
+			conversion_rate = frappe.db.get_value(key[2], {"name": key[1]}, "conversion_rate")
+			base_paid_amount_precision = get_field_precision(
+				frappe.get_meta("Payment Schedule").get_field("base_paid_amount")
+			)
+			base_outstanding_precision = get_field_precision(
+				frappe.get_meta("Payment Schedule").get_field("base_outstanding")
+			)
+
+			base_paid_amount = flt(
+				(allocated_amount - discounted_amt) * conversion_rate, base_paid_amount_precision
+			)
+			base_outstanding = flt(allocated_amount * conversion_rate, base_outstanding_precision)
+
 			if cancel:
 				frappe.db.sql(
 					"""
 					UPDATE `tabPayment Schedule`
 					SET
 						paid_amount = `paid_amount` - %s,
+						base_paid_amount = `base_paid_amount` - %s,
 						discounted_amount = `discounted_amount` - %s,
-						outstanding = `outstanding` + %s
+						outstanding = `outstanding` + %s,
+						base_outstanding = `base_outstanding` - %s
 					WHERE parent = %s and payment_term = %s""",
-					(allocated_amount - discounted_amt, discounted_amt, allocated_amount, key[1], key[0]),
+					(
+						allocated_amount - discounted_amt,
+						base_paid_amount,
+						discounted_amt,
+						allocated_amount,
+						base_outstanding,
+						key[1],
+						key[0],
+					),
 				)
 			else:
 				if allocated_amount > outstanding:
@@ -850,10 +874,20 @@ class PaymentEntry(AccountsController):
 						UPDATE `tabPayment Schedule`
 						SET
 							paid_amount = `paid_amount` + %s,
+							base_paid_amount = `base_paid_amount` + %s,
 							discounted_amount = `discounted_amount` + %s,
-							outstanding = `outstanding` - %s
+							outstanding = `outstanding` - %s,
+							base_outstanding = `base_outstanding` - %s
 						WHERE parent = %s and payment_term = %s""",
-						(allocated_amount - discounted_amt, discounted_amt, allocated_amount, key[1], key[0]),
+						(
+							allocated_amount - discounted_amt,
+							base_paid_amount,
+							discounted_amt,
+							allocated_amount,
+							base_outstanding,
+							key[1],
+							key[0],
+						),
 					)
 
 	def get_allocated_amount_in_transaction_currency(

--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
@@ -24,7 +24,9 @@
   "paid_amount",
   "discounted_amount",
   "column_break_3",
-  "base_payment_amount"
+  "base_payment_amount",
+  "base_outstanding",
+  "base_paid_amount"
  ],
  "fields": [
   {
@@ -155,18 +157,34 @@
    "fieldtype": "Currency",
    "label": "Payment Amount (Company Currency)",
    "options": "Company:company:default_currency"
+  },
+  {
+   "fieldname": "base_outstanding",
+   "fieldtype": "Currency",
+   "label": "Outstanding (Company Currency)",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "depends_on": "base_paid_amount",
+   "fieldname": "base_paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount (Company Currency)",
+   "options": "Company:company:default_currency",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:11.356171",
+ "modified": "2025-03-11 11:06:51.792982",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Schedule",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.py
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.py
@@ -14,6 +14,8 @@ class PaymentSchedule(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		base_outstanding: DF.Currency
+		base_paid_amount: DF.Currency
 		base_payment_amount: DF.Currency
 		description: DF.SmallText | None
 		discount: DF.Float

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -529,7 +529,7 @@ class ReceivablePayableReport:
 			select
 				si.name, si.party_account_currency, si.currency, si.conversion_rate,
 				si.total_advance, ps.due_date, ps.payment_term, ps.payment_amount, ps.base_payment_amount,
-				ps.description, ps.paid_amount, ps.discounted_amount
+				ps.description, ps.paid_amount, ps.base_paid_amount, ps.discounted_amount
 			from `tab{row.voucher_type}` si, `tabPayment Schedule` ps
 			where
 				si.name = ps.parent and
@@ -552,20 +552,24 @@ class ReceivablePayableReport:
 		# Deduct that from paid amount pre allocation
 		row.paid -= flt(payment_terms_details[0].total_advance)
 
+		company_currency = frappe.get_value("Company", self.filters.get("company"), "default_currency")
+
 		# If single payment terms, no need to split the row
 		if len(payment_terms_details) == 1 and payment_terms_details[0].payment_term:
-			self.append_payment_term(row, payment_terms_details[0], original_row)
+			self.append_payment_term(row, payment_terms_details[0], original_row, company_currency)
 			return
 
 		for d in payment_terms_details:
 			term = frappe._dict(original_row)
-			self.append_payment_term(row, d, term)
+			self.append_payment_term(row, d, term, company_currency)
 
-	def append_payment_term(self, row, d, term):
-		if d.currency == d.party_account_currency:
+	def append_payment_term(self, row, d, term, company_currency):
+		invoiced = d.base_payment_amount
+		paid_amount = d.base_paid_amount
+
+		if company_currency == d.party_account_currency or self.filters.get("in_party_currency"):
 			invoiced = d.payment_amount
-		else:
-			invoiced = d.base_payment_amount
+			paid_amount = d.paid_amount
 
 		row.payment_terms.append(
 			term.update(
@@ -574,15 +578,15 @@ class ReceivablePayableReport:
 					"invoiced": invoiced,
 					"invoice_grand_total": row.invoiced,
 					"payment_term": d.description or d.payment_term,
-					"paid": d.paid_amount + d.discounted_amount,
+					"paid": paid_amount + d.discounted_amount,
 					"credit_note": 0.0,
-					"outstanding": invoiced - d.paid_amount - d.discounted_amount,
+					"outstanding": invoiced - paid_amount - d.discounted_amount,
 				}
 			)
 		)
 
-		if d.paid_amount:
-			row["paid"] -= d.paid_amount + d.discounted_amount
+		if paid_amount:
+			row["paid"] -= paid_amount + d.discounted_amount
 
 	def allocate_closing_to_term(self, row, term, key):
 		if row[key]:

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2343,6 +2343,9 @@ class AccountsController(TransactionBase):
 						base_grand_total * flt(d.invoice_portion) / 100, d.precision("base_payment_amount")
 					)
 					d.outstanding = d.payment_amount
+					d.base_outstanding = flt(
+						d.payment_amount * self.get("conversion_rate"), d.precision("base_outstanding")
+					)
 				elif not d.invoice_portion:
 					d.base_payment_amount = flt(
 						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -408,3 +408,4 @@ erpnext.patches.v15_0.rename_sla_fields
 erpnext.stock.doctype.stock_ledger_entry.patches.ensure_sle_indexes
 erpnext.patches.v15_0.update_query_report
 erpnext.patches.v15_0.set_purchase_receipt_row_item_to_capitalization_stock_item
+erpnext.patches.v15_0.update_payment_schedule_fields_in_invoices

--- a/erpnext/patches/v15_0/update_payment_schedule_fields_in_invoices.py
+++ b/erpnext/patches/v15_0/update_payment_schedule_fields_in_invoices.py
@@ -1,0 +1,18 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	invoice_types = ["Sales Invoice", "Purchase Invoice"]
+	for invoice_type in invoice_types:
+		invoice = DocType(invoice_type)
+		invoice_details = frappe.qb.from_(invoice).select(invoice.conversion_rate, invoice.name)
+		update_payment_schedule(invoice_details)
+
+
+def update_payment_schedule(invoice_details):
+	ps = DocType("Payment Schedule")
+
+	frappe.qb.update(ps).join(invoice_details).on(ps.parent == invoice_details.name).set(
+		ps.base_paid_amount, ps.paid_amount * invoice_details.conversion_rate
+	).set(ps.base_outstanding, ps.outstanding * invoice_details.conversion_rate).run()


### PR DESCRIPTION
**Issue:**
Steps to reproduce:

- Create two new Payment Terms and create Payment Term Template with these terms
- Create an Invoice with foreign currency Customer and use the newly created Payment Term Template.
- Pay first term fully and second term half.
- While checking data in Account Receivable report for this customer after enabling based_on_payment_terms, extra payment row added and values were wrong.
- If we enable in_party_currency, values were correct.

**ref:** [32015](https://support.frappe.io/helpdesk/tickets/32015l)

**Before:**

https://github.com/user-attachments/assets/d9777ddb-a279-4c39-90ab-d3a91face483

**After:**

https://github.com/user-attachments/assets/4b243718-d3dd-462c-98f8-e2842eef19ea

**Back port needed for version-15**