### PR TITLE
fix: update quantity validation using asset quantity field instead of…

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.meta import get_field_precision
 from frappe.query_builder.custom import ConstantColumn
-from frappe.utils import flt
+from frappe.utils import cint, flt
 
 import erpnext
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
@@ -273,9 +273,12 @@ class LandedCostVoucher(Document):
 						"item_code": item.item_code,
 						"docstatus": ["!=", 2],
 					},
-					fields=["name", "docstatus"],
+					fields=["name", "docstatus", "asset_quantity"],
 				)
-				if not docs or len(docs) < item.qty:
+
+				total_asset_qty = sum((cint(d.asset_quantity)) for d in docs)
+
+				if not docs or total_asset_qty < item.qty:
 					frappe.throw(
 						_(
 							"There are only {0} asset created or linked to {1}. Please create or link {2} Assets with respective document."

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -281,8 +281,11 @@ class LandedCostVoucher(Document):
 				if not docs or total_asset_qty < item.qty:
 					frappe.throw(
 						_(
-							"There are only {0} asset created or linked to {1}. Please create or link {2} Assets with respective document."
-						).format(len(docs), item.receipt_document, item.qty)
+							"For item <b>{0}</b>, only <b>{1}</b> asset have been created or linked to <b>{2}</b>. "
+							"Please create or link <b>{3}</b> more asset with the respective document."
+						).format(
+							item.item_code, total_asset_qty, item.receipt_document, item.qty - total_asset_qty
+						)
 					)
 				if docs:
 					for d in docs:


### PR DESCRIPTION
Issue:

On submission of Landed Cost Voucher for Asset Items the Qty validation is happening based on the total record  instead of utilizing the asset_quantity field.

Before:


[Screencast from 26-03-25 12:55:34 PM IST.webm](https://github.com/user-attachments/assets/f97ba976-4c40-4134-ba06-a9c634c0b6a8)


After:

![image](https://github.com/user-attachments/assets/64864bff-490c-4faf-8345-0b3b92bfbebb)


Backport needed: Version15
