### PR TITLE
fix: pos checking opened entry closed or not

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -124,9 +124,7 @@ class POSClosingEntry(StatusUpdater):
 
 	def on_submit(self):
 		consolidate_pos_invoices(closing_entry=self)
-		frappe.publish_realtime(
-			f"poe_{self.pos_opening_entry}_closed", {"is_closed": True, "closed_on": self.creation}
-		)
+		frappe.publish_realtime(f"poe_{self.pos_opening_entry}_closed", self)
 
 	def on_cancel(self):
 		unconsolidate_pos_invoices(closing_entry=self)

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -124,6 +124,9 @@ class POSClosingEntry(StatusUpdater):
 
 	def on_submit(self):
 		consolidate_pos_invoices(closing_entry=self)
+		frappe.publish_realtime(
+			f"poe_{self.pos_opening_entry}_closed", {"is_closed": True, "closed_on": self.creation}
+		)
 
 	def on_cancel(self):
 		unconsolidate_pos_invoices(closing_entry=self)

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -124,7 +124,11 @@ class POSClosingEntry(StatusUpdater):
 
 	def on_submit(self):
 		consolidate_pos_invoices(closing_entry=self)
-		frappe.publish_realtime(f"poe_{self.pos_opening_entry}_closed", self)
+		frappe.publish_realtime(
+			f"poe_{self.pos_opening_entry}_closed",
+			self,
+			docname=f"POS Opening Entry/{self.pos_opening_entry}",
+		)
 
 	def on_cancel(self):
 		unconsolidate_pos_invoices(closing_entry=self)

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -151,13 +151,13 @@ erpnext.PointOfSale.Controller = class {
 		});
 
 		frappe.realtime.on(`poe_${this.pos_opening}_closed`, (data) => {
-			if (data.is_closed) {
+			if (data) {
 				frappe.dom.freeze();
 				frappe.msgprint({
 					title: __("POS Closed"),
 					indicator: "orange",
 					message: __("POS has been closed at {0}. Please refresh the page.", [
-						frappe.datetime.str_to_user(data.closed_on).bold(),
+						frappe.datetime.str_to_user(data.creation).bold(),
 					]),
 					primary_action_label: __("Refresh"),
 					primary_action: {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -149,6 +149,25 @@ erpnext.PointOfSale.Controller = class {
 				this.make_app();
 			},
 		});
+
+		frappe.realtime.on(`poe_${this.pos_opening}_closed`, (data) => {
+			if (data.is_closed) {
+				frappe.dom.freeze();
+				frappe.msgprint({
+					title: __("POS Closed"),
+					indicator: "orange",
+					message: __("POS has been closed at {0}. Please refresh the page.", [
+						frappe.datetime.str_to_user(data.closed_on).bold(),
+					]),
+					primary_action_label: __("Refresh"),
+					primary_action: {
+						action() {
+							window.location.reload();
+						},
+					},
+				});
+			}
+		});
 	}
 
 	set_opening_entry_status() {


### PR DESCRIPTION
Fixes #46570.

If a POS is closed by a person other than the `cashier` (the person who opened the POS in the first place), the POS continues to function normally.

Added a fix to freeze the POS on creation of the Closing Entry for that POS and notify the `cashier` that the POS has been closed.

![image](https://github.com/user-attachments/assets/3482e8db-1884-4729-b0d6-823785d62385)

