### PR TITLE
feat: add docstatus filter for asset

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
@@ -38,6 +38,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Asset",
+   "link_filters": "[[\"Asset\",\"docstatus\",\"=\",\"1\"]]",
    "options": "Asset",
    "reqd": 1
   },
@@ -207,7 +208,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:34.135004",
+ "modified": "2025-03-19 12:33:17.150605",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Depreciation Schedule",


### PR DESCRIPTION
**Issue:** Filter is not applied to the Asset field in the Asset Depreciation Schedule, causing an error while saving

**Solution:**
Applied filter for asset field

**Before:**

[before.webm](https://github.com/user-attachments/assets/c3b782a9-1f55-4193-974b-43eff887aa8b)

**After:**

[after.webm](https://github.com/user-attachments/assets/de22dc9e-ae71-497d-8d65-84127b46e51c)

**Backport Needed for version-15**