### PR TITLE
fix: assign dialog instance to a variable in update_child_items function

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -788,7 +788,7 @@ erpnext.utils.update_child_items = function (opts) {
 		},
 		primary_action_label: __("Update"),
 	});
-	
+
 	dialog.show();
 };
 

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -750,7 +750,7 @@ erpnext.utils.update_child_items = function (opts) {
 		});
 	}
 
-	new frappe.ui.Dialog({
+	let dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		size: "extra-large",
 		fields: [
@@ -787,7 +787,9 @@ erpnext.utils.update_child_items = function (opts) {
 			refresh_field("items");
 		},
 		primary_action_label: __("Update"),
-	}).show();
+	});
+	
+	dialog.show();
 };
 
 erpnext.utils.map_current_doc = function (opts) {


### PR DESCRIPTION
Inside erpnext/erpnext/public/js/utils.js update_child_items function dialog is being referred in onchange handlers of the fields. Without this fix, they are failing because dialog is not defined in the context. In this PR, we are assigning the created dialog to a variable.

This is already addressed in version-15 branch.

closes https://github.com/frappe/erpnext/issues/46686

backport version-14
