### PR TITLE
fix: validate if pos is opened before pos invoice creation

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -196,6 +196,7 @@ class POSInvoice(SalesInvoice):
 
 		# run on validate method of selling controller
 		super(SalesInvoice, self).validate()
+		self.validate_pos_opening_entry()
 		self.validate_auto_set_posting_time()
 		self.validate_mode_of_payment()
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
@@ -326,6 +327,13 @@ class POSInvoice(SalesInvoice):
 					return frappe.throw(
 						_("Payment related to {0} is not completed").format(pay.mode_of_payment)
 					)
+
+	def validate_pos_opening_entry(self):
+		opening_entries = frappe.get_list(
+			"POS Opening Entry", filters={"pos_profile": self.pos_profile, "status": "Open", "docstatus": 1}
+		)
+		if len(opening_entries) == 0:
+			frappe.throw(_("No open POS Opening Entry found for POS Profile {0}").format(self.pos_profile))
 
 	def validate_stock_availablility(self):
 		if self.is_return:

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -333,7 +333,12 @@ class POSInvoice(SalesInvoice):
 			"POS Opening Entry", filters={"pos_profile": self.pos_profile, "status": "Open", "docstatus": 1}
 		)
 		if len(opening_entries) == 0:
-			frappe.throw(_("No open POS Opening Entry found for POS Profile {0}").format(self.pos_profile))
+			frappe.throw(
+				title=_("POS Opening Entry Missing"),
+				msg=_("No open POS Opening Entry found for POS Profile {0}.").format(
+					frappe.bold(self.pos_profile)
+				),
+			)
 
 	def validate_stock_availablility(self):
 		if self.is_return:

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -28,6 +28,12 @@ class TestPOSInvoice(IntegrationTestCase):
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 
+		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
+		from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
+
+		cls.test_user, cls.pos_profile = init_user_and_profile()
+		create_opening_entry(cls.pos_profile, cls.test_user)
+
 	def tearDown(self):
 		if frappe.session.user != "Administrator":
 			frappe.set_user("Administrator")


### PR DESCRIPTION
Added a validation to check whether a POS Opening Entry is created for the POS Profile before saving the POS Invoice. This resolves the issue of non-inclusion of those POS Invoices in POS Closing that were created before the POS was opened.

![image](https://github.com/user-attachments/assets/907bbaa9-1983-4155-82da-cc28612a1990)
