### PR TITLE
perf: faster count estimation

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -139,7 +139,7 @@ class PeriodClosingVoucher(AccountsController):
 		self.cancel_gl_entries()
 
 	def make_gl_entries(self):
-		if self.get_gle_count_in_selected_period() > 5000:
+		if frappe.db.estimate_count("GL Entry") > 100_000:
 			frappe.enqueue(
 				process_gl_and_closing_entries,
 				doc=self,
@@ -153,16 +153,6 @@ class PeriodClosingVoucher(AccountsController):
 			)
 		else:
 			process_gl_and_closing_entries(self)
-
-	def get_gle_count_in_selected_period(self):
-		return frappe.db.count(
-			"GL Entry",
-			{
-				"posting_date": ["between", [self.period_start_date, self.period_end_date]],
-				"company": self.company,
-				"is_cancelled": 0,
-			},
-		)
 
 	def get_pcv_gl_entries(self):
 		self.pl_accounts_reverse_gle = []

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -11,25 +11,14 @@ from erpnext.deprecation_dumpster import deprecated
 from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import StockClosing
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
 
-SLE_COUNT_LIMIT = 10_000
-
-
-def _estimate_table_row_count(doctype: str):
-	table = get_table_name(doctype)
-	return cint(
-		frappe.db.sql(
-			f"""select table_rows
-			   from  information_schema.tables
-			   where table_name = '{table}' ;"""
-		)[0][0]
-	)
+SLE_COUNT_LIMIT = 100_000
 
 
 def execute(filters=None):
 	if not filters:
 		filters = {}
 
-	sle_count = _estimate_table_row_count("Stock Ledger Entry")
+	sle_count = frappe.db.estimate_count("Stock Ledger Entry")
 
 	if (
 		sle_count > SLE_COUNT_LIMIT


### PR DESCRIPTION
These count queries themselves take quite a long time. `estimate_count`
uses info_schema stats to guess the approx count.
