### PR TITLE
refactor: remove default print format from sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -3,7 +3,6 @@
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2022-01-25 10:29:57.771398",
- "default_print_format": "Sales Invoice Print",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -2213,7 +2212,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-03-05 17:06:59.720616",
+ "modified": "2025-03-17 19:32:31.809658",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Reverting default print format changes from https://github.com/frappe/erpnext/pull/45403
![image](https://github.com/user-attachments/assets/80ca16a8-7a2e-4011-b9cb-95eedf6e31fa)

Reason https://github.com/frappe/frappe/pull/31708#issuecomment-2721155745
