### PR TITLE
fix: empty party filter on change of party type in General Ledger Report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -66,7 +66,7 @@ frappe.query_reports["General Ledger"] = {
 			fieldtype: "Autocomplete",
 			options: Object.keys(frappe.boot.party_account_types),
 			on_change: function () {
-				frappe.query_report.set_filter_value("party", "");
+				frappe.query_report.set_filter_value("party", []);
 			},
 		},
 		{


### PR DESCRIPTION
Before: 
![simplescreenrecorder-2025-04-07_14 12 32](https://github.com/user-attachments/assets/39da9c0f-f2a1-438f-ad76-624d6afc7ee2)



After
![simplescreenrecorder-2025-04-07_14 11 11](https://github.com/user-attachments/assets/fae95afc-de16-42dd-9e3a-1e6531cc3ee0)

