### PR TITLE
fix(invoice):validate return invoice qty

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2686,6 +2686,20 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		)
 		self.assertEqual(actual, expected)
 
+	def test_prevents_fully_returned_invoice_with_zero_quantity(self):
+		from erpnext.controllers.sales_and_purchase_return import StockOverReturnError, make_return_doc
+
+		invoice = make_purchase_invoice(qty=10)
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -10
+		return_doc.save().submit()
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = 0
+
+		self.assertRaises(StockOverReturnError, return_doc.save)
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4354,6 +4354,20 @@ class TestSalesInvoice(IntegrationTestCase):
 		pos_return = make_sales_return(pos.name)
 		self.assertEqual(abs(pos_return.payments[0].amount), pos.payments[0].amount)
 
+	def test_prevents_fully_returned_invoice_with_zero_quantity(self):
+		from erpnext.controllers.sales_and_purchase_return import StockOverReturnError, make_return_doc
+
+		invoice = create_sales_invoice(qty=10)
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -10
+		return_doc.save().submit()
+
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = 0
+
+		self.assertRaises(StockOverReturnError, return_doc.save)
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(


### PR DESCRIPTION
1. A validation check to prevent the return invoice item quantity from exceeding the corresponding voucher item quantity.
2. A restriction to disallow zero-quantity returns when the invoice item is already fully returned.

Ref: [31768](https://support.frappe.io/helpdesk/tickets/31768)

**Before:**

[before.webm](https://github.com/user-attachments/assets/e39782c7-e8a3-44a6-bc50-fc85146bb6c1)


**After:**

[after.webm](https://github.com/user-attachments/assets/3968331b-e8b5-48c9-ad16-1db8bae16e4f)


Backport Needed: v15
