### PR TITLE
fix: use `grand_total_diff` instead of `rounding_adjustment` in `taxes_and_totals`

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -384,9 +384,7 @@ class calculate_taxes_and_totals:
 			self._calculate()
 
 	def calculate_taxes(self):
-		rounding_adjustment_computed = self.doc.get("is_consolidated") and self.doc.get("rounding_adjustment")
-		if not rounding_adjustment_computed:
-			self.doc.rounding_adjustment = 0
+		self.grand_total_diff = 0
 
 		# maintain actual tax rate based on idx
 		actual_tax_dict = dict(
@@ -461,9 +459,8 @@ class calculate_taxes_and_totals:
 						and self.discount_amount_applied
 						and self.doc.discount_amount
 						and self.doc.apply_discount_on == "Grand Total"
-						and not rounding_adjustment_computed
 					):
-						self.doc.rounding_adjustment = flt(
+						self.grand_total_diff = flt(
 							self.doc.grand_total - flt(self.doc.discount_amount) - tax.total,
 							self.doc.precision("rounding_adjustment"),
 						)
@@ -593,11 +590,11 @@ class calculate_taxes_and_totals:
 		return self.adjust_grand_total_for_inclusive_tax()
 
 	def adjust_grand_total_for_inclusive_tax(self):
-		# if fully inclusive taxes and diff
+		# if any inclusive taxes and diff
 		if self.doc.get("taxes") and any(cint(t.included_in_print_rate) for t in self.doc.get("taxes")):
 			last_tax = self.doc.get("taxes")[-1]
 			non_inclusive_tax_amount = sum(
-				flt(d.tax_amount_after_discount_amount)
+				self.get_tax_amount_if_for_valuation_or_deduction(d.tax_amount_after_discount_amount, d)
 				for d in self.doc.get("taxes")
 				if not d.included_in_print_rate
 			)
@@ -614,27 +611,23 @@ class calculate_taxes_and_totals:
 			diff = flt(diff, self.doc.precision("rounding_adjustment"))
 
 			if diff and abs(diff) <= (5.0 / 10 ** last_tax.precision("tax_amount")):
-				self.doc.grand_total_diff = diff
-			else:
-				self.doc.grand_total_diff = 0
+				self.grand_total_diff = diff
 
 	def calculate_totals(self):
 		if self.doc.get("taxes"):
-			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(
-				self.doc.get("grand_total_diff")
-			)
+			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + self.grand_total_diff
 		else:
 			self.doc.grand_total = flt(self.doc.net_total)
 
 		if self.doc.get("taxes"):
 			self.doc.total_taxes_and_charges = flt(
-				self.doc.grand_total - self.doc.net_total - flt(self.doc.get("grand_total_diff")),
+				self.doc.grand_total - self.doc.net_total - self.grand_total_diff,
 				self.doc.precision("total_taxes_and_charges"),
 			)
 		else:
 			self.doc.total_taxes_and_charges = 0.0
 
-		self._set_in_company_currency(self.doc, ["total_taxes_and_charges", "rounding_adjustment"])
+		self._set_in_company_currency(self.doc, ["total_taxes_and_charges"])
 
 		if self.doc.doctype in [
 			"Quotation",
@@ -684,7 +677,9 @@ class calculate_taxes_and_totals:
 
 		if self.doc.meta.get_field("rounded_total"):
 			if self.doc.is_rounded_total_disabled():
-				self.doc.rounded_total = self.doc.base_rounded_total = 0
+				self.doc.rounded_total = 0
+				self.doc.base_rounded_total = 0
+				self.doc.rounding_adjustment = 0
 				return
 
 			self.doc.rounded_total = round_based_on_smallest_currency_fraction(

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -344,7 +344,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	calculate_taxes() {
 		var me = this;
-		this.frm.doc.rounding_adjustment = 0;
+		this.grand_total_diff = 0;
 		var actual_tax_dict = {};
 
 		// maintain actual tax rate based on idx
@@ -418,7 +418,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					// adjust Discount Amount loss in last tax iteration
 					if ((i == me.frm.doc["taxes"].length - 1) && me.discount_amount_applied
 						&& me.frm.doc.apply_discount_on == "Grand Total" && me.frm.doc.discount_amount) {
-						me.frm.doc.rounding_adjustment = flt(me.frm.doc.grand_total -
+						me.grand_total_diff = flt(me.frm.doc.grand_total -
 							flt(me.frm.doc.discount_amount) - tax.total, precision("rounding_adjustment"));
 					}
 				}
@@ -551,7 +551,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	adjust_grand_total_for_inclusive_tax() {
 		var me = this;
 
-		// if fully inclusive taxes and diff
+		// if any inclusive taxes and diff
 		if (this.frm.doc["taxes"] && this.frm.doc["taxes"].length) {
 			var any_inclusive_tax = false;
 			$.each(this.frm.doc.taxes || [], function(i, d) {
@@ -562,7 +562,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				var non_inclusive_tax_amount = frappe.utils.sum($.map(this.frm.doc.taxes || [],
 					function(d) {
 						if(!d.included_in_print_rate) {
-							return flt(d.tax_amount_after_discount_amount);
+							let tax_amount = d.category === "Valuation" ? 0 : d.tax_amount_after_discount_amount;
+							if (d.add_deduct_tax === "Deduct") tax_amount *= -1;
+							return tax_amount;
 						}
 					}
 				));
@@ -576,9 +578,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				diff = flt(diff, precision("rounding_adjustment"));
 
 				if ( diff && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
-					me.frm.doc.grand_total_diff = diff;
-				} else {
-					me.frm.doc.grand_total_diff = 0;
+					me.grand_total_diff = diff;
 				}
 			}
 		}
@@ -589,7 +589,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var me = this;
 		var tax_count = this.frm.doc["taxes"] ? this.frm.doc["taxes"].length : 0;
 		this.frm.doc.grand_total = flt(tax_count
-			? this.frm.doc["taxes"][tax_count - 1].total + flt(this.frm.doc.grand_total_diff)
+			? this.frm.doc["taxes"][tax_count - 1].total + this.grand_total_diff
 			: this.frm.doc.net_total);
 
 		if(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
@@ -621,9 +621,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 
 		this.frm.doc.total_taxes_and_charges = flt(this.frm.doc.grand_total - this.frm.doc.net_total
-			- flt(this.frm.doc.grand_total_diff), precision("total_taxes_and_charges"));
+			- this.grand_total_diff, precision("total_taxes_and_charges"));
 
-		this.set_in_company_currency(this.frm.doc, ["total_taxes_and_charges", "rounding_adjustment"]);
+		this.set_in_company_currency(this.frm.doc, ["total_taxes_and_charges"]);
 
 		// Round grand total as per precision
 		frappe.model.round_floats_in(this.frm.doc, ["grand_total", "base_grand_total"]);
@@ -643,6 +643,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		if (cint(disable_rounded_total)) {
 			this.frm.doc.rounded_total = 0;
 			this.frm.doc.base_rounded_total = 0;
+			this.frm.doc.rounding_adjustment = 0;
 			return;
 		}
 


### PR DESCRIPTION
- Changes made:
    - Use `grand_total_diff` instead of `rounding_adjustment` in `taxes_and_totals` to adjust rounding difference while calculating taxes.
    - Consider the tax category Valuation and `add_deduct_tax` in `adjust_grand_total_for_inclusive_tax`.
    
 
`grand_total_diff` was introduced as a replacement for rounding adjustment in https://github.com/frappe/erpnext/pull/39481, but  it was not used in all places where rounding adjustment was being used earlier to adjust grand total. This PR fixes that.