### PR TITLE
fix: ignore backflush setting on subcontracting return

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -749,7 +749,9 @@ class SubcontractingController(StockController):
 			):
 				continue
 
-			if self.doctype == self.subcontract_data.order_doctype or self.backflush_based_on == "BOM":
+			if self.doctype == self.subcontract_data.order_doctype or (
+				self.backflush_based_on == "BOM" or self.is_return
+			):
 				for bom_item in self.__get_materials_from_bom(
 					row.item_code, row.bom, row.get("include_exploded_items")
 				):


### PR DESCRIPTION
Reference support ticket [35203](https://support.frappe.io/helpdesk/tickets/35203)

When subcontracting backflush was set to based on material transfer, supplied items table was not set causing valuation rate of returned items to go in negative when subcontracting receipt (return) document was being saved.