### PR TITLE
fix: unwired order_by argument in get_transaction_list

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -69,7 +69,7 @@ def get_transaction_list(
 	filters=None,
 	limit_start=0,
 	limit_page_length=20,
-	order_by="creation",
+	order_by="creation desc",
 	custom=False,
 ):
 	user = frappe.session.user
@@ -115,7 +115,7 @@ def get_transaction_list(
 		limit_page_length,
 		fields="name",
 		ignore_permissions=ignore_permissions,
-		order_by="creation desc",
+		order_by=order_by,
 	)
 
 	if custom:


### PR DESCRIPTION
* lol on how it was updated from modified in both the places (version 15), but wasn't fixed
