### PR TITLE
fix: ensure qty conversion when creating production plan from SO

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -364,8 +364,8 @@ class ProductionPlan(Document):
 
 		for item in items:
 			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
-			)
+				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)
+			) * item.conversion_factor
 
 		pi = frappe.qb.DocType("Packed Item")
 


### PR DESCRIPTION
Production Plan was created for `qty` instead of `stock_qty` (converted qty)

## Before

https://github.com/user-attachments/assets/9d7284d8-142e-4250-b50e-5035c78ba365


## After


https://github.com/user-attachments/assets/16a4eb19-a9bc-417a-b3f6-917dcdc0399e

