### PR TITLE
refactor: print receipt on order complete on pos

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -449,6 +449,7 @@ erpnext.PointOfSale.Controller = class {
 	init_order_summary() {
 		this.order_summary = new erpnext.PointOfSale.PastOrderSummary({
 			wrapper: this.$components_wrapper,
+			settings: this.settings,
 			events: {
 				get_frm: () => this.frm,
 
@@ -489,7 +490,6 @@ erpnext.PointOfSale.Controller = class {
 					]);
 				},
 			},
-			pos_profile: this.pos_profile,
 		});
 	}
 

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -1,8 +1,8 @@
 erpnext.PointOfSale.PastOrderSummary = class {
-	constructor({ wrapper, events, pos_profile }) {
+	constructor({ wrapper, settings, events }) {
 		this.wrapper = wrapper;
 		this.events = events;
-		this.pos_profile = pos_profile;
+		this.print_receipt_on_order_complete = settings.print_receipt_on_order_complete;
 
 		this.init_component();
 	}
@@ -391,8 +391,8 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 		this.add_summary_btns(condition_btns_map);
 
-		if (after_submission) {
-			this.print_receipt_on_order_complete();
+		if (after_submission && this.print_receipt_on_order_complete) {
+			this.print_receipt();
 		}
 	}
 
@@ -459,18 +459,6 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 	toggle_component(show) {
 		show ? this.$component.css("display", "flex") : this.$component.css("display", "none");
-	}
-
-	async print_receipt_on_order_complete() {
-		const res = await frappe.db.get_value(
-			"POS Profile",
-			this.pos_profile,
-			"print_receipt_on_order_complete"
-		);
-
-		if (res.message.print_receipt_on_order_complete) {
-			this.print_receipt();
-		}
 	}
 
 	async is_pos_invoice_returnable(invoice) {


### PR DESCRIPTION
Fetching the configuration for `print_receipt_on_order_complete` from `settings` in `pos_controller.js` instead of making a separate call to fetch the configuration from POS Profile.