### PR TITLE
fix: remove against_voucher and against_voucher_type column from General Ledger Report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -53,11 +53,6 @@ frappe.query_reports["General Ledger"] = {
 			},
 		},
 		{
-			fieldname: "against_voucher_no",
-			label: __("Against Voucher No"),
-			fieldtype: "Data",
-		},
-		{
 			fieldtype: "Break",
 		},
 		{

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -224,9 +224,6 @@ def get_conditions(filters):
 	if filters.get("voucher_no"):
 		conditions.append("voucher_no=%(voucher_no)s")
 
-	if filters.get("against_voucher_no"):
-		conditions.append("against_voucher=%(against_voucher_no)s")
-
 	if filters.get("ignore_err"):
 		err_journals = frappe.db.get_all(
 			"Journal Entry",
@@ -490,16 +487,12 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map, tot
 			data[key][rev_dr_or_cr] = 0
 			data[key][rev_dr_or_cr + "_in_account_currency"] = 0
 
-		if data[key].against_voucher and gle.against_voucher:
-			data[key].against_voucher += ", " + gle.against_voucher
-
 	from_date, to_date = getdate(filters.from_date), getdate(filters.to_date)
 	show_opening_entries = filters.get("show_opening_entries")
 
 	for gle in gl_entries:
 		group_by_value = gle.get(group_by)
 		gle.voucher_subtype = _(gle.voucher_subtype)
-		gle.against_voucher_type = _(gle.against_voucher_type)
 		gle.remarks = _(gle.remarks)
 		gle.party_type = _(gle.party_type)
 
@@ -698,14 +691,6 @@ def get_columns(filters):
 
 	columns.extend(
 		[
-			{"label": _("Against Voucher Type"), "fieldname": "against_voucher_type", "width": 100},
-			{
-				"label": _("Against Voucher"),
-				"fieldname": "against_voucher",
-				"fieldtype": "Dynamic Link",
-				"options": "against_voucher_type",
-				"width": 100,
-			},
 			{"label": _("Supplier Invoice No"), "fieldname": "bill_no", "fieldtype": "Data", "width": 100},
 		]
 	)


### PR DESCRIPTION
Issue: After the Payment Ledger Entries `against_voucher` and `against_voucher_type` are not updated in GL Entries which causes inconsistency in General Ledger Report.

Steps to replicate:
- Create a Sales Invoice
- Create a Payement Entry
- Reconcile Sales Invoice and Payment Entry
- Check General Ledger Report

`Against Voucher` will be incorrect because it is not updated in the GL Entry.

Before:
![image](https://github.com/user-attachments/assets/d8e92af5-caec-45b1-8460-fe2bcb8aeabc)

After:
![image](https://github.com/user-attachments/assets/2d7fa3a8-5c33-4e63-b67c-9f8b7ba82dea)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35143