### PR TITLE
fix: don't filter payment entries on Bank Account in Payment Clearance

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -160,9 +160,6 @@ def get_payment_entries_for_bank_clearance(
 		as_dict=1,
 	)
 
-	if bank_account:
-		condition += "and bank_account = %(bank_account)s"
-
 	payment_entries = frappe.db.sql(
 		f"""
 			select
@@ -184,7 +181,6 @@ def get_payment_entries_for_bank_clearance(
 			"account": account,
 			"from": from_date,
 			"to": to_date,
-			"bank_account": bank_account,
 		},
 		as_dict=1,
 	)


### PR DESCRIPTION
Issue:
Payment Entry Not showing in Bank Clearance even when the account is same.

Reason:
There is a filter for **Bank Account** in the SQL query. But there can be cases where the account (`paid_from` or`paid_to`) is same as the account in the filter and the **Bank Account** is not set. In this case, that **Payment Entry** is not visible in **Bank Clearance**.

Support ticket: https://support.frappe.io/helpdesk/tickets/33801