### PR TITLE
refactor: removed redundant message display for each item row cost center update

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -447,22 +447,21 @@ erpnext.sales_common = {
 							args: { project: this.frm.doc.project },
 							callback: function (r, rt) {
 								if (!r.exc) {
-									$.each(me.frm.doc["items"] || [], function (i, row) {
-										if (r.message) {
+									if (r.message) {
+										$.each(me.frm.doc["items"] || [], function (i, row) {
 											frappe.model.set_value(
 												row.doctype,
 												row.name,
 												"cost_center",
 												r.message
 											);
-											frappe.msgprint(
-												__(
-													"Cost Center For Item with Item Code {0} has been Changed to {1}",
-													[row.item_name, r.message]
-												)
-											);
-										}
-									});
+										});
+										frappe.msgprint(
+											__("Cost Center for Item rows has been updated to {0}", [
+												r.message,
+											])
+										);
+									}
 								}
 							},
 						});


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/312b2b67-55b0-4a28-8643-d1666ba16bb2)


After:
![image](https://github.com/user-attachments/assets/41e24166-08db-4664-b6bd-305ce040abd3)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/34099
