### PR TITLE
fix: using `in` for lookup in list instead of directly assigning

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -745,7 +745,8 @@ class ReceivablePayableReport:
 		for party_type in self.party_type:
 			party_field = scrub(party_type)
 			if self.filters.get(party_field):
-				or_filters.update({party_field: self.filters.get(party_field)})
+				or_filters.update({party_field: ["in", self.filters.get(party_field)]})
+
 		self.return_entries = frappe._dict(
 			frappe.get_all(
 				doctype, filters=filters, or_filters=or_filters, fields=["name", "return_against"], as_list=1


### PR DESCRIPTION
Support ticket: [Support Ticket  - 33491](https://support.frappe.io/helpdesk/tickets/33491)

self.filters.get(party_field) is a list, not a value, so using the in operator to look into it.