### PR TITLE
fix: assign dialog instance to a variable in update_child_items function

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -750,7 +750,7 @@ erpnext.utils.update_child_items = function (opts) {
 		});
 	}
 
-	new frappe.ui.Dialog({
+	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		size: "extra-large",
 		fields: [
@@ -787,7 +787,8 @@ erpnext.utils.update_child_items = function (opts) {
 			refresh_field("items");
 		},
 		primary_action_label: __("Update"),
-	}).show();
+	});
+	dialog.show();
 };
 
 erpnext.utils.map_current_doc = function (opts) {


### PR DESCRIPTION
Inside `erpnext/erpnext/public/js/utils.js` `update_child_items` function `dialog` is being referred in `onchange` handlers of the fields. Without this fix, they are failing because `dialog` is not defined in the context. In this PR, we are assigning the created dialog to a variable.

closes #46686

backport version-14

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
