### PR TITLE
fix: clear company and account fields for non-company bank accounts

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -72,6 +72,10 @@ class BankAccount(Document):
 		if self.is_company_account and not self.company:
 			frappe.throw(_("Company is mandatory for company account"))
 
+		if not self.is_company_account:
+			self.company = None
+			self.account = None
+
 	def validate_iban(self):
 		"""
 		Algorithm: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN


### PR DESCRIPTION
**Issue:** If `Bank Account` is not a company bank account and company details are already set, the company details are not being cleared.

https://github.com/user-attachments/assets/d098e69e-1565-42c8-82d5-51432a0ba70a

> [!NOTE]
> Backport to version-15 and version-14 