### PR TITLE
feat: option to recreate Stock Ledger Entries against stock transactions

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -19,6 +19,7 @@
   "allow_negative_stock",
   "via_landed_cost_voucher",
   "allow_zero_rate",
+  "recreate_stock_ledgers",
   "amended_from",
   "error_section",
   "error_log",
@@ -220,12 +221,20 @@
    "label": "Reposting Data File",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.based_on == \"Transaction\"",
+   "fieldname": "recreate_stock_ledgers",
+   "fieldtype": "Check",
+   "label": "Recreate Stock Ledgers"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-06-27 16:55:23.150146",
+ "modified": "2025-03-31 12:38:20.566196",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",
@@ -274,6 +283,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -47,6 +47,7 @@ class RepostItemValuation(Document):
 		items_to_be_repost: DF.Code | None
 		posting_date: DF.Date
 		posting_time: DF.Time | None
+		recreate_stock_ledgers: DF.Check
 		reposting_data_file: DF.Attach | None
 		status: DF.Literal["Queued", "In Progress", "Completed", "Skipped", "Failed"]
 		total_reposting_count: DF.Int
@@ -74,6 +75,7 @@ class RepostItemValuation(Document):
 		self.reset_field_values()
 		self.set_company()
 		self.validate_accounts_freeze()
+		self.reset_recreate_stock_ledgers()
 
 	def validate_period_closing_voucher(self):
 		# Period Closing Voucher
@@ -107,6 +109,10 @@ class RepostItemValuation(Document):
 					name, to_date
 				)
 			)
+
+	def reset_recreate_stock_ledgers(self):
+		if self.recreate_stock_ledgers and self.based_on != "Transaction":
+			self.recreate_stock_ledgers = 0
 
 	def get_closing_stock_balance(self):
 		filters = {
@@ -245,6 +251,16 @@ class RepostItemValuation(Document):
 			filters,
 		)
 
+	def recreate_stock_ledger_entries(self):
+		"""Recreate Stock Ledger Entries for the transaction."""
+		if self.based_on == "Transaction" and self.recreate_stock_ledgers:
+			doc = frappe.get_doc(self.voucher_type, self.voucher_no)
+			doc.docstatus = 2
+			doc.update_stock_ledger(allow_negative_stock=True, via_landed_cost_voucher=True)
+
+			doc.docstatus = 1
+			doc.update_stock_ledger(allow_negative_stock=True)
+
 
 def on_doctype_update():
 	frappe.db.add_index("Repost Item Valuation", ["warehouse", "item_code"], "item_warehouse")
@@ -262,6 +278,9 @@ def repost(doc):
 		doc.set_status("In Progress")
 		if not frappe.flags.in_test:
 			frappe.db.commit()
+
+		if doc.recreate_stock_ledgers:
+			doc.recreate_stock_ledger_entries()
 
 		repost_sl_entries(doc)
 		repost_gl_entries(doc)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -189,7 +189,12 @@ def validate_cancellation(args):
 	if args[0].get("is_cancelled"):
 		repost_entry = frappe.db.get_value(
 			"Repost Item Valuation",
-			{"voucher_type": args[0].voucher_type, "voucher_no": args[0].voucher_no, "docstatus": 1},
+			{
+				"voucher_type": args[0].voucher_type,
+				"voucher_no": args[0].voucher_no,
+				"docstatus": 1,
+				"recreate_stock_ledgers": 0,
+			},
 			["name", "status"],
 			as_dict=1,
 		)


### PR DESCRIPTION
Sometimes, due to customization, the system performs a partial commit and fails to create stock ledger entries properly. In such cases, users need an option to recreate the stock ledger entries for the corresponding stock transactions.

Currently, in ERPNext, the 'Repost Item Valuation' feature is available, but it only corrects the quantity and valuation calculations of stock ledgers—it does not recreate the stock ledger entries. To address this, a checkbox 'Recreate Stock Ledgers' has been added to the 'Repost Item Valuation' doctype. If this checkbox enabled, the system will Recreate stock ledgers and do reposting of the future transactions if exists. This checkbox will only be visible when reposting is based on a transaction.

<img width="952" alt="Screenshot 2025-03-31 at 1 33 09 PM" src="https://github.com/user-attachments/assets/447b6ee2-abf7-47ec-aee9-8b9bcc613859" />
