### PR TITLE
fix: Debit and Credit not equal for Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1316,6 +1316,37 @@ class PurchaseInvoice(BuyingController):
 
 			warehouse_debit_amount = stock_amount
 
+		elif self.is_return and self.update_stock and self.is_internal_supplier and warehouse_debit_amount:
+			net_rate = item.base_net_amount
+			if item.sales_incoming_rate:  # for internal transfer
+				net_rate = item.qty * item.sales_incoming_rate
+
+			stock_amount = (
+				net_rate
+				+ item.item_tax_amount
+				+ flt(item.landed_cost_voucher_amount)
+				+ flt(item.get("amount_difference_with_purchase_invoice"))
+			)
+
+			if flt(stock_amount, net_amt_precision) != flt(warehouse_debit_amount, net_amt_precision):
+				cost_of_goods_sold_account = self.get_company_default("default_expense_account")
+				stock_adjustment_amt = stock_amount - warehouse_debit_amount
+
+				gl_entries.append(
+					self.get_gl_dict(
+						{
+							"account": cost_of_goods_sold_account,
+							"against": item.expense_account,
+							"debit": stock_adjustment_amt,
+							"remarks": self.get("remarks") or _("Stock Adjustment"),
+							"cost_center": item.cost_center,
+							"project": item.project or self.project,
+						},
+						account_currency,
+						item=item,
+					)
+				)
+
 		return warehouse_debit_amount
 
 	def make_tax_gl_entries(self, gl_entries):


### PR DESCRIPTION
Rate gets change during the purchase returns in case of moving average and cause the difference which needs to be booked under the COGS account