### PR TITLE
fix: multiple Bank Reconciliation Tool issues

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt
 
 from erpnext import get_default_cost_center
@@ -517,10 +518,9 @@ def subtract_allocations(gl_account, vouchers):
 	voucher_allocated_amounts = get_total_allocated_amount(voucher_docs)
 
 	for voucher in vouchers:
-		rows = voucher_allocated_amounts.get((voucher.get("doctype"), voucher.get("name"))) or []
-		filtered_row = list(filter(lambda row: row.get("gl_account") == gl_account, rows))
+		row = voucher_allocated_amounts.get((voucher.get("doctype"), voucher.get("name")), {}).get(gl_account)
 
-		if amount := None if not filtered_row else filtered_row[0]["total"]:
+		if amount := None if not row else row["total"]:
 			voucher["paid_amount"] -= amount
 
 		copied.append(voucher)
@@ -796,26 +796,20 @@ def get_je_matching_query(
 	je = frappe.qb.DocType("Journal Entry")
 	jea = frappe.qb.DocType("Journal Entry Account")
 
-	ref_condition = je.cheque_no == transaction.reference_number
-	ref_rank = frappe.qb.terms.Case().when(ref_condition, 1).else_(0)
-
 	amount_field = f"{cr_or_dr}_in_account_currency"
-	amount_equality = getattr(jea, amount_field) == transaction.unallocated_amount
-	amount_rank = frappe.qb.terms.Case().when(amount_equality, 1).else_(0)
 
 	filter_by_date = je.posting_date.between(from_date, to_date)
 	if cint(filter_by_reference_date):
 		filter_by_date = je.cheque_date.between(from_reference_date, to_reference_date)
 
-	query = (
+	subquery = (
 		frappe.qb.from_(jea)
 		.join(je)
 		.on(jea.parent == je.name)
 		.select(
-			(ref_rank + amount_rank + 1).as_("rank"),
+			Sum(getattr(jea, amount_field)).as_("paid_amount"),
 			ConstantColumn("Journal Entry").as_("doctype"),
 			je.name,
-			getattr(jea, amount_field).as_("paid_amount"),
 			je.cheque_no.as_("reference_no"),
 			je.cheque_date.as_("reference_date"),
 			je.pay_to_recd_from.as_("party"),
@@ -827,9 +821,23 @@ def get_je_matching_query(
 		.where(je.voucher_type != "Opening Entry")
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
-		.where(amount_equality if exact_match else getattr(jea, amount_field) > 0.0)
 		.where(filter_by_date)
+		.groupby(je.name)
 		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
+	)
+
+	ref_condition = subquery.reference_no == transaction.reference_number
+	ref_rank = frappe.qb.terms.Case().when(ref_condition, 1).else_(0)
+	amount_equality = subquery.paid_amount == transaction.unallocated_amount
+	amount_rank = frappe.qb.terms.Case().when(amount_equality, 1).else_(0)
+
+	query = (
+		frappe.qb.from_(subquery)
+		.select(
+			"*",
+			(ref_rank + amount_rank + 1).as_("rank"),
+		)
+		.where(amount_equality if exact_match else subquery.paid_amount > 0.0)
 	)
 
 	if frappe.flags.auto_reconcile_vouchers is True:

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -39,31 +39,6 @@ frappe.ui.form.on("Bank Transaction", {
 	},
 });
 
-frappe.ui.form.on("Bank Transaction Payments", {
-	payment_entries_remove: function (frm, cdt, cdn) {
-		update_clearance_date(frm, cdt, cdn);
-	},
-});
-
-const update_clearance_date = (frm, cdt, cdn) => {
-	if (frm.doc.docstatus === 1) {
-		frappe
-			.xcall("erpnext.accounts.doctype.bank_transaction.bank_transaction.unclear_reference_payment", {
-				doctype: cdt,
-				docname: cdn,
-				bt_name: frm.doc.name,
-			})
-			.then((e) => {
-				if (e == "success") {
-					frappe.show_alert({
-						message: __("Document {0} successfully uncleared", [e]),
-						indicator: "green",
-					});
-				}
-			});
-	}
-};
-
 function set_bank_statement_filter(frm) {
 	frm.set_query("bank_statement", function () {
 		return {

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -31,6 +31,12 @@ frappe.ui.form.on("Bank Transaction", {
 				},
 			};
 		});
+
+		frm.set_query("bank_account", function () {
+			return {
+				filters: { is_company_account: 1 },
+			};
+		});
 	},
 
 	get_payment_doctypes: function () {

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -84,16 +84,16 @@ class BankTransaction(Document):
 		if not self.payment_entries:
 			return
 
-		pe = []
+		references = set()
 		for row in self.payment_entries:
 			reference = (row.payment_document, row.payment_entry)
-			if reference in pe:
+			if reference in references:
 				frappe.throw(
 					_("{0} {1} is allocated twice in this Bank Transaction").format(
 						row.payment_document, row.payment_entry
 					)
 				)
-			pe.append(reference)
+			references.add(reference)
 
 	def update_allocated_amount(self):
 		allocated_amount = (
@@ -113,8 +113,8 @@ class BankTransaction(Document):
 
 	def before_update_after_submit(self):
 		self.validate_duplicate_references()
-		self.allocate_payment_entries()
 		self.update_allocated_amount()
+		self.allocate_payment_entries()
 		self.set_status()
 
 	def on_cancel(self):
@@ -156,39 +156,55 @@ class BankTransaction(Document):
 		to_remove = []
 		payment_entry_docs = [(pe.payment_document, pe.payment_entry) for pe in self.payment_entries]
 		pe_bt_allocations = get_total_allocated_amount(payment_entry_docs)
+		gles = get_related_bank_gl_entries(payment_entry_docs)
+		gl_bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
 
 		for payment_entry in self.payment_entries:
 			if payment_entry.allocated_amount == 0.0:
-				unallocated_amount, should_clear, latest_transaction = get_clearance_details(
+				allocable_amount, should_clear, clearance_date = get_clearance_details(
 					self,
 					payment_entry,
 					pe_bt_allocations.get((payment_entry.payment_document, payment_entry.payment_entry))
-					or [],
+					or {},
+					gles.get((payment_entry.payment_document, payment_entry.payment_entry)) or {},
+					gl_bank_account,
 				)
 
-				if 0.0 == unallocated_amount:
+				if 0.0 == allocable_amount:
 					if should_clear:
-						latest_transaction.clear_linked_payment_entry(payment_entry)
+						self.clear_linked_payment_entry(payment_entry, clearance_date=clearance_date)
 					to_remove.append(payment_entry)
 
 				elif remaining_amount <= 0.0:
 					to_remove.append(payment_entry)
 
-				elif 0.0 < unallocated_amount <= remaining_amount:
-					payment_entry.allocated_amount = unallocated_amount
-					remaining_amount -= unallocated_amount
+				elif 0.0 < allocable_amount <= remaining_amount:
+					payment_entry.allocated_amount = allocable_amount
+					remaining_amount = flt(
+						remaining_amount - allocable_amount, self.precision("unallocated_amount")
+					)
 					if should_clear:
-						latest_transaction.clear_linked_payment_entry(payment_entry)
+						self.clear_linked_payment_entry(
+							payment_entry, clearance_date=clearance_date, allocated_amount=allocable_amount
+						)
 
-				elif 0.0 < unallocated_amount:
+				elif 0.0 < allocable_amount:
 					payment_entry.allocated_amount = remaining_amount
 					remaining_amount = 0.0
+					if payment_entry.payment_document == "Bank Transaction":
+						self.clear_linked_payment_entry(
+							payment_entry,
+							clearance_date=clearance_date,
+							allocated_amount=payment_entry.allocated_amount,
+						)
 
-				elif 0.0 > unallocated_amount:
-					frappe.throw(_("Voucher {0} is over-allocated by {1}").format(unallocated_amount))
+				elif 0.0 > allocable_amount:
+					frappe.throw(_("Voucher {0} is over-allocated by {1}").format(allocable_amount))
 
 		for payment_entry in to_remove:
 			self.remove(payment_entry)
+
+		self.update_allocated_amount()
 
 	@frappe.whitelist()
 	def remove_payment_entries(self):
@@ -202,11 +218,44 @@ class BankTransaction(Document):
 		self.clear_linked_payment_entry(payment_entry, for_cancel=True)
 		self.remove(payment_entry)
 
-	def clear_linked_payment_entry(self, payment_entry, for_cancel=False):
-		clearance_date = None if for_cancel else self.date
-		set_voucher_clearance(
-			payment_entry.payment_document, payment_entry.payment_entry, clearance_date, self
-		)
+	def clear_linked_payment_entry(
+		self, payment_entry, clearance_date=None, allocated_amount=None, for_cancel=False
+	):
+		clearance_date = None if for_cancel else (clearance_date or self.date)
+		doctype = payment_entry.payment_document
+		docname = payment_entry.payment_entry
+
+		if doctype in get_doctypes_for_bank_reconciliation():
+			if doctype == "Sales Invoice":
+				frappe.db.set_value(
+					"Sales Invoice Payment",
+					dict(parenttype=doctype, parent=docname),
+					"clearance_date",
+					clearance_date,
+				)
+				return
+
+			frappe.db.set_value(doctype, docname, "clearance_date", clearance_date)
+
+		elif doctype == "Bank Transaction":
+			# For when a second bank transaction has fixed another, e.g. refund
+			bt = frappe.get_doc(doctype, docname)
+			if clearance_date and allocated_amount:
+				bt.append(
+					"payment_entries",
+					{
+						"payment_document": "Bank Transaction",
+						"payment_entry": self.name,
+						"allocated_amount": allocated_amount,
+					},
+				)
+				bt.save()
+			else:
+				for pe in bt.payment_entries:
+					if pe.payment_document == self.doctype and pe.payment_entry == self.name:
+						bt.remove(pe)
+						bt.save()
+						break
 
 	def auto_set_party(self):
 		from erpnext.accounts.doctype.bank_transaction.auto_match_party import AutoMatchParty
@@ -238,65 +287,87 @@ def get_doctypes_for_bank_reconciliation():
 	return frappe.get_hooks("bank_reconciliation_doctypes")
 
 
-def get_clearance_details(transaction, payment_entry, bt_allocations):
+def get_clearance_details(transaction, payment_entry, bt_allocations, gles, gl_bank_account):
 	"""
 	There should only be one bank gle for a voucher.
 	Could be none for a Bank Transaction.
 	But if a JE, could affect two banks.
 	Should only clear the voucher if all bank gles are allocated.
 	"""
-	gl_bank_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
-	gles = get_related_bank_gl_entries(payment_entry.payment_document, payment_entry.payment_entry)
+	transaction_date = frappe.utils.getdate(transaction.date)
 
-	unallocated_amount = min(
-		transaction.unallocated_amount,
-		get_paid_amount(payment_entry, transaction.currency, gl_bank_account),
+	if payment_entry.payment_document == "Bank Transaction":
+		unallocated_amount = abs(
+			frappe.db.get_value("Bank Transaction", payment_entry.payment_entry, "unallocated_amount")
+		)
+		return unallocated_amount, True, transaction_date
+
+	has_matching_gle = any(gle_account == gl_bank_account for gle_account in gles)
+
+	if not has_matching_gle:
+		frappe.throw(
+			_("Voucher {0} is not affecting bank account {1}").format(
+				payment_entry.payment_entry, gl_bank_account
+			)
+		)
+
+	allocable_amount = gles.pop(gl_bank_account) or 0
+
+	if allocable_amount <= 0.0:
+		frappe.throw(
+			_("Voucher {0} value is broken: {1}").format(payment_entry.payment_entry, allocable_amount)
+		)
+
+	matching_bt_allocaion = bt_allocations.pop(gl_bank_account, {})
+	allocable_amount = flt(
+		allocable_amount - matching_bt_allocaion.get("total", 0), transaction.precision("unallocated_amount")
 	)
-	unmatched_gles = len(gles)
-	latest_transaction = transaction
-	for gle in gles:
-		if gle["gl_account"] == gl_bank_account:
-			if gle["amount"] <= 0.0:
-				frappe.throw(
-					_("Voucher {0} value is broken: {1}").format(payment_entry.payment_entry, gle["amount"])
-				)
+	bt_allocation_date = matching_bt_allocaion.get("latest_date", None)
 
-			unmatched_gles -= 1
-			unallocated_amount = gle["amount"]
-			for a in bt_allocations:
-				if a["gl_account"] == gle["gl_account"]:
-					unallocated_amount = gle["amount"] - a["total"]
-					if frappe.utils.getdate(transaction.date) < a["latest_date"]:
-						latest_transaction = frappe.get_doc("Bank Transaction", a["latest_name"])
-		else:
-			# Must be a Journal Entry affecting more than one bank
-			for a in bt_allocations:
-				if a["gl_account"] == gle["gl_account"] and a["total"] == gle["amount"]:
-					unmatched_gles -= 1
+	clearance_date = transaction_date if not bt_allocation_date else max(transaction_date, bt_allocation_date)
 
-	return unallocated_amount, unmatched_gles == 0, latest_transaction
+	should_clear = all(
+		gles[gle_account] == bt_allocations.get(gle_account, {}).get("total", 0) for gle_account in gles
+	)
+
+	return allocable_amount, should_clear, clearance_date
 
 
-def get_related_bank_gl_entries(doctype, docname):
+def get_related_bank_gl_entries(docs):
 	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
-	return frappe.db.sql(
+	if not docs:
+		return {}
+
+	result = frappe.db.sql(
 		"""
-		SELECT
-			ABS(gle.credit_in_account_currency - gle.debit_in_account_currency) AS amount,
-			gle.account AS gl_account
-		FROM
-			`tabGL Entry` gle
-		LEFT JOIN
-			`tabAccount` ac ON ac.name=gle.account
-		WHERE
-			ac.account_type = 'Bank'
-			AND gle.voucher_type = %(doctype)s
-			AND gle.voucher_no = %(docname)s
-			AND is_cancelled = 0
-		""",
-		dict(doctype=doctype, docname=docname),
+        SELECT
+            gle.voucher_type AS doctype,
+            gle.voucher_no AS docname,
+            gle.account AS gl_account,
+            SUM(ABS(gle.credit_in_account_currency - gle.debit_in_account_currency)) AS amount
+        FROM
+            `tabGL Entry` gle
+        LEFT JOIN
+            `tabAccount` ac ON ac.name = gle.account
+        WHERE
+            ac.account_type = 'Bank'
+            AND (gle.voucher_type, gle.voucher_no) IN %(docs)s
+            AND gle.is_cancelled = 0
+        GROUP BY
+            gle.voucher_type, gle.voucher_no, gle.account
+        """,
+		dict(docs=docs),
 		as_dict=True,
 	)
+
+	entries = {}
+	for row in result:
+		key = (row["doctype"], row["docname"])
+		if key not in entries:
+			entries[key] = {}
+		entries[key][row["gl_account"]] = row["amount"]
+
+	return entries
 
 
 def get_total_allocated_amount(docs):
@@ -311,11 +382,10 @@ def get_total_allocated_amount(docs):
 	# nosemgrep: frappe-semgrep-rules.rules.frappe-using-db-sql
 	result = frappe.db.sql(
 		"""
-		SELECT total, latest_name, latest_date, gl_account, payment_document, payment_entry FROM (
+		SELECT total, latest_date, gl_account, payment_document, payment_entry FROM (
 			SELECT
 				ROW_NUMBER() OVER w AS rownum,
 				SUM(btp.allocated_amount) OVER(PARTITION BY ba.account, btp.payment_document, btp.payment_entry) AS total,
-				FIRST_VALUE(bt.name) OVER w AS latest_name,
 				FIRST_VALUE(bt.date) OVER w AS latest_date,
 				ba.account AS gl_account,
 				btp.payment_document,
@@ -338,102 +408,12 @@ def get_total_allocated_amount(docs):
 
 	payment_allocation_details = {}
 	for row in result:
-		# Why is this *sometimes* a byte string?
-		if isinstance(row["latest_name"], bytes):
-			row["latest_name"] = row["latest_name"].decode()
 		row["latest_date"] = frappe.utils.getdate(row["latest_date"])
-		payment_allocation_details.setdefault((row["payment_document"], row["payment_entry"]), []).append(row)
+		payment_allocation_details.setdefault((row["payment_document"], row["payment_entry"]), {}).update(
+			{row["gl_account"]: row}
+		)
 
 	return payment_allocation_details
-
-
-def get_paid_amount(payment_entry, currency, gl_bank_account):
-	if payment_entry.payment_document in ["Payment Entry", "Sales Invoice", "Purchase Invoice"]:
-		paid_amount_field = "paid_amount"
-		if payment_entry.payment_document == "Payment Entry":
-			doc = frappe.get_doc("Payment Entry", payment_entry.payment_entry)
-
-			if doc.payment_type == "Receive":
-				paid_amount_field = (
-					"received_amount" if doc.paid_to_account_currency == currency else "base_received_amount"
-				)
-			elif doc.payment_type == "Pay":
-				paid_amount_field = (
-					"paid_amount" if doc.paid_from_account_currency == currency else "base_paid_amount"
-				)
-
-		return frappe.db.get_value(
-			payment_entry.payment_document, payment_entry.payment_entry, paid_amount_field
-		)
-
-	elif payment_entry.payment_document == "Journal Entry":
-		return abs(
-			frappe.db.get_value(
-				"Journal Entry Account",
-				{"parent": payment_entry.payment_entry, "account": gl_bank_account},
-				"sum(debit_in_account_currency-credit_in_account_currency)",
-			)
-			or 0
-		)
-
-	elif payment_entry.payment_document == "Expense Claim":
-		return frappe.db.get_value(
-			payment_entry.payment_document, payment_entry.payment_entry, "total_amount_reimbursed"
-		)
-
-	elif payment_entry.payment_document == "Loan Disbursement":
-		return frappe.db.get_value(
-			payment_entry.payment_document, payment_entry.payment_entry, "disbursed_amount"
-		)
-
-	elif payment_entry.payment_document == "Loan Repayment":
-		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "amount_paid")
-
-	elif payment_entry.payment_document == "Bank Transaction":
-		dep, wth = frappe.db.get_value(
-			"Bank Transaction", payment_entry.payment_entry, ("deposit", "withdrawal")
-		)
-		return abs(flt(wth) - flt(dep))
-
-	else:
-		frappe.throw(
-			f"Please reconcile {payment_entry.payment_document}: {payment_entry.payment_entry} manually"
-		)
-
-
-def set_voucher_clearance(doctype, docname, clearance_date, self):
-	if doctype in get_doctypes_for_bank_reconciliation():
-		if (
-			doctype == "Payment Entry"
-			and frappe.db.get_value("Payment Entry", docname, "payment_type") == "Internal Transfer"
-			and len(get_reconciled_bank_transactions(doctype, docname)) < 2
-		):
-			return
-
-		if doctype == "Sales Invoice":
-			frappe.db.set_value(
-				"Sales Invoice Payment",
-				dict(parenttype=doctype, parent=docname),
-				"clearance_date",
-				clearance_date,
-			)
-			return
-
-		frappe.db.set_value(doctype, docname, "clearance_date", clearance_date)
-
-	elif doctype == "Bank Transaction":
-		# For when a second bank transaction has fixed another, e.g. refund
-		bt = frappe.get_doc(doctype, docname)
-		if clearance_date:
-			vouchers = [{"payment_doctype": "Bank Transaction", "payment_name": self.name}]
-			bt.add_payment_entries(vouchers)
-			bt.save()
-		else:
-			for pe in bt.payment_entries:
-				if pe.payment_document == self.doctype and pe.payment_entry == self.name:
-					bt.remove(pe)
-					bt.save()
-					break
 
 
 def get_reconciled_bank_transactions(doctype, docname):
@@ -442,13 +422,6 @@ def get_reconciled_bank_transactions(doctype, docname):
 		filters={"payment_document": doctype, "payment_entry": docname},
 		pluck="parent",
 	)
-
-
-@frappe.whitelist()
-def unclear_reference_payment(doctype, docname, bt_name):
-	bt = frappe.get_doc("Bank Transaction", bt_name)
-	set_voucher_clearance(doctype, docname, None, bt)
-	return docname
 
 
 def remove_from_bank_transaction(doctype, docname):

--- a/erpnext/accounts/test/accounts_mixin.py
+++ b/erpnext/accounts/test/accounts_mixin.py
@@ -91,6 +91,7 @@ class AccountsTestMixin:
 					"attribute_name": "bank",
 					"account_name": "HDFC",
 					"parent_account": "Bank Accounts - " + abbr,
+					"account_type": "Bank",
 				}
 			),
 			frappe._dict(


### PR DESCRIPTION
Issues:

- Unable to reconcile because of floating point error
- Unable to properly reconcile Journal Entries.
    - Journal Entry having multiple rows with the same Bank Account are not being able to reconcile against multiple Bank Transactions usning the **Bank Reconciliation Tool**.
    - Only a partial amount of the **Bank Transaction** is allocated instead of the full amount, and the **Journal Entry** is cleared.

![image](https://github.com/user-attachments/assets/10133e76-60c0-4827-aec2-dc986e8c8c7b)
![image](https://github.com/user-attachments/assets/1aa5cd2b-eb1b-4533-b663-3fb781d7a866)



- On fixing the above issue, another issue occured:
    - On allocating one **Bank Transaction** with the **Journal Entry** having multiple rows with same Bank Account, the **Reconcile the Bank Transaction** shows one of the amount of that **Journal Entry** -ve as the allocated amount is subtracted from both the rows of the **Journal Entry**.
    - So instead of showing individual Accounting Entries for the Journal Entry, I have modified the query to show only one row for the Journal Entry.

- Unable to reconcile one Bank Transaction with other Bank Transaction (maximum recursion depth exceeded)

![image](https://github.com/user-attachments/assets/acd783bc-08e9-4375-843b-b351c44d69d6)


Support ticket: https://support.frappe.io/helpdesk/tickets/33801
