### PR TITLE
fix: fetch quality inspection parameter group

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -181,6 +181,9 @@ class QualityInspection(Document):
 			child = self.append("readings", {})
 			child.update(d)
 			child.status = "Accepted"
+			child.parameter_group = frappe.get_value(
+				"Quality Inspection Parameter", d.specification, "parameter_group"
+			)
 
 	@frappe.whitelist()
 	def get_quality_inspection_template(self):


### PR DESCRIPTION
Reference support ticket [34161](https://support.frappe.io/helpdesk/tickets/34161?view=VIEW-HD%20Ticket-003)

Quality Inspection Parameter Group was not being fetched when Quality Inspection Template field is set in Quality Inspection DocType