### PR TITLE
fix(Sales Order): make `set_missing_values` set delivery date in item rows

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -766,6 +766,13 @@ class SalesOrder(SellingController):
 			voucher_type=self.doctype, voucher_no=self.name, sre_list=sre_list, notify=notify
 		)
 
+	def set_missing_values(self, for_validate=False):
+		super().set_missing_values(for_validate)
+
+		if self.delivery_date:
+			for item in self.items:
+				item.delivery_date = self.delivery_date
+
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:
 	"""Returns the unreserved quantity for the Sales Order Item."""


### PR DESCRIPTION
If the _Delivery Date_ is set at the top level of the **Sales Order** but missing in the item rows, `set_missing_values` should fix that.

For example, create a Sales Order, set the delivery date, then fetch items from a Quotation. Before, the new item rows didn't get the _Delivery Date_, now they do.