### PR TITLE
fix: pos opening entry's status not getting updated on cancel

### DIFF
--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
@@ -70,3 +70,6 @@ class POSOpeningEntry(StatusUpdater):
 
 	def on_submit(self):
 		self.set_status(update=True)
+
+	def on_cancel(self):
+		self.set_status(update=True)


### PR DESCRIPTION
The `status` field in the POS Opening Entry was not updated upon document cancellation. The `status` remained to what it was set before cancellation and never got updated to `Cancelled` state, even though the docstatus gets updated.