### PR TITLE
fix: fetch bom_no when updating items in sales order

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3731,6 +3731,9 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		if d.get("schedule_date") and parent_doctype == "Purchase Order":
 			child_item.schedule_date = d.get("schedule_date")
 
+		if d.get("bom_no") and parent_doctype == "Sales Order":
+			child_item.bom_no = d.get("bom_no")
+
 		if flt(child_item.price_list_rate):
 			if flt(child_item.rate) > flt(child_item.price_list_rate):
 				#  if rate is greater than price_list_rate, set margin

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -713,6 +713,7 @@ erpnext.utils.update_child_items = function (opts) {
 								uom,
 								conversion_factor,
 								item_name,
+								default_bom,
 							} = r.message;
 
 							const row = dialog.fields_dict.trans_items.df.data.find(
@@ -725,6 +726,7 @@ erpnext.utils.update_child_items = function (opts) {
 									qty: me.doc.qty || qty,
 									rate: me.doc.rate || rate,
 									item_name: item_name,
+									bom_no: default_bom,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -713,7 +713,7 @@ erpnext.utils.update_child_items = function (opts) {
 								uom,
 								conversion_factor,
 								item_name,
-								default_bom,
+								bom_no,
 							} = r.message;
 
 							const row = dialog.fields_dict.trans_items.df.data.find(
@@ -726,7 +726,7 @@ erpnext.utils.update_child_items = function (opts) {
 									qty: me.doc.qty || qty,
 									rate: me.doc.rate || rate,
 									item_name: item_name,
-									bom_no: default_bom,
+									bom_no: bom_no,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -479,6 +479,7 @@ def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> It
 			"weight_per_unit": ctx.weight_per_unit or item.get("weight_per_unit"),
 			"weight_uom": ctx.weight_uom or item.get("weight_uom"),
 			"grant_commission": item.get("grant_commission"),
+			"default_bom": item.default_bom,
 		}
 	)
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -479,7 +479,6 @@ def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> It
 			"weight_per_unit": ctx.weight_per_unit or item.get("weight_per_unit"),
 			"weight_uom": ctx.weight_uom or item.get("weight_uom"),
 			"grant_commission": item.get("grant_commission"),
-			"default_bom": item.default_bom,
 		}
 	)
 


### PR DESCRIPTION
Reference support ticket [34183](https://support.frappe.io/helpdesk/tickets/34183?view=VIEW-HD%20Ticket-003)

This PR will fetch default BOM of item and apply it on the new item when updating items in a sales order