### PR TITLE
fix: repost future sle and gle after capitalization

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -124,6 +124,7 @@ class AssetCapitalization(StockController):
 		self.make_bundle_using_old_serial_batch_fields()
 		self.update_stock_ledger()
 		self.make_gl_entries()
+		self.repost_future_sle_and_gle()
 		self.update_target_asset()
 
 	def on_cancel(self):
@@ -137,6 +138,7 @@ class AssetCapitalization(StockController):
 		)
 		self.update_stock_ledger()
 		self.make_gl_entries()
+		self.repost_future_sle_and_gle()
 		self.restore_consumed_asset_items()
 
 	def set_title(self):


### PR DESCRIPTION
Added `self.repost_future_sle_and_gle()` in on_submit and on_cancel to ensure that future stock ledger entries are correctly updated when the transaction is submitted or cancelled for asset capitalization record.