### PR TITLE
fix: add validation to rename_subcontracting_fields patch

### DIFF
--- a/erpnext/patches/v15_0/rename_subcontracting_fields.py
+++ b/erpnext/patches/v15_0/rename_subcontracting_fields.py
@@ -3,5 +3,12 @@ from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	rename_field("Purchase Order Item", "sco_qty", "subcontracted_quantity")
-	rename_field("Subcontracting Order Item", "sc_conversion_factor", "subcontracting_conversion_factor")
+	if frappe.db.table_exists("Purchase Order Item") and frappe.db.has_column(
+		"Purchase Order Item", "sco_qty"
+	):
+		rename_field("Purchase Order Item", "sco_qty", "subcontracted_quantity")
+
+	if frappe.db.table_exists("Subcontracting Order Item") and frappe.db.has_column(
+		"Subcontracting Order Item", "sc_conversion_factor"
+	):
+		rename_field("Subcontracting Order Item", "sc_conversion_factor", "subcontracting_conversion_factor")


### PR DESCRIPTION
Adds extra validation to the patch to prevent rare migration errors