### PR TITLE
fix: pos button and on hover color

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -608,6 +608,7 @@
 
 		&:hover {
 			background-color: var(--gray-50);
+			color: var(--neutral);
 		}
 
 		> .invoice-name-date {
@@ -1157,8 +1158,8 @@
 					}
 
 					> .new-btn {
-						background-color: var(--blue-500);
-						color: white;
+						background-color: var(--btn-primary);
+						color: var(--neutral);
 						font-weight: 500;
 					}
 				}

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -607,8 +607,7 @@
 		padding: var(--padding-sm);
 
 		&:hover {
-			background-color: var(--gray-50);
-			color: var(--neutral);
+			background-color: var(--control-bg);
 		}
 
 		> .invoice-name-date {


### PR DESCRIPTION
Changed the POS 'New Order' button color to Frappe's color scheme and fixed the on hover text color in dark mode on 'Toggle Recent Orders'.

### Button

Before:
<img width="479" alt="Screenshot 2025-03-28 at 2 29 15 AM" src="https://github.com/user-attachments/assets/fe35d970-d17b-46a6-b238-a81d202e248a" />
After:
<img width="480" alt="Screenshot 2025-03-28 at 2 27 39 AM" src="https://github.com/user-attachments/assets/a200a590-7b17-48a5-be5f-0e38cbf7ef30" />

### Recent Orders on hover

Before:

https://github.com/user-attachments/assets/8043e5d8-7a0b-4844-9217-e449440ee30c

After:

https://github.com/user-attachments/assets/fb0552be-c6e7-45bc-a3ca-cdb75c41d1e6


