### PR TITLE
refactor: Use `status_updater` as a class property

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -226,11 +226,11 @@ class PurchaseInvoice(BuyingController):
 
 	@property
 	def status_updater(self) -> list[dict]:
-		if self.is_return and not self.update_billed_amount_in_purchase_order:
-			# `billed_amt` updation is bypassed
-			updater = []
-		else:
-			updater = [
+		updater = []
+
+		# Skip `billed_amt updation` if True
+		if not (self.is_return and not self.update_billed_amount_in_purchase_order):
+			updater.append(
 				{
 					"source_dt": "Purchase Invoice Item",
 					"target_dt": "Purchase Order Item",
@@ -243,7 +243,7 @@ class PurchaseInvoice(BuyingController):
 					"percent_join_field": "purchase_order",
 					"overflow_type": "billing",
 				}
-			]
+			)
 
 		if cint(self.update_stock):
 			updater.extend(

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -240,11 +240,11 @@ class SalesInvoice(SellingController):
 
 	@property
 	def status_updater(self) -> list[dict]:
-		if self.is_return and not self.update_billed_amount_in_sales_order:
-			# `billed_amt` updation is bypassed
-			updater = []
-		else:
-			updater = [
+		updater = []
+
+		# Skip `billed_amt` updation if True
+		if not (self.is_return and not self.update_billed_amount_in_sales_order):
+			updater.append(
 				{
 					"source_dt": "Sales Invoice Item",
 					"target_field": "billed_amt",
@@ -259,7 +259,7 @@ class SalesInvoice(SellingController):
 					"keyword": "Billed",
 					"overflow_type": "billing",
 				}
-			]
+			)
 
 		if not cint(self.update_stock):
 			return updater

--- a/erpnext/selling/doctype/installation_note/installation_note.py
+++ b/erpnext/selling/doctype/installation_note/installation_note.py
@@ -46,7 +46,10 @@ class InstallationNote(TransactionBase):
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.status_updater = [
+
+	@property
+	def status_updater(self) -> list[dict]:
+		return [
 			{
 				"source_dt": "Installation Note Item",
 				"target_dt": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -144,7 +144,10 @@ class DeliveryNote(SellingController):
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.status_updater = [
+
+	@property
+	def status_updater(self) -> list[dict]:
+		updater = [
 			{
 				"source_dt": "Delivery Note Item",
 				"target_dt": "Sales Order Item",
@@ -178,7 +181,7 @@ class DeliveryNote(SellingController):
 			},
 		]
 		if cint(self.is_return):
-			self.status_updater.extend(
+			updater.extend(
 				[
 					{
 						"source_dt": "Delivery Note Item",
@@ -208,6 +211,8 @@ class DeliveryNote(SellingController):
 					},
 				]
 			)
+
+		return updater
 
 	def onload(self):
 		super().onload()

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -35,7 +35,10 @@ class PackingSlip(StatusUpdater):
 
 	def __init__(self, *args, **kwargs) -> None:
 		super().__init__(*args, **kwargs)
-		self.status_updater = [
+
+	@property
+	def status_updater(self) -> list[dict]:
+		return [
 			{
 				"target_dt": "Delivery Note Item",
 				"join_field": "dn_detail",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -141,7 +141,10 @@ class PurchaseReceipt(BuyingController):
 
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
-		self.status_updater = [
+
+	@property
+	def status_updater(self) -> list[dict]:
+		updater = [
 			{
 				"target_dt": "Purchase Order Item",
 				"join_field": "purchase_order_item",
@@ -195,7 +198,7 @@ class PurchaseReceipt(BuyingController):
 		]
 
 		if cint(self.is_return):
-			self.status_updater.extend(
+			updater.extend(
 				[
 					{
 						"source_dt": "Purchase Receipt Item",
@@ -224,6 +227,8 @@ class PurchaseReceipt(BuyingController):
 					},
 				]
 			)
+
+		return updater
 
 	def before_validate(self):
 		from erpnext.stock.doctype.putaway_rule.putaway_rule import apply_putaway_rule

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -84,7 +84,9 @@ class SubcontractingOrder(SubcontractingController):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 
-		self.status_updater = [
+	@property
+	def status_updater(self) -> list[dict]:
+		return [
 			{
 				"source_dt": "Subcontracting Order Item",
 				"target_dt": "Material Request Item",


### PR DESCRIPTION
## Issue
- The current design entirely relies on `__init__` to resolve/set the `status_updater` attribute
- Any changes to this attribute are later manually done elsewhere before evaluating the `status_updater` (on submit/cancel)
- This works fine via desk because each save/submit/cancel action creates a new instance of the class and so `status_updater` is (re)initialized with the doc's newer values
- This does not work fine/is not intuitive via scripts/tests. _I discovered this while writing a test_

Example:

Consider the `status_updater` in `delivery_note.py` where:
```py
1 def __init__(self):
2	# Watered down for obvious reasons
3	...
4	self.status_updater = [1, 2]
5	if cint(self.is_return):
6		self.status_updater.extend([3,4])
```

On instantiation of class `DeliveryNote` if it does not have the document values, line **5** does not evaluate to True ever.

```py
# Creates an instance of a Delivery Note -> runs `__init__` -> `self.status_updater` is computed and set
# `self.is_return` is falsy. So even though we intend to create a return document the status updater has an incorrect state
1	delivery_note_return = frappe.new_doc("Delivery Note")
# `self.status_updater` is already initialized so this has no automatic impact
2	delivery_note_return.is_return = 1
3	...
# Does not back update some fields because [3,4] are missing
4	delivery_note.submit()
```
<hr>
_Our solution here is to modify this attribute explicitly, which now has to be done in tests as well._ 

## Solution
- Switch this attribute to a property that dynamically determines `status_updater` based on the document's current state
- Behaviours are now predictable and `status_updater`'s value definition is in one place

A pattern like:
```py
def __init__(self):
	...
	self.status_updater = [1]

def on_submit(self):
	if self.some_value:
		self.status_updater = []
	self.status_updater.append(2)

	self.update_prevdoc_status()  # Applies the status updater

def on_cancel(self):
	if self.some_value:
		self.status_updater = []
	self.status_updater.append(2)

	self.update_prevdoc_status()  # Applies the status updater
```

Is rewritten like this:
```py
def __init__(self):
	...

@property
def status_updater(self):
	updater = [2]
	if not self.some_value:
		updater.append(1)
	return updater

def on_submit(self):
	self.update_prevdoc_status()  # Applies the status updater

def on_cancel(self):
	self.update_prevdoc_status()  # Applies the status updater
```

Todo:

- [ ] Add a setter for the property as other apps might use `self.status_updater = ...`