### PR TITLE
feat: allow UOMs to select for which conversion rate defined in item

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -905,3 +905,32 @@ def get_filtered_child_rows(doctype, txt, searchfield, start, page_len, filters)
 		)
 
 	return query.run(as_dict=False)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_item_uom_query(doctype, txt, searchfield, start, page_len, filters):
+	if frappe.db.get_single_value("Stock Settings", "allow_uom_with_conversion_rate_defined_in_item"):
+		query_filters = {"parent": filters.get("item_code")}
+
+		if txt:
+			query_filters["uom"] = ["like", f"%{txt}%"]
+
+		return frappe.get_all(
+			"UOM Conversion Detail",
+			filters=query_filters,
+			fields=["uom", "conversion_factor"],
+			limit_start=start,
+			limit_page_length=page_len,
+			order_by="idx",
+			as_list=1,
+		)
+
+	return frappe.get_all(
+		"UOM",
+		filters={"name": ["like", f"%{txt}%"]},
+		fields=["name"],
+		limit_start=start,
+		limit_page_length=page_len,
+		as_list=1,
+	)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -150,6 +150,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			});
 		}
 
+		if (this.frm.fields_dict["items"].grid.get_field("uom")) {
+			this.frm.set_query("uom", "items", function(doc, cdt, cdn) {
+				let row = locals[cdt][cdn];
+
+				return {
+					query: "erpnext.controllers.queries.get_item_uom_query",
+					filters: {
+						"item_code": row.item_code
+					}
+				};
+			});
+		}
+
 		if(
 			this.frm.docstatus < 2
 			&& this.frm.fields_dict["payment_terms_template"]

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -22,6 +22,8 @@
   "allow_to_edit_stock_uom_qty_for_sales",
   "column_break_lznj",
   "allow_to_edit_stock_uom_qty_for_purchase",
+  "section_break_ylhd",
+  "allow_uom_with_conversion_rate_defined_in_item",
   "stock_validations_tab",
   "section_break_9",
   "over_delivery_receipt_allowance",
@@ -498,6 +500,17 @@
   {
    "fieldname": "column_break_wslv",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ylhd",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, the system will allow selecting UOMs in sales and purchase transactions only if the conversion rate is set in the item master.",
+   "fieldname": "allow_uom_with_conversion_rate_defined_in_item",
+   "fieldtype": "Check",
+   "label": "Allow UOM with Conversion Rate Defined in Item"
   }
  ],
  "icon": "icon-cog",
@@ -505,7 +518,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-28 15:08:35.938840",
+ "modified": "2025-03-31 15:34:20.752065",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",
@@ -526,6 +539,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": [],

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -33,6 +33,7 @@ class StockSettings(Document):
 		allow_partial_reservation: DF.Check
 		allow_to_edit_stock_uom_qty_for_purchase: DF.Check
 		allow_to_edit_stock_uom_qty_for_sales: DF.Check
+		allow_uom_with_conversion_rate_defined_in_item: DF.Check
 		auto_create_serial_and_batch_bundle_for_outward: DF.Check
 		auto_indent: DF.Check
 		auto_insert_price_list_rate_if_missing: DF.Check


### PR DESCRIPTION
<img width="896" alt="Screenshot 2025-03-31 at 3 55 03 PM" src="https://github.com/user-attachments/assets/9b5ca81c-67a3-43cf-990b-ac0adc46f959" />


docs https://docs.frappe.io/erpnext/user/manual/en/stock-settings#15-allow-uom-with-conversion-rate-defined-in-item