### PR TITLE
fix: Mark `multi_currency` in Journal Entry Based on Account and Company Currency

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -567,6 +567,13 @@ def book_revenue_via_journal_entry(
 	journal_entry.company = doc.company
 	journal_entry.voucher_type = "Deferred Revenue" if doc.doctype == "Sales Invoice" else "Deferred Expense"
 	journal_entry.process_deferred_accounting = deferred_process
+	company_currency = frappe.get_cached_value("Company", doc.company, "default_currency")
+
+	account_currencies = frappe.get_all(
+		"Account", filters={"name": ["in", [debit_account, credit_account]]}, pluck="account_currency"
+	)
+
+	journal_entry.multi_currency = any(currency != company_currency for currency in account_currencies)
 
 	debit_entry = {
 		"account": credit_account,


### PR DESCRIPTION
Support ticket: [Support Ticket  - 33868](https://support.frappe.io/helpdesk/tickets/33868)

Before: While creating a Journal Entry through `Process Deferred Accounting`, if the account currency differed from the company currency, the system would throw a validation error because the `multi_currency` checkbox was not checked.

Now: The `multi_currency` checkbox is checked when the account currency differs from the company currency, preventing the validation error.