### PR TITLE
fix: improve translatability of query report print formats

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -282,4 +282,4 @@
 			{% } %}
 		</tbody>
 	</table>
-	<p class="text-right text-muted">{{ __("Printed On ") }}{%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+	<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -282,4 +282,4 @@
 			{% } %}
 		</tbody>
 	</table>
-	<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
+	<p class="text-right text-muted">{%= __("Printed on {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>

--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
@@ -46,4 +46,4 @@
 		{% } %}
 	</tbody>
 </table>
-<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
+<p class="text-right text-muted">{%= __("Printed on {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>

--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
@@ -1,6 +1,3 @@
-<div style="margin-bottom: 7px;">
-	{%= frappe.boot.letter_heads[frappe.defaults.get_default("letter_head")] %}
-</div>
 <h2 class="text-center">{%= __("Bank Reconciliation Statement") %}</h2>
 <h4 class="text-center">{%= filters.account && (filters.account + ", "+filters.report_date)  || "" %} {%= filters.company %}</h4>
 <hr>

--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
@@ -46,4 +46,4 @@
 		{% } %}
 	</tbody>
 </table>
-<p class="text-right text-muted">Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -67,5 +67,5 @@
 	</tbody>
 </table>
 <p class="text-right text-muted">
-	{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}
+	{%= __("Printed on {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}
 </p>

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -67,5 +67,5 @@
 	</tbody>
 </table>
 <p class="text-right text-muted">
-	Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}
+	{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}
 </p>

--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -78,14 +78,14 @@
 	<table style="width:100%; font-size: 11px">
 		<thead>
 			<tr class="title-letter-spacing" style="text-align: center; font-weight:bold">
-				<td style="border: 1.5px solid black; width: 7em">DATE</td>
-				<td style="border: 1.5px solid black">PARTICULARS</td>
+				<td style="border: 1.5px solid black; width: 7em">{%= __("Date").toLocaleUpperCase() %}</td>
+				<td style="border: 1.5px solid black">{%= __("Particulars").toLocaleUpperCase() %}</td>
 				{% if(filters.show_remarks) { %}
-						<td style="border: 1.5px solid black">REMARKS</td>
+						<td style="border: 1.5px solid black">{%= __("Remarks").toLocaleUpperCase() %}</td>
 				{% } %}
-				<td style="border: 1.5px solid black; width: 9em">DEBIT</td>
-				<td style="border: 1.5px solid black; width: 9em">CREDIT</td>
-				<td style="border: 1.5px solid black; width: 10.2em">BALANCE</td>
+				<td style="border: 1.5px solid black; width: 9em">{%= __("Debit").toLocaleUpperCase() %}</td>
+				<td style="border: 1.5px solid black; width: 9em">{%= __("Credit").toLocaleUpperCase() %}</td>
+				<td style="border: 1.5px solid black; width: 10.2em">{%= __("Balance").toLocaleUpperCase() %}</td>
 			</tr>
 		</thead>
 		<tbody>
@@ -129,10 +129,10 @@
 						</td>
 						<td style="text-align: left; border-right: 1px dotted black"><b>
 							{% if(i == l-2) { %}
-								{%= "Total" %}
+								{%= __("Total") %}
 							{% } else { %}
 								{% if(i == l-1) { %}
-									{%= "Closing [Opening + Total] " %}
+									{%= __("Closing [Opening + Total] ") %}
 								{% } else { %}
 									{%= frappe.format(data[i].account, {fieldtype: "Link"}) || "&nbsp;" %}
 								{% } %}

--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -171,5 +171,5 @@
 			{% endfor%}
 		</tbody>
 	</table>
-	<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
+	<p class="text-right text-muted">{%= __("Printed on {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
 </div>

--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -71,9 +71,7 @@
 		</div>
 		<div style="text-align:center; font-size:13px;">
 			<b>
-				{%= frappe.datetime.str_to_user(filters.from_date) %}
-				{%= __("to") %}
-				{%= frappe.datetime.str_to_user(filters.to_date) %}<br><br>
+				{%= __("{0} to {1}", [frappe.datetime.str_to_user(filters.from_date), frappe.datetime.str_to_user(filters.to_date)]) %}<br><br>
 			</b>
 		</div>
 	</div>
@@ -173,5 +171,5 @@
 			{% endfor%}
 		</tbody>
 	</table>
-	<p class="text-right text-muted">Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+	<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
 </div>

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
@@ -127,4 +127,4 @@
 <h4 class="text-center">{%= __("Analysis Chart") %}</h4>
 <div id="chart_div"></div>
 
-<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>
+<p class="text-right text-muted">{%= __("Printed on {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
@@ -94,9 +94,6 @@
     </script>
 
  </head>
-<div style="margin-bottom: 7px;" class="text-center">
-	{%= frappe.boot.letter_heads[frappe.defaults.get_default("letter_head")] %}
-</div>
 <h2 class="text-center">{%= __(report.report_name) %}</h2>
 <h4 class="text-center">{%= filters.item %} </h4>
 

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.html
@@ -124,9 +124,7 @@
 	</tbody>
 </table>
 
-<h4 class="text-center"> Analysis Chart </h4>
+<h4 class="text-center">{%= __("Analysis Chart") %}</h4>
 <div id="chart_div"></div>
 
-
-
-<p class="text-right text-muted">Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+<p class="text-right text-muted">{%= __("Printed On {0}", [frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())]) %}</p>


### PR DESCRIPTION
For some financial reports we have specific print formats

- The footer line "Printed on [datetime]" was not translatable, now it is.
- The header is added via a separate mechanism, redundant headers in the print formats are removed.
- Column headers in General Ledger were not translated at all. Went for translating title case strings because we already have translations for them, then converting to upper case.