### PR TITLE
feat(regional): Address Template for Germany & Add Switzerland Template

### DIFF
--- a/erpnext/regional/address_template/templates/germany.html
+++ b/erpnext/regional/address_template/templates/germany.html
@@ -1,8 +1,4 @@
 {{ address_line1 }}<br>
 {% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
-{% if country in ["Germany", "Deutschland"] %}
-    {{ pincode }} {{ city }}
-{% else %}
-    {{ pincode }} {{ city | upper }}<br>
-    {{ country | upper }}
-{% endif %}
+{{ pincode }} {{ city | upper }}<br>
+{{ country | upper }}

--- a/erpnext/regional/address_template/templates/switzerland.html
+++ b/erpnext/regional/address_template/templates/switzerland.html
@@ -1,0 +1,4 @@
+{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ pincode }} {{ city | upper }}<br>
+{{ country | upper }}


### PR DESCRIPTION
**Summary:**

Ensures correct address formatting for businesses outside Germany (e.g., in Switzerland or Austria) using ERPNext in German.

Adds a Switzerland-specific address template.

Implements a temporary workaround to force international formatting for German addresses when required.

**Changes:**

Germany Address Template:

Fixes an issue where addresses in Germany were displayed in their national format instead of the international format when the company is outside Germany.

Now ensures the country is always included when necessary for postal services.

Switzerland Address Template:

Introduces a new template for Swiss addresses, ensuring proper formatting.

**Note:**
This is a workaround. A proper fix would determine the company's location and dynamically apply the correct format (national or international) based on that. This would be a bigger refactoring which would need to be done by a core team developer.