### PR TITLE
ci: ignore PRs labeled with "skip-release-notes" when generating release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - skip-release-notes


### PR DESCRIPTION
In the change log generated by GitHub, ignore PRs labeled with "skip-release-notes".

Ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations