### PR TITLE
fix: removed customer_group query in customer.js

### DIFF
--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -31,7 +31,6 @@ frappe.ui.form.on("Customer", {
 
 		frm.add_fetch("lead_name", "company_name", "customer_name");
 		frm.add_fetch("default_sales_partner", "commission_rate", "default_commission_rate");
-		frm.set_query("customer_group", { is_group: 0 });
 		frm.set_query("default_price_list", { selling: 1 });
 		frm.set_query("account", "accounts", function (doc, cdt, cdn) {
 			let d = locals[cdt][cdn];


### PR DESCRIPTION
Issue: Customer groups in customers are filtered for child nodes(is_group:0) in the frontend but not validated in the backend.
 
Removing customer group query for consistency.

Related PR: https://github.com/frappe/erpnext/pull/37050
Related comment: https://github.com/frappe/erpnext/issues/36849#issuecomment-1695545979
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35082