### PR TITLE
fix: update posting date before running validations

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -273,8 +273,8 @@ class SalesInvoice(SellingController):
 			self.indicator_title = _("Paid")
 
 	def validate(self):
-		super().validate()
 		self.validate_auto_set_posting_time()
+		super().validate()
 
 		if not (self.is_pos or self.is_debit_note):
 			self.so_dn_required()


### PR DESCRIPTION
Validations including `posting_date < due_date` are currently run **before** calling `self.validate_auto_set_posting_time()`.
Meaning posting_date is changed after those validations(if `set_posting_time` is 0)

Steps to replicate:
1. Create an invoice with `today` date and due date as `today + 1 `date 
2. Keep `set_posting_time` unchecked and let the invoice sit in draft
3. Submit the invoice on `today + 2` date with no other edits (direct submission)

Observe how posting date gets changed to `today + 2` while due date is still `today + 1`.
If you don't want to wait, just set the dates manually(backdate with similar gaps) and then use system console to set `set_posting_time` as 0 in the db and then submit the invoice directly.