### PR TITLE
fix: get bom_no from sales order item and material request item

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -426,6 +426,7 @@ class ProductionPlan(Document):
 				mr_item.item_code,
 				mr_item.warehouse,
 				mr_item.description,
+				mr_item.bom_no,
 				((mr_item.qty - mr_item.ordered_qty) * mr_item.conversion_factor).as_("pending_qty"),
 			)
 			.distinct()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -892,6 +892,7 @@ def make_material_request(source_name, target_doc=None):
 					"name": "sales_order_item",
 					"parent": "sales_order",
 					"delivery_date": "required_by",
+					"bom_no": "bom_no",
 				},
 				"condition": lambda item: not frappe.db.exists(
 					"Product Bundle", {"name": item.item_code, "disabled": 0}


### PR DESCRIPTION
fixes #46043 

bom_no was not being fetched when:
1. MR is created from SO
2. Production Plan fetches items from MR