### PR TITLE
fix: hide subcontracted qty field if PO is not subcontracted

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -933,6 +933,7 @@
   },
   {
    "allow_on_submit": 1,
+   "depends_on": "eval:parent.is_subcontracted && !parent.is_old_subcontracting_flow",
    "fieldname": "subcontracted_quantity",
    "fieldtype": "Float",
    "label": "Subcontracted Quantity",
@@ -946,7 +947,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-02 16:58:26.059601",
+ "modified": "2025-03-13 17:27:43.468602",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",


### PR DESCRIPTION
The Subcontracted Quantity field should be hidden if PO is not subcontracted.