### PR TITLE
refactor: add optional company parameter to create_payment_gateway_account

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1281,12 +1281,13 @@ def get_account_balances(accounts, company):
 	return accounts
 
 
-def create_payment_gateway_account(gateway, payment_channel="Email"):
+def create_payment_gateway_account(gateway, payment_channel="Email", company=None):
 	from erpnext.setup.setup_wizard.operations.install_fixtures import create_bank_account
 
-	company = frappe.get_cached_value("Global Defaults", "Global Defaults", "default_company")
 	if not company:
-		return
+		company = frappe.get_cached_value("Global Defaults", "Global Defaults", "default_company")
+		if not company:
+			return
 
 	# NOTE: we translate Payment Gateway account name because that is going to be used by the end user
 	bank_account = frappe.db.get_value(


### PR DESCRIPTION
### **Description:**  
This PR enhances the `create_payment_gateway_account` function by adding an optional `company` parameter.  

#### **Key Changes:**  
- Introduced an **optional** `company` parameter to allow specifying a different company when creating a payment gateway account.  
- By default, the function continues to use the **global default company**, ensuring backward compatibility.  
- This change provides flexibility for cases where a payment gateway account needs to be associated with a company other than the default.  
