### PR TITLE
fix: added missing project field on pos profile

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -58,7 +58,8 @@
   "apply_discount_on",
   "accounting_dimensions_section",
   "cost_center",
-  "dimension_col_break"
+  "dimension_col_break",
+  "project"
  ],
  "fields": [
   {
@@ -406,6 +407,14 @@
    "fieldname": "disable_grand_total_to_default_mop",
    "fieldtype": "Check",
    "label": "Disable auto setting Grand Total to default Payment Mode"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "oldfieldname": "cost_center",
+   "oldfieldtype": "Link",
+   "options": "Project"
   }
  ],
  "icon": "icon-cog",
@@ -433,7 +442,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-01-29 13:12:30.796630",
+ "modified": "2025-04-09 11:35:13.779613",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",
@@ -459,6 +468,7 @@
    "role": "Accounts User"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -53,6 +53,7 @@ class POSProfile(Document):
 		payments: DF.Table[POSPaymentMethod]
 		print_format: DF.Link | None
 		print_receipt_on_order_complete: DF.Check
+		project: DF.Link | None
 		select_print_heading: DF.Link | None
 		selling_price_list: DF.Link | None
 		tax_category: DF.Link | None


### PR DESCRIPTION
Added the project field on POS Profile, which was missing as cost_center and project are default dimensions for Accounting Transactions. Ref: https://github.com/frappe/erpnext/pull/46961#discussion_r2034496178