### PR TITLE
fix: use work_order bom_no if no bom present in operation

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1616,7 +1616,7 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 			"posting_date": nowdate(),
 			"for_quantity": row.job_card_qty or work_order.get("qty", 0),
 			"operation_id": row.get("name"),
-			"bom_no": row.get("bom"),
+			"bom_no": row.get("bom") or work_order.bom_no,
 			"project": work_order.project,
 			"company": work_order.company,
 			"sequence_id": row.get("sequence_id"),


### PR DESCRIPTION
Reference support ticket [35124](https://support.frappe.io/helpdesk/tickets/35214?view=VIEW-HD%20Ticket-003)