### PR TITLE
fix: use docstatus for status filter

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_list.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_list.js
@@ -25,15 +25,27 @@ frappe.listview_settings["Purchase Order"] = {
 				return [
 					__("To Receive and Bill"),
 					"orange",
-					"per_received,<,100|per_billed,<,100|status,!=,Closed",
+					"per_received,<,100|per_billed,<,100|status,!=,Closed|docstatus,=,1",
 				];
 			} else {
-				return [__("To Receive"), "orange", "per_received,<,100|per_billed,=,100|status,!=,Closed"];
+				return [
+					__("To Receive"),
+					"orange",
+					"per_received,<,100|per_billed,=,100|status,!=,Closed|docstatus,=,1",
+				];
 			}
 		} else if (flt(doc.per_received) >= 100 && flt(doc.per_billed) < 100 && doc.status !== "Closed") {
-			return [__("To Bill"), "orange", "per_received,=,100|per_billed,<,100|status,!=,Closed"];
+			return [
+				__("To Bill"),
+				"orange",
+				"per_received,=,100|per_billed,<,100|status,!=,Closed|docstatus,=,1",
+			];
 		} else if (flt(doc.per_received) >= 100 && flt(doc.per_billed) == 100 && doc.status !== "Closed") {
-			return [__("Completed"), "green", "per_received,=,100|per_billed,=,100|status,!=,Closed"];
+			return [
+				__("Completed"),
+				"green",
+				"per_received,=,100|per_billed,=,100|status,!=,Closed|docstatus,=,1",
+			];
 		}
 	},
 	onload: function (listview) {

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -26,10 +26,18 @@ frappe.listview_settings["Sales Order"] = {
 		} else if (!doc.skip_delivery_note && flt(doc.per_delivered) < 100) {
 			if (frappe.datetime.get_diff(doc.delivery_date) < 0) {
 				// not delivered & overdue
-				return [__("Overdue"), "red", "per_delivered,<,100|delivery_date,<,Today|status,!=,Closed"];
+				return [
+					__("Overdue"),
+					"red",
+					"per_delivered,<,100|delivery_date,<,Today|status,!=,Closed|docstatus,=,1",
+				];
 			} else if (flt(doc.grand_total) === 0) {
 				// not delivered (zeroount order)
-				return [__("To Deliver"), "orange", "per_delivered,<,100|grand_total,=,0|status,!=,Closed"];
+				return [
+					__("To Deliver"),
+					"orange",
+					"per_delivered,<,100|grand_total,=,0|status,!=,Closed|docstatus,=,1",
+				];
 			} else if (flt(doc.per_billed) < 100) {
 				// not delivered & not billed
 				return [

--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -19,9 +19,9 @@ frappe.listview_settings["Delivery Note"] = {
 		} else if (doc.status === "Return Issued") {
 			return [__("Return Issued"), "grey", "status,=,Return Issued"];
 		} else if (flt(doc.per_billed, 2) < 100) {
-			return [__("To Bill"), "orange", "per_billed,<,100"];
+			return [__("To Bill"), "orange", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.per_billed, 2) === 100) {
-			return [__("Completed"), "green", "per_billed,=,100"];
+			return [__("Completed"), "green", "per_billed,=,100|docstatus,=,1"];
 		}
 	},
 	onload: function (doclist) {

--- a/erpnext/stock/doctype/material_request/material_request_list.js
+++ b/erpnext/stock/doctype/material_request/material_request_list.js
@@ -13,7 +13,7 @@ frappe.listview_settings["Material Request"] = {
 				return [__("Completed"), "green"];
 			}
 		} else if (doc.docstatus == 1 && flt(doc.per_ordered, precision) == 0) {
-			return [__("Pending"), "orange", "per_ordered,=,0"];
+			return [__("Pending"), "orange", "per_ordered,=,0|docstatus,=,1"];
 		} else if (
 			doc.docstatus == 1 &&
 			flt(doc.per_ordered, precision) < 100 &&

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
@@ -16,13 +16,13 @@ frappe.listview_settings["Purchase Receipt"] = {
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
 		} else if (flt(doc.per_returned, 2) === 100) {
-			return [__("Return Issued"), "grey", "per_returned,=,100"];
+			return [__("Return Issued"), "grey", "per_returned,=,100|docstatus,=,1"];
 		} else if (flt(doc.grand_total) !== 0 && flt(doc.per_billed, 2) == 0) {
-			return [__("To Bill"), "orange", "per_billed,<,100"];
+			return [__("To Bill"), "orange", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.per_billed, 2) > 0 && flt(doc.per_billed, 2) < 100) {
-			return [__("Partly Billed"), "yellow", "per_billed,<,100"];
+			return [__("Partly Billed"), "yellow", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.grand_total) === 0 || flt(doc.per_billed, 2) === 100) {
-			return [__("Completed"), "green", "per_billed,=,100"];
+			return [__("Completed"), "green", "per_billed,=,100|docstatus,=,1"];
 		}
 	},
 


### PR DESCRIPTION
**Issue:**
While applying the filter to "Status" in the list view, the "Docstatus" filter is not being applied
Ref: [32898](https://support.frappe.io/helpdesk/tickets/32898)

**Solution:**
Added the "Docstatus" filter for "Status"

**Before:**

[before.webm](https://github.com/user-attachments/assets/75d5103e-823d-40b4-bb42-2382b0241570)

**After:**

[after.webm](https://github.com/user-attachments/assets/d8e0bc5f-74dd-4171-90d5-07041f57f971)


**Backport Needed for version-15**