### PR TITLE
fix: customer credit limit check based on `bypass_credit_limit_check` in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -579,8 +579,22 @@ class JournalEntry(AccountsController):
 		if customers:
 			from erpnext.selling.doctype.customer.customer import check_credit_limit
 
+			customer_details = frappe._dict(
+				frappe.db.get_all(
+					"Customer Credit Limit",
+					filters={
+						"parent": ["in", customers],
+						"parenttype": ["=", "Customer"],
+						"company": ["=", self.company],
+					},
+					fields=["parent", "bypass_credit_limit_check"],
+					as_list=True,
+				)
+			)
+
 			for customer in customers:
-				check_credit_limit(customer, self.company)
+				ignore_outstanding_sales_order = bool(customer_details.get(customer))
+				check_credit_limit(customer, self.company, ignore_outstanding_sales_order)
 
 	def validate_cheque_info(self):
 		if self.voucher_type in ["Bank Entry"]:


### PR DESCRIPTION
Issue: In the journal Entry, while checking the credit limit `bypass_credit_limit_check`(Bypass Credit Limit Check at Sales Order) is not respected.


Steps to replicate:
- Create a Customer with a Credit Limit of 1000 and check Bypass Credit Limit Check at Sales Order.
- Create a sales order for 1000.
- Create a Journal Entry for the customer debiting 1000 rs.

The error will be raised even though bypass_credit_limit_check is checked.

Closes: https://github.com/frappe/erpnext/issues/41426
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/33400