### PR TITLE
fix: allow warehouse to set title

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.json
+++ b/erpnext/stock/doctype/warehouse/warehouse.json
@@ -264,7 +264,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2025-01-22 10:47:00.674163",
+ "modified": "2025-04-08 13:46:38.674163",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Warehouse",
@@ -321,5 +321,6 @@
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "warehouse_name",
  "track_changes": 1
 }


### PR DESCRIPTION
Introduced in: https://github.com/frappe/erpnext/issues/42698

We should be able to set the title for search and display reasons. 

I know this is easy fix with property setters. But I think it should be the default.

For example:
01 - TEST (warehouse_name: City of Warehouse)
      - tree of bins
02 - TEST (warehouse_name: City of Warehouse)
      - tree of bins

This makes warehouse easy to search by it's unique ID or it's given alias name.
![image](https://github.com/user-attachments/assets/e9a6a2e6-9b33-48bc-9029-c31431f77a67)

