### PR TITLE
fix: include auto_reconcile_vouchers flag in background job

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -373,8 +373,6 @@ def auto_reconcile_vouchers(
 	from_reference_date=None,
 	to_reference_date=None,
 ):
-	frappe.flags.auto_reconcile_vouchers = True
-
 	bank_transactions = get_bank_transactions(bank_account)
 
 	if len(bank_transactions) > 10:
@@ -403,6 +401,8 @@ def auto_reconcile_vouchers(
 def start_auto_reconcile(
 	bank_transactions, from_date, to_date, filter_by_reference_date, from_reference_date, to_reference_date
 ):
+	frappe.flags.auto_reconcile_vouchers = True
+
 	reconciled, partially_reconciled = set(), set()
 	for transaction in bank_transactions:
 		linked_payments = get_linked_payments(


### PR DESCRIPTION
**Issue:**
Auto Bank Reconciliation reconciles against a voucher irrespective of the reference number
**ref:** [32507](https://support.frappe.io/helpdesk/tickets/32507)

**Before:**

https://github.com/user-attachments/assets/b7a91545-bf6c-476e-aca8-c4deff5666f4


**After:**

https://github.com/user-attachments/assets/cb90e849-9462-44bf-9611-cdad93fa766e


**Backport Needed: v15**