### PR TITLE
fix: correct outstanding amount for invoice in dunning

### DIFF
--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
+import json
+
 import frappe
+from frappe.model import mapper
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.utils import add_days, nowdate, today
 
@@ -76,6 +79,36 @@ class TestDunning(IntegrationTestCase):
 
 		dunning.reload()
 		self.assertEqual(dunning.status, "Resolved")
+
+	def test_fetch_overdue_payments(self):
+		"""
+		Create SI with overdue payment. Check if overdue payment is fetched in Dunning.
+		"""
+		si1 = create_sales_invoice_against_cost_center(
+			posting_date=add_days(today(), -1 * 6),
+			qty=1,
+			rate=100,
+		)
+
+		si2 = create_sales_invoice_against_cost_center(
+			posting_date=add_days(today(), -1 * 6),
+			qty=1,
+			rate=300,
+		)
+
+		dunning = create_dunning_from_sales_invoice(si1.name)
+		dunning.overdue_payments = []
+
+		method = "erpnext.accounts.doctype.sales_invoice.sales_invoice.create_dunning"
+		updated_dunning = mapper.map_docs(method, json.dumps([si1.name, si2.name]), dunning)
+
+		self.assertEqual(len(updated_dunning.overdue_payments), 2)
+
+		self.assertEqual(updated_dunning.overdue_payments[0].sales_invoice, si1.name)
+		self.assertEqual(updated_dunning.overdue_payments[0].outstanding, si1.outstanding_amount)
+
+		self.assertEqual(updated_dunning.overdue_payments[1].sales_invoice, si2.name)
+		self.assertEqual(updated_dunning.overdue_payments[1].outstanding, si2.outstanding_amount)
 
 	def test_dunning_and_payment_against_partially_due_invoice(self):
 		"""

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -2717,9 +2717,11 @@ def create_dunning(source_name, target_doc=None, ignore_permissions=False):
 				target.closing_text = letter_text.get("closing_text")
 				target.language = letter_text.get("language")
 
-		# update outstanding
+		# update outstanding from doc
 		if source.payment_schedule and len(source.payment_schedule) == 1:
-			target.overdue_payments[0].outstanding = source.get("outstanding_amount")
+			for row in target.overdue_payments:
+				if row.payment_schedule == source.payment_schedule[0].name:
+					row.outstanding = source.get("outstanding_amount")
 
 		target.validate()
 


### PR DESCRIPTION
Issue: Incorrect dunning amount if fetched for multiple invoices.


Steps to replicate:

- Go to Dunning Doctype
- Fetch Overdue Payments for two outstanding invoices.

For the first invoice outstanding amount will be incorrect because it will be set from the last document.


Closes: https://github.com/frappe/erpnext/issues/46650, Closes: https://github.com/frappe/erpnext/issues/42605

