### PR TITLE
fix: improved rounding adjustment when applying discount

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2705,13 +2705,13 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 		To test if after applying discount on grand total,
 		the grand total is calculated correctly without any rounding errors
 		"""
-		invoice = make_purchase_invoice(qty=3, rate=100, do_not_save=True, do_not_submit=True)
+		invoice = make_purchase_invoice(qty=2, rate=100, do_not_save=True, do_not_submit=True)
 		invoice.append(
 			"items",
 			{
 				"item_code": "_Test Item",
-				"qty": 3,
-				"rate": 50.5,
+				"qty": 1,
+				"rate": 21.39,
 			},
 		)
 		invoice.append(
@@ -2720,19 +2720,18 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 				"charge_type": "On Net Total",
 				"account_head": "_Test Account VAT - _TC",
 				"description": "VAT",
-				"rate": 10,
+				"rate": 15.5,
 			},
 		)
 
-		# the grand total here will be 496.65
+		# the grand total here will be 255.71
 		invoice.disable_rounded_total = 1
-		# apply discount on grand total to adjust the grand total to 496
-		invoice.discount_amount = 0.65
-
+		# apply discount on grand total to adjust the grand total to 255
+		invoice.discount_amount = 0.71
 		invoice.save()
 
-		# check if grand total is 496 and not something like 495.99 due to rounding errors
-		self.assertEqual(invoice.grand_total, 496)
+		# check if grand total is 496 and not something like 254.99 due to rounding errors
+		self.assertEqual(invoice.grand_total, 255)
 
 
 def set_advance_flag(company, flag, default_account):

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2711,7 +2711,7 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 			{
 				"item_code": "_Test Item",
 				"qty": 3,
-				"rate": 50.3,
+				"rate": 50.5,
 			},
 		)
 		invoice.append(
@@ -2720,19 +2720,19 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 				"charge_type": "On Net Total",
 				"account_head": "_Test Account VAT - _TC",
 				"description": "VAT",
-				"rate": 15,
+				"rate": 10,
 			},
 		)
 
-		# the grand total here will be 518.54
+		# the grand total here will be 496.65
 		invoice.disable_rounded_total = 1
-		# apply discount on grand total to adjust the grand total to 518
-		invoice.discount_amount = 0.54
+		# apply discount on grand total to adjust the grand total to 496
+		invoice.discount_amount = 0.65
 
 		invoice.save()
 
-		# check if grand total is 518 and not something like 517.99 due to rounding errors
-		self.assertEqual(invoice.grand_total, 518)
+		# check if grand total is 496 and not something like 495.99 due to rounding errors
+		self.assertEqual(invoice.grand_total, 496)
 
 
 def set_advance_flag(company, flag, default_account):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -786,7 +786,7 @@ class calculate_taxes_and_totals:
 			if tax.get("category") != "Valuation":
 				total_actual_tax += tax_amount
 
-			actual_taxes_dict[tax.idx] = {
+			actual_taxes_dict[int(tax.idx)] = {
 				"tax_amount": tax_amount,
 				"cumulative_tax_amount": total_actual_tax,
 			}
@@ -794,11 +794,11 @@ class calculate_taxes_and_totals:
 		for tax in self.doc.get("taxes"):
 			if tax.charge_type in ["Actual", "On Item Quantity"]:
 				update_actual_tax_dict(tax, tax.tax_amount)
-			elif tax.row_id in actual_taxes_dict:
+			elif base_row := actual_taxes_dict.get(int(tax.row_id)):
 				base_tax_amount = (
-					actual_taxes_dict[tax.row_id]["tax_amount"]
+					base_row["tax_amount"]
 					if tax.charge_type == "On Previous Row Amount"
-					else actual_taxes_dict[tax.row_id]["cumulative_tax_amount"]
+					else base_row["cumulative_tax_amount"]
 				)
 				actual_tax_amount = base_tax_amount * tax.rate / 100
 				update_actual_tax_dict(tax, actual_tax_amount)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -779,13 +779,16 @@ class calculate_taxes_and_totals:
 
 		def update_actual_tax_dict(tax, tax_amount):
 			nonlocal total_actual_tax
-			actual_tax_amount = tax_amount * (-1 if tax.get("add_deduct_tax") == "Deduct" else 1)
+
+			if tax.get("add_deduct_tax") == "Deduct":
+				tax_amount *= -1
+
 			if tax.get("category") != "Valuation":
-				total_actual_tax += actual_tax_amount
+				total_actual_tax += tax_amount
 
 			actual_taxes_dict[tax.idx] = {
-				"tax_amount": actual_tax_amount,
-				"cumulative_tax_amount": actual_tax_amount,
+				"tax_amount": tax_amount,
+				"cumulative_tax_amount": total_actual_tax,
 			}
 
 		for tax in self.doc.get("taxes"):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -786,7 +786,7 @@ class calculate_taxes_and_totals:
 			if tax.get("category") != "Valuation":
 				total_actual_tax += tax_amount
 
-			actual_taxes_dict[int(tax.idx)] = {
+			actual_taxes_dict[cint(tax.idx)] = {
 				"tax_amount": tax_amount,
 				"cumulative_tax_amount": total_actual_tax,
 			}
@@ -794,7 +794,7 @@ class calculate_taxes_and_totals:
 		for tax in self.doc.get("taxes"):
 			if tax.charge_type in ["Actual", "On Item Quantity"]:
 				update_actual_tax_dict(tax, tax.tax_amount)
-			elif base_row := actual_taxes_dict.get(int(tax.row_id)):
+			elif base_row := actual_taxes_dict.get(cint(tax.row_id)):
 				base_tax_amount = (
 					base_row["tax_amount"]
 					if tax.charge_type == "On Previous Row Amount"

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -737,18 +737,20 @@ class calculate_taxes_and_totals:
 						flt(self.doc.discount_amount) * item.net_amount / total_for_discount_amount
 					)
 
-					expected_net_total += item.net_amount - distributed_amount
-					item.net_amount = flt(item.net_amount - distributed_amount, item.precision("net_amount"))
+					adjusted_net_amount = item.net_amount - distributed_amount
+					expected_net_total += adjusted_net_amount
+					item.net_amount = flt(adjusted_net_amount, item.precision("net_amount"))
 					item.distributed_discount_amount = flt(
 						distributed_amount, item.precision("distributed_discount_amount")
 					)
 					net_total += item.net_amount
 
 					# discount amount rounding adjustment
-					if i == len(self._items) - 1:
-						rounding_difference = flt(
+					if i == len(self._items) - 1 and (
+						rounding_difference := flt(
 							expected_net_total - net_total, self.doc.precision("net_total")
 						)
+					):
 						item.net_amount = flt(
 							item.net_amount + rounding_difference, item.precision("net_amount")
 						)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -793,11 +793,11 @@ class calculate_taxes_and_totals:
 				update_actual_tax_dict(tax, tax.tax_amount)
 			elif tax.row_id in actual_taxes_dict:
 				base_tax_amount = (
-					flt(actual_taxes_dict[tax.row_id]["tax_amount"])
+					actual_taxes_dict[tax.row_id]["tax_amount"]
 					if tax.charge_type == "On Previous Row Amount"
-					else flt(actual_taxes_dict[tax.row_id]["cumulative_tax_amount"])
+					else actual_taxes_dict[tax.row_id]["cumulative_tax_amount"]
 				)
-				actual_tax_amount = base_tax_amount * flt(tax.rate) / 100
+				actual_tax_amount = base_tax_amount * tax.rate / 100
 				update_actual_tax_dict(tax, actual_tax_amount)
 
 		return flt(self.doc.grand_total - total_actual_tax, self.doc.precision("grand_total"))

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -698,7 +698,7 @@ class calculate_taxes_and_totals:
 
 		if self.doc.meta.get_field("rounded_total"):
 			if self.doc.is_rounded_total_disabled():
-				self.doc.rounded_total = self.doc.base_rounded_total = 0
+				self.doc.rounded_total = self.doc.base_rounded_total = self.doc.rounding_adjustment = 0
 				return
 
 			self.doc.rounded_total = round_based_on_smallest_currency_fraction(

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -766,10 +766,10 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				// else (On Previous Row Total) calculate tax on cumulative total
 				const base_tax_amount =
 				tax.charge_type == "On Previous Row Amount" ?
-					flt(actual_taxes_dict[tax.row_id]["tax_amount"]):
-					flt(actual_taxes_dict[tax.row_id]["cumulative_total"]);
+					actual_taxes_dict[tax.row_id]["tax_amount"]:
+					actual_taxes_dict[tax.row_id]["cumulative_total"];
 
-				const actual_tax_amount = base_tax_amount * flt(tax.rate) / 100;
+				const actual_tax_amount = base_tax_amount * tax.rate / 100;
 				update_actual_taxes_dict(tax, actual_tax_amount);
 			}
 		});

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -727,7 +727,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 					// discount amount rounding adjustment
 					// assignment to rounding_difference is intentional
-					if (rounding_difference = flt(expected_net_total - net_total, precision("net_total"))) {
+					rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
+					if (rounding_difference) {
 						item.net_amount = flt(item.net_amount + rounding_difference, precision("net_amount", item));
 						net_total += rounding_difference;
 					}
@@ -749,11 +750,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		let actual_taxes_dict = {};
 
 		function update_actual_taxes_dict(tax, tax_amount) {
-			const actual_tax_amount = tax_amount * (tax.add_deduct_tax == "Deduct" ? -1.0 : 1.0);
-			if (tax.category != "Valuation") total_actual_tax += actual_tax_amount;
+			if (tax.add_deduct_tax == "Deduct") tax_amount *= -1;
+			if (tax.category != "Valuation") total_actual_tax += tax_amount;
 
 			actual_taxes_dict[tax.idx] = {
-				tax_amount: actual_tax_amount,
+				tax_amount: tax_amount,
 				cumulative_total: total_actual_tax
 			};
 		}

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -713,21 +713,21 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 			var total_for_discount_amount = this.get_total_for_discount_amount();
 			var net_total = 0;
+			var expected_net_total = 0;
 			// calculate item amount after Discount Amount
 			if (total_for_discount_amount) {
 				$.each(this.frm._items || [], function(i, item) {
 					distributed_amount = flt(me.frm.doc.discount_amount) * item.net_amount / total_for_discount_amount;
+					expected_net_total += item.net_amount - distributed_amount
 					item.net_amount = flt(item.net_amount - distributed_amount, precision("net_amount", item));
 					net_total += item.net_amount;
 
-					// discount amount rounding loss adjustment if no taxes
-					if ((!(me.frm.doc.taxes || []).length || total_for_discount_amount==me.frm.doc.net_total || (me.frm.doc.apply_discount_on == "Net Total"))
-							&& i == (me.frm._items || []).length - 1) {
-						var discount_amount_loss = flt(me.frm.doc.net_total - net_total
-							- me.frm.doc.discount_amount, precision("net_total"));
-						item.net_amount = flt(item.net_amount + discount_amount_loss,
-							precision("net_amount", item));
+					// discount amount rounding adjustment
+					if (i == (me.frm._items || []).length - 1) {
+						var rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
+						item.net_amount = flt(item.net_amount + rounding_difference, precision("net_amount", item));
 					}
+
 					item.net_rate = item.qty ? flt(item.net_amount / item.qty, precision("net_rate", item)) : 0;
 					me.set_in_company_currency(item, ["net_rate", "net_amount"]);
 				});

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -760,20 +760,21 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 
 		$.each(this.frm.doc["taxes"] || [], function(i, tax) {
-			if (["Actual", "On Item Quantity"].includes(tax.charge_type))
-				return update_actual_taxes_dict(tax, tax.tax_amount);
+			if (["Actual", "On Item Quantity"].includes(tax.charge_type)) {
+				update_actual_taxes_dict(tax, tax.tax_amount);
+				return;
+			}
 
 			const base_row = actual_taxes_dict[tax.row_id];
-			if (base_row) {
-				// if charge type is 'On Previous Row Amount', calculate tax on previous row amount
-				// else (On Previous Row Total) calculate tax on cumulative total
-				const base_tax_amount = tax.charge_type == "On Previous Row Amount" ? base_row["tax_amount"]: base_row["cumulative_total"];
-				const actual_tax_amount = base_tax_amount * tax.rate / 100;
-				update_actual_taxes_dict(tax, actual_tax_amount);
-			}
+			if (!base_row) return;
+
+			// if charge type is 'On Previous Row Amount', calculate tax on previous row amount
+			// else (On Previous Row Total) calculate tax on cumulative total
+			const base_tax_amount = tax.charge_type == "On Previous Row Amount" ? base_row["tax_amount"]: base_row["cumulative_total"];
+			update_actual_taxes_dict(tax, base_tax_amount * tax.rate / 100);
 		});
 
-		return flt(this.frm.doc.grand_total - total_actual_tax, precision("grand_total"));
+		return this.frm.doc.grand_total - total_actual_tax;
 	}
 
 	calculate_total_advance(update_paid_amount) {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -650,6 +650,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		if (cint(disable_rounded_total)) {
 			this.frm.doc.rounded_total = 0;
 			this.frm.doc.base_rounded_total = 0;
+			this.frm.doc.rounding_adjustment = 0;
 			return;
 		}
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -714,7 +714,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			const total_for_discount_amount = this.get_total_for_discount_amount();
 			let net_total = 0;
 			let expected_net_total = 0;
-			let rounding_difference;
+
 			// calculate item amount after Discount Amount
 			if (total_for_discount_amount) {
 				$.each(this.frm._items || [], function(i, item) {
@@ -727,7 +727,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 					// discount amount rounding adjustment
 					// assignment to rounding_difference is intentional
-					rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
+					const rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
 					if (rounding_difference) {
 						item.net_amount = flt(item.net_amount + rounding_difference, precision("net_amount", item));
 						net_total += rounding_difference;

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -711,22 +711,24 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				return;
 			}
 
-			var total_for_discount_amount = this.get_total_for_discount_amount();
-			var net_total = 0;
-			var expected_net_total = 0;
+			const total_for_discount_amount = this.get_total_for_discount_amount();
+			let net_total = 0;
+			let expected_net_total = 0;
+			let rounding_difference;
 			// calculate item amount after Discount Amount
 			if (total_for_discount_amount) {
 				$.each(this.frm._items || [], function(i, item) {
 					distributed_amount = flt(me.frm.doc.discount_amount) * item.net_amount / total_for_discount_amount;
-					expected_net_total += item.net_amount - distributed_amount
-					item.net_amount = flt(item.net_amount - distributed_amount, precision("net_amount", item));
+
+					const adjusted_net_amount = item.net_amount - distributed_amount;
+					expected_net_total += adjusted_net_amount
+					item.net_amount = flt(adjusted_net_amount, precision("net_amount", item));
 					net_total += item.net_amount;
 
 					// discount amount rounding adjustment
-					if (i == (me.frm._items || []).length - 1) {
-						var rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
+					// assignment to rounding_difference is intentional
+					if (i == me.frm._items.length - 1 && (rounding_difference = flt(expected_net_total - net_total, precision("net_total"))))
 						item.net_amount = flt(item.net_amount + rounding_difference, precision("net_amount", item));
-					}
 
 					item.net_rate = item.qty ? flt(item.net_amount / item.qty, precision("net_rate", item)) : 0;
 					me.set_in_company_currency(item, ["net_rate", "net_amount"]);

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -762,7 +762,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		$.each(this.frm.doc["taxes"] || [], function(i, tax) {
 			if (["Actual", "On Item Quantity"].includes(tax.charge_type)) {
 				update_actual_taxes_dict(tax, tax.tax_amount);
-			} else if (actual_taxes_dict[tax.row_id] != null) {
+			} else if (actual_taxes_dict[tax.row_id] !== undefined) {
 				// if charge type is 'On Previous Row Amount', calculate tax on previous row amount
 				// else (On Previous Row Total) calculate tax on cumulative total
 				const base_tax_amount =

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -760,16 +760,14 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 
 		$.each(this.frm.doc["taxes"] || [], function(i, tax) {
-			if (["Actual", "On Item Quantity"].includes(tax.charge_type)) {
-				update_actual_taxes_dict(tax, tax.tax_amount);
-			} else if (actual_taxes_dict[tax.row_id] !== undefined) {
+			if (["Actual", "On Item Quantity"].includes(tax.charge_type))
+				return update_actual_taxes_dict(tax, tax.tax_amount);
+
+			const base_row = actual_taxes_dict[tax.row_id];
+			if (base_row) {
 				// if charge type is 'On Previous Row Amount', calculate tax on previous row amount
 				// else (On Previous Row Total) calculate tax on cumulative total
-				const base_tax_amount =
-				tax.charge_type == "On Previous Row Amount" ?
-					actual_taxes_dict[tax.row_id]["tax_amount"]:
-					actual_taxes_dict[tax.row_id]["cumulative_total"];
-
+				const base_tax_amount = tax.charge_type == "On Previous Row Amount" ? base_row["tax_amount"]: base_row["cumulative_total"];
 				const actual_tax_amount = base_tax_amount * tax.rate / 100;
 				update_actual_taxes_dict(tax, actual_tax_amount);
 			}


### PR DESCRIPTION
Issue:

On applying discount on Grand Total in Sales/Purchase Invoice, there was a rounding error.

Before applying discount:

![image](https://github.com/user-attachments/assets/e74b2186-2022-498a-9f67-7fe4bfa41dd0)

After applying discount:

![image](https://github.com/user-attachments/assets/72fbdc33-fb29-46e6-a165-c0b344758f06)


Changes made:

- Previously, we were adjusting the Rounding Difference only if Discount was applied on Net Total, now we are doing it for Grand Total too.
- Previously, we were adjusting the Rounding Difference only in the last item. Now, we are adjusting it in the items where the rounding difference occur.


Support ticket: https://support.frappe.io/helpdesk/tickets/34337