### PR TITLE
fix: correct invoice order in payment reconcillaiton

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -9,8 +9,8 @@ import frappe
 import frappe.defaults
 from frappe import _, qb, throw
 from frappe.model.meta import get_field_precision
-from frappe.query_builder import AliasedQuery, Criterion, Table
-from frappe.query_builder.functions import Count, Round, Sum
+from frappe.query_builder import AliasedQuery, Case, Criterion, Table
+from frappe.query_builder.functions import Count, Max, Round, Sum
 from frappe.query_builder.utils import DocType
 from frappe.utils import (
 	add_days,
@@ -2008,6 +2008,15 @@ class QueryPaymentLedger:
 				.select(
 					ple.against_voucher_no.as_("voucher_no"),
 					Sum(ple.amount_in_account_currency).as_("amount_in_account_currency"),
+					Max(
+						Case().when(
+							(
+								(ple.voucher_no == ple.against_voucher_no)
+								& (ple.voucher_type == ple.against_voucher_type)
+							),
+							(ple.posting_date),
+						)
+					).as_("invoice_date"),
 				)
 				.where(ple.delinked == 0)
 				.where(Criterion.all(filter_on_against_voucher_no))
@@ -2015,7 +2024,7 @@ class QueryPaymentLedger:
 				.where(Criterion.all(self.dimensions_filter))
 				.where(Criterion.all(self.voucher_posting_date))
 				.groupby(ple.against_voucher_type, ple.against_voucher_no, ple.party_type, ple.party)
-				.orderby(ple.posting_date, ple.voucher_no)
+				.orderby(ple.invoice_date, ple.voucher_no)
 				.having(qb.Field("amount_in_account_currency") > 0)
 				.limit(self.limit)
 				.run()


### PR DESCRIPTION
Issue: When a query is executed without an ORDER BY clause, the data is sorted according to the primary key.
In a GROUP BY query, non-aggregate values are retrieved either randomly or from the first row of each aggregation (the exact behaviour is unclear). As a result, when retrieving outstanding invoices during payment reconciliation with limit, some invoices that have payments made on a later date do not appear because their posting dates are considered from the another payment ledger entry.

Steps to replicate:
- Create a Sales Invoice with the posting date as  1/9/2024
- Create a second sales invoice with the posting date as 1/10/2024
- Create a Partial Payment against 1 invoice on 2/10/2024 (with payment ledger entry name as 1 so that it will be first in ascending order)
- Now fetch Unreconciled Entries in Payment Reconciliation with invoice limit as 1.

2nd invoice will be fetched even though 1st invoice should be fetched because the first invoice's posting date will be from payment ledger entry of payment.

Query:
```
SELECT `against_voucher_no`,name,`amount_in_account_currency`,posting_date FROM `tabPayment Ledger Entry` WHERE `delinked`=0 AND `company`='ABC Ltd' AND `account_type`='Receivable' AND `account` IN ('1301 - Debtors - K') AND `party_type`='Customer' AND `party`='Registered'
```
<pre>+-----------------------+------------+----------------------------+--------------+
| against_voucher_no    | name       | amount_in_account_currency | posting_date |
+-----------------------+------------+----------------------------+--------------+
| ACC-SINV-2025-00034-1 | 03573      |           -20000.000000000 | 2025-03-26   |
| ACC-PAY-2025-00180    | 03574      |            20000.000000000 | 2025-03-18   |
| ACC-SINV-2025-00036   | 1oeddk6mok |           -50000.000000000 | 2025-03-17   |
| ACC-SINV-2025-00034-1 | 3plt76e1s8 |           348404.000000000 | 2024-09-01   |
| ACC-SINV-2025-00034-1 | 4jm3j8h1ib |           -20000.000000000 | 2025-03-17   |
| ACC-SINV-2025-00034-1 | 75qbtni7pn |           -20000.000000000 | 2025-03-18   |
| ACC-SINV-2025-00034-1 | 7ddqvelv59 |           -20000.000000000 | 2025-03-19   |
| ACC-SINV-2025-00034-1 | 7md88h2csr |           -20000.000000000 | 2025-03-19   |
| ACC-SINV-2025-00009   | 9ktanrhuq5 |          -314677.090000000 | 2025-02-28   |
| ACC-SINV-2025-00011   | 9l9nj060fo |           -52428.500000000 | 2025-02-28   |
| ACC-SINV-2025-00010   | 9majg9i9jm |          -126544.280000000 | 2025-02-28   |
| ACC-SINV-2025-00009   | t2ttd44fjc |           314677.090000000 | 2025-01-31   |
| ACC-SINV-2025-00010   | t6otqcv62m |           126544.280000000 | 2025-01-31   |
| ACC-SINV-2025-00011   | t9ma7jinr3 |            52428.500000000 | 2025-01-31   |
| ACC-SINV-2025-00036   | v4e25s0e9g |           295723.710000000 | 2025-02-28   |
| ACC-SINV-2025-00035   | v7i427iv7j |           126544.280000000 | 2025-02-28   |
+-----------------------+------------+----------------------------+--------------+
</pre>

Before
```
SELECT `against_voucher_no` `voucher_no`,SUM(`amount_in_account_currency`) `amount_in_account_currency`,posting_date FROM `tabPayment Ledger Entry` WHERE `delinked`=0 AND `company`='ABC Ltd' AND `account_type`='Receivable' AND `account` IN ('1301 - Debtors - K') AND `party_type`='Customer' AND `par
ty`='Registered' GROUP BY `against_voucher_type`,`against_voucher_no`,`party_type`,`party` HAVING `amount_in_account_currency`>0 ORDER BY `posting_date`,`voucher_no`;
```

<pre>+-----------------------+----------------------------+--------------+
| voucher_no            | amount_in_account_currency | posting_date |
+-----------------------+----------------------------+--------------+
| ACC-SINV-2025-00035   |           126544.280000000 | 2025-02-28   |
| ACC-SINV-2025-00036   |           245723.710000000 | 2025-03-17   |
| ACC-PAY-2025-00180    |            20000.000000000 | 2025-03-18   |
| ACC-SINV-2025-00034-1 |           248404.000000000 | 2025-03-26   |
+-----------------------+----------------------------+--------------+
</pre>
For voucher, ACC-SINV-2025-00034-1 posting date is 26-03-2025 even though voucher is created on 01-09-2024


After:
```
SELECT `against_voucher_no` `voucher_no`,SUM(`amount_in_account_currency`) `amount_in_account_currency`,MAX(CASE WHEN `voucher_no`=`against_voucher_no` AND `voucher_type`=`against_voucher_type` THEN `posting_date` END) `invoice_date` FROM `tabPayment Ledger Entry` WHERE `delinked`=0 AND `company`='ABC Ltd' AND `account_type`='Receivable' AND `account` IN ('1301 - Debtors - K') AND `party_type`='Customer' AND `party`='Registered' GROUP BY `against_voucher_type`,`against_voucher_no`,`party_type`,`party` HAVING `amount_in_account_currency`>0 ORDER BY `invoice_date`,`voucher_no`
```

<pre>+-----------------------+----------------------------+--------------+
| voucher_no            | amount_in_account_currency | invoice_date |
+-----------------------+----------------------------+--------------+
| ACC-SINV-2025-00034-1 |           248404.000000000 | 2024-09-01   |
| ACC-SINV-2025-00035   |           126544.280000000 | 2025-02-28   |
| ACC-SINV-2025-00036   |           245723.710000000 | 2025-02-28   |
| ACC-PAY-2025-00180    |            20000.000000000 | 2025-03-18   |
+-----------------------+----------------------------+--------------+
</pre>






Frappe Support Issue: https://support.frappe.io/app/hd-ticket/33761

