### PR TITLE
fix: date added to wrong patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -402,8 +402,8 @@ erpnext.patches.v15_0.sync_auto_reconcile_config
 execute:frappe.db.set_single_value("Accounts Settings", "exchange_gain_loss_posting_date", "Payment")
 erpnext.patches.v14_0.disable_add_row_in_gross_profit
 erpnext.patches.v14_0.update_posting_datetime
-erpnext.patches.v15_0.rename_field_from_rate_difference_to_amount_difference #2025-03-18
-erpnext.patches.v15_0.recalculate_amount_difference_field
+erpnext.patches.v15_0.rename_field_from_rate_difference_to_amount_difference
+erpnext.patches.v15_0.recalculate_amount_difference_field #2025-03-18
 erpnext.patches.v15_0.rename_sla_fields #2025-03-12
 erpnext.stock.doctype.stock_ledger_entry.patches.ensure_sle_indexes
 erpnext.patches.v15_0.update_query_report


### PR DESCRIPTION
I don't know how I made this mistake but in PR https://github.com/frappe/erpnext/pull/46573, I added the date to rerun the `recalculate_amount_difference_field` patch to `rename_field_from_rate_difference_to_amount_difference` instead.