### PR TITLE
fix: correct mapping(schedule_date) sales order to material request

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -898,7 +898,7 @@ def make_material_request(source_name, target_doc=None):
 				"field_map": {
 					"name": "sales_order_item",
 					"parent": "sales_order",
-					"delivery_date": "required_by",
+					"delivery_date": "schedule_date",
 					"bom_no": "bom_no",
 				},
 				"condition": lambda item: not frappe.db.exists(


### PR DESCRIPTION
**Fix issue** correct mapping(schedule_date) sales order to material request




Backport Needed: v15