### PR TITLE
fix: not able to make PR against stand alone Debit Note

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -194,7 +194,7 @@ erpnext.buying = {
 			}
 
 			qty(doc, cdt, cdn) {
-				if ((doc.doctype == "Purchase Receipt") || (doc.doctype == "Purchase Invoice" && (doc.update_stock || doc.is_return))) {
+				if ((doc.doctype == "Purchase Receipt") || (doc.doctype == "Purchase Invoice" && doc.update_stock)) {
 					this.calculate_received_qty(doc, cdt, cdn)
 				}
 				super.qty(doc, cdt, cdn);


### PR DESCRIPTION
- Make stand alone Debit Note
- Change the qty to -2 and save and submit
- Make purchase receipt against the Debit Note
- You will see the items table blank in the purchase receipt.