### PR TITLE
fix: incorrect status of Quotation under certain circumstances

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -3,8 +3,6 @@
 
 
 import frappe
-import frappe.query_builder
-import frappe.query_builder.functions
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import flt, getdate, nowdate


### PR DESCRIPTION
fixes #45801 

Fixed logical errors in code where status of Quotation was incorrectly set to Ordered instead of Partially Ordered. As per @nabinhait 's instructions, I have created a new PR where I am grouping using quotation_item reference and not item_code.