### PR TITLE
fix: interaction with due date / payment terms / payment schedule

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1042,32 +1042,32 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 	}
 
-	due_date() {
+	due_date(doc) {
 		// due_date is to be changed, payment terms template and/or payment schedule must
 		// be removed as due_date is automatically changed based on payment terms
 
 		// if there is only one row in payment schedule child table, set its due date as the due date
-		if (this.frm.doc.payment_schedule.length == 1){
-			this.frm.doc.payment_schedule[0].due_date = this.frm.doc.due_date;
+		if (doc.payment_schedule.length == 1){
+			doc.payment_schedule[0].due_date = doc.due_date;
 			this.frm.refresh_field("payment_schedule");
 			return
 		}
 
 		if (
-			this.frm.doc.due_date &&
+			doc.due_date &&
 			!this.frm.updating_party_details &&
-			!this.frm.doc.is_pos &&
+			!doc.is_pos &&
 			(
-				this.frm.doc.payment_terms_template ||
-				this.frm.doc.payment_schedule?.length
+				doc.payment_terms_template ||
+				doc.payment_schedule?.length
 			)
 		) {
 			const to_clear = [];
-			if (this.frm.doc.payment_terms_template) {
+			if (doc.payment_terms_template) {
 				to_clear.push("Payment Terms Template");
 			}
 
-			if (this.frm.doc.payment_schedule?.length) {
+			if (doc.payment_schedule?.length) {
 				to_clear.push("Payment Schedule Table");
 			}
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1078,8 +1078,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 			frappe.confirm(
 				__(
-					"Do you want to clear the selected {0}?",
-					[frappe.utils.comma_and(to_clear.map(dt => __(dt)))]
+					"For the new {0} to take effect, would you like to clear the current {1}?",
+					[
+						__(frappe.meta.get_label(cdt, "due_date")),
+						frappe.utils.comma_and(to_clear)
+					],
 				),
 				() => {
 					this.frm.set_value("payment_terms_template", "");

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1083,6 +1083,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 						__(frappe.meta.get_label(cdt, "due_date")),
 						frappe.utils.comma_and(to_clear)
 					],
+					"Clear payment terms template and/or payment schedule when due date is changed"
 				),
 				() => {
 					this.frm.set_value("payment_terms_template", "");

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1042,9 +1042,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 	}
 
-	due_date(doc) {
+	due_date(doc, cdt) {
 		// due_date is to be changed, payment terms template and/or payment schedule must
 		// be removed as due_date is automatically changed based on payment terms
+		if (doc.doctype !== cdt) {
+			// triggered by change to the due_date field in payment schedule child table
+			// do nothing to avoid infinite clearing loop
+			return;
+		}
 
 		// if there is only one row in payment schedule child table, set its due date as the due date
 		if (doc.payment_schedule.length == 1){

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1069,11 +1069,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		) {
 			const to_clear = [];
 			if (doc.payment_terms_template) {
-				to_clear.push("Payment Terms Template");
+				to_clear.push(__(frappe.meta.get_label(cdt, "payment_terms_template")));
 			}
 
 			if (doc.payment_schedule?.length) {
-				to_clear.push("Payment Schedule Table");
+				to_clear.push(__(frappe.meta.get_label(cdt, "payment_schedule")));
 			}
 
 			frappe.confirm(


### PR DESCRIPTION
- Use `doc` parameter instead of `this.frm.doc` (refactor, make code easier to read)
- Recognize trigger from child table in order to avoid a prompt to clear the child table while editing it
- Use the actual field labels instead of new made up labels
- Clarify message for confirmation dialog
- Add context to make it easier to correctly translate this message
