### PR TITLE
fix: use `party` explicitly instead of party_field

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -729,11 +729,12 @@ class ReceivablePayableReport:
 			"company": self.filters.company,
 			"update_outstanding_for_self": 0,
 		}
+
 		or_filters = {}
-		for party_type in self.party_type:
+		if party_type := self.filters.party_type:
 			party_field = scrub(party_type)
-			if self.filters.get(party_field):
-				or_filters.update({party_field: ["in", self.filters.get(party_field)]})
+			if parties := self.filters.get("party"):
+				or_filters.update({party_field: ["in", parties]})
 
 		self.return_entries = frappe._dict(
 			frappe.get_all(


### PR DESCRIPTION
If we create an account dimension like Supplier, at that time, it creates the wrong or_filters.