### PR TITLE
fix: broken Frappe School links

### DIFF
--- a/erpnext/accounts/workspace/accounting/accounting.json
+++ b/erpnext/accounts/workspace/accounting/accounting.json
@@ -621,7 +621,7 @@
    "doc_view": "List",
    "label": "Learn Accounting",
    "type": "URL",
-   "url": "https://frappe.school/courses/erpnext-accounting?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/erpnext-accounting?utm_source=in_app"
   },
   {
    "label": "Chart of Accounts",

--- a/erpnext/buying/workspace/buying/buying.json
+++ b/erpnext/buying/workspace/buying/buying.json
@@ -537,7 +537,7 @@
    "doc_view": "List",
    "label": "Learn Procurement",
    "type": "URL",
-   "url": "https://frappe.school/courses/procurement?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/procurement?utm_source=in_app"
   },
   {
    "color": "Yellow",

--- a/erpnext/manufacturing/workspace/manufacturing/manufacturing.json
+++ b/erpnext/manufacturing/workspace/manufacturing/manufacturing.json
@@ -415,7 +415,7 @@
    "doc_view": "List",
    "label": "Learn Manufacturing",
    "type": "URL",
-   "url": "https://frappe.school/courses/manufacturing?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/manufacturing?utm_source=in_app"
   },
   {
    "color": "Grey",

--- a/erpnext/projects/workspace/projects/projects.json
+++ b/erpnext/projects/workspace/projects/projects.json
@@ -210,7 +210,7 @@
    "doc_view": "List",
    "label": "Learn Project Management",
    "type": "URL",
-   "url": "https://frappe.school/courses/project-management?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/project-management?utm_source=in_app"
   },
   {
    "color": "Blue",

--- a/erpnext/selling/workspace/selling/selling.json
+++ b/erpnext/selling/workspace/selling/selling.json
@@ -640,7 +640,7 @@
    "doc_view": "List",
    "label": "Learn Sales Management",
    "type": "URL",
-   "url": "https://frappe.school/courses/sales-management-course?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/sales-management-course?utm_source=in_app"
   },
   {
    "label": "Point of Sale",

--- a/erpnext/stock/workspace/stock/stock.json
+++ b/erpnext/stock/workspace/stock/stock.json
@@ -802,7 +802,7 @@
    "doc_view": "List",
    "label": "Learn Inventory Management",
    "type": "URL",
-   "url": "https://frappe.school/courses/inventory-management?utm_source=in_app"
+   "url": "https://frappe.school/lms/courses/inventory-management?utm_source=in_app"
   },
   {
    "color": "Yellow",


### PR DESCRIPTION
Frappe School links in the workspace JSON files were outdated, so I updated them to their correct URLs.

Updated the links by adding /lms/  in the path:

Old: https://school.frappe.io/courses/<module-name>?utm_source=in_app
New: https://school.frappe.io/lms/courses/<module-name>?utm_source=in_app

This replaces PR #46599 which was closed due to an issue with commit message formatting.