### PR TITLE
refactor: replace get_list with get_all for dynamic link child access

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -465,7 +465,7 @@ class AccountsController(TransactionBase):
 
 	def validate_party_address(self, party, party_type, billing_address, shipping_address=None):
 		if billing_address or shipping_address:
-			party_address = frappe.get_list(
+			party_address = frappe.get_all(
 				"Dynamic Link",
 				{"link_doctype": party_type, "link_name": party, "parenttype": "Address"},
 				pluck="parent",
@@ -477,7 +477,7 @@ class AccountsController(TransactionBase):
 
 	def validate_party_contact(self, party, party_type):
 		if self.get("contact_person"):
-			contact = frappe.get_list(
+			contact = frappe.get_all(
 				"Dynamic Link",
 				{"link_doctype": party_type, "link_name": party, "parenttype": "Contact"},
 				pluck="parent",


### PR DESCRIPTION
**Issue:**
Users other than Administrator doesn't have permission to access Dynamic Link child.

**Before:**

[address_validation_permission_bfr.webm](https://github.com/user-attachments/assets/3f78f82c-825d-4661-97b1-7ea08fb2e45a)

**After:**

[address_validation_permission_afr.webm](https://github.com/user-attachments/assets/9586fb0a-654a-4413-83ad-82c4fcb73c43)

**Back port needed for version-15**