### PR TITLE
fix: prevent creation of "Purchase Receipt" when update_stock is enabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -645,7 +645,7 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	add_custom_buttons: function (frm) {
-		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100) {
+		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100 && frm.doc.update_stock == 0) {
 			frm.add_custom_button(
 				__("Purchase Receipt"),
 				() => {


### PR DESCRIPTION
When update_stock is enabled on a Purchase Invoice, stock has already been updated.

Creating a Purchase Receipt in this case would result in a document with zero items.

This fix ensures users cannot create a Purchase Receipt when update_stock == 1