### PR TITLE
Delete the expired Serial No Warranty Expiry

### DIFF
--- a/erpnext/stock/workspace/stock/stock.json
+++ b/erpnext/stock/workspace/stock/stock.json
@@ -350,17 +350,6 @@
    "type": "Link"
   },
   {
-   "dependencies": "Serial No",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Serial No Warranty Expiry",
-   "link_count": 0,
-   "link_to": "Serial No Warranty Expiry",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
    "hidden": 0,
    "is_query_report": 0,
    "label": "Tools",


### PR DESCRIPTION
删掉失效的
Serial No Warranty Expiry

删掉失效的



![image](https://github.com/user-attachments/assets/b5822a15-16ef-4a7a-b70f-9e1f833cc4ce)


库存点击编辑
![image](https://github.com/user-attachments/assets/922ad4c3-61e5-4c1b-8254-cba5367b9ab7)
然后点击保存(不做任何更改)
![image](https://github.com/user-attachments/assets/c84a42ee-45aa-4fdf-bbca-ccec37473f0d)
然后显示这个已经失效,我感觉可以删掉这个代码【Serial No Warranty Expiry】   
![image](https://github.com/user-attachments/assets/46a73620-e465-47e4-9ac9-66b019e47d3b)



因为  全局搜索【Serial No Warranty Expiry】一共43个，但是其中41个都在翻译文件内
剩余2个也是无用的代码，我感觉可以删除

![image](https://github.com/user-attachments/assets/15f3dec4-0c5c-40c0-9dbe-f796f8da47ca)

