### PR TITLE
fix: map serial no and batch no from delivery note while creating sales invoice

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -872,6 +872,8 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 				"field_map": {
 					"name": "dn_detail",
 					"parent": "delivery_note",
+					"batch_no": "batch_no",
+					"serial_no": "serial_no",
 					"so_detail": "so_detail",
 					"against_sales_order": "sales_order",
 					"cost_center": "cost_center",


### PR DESCRIPTION
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35099