### PR TITLE
fix: pos closed dialog on pos closing entry

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -151,7 +151,8 @@ erpnext.PointOfSale.Controller = class {
 		});
 
 		frappe.realtime.on(`poe_${this.pos_opening}_closed`, (data) => {
-			if (data) {
+			const route = frappe.get_route_str();
+			if (data && route == "point-of-sale") {
 				frappe.dom.freeze();
 				frappe.msgprint({
 					title: __("POS Closed"),


### PR DESCRIPTION
The POS closed dialog was appearing on the POS Closing Entry when the POS was closed using `Close POS`. This dialog was intended to show only if the POS was closed by another user or from another tab.

Before:

https://github.com/user-attachments/assets/218c599e-913e-4cb5-bcd3-e5893bac11dc

After:

https://github.com/user-attachments/assets/607aa1d7-0a56-4cdb-89b0-dc2b34a79f6c

