### PR TITLE
fix: decimal garbage on variable total

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -833,9 +833,8 @@ class JournalEntry(AccountsController):
 				if invoice.docstatus != 1:
 					frappe.throw(_("{0} {1} is not submitted").format(reference_type, reference_name))
 
-				if flt(total, invoice.precision("outstanding_amount")) and flt(
-					invoice.outstanding_amount, invoice.precision("outstanding_amount")
-				) < flt(total, invoice.precision("outstanding_amount")):
+				precision = invoice.precision("outstanding_amount")
+				if total and flt(invoice.outstanding_amount, precision) < flt(total, precision):
 					frappe.throw(
 						_("Payment against {0} {1} cannot be greater than Outstanding Amount {2}").format(
 							reference_type, reference_name, invoice.outstanding_amount

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -833,11 +833,9 @@ class JournalEntry(AccountsController):
 				if invoice.docstatus != 1:
 					frappe.throw(_("{0} {1} is not submitted").format(reference_type, reference_name))
 
-				outstanding_precision = invoice.precision("outstanding_amount")
-				if (
-					flt(total, outstanding_precision) and 
-					flt(invoice.outstanding_amount, outstanding_precision) < flt(total, outstanding_precision)
-				):
+				if flt(total, invoice.precision("outstanding_amount")) and flt(
+					invoice.outstanding_amount, invoice.precision("outstanding_amount")
+				) < flt(total, invoice.precision("outstanding_amount")):
 					frappe.throw(
 						_("Payment against {0} {1} cannot be greater than Outstanding Amount {2}").format(
 							reference_type, reference_name, invoice.outstanding_amount

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -828,14 +828,16 @@ class JournalEntry(AccountsController):
 				"Debit Note",
 				"Credit Note",
 			]:
-				invoice = frappe.db.get_value(
-					reference_type, reference_name, ["docstatus", "outstanding_amount"], as_dict=1
-				)
+				invoice = frappe.get_doc(reference_type, reference_name)
 
 				if invoice.docstatus != 1:
 					frappe.throw(_("{0} {1} is not submitted").format(reference_type, reference_name))
 
-				if total and flt(invoice.outstanding_amount) < total:
+				outstanding_precision = invoice.precision("outstanding_amount")
+				if (
+					flt(total, outstanding_precision) and 
+					flt(invoice.outstanding_amount, outstanding_precision) < flt(total, outstanding_precision)
+				):
 					frappe.throw(
 						_("Payment against {0} {1} cannot be greater than Outstanding Amount {2}").format(
 							reference_type, reference_name, invoice.outstanding_amount


### PR DESCRIPTION
Problem:
When we add more than one line for the same invoice, following the payment schedule, we come across the following stack:

"Payment against {0} {1} cannot be greater than Outstanding Amount {2}"

However, the values ​​are correct, but in Python it looks like garbage.

total = 7096.780000000001
but the right value is "7096.78" the "0000000001" is garbage.

![image](https://github.com/user-attachments/assets/84346644-0918-4dae-a4cb-4d9bbfda35c1)


To reproduce is only make on Journal Entry and add 3 rows on Accounting Entries for the same Sales Invoice (following the payment schedule)
![image](https://github.com/user-attachments/assets/e5f23b54-5099-4d9c-8cfa-e744e6fcc8a2)

We carry out this inclusion based on the payment schedule following a personalization...
