### PR TITLE
fix: do not use self object for setting party and party type 

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -444,21 +444,22 @@ class AccountsController(TransactionBase):
 					)
 
 	def validate_party_address_and_contact(self):
-		party, party_type = None, None
-		if self.get("customer"):
-			party, party_type = self.customer, "Customer"
+		party_type, party = self.get_party()
+
+		if not (party_type and party):
+			return
+
+		if party_type == "Customer":
 			billing_address, shipping_address = (
 				self.get("customer_address"),
 				self.get("shipping_address_name"),
 			)
 			self.validate_party_address(party, party_type, billing_address, shipping_address)
-		elif self.get("supplier"):
-			party, party_type = self.supplier, "Supplier"
+		elif party_type == "Supplier":
 			billing_address = self.get("supplier_address")
 			self.validate_party_address(party, party_type, billing_address)
 
-		if party and party_type:
-			self.validate_party_contact(party, party_type)
+		self.validate_party_contact(party, party_type)
 
 	def validate_party_address(self, party, party_type, billing_address, shipping_address=None):
 		if billing_address or shipping_address:


### PR DESCRIPTION
Issue: due to setting of party and party type from self incorrect validation is raised.

Steps to replicate:

- Create a drop shipping sales order with "Supplier delivers to Customer" in item as checked.
- Now create a PO against this order.

Due to the customer being set in the Purchase Order class in mapped doc function, an incorrect validation is raised.

related pr:https://github.com/frappe/erpnext/pull/46473

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/34708