### PR TITLE
fix:propagate lost reason from Quotation to Opportunity (Issue:46948)

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -239,8 +239,34 @@ class Quotation(SellingController):
 		if not opportunity:
 			opportunity = self.opportunity
 
+		if not opportunity:
+			return
+
 		opp = frappe.get_doc("Opportunity", opportunity)
 		opp.set_status(status=status, update=True)
+
+		if status == "Lost":
+			# Propagate lost reasons from Quotation to Opportunity
+
+			opp.lost_reasons = []
+
+			for reason_row in self.lost_reasons:
+				# Ensure the reason exists in Opportunity Lost Reason
+				if not frappe.db.exists("Opportunity Lost Reason", reason_row.lost_reason):
+					frappe.get_doc({
+						"doctype": "Opportunity Lost Reason",
+						"lost_reason": reason_row.lost_reason
+					}).insert(ignore_permissions=True)
+
+				opp.append("lost_reasons", {
+					"lost_reason": reason_row.lost_reason
+				})
+
+			if self.order_lost_reason:
+				opp.order_lost_reason = self.order_lost_reason
+
+			opp.save(ignore_permissions=True)
+
 
 	@frappe.whitelist()
 	def declare_enquiry_lost(self, lost_reasons_list, competitors, detailed_reason=None):


### PR DESCRIPTION
> Branch to merge into: `version-15`  
> PR Title: `fix: propagate lost reasons from Quotation to Opportunity when status is Lost`  
> Closes: #46948 (if an issue is created)

---

### Problem

When a Quotation is marked as "Lost", ERPNext automatically updates the linked Opportunity to "Lost" via `update_opportunity()`. However, the Opportunity fails to save if no `lost_reason` is set, because this field is mandatory when status is "Lost".

This causes a silent failure and leaves the Opportunity in an inconsistent state, with the status field updated in memory but not saved to the database.

---

### Solution

This PR extends the `update_opportunity_status()` method to handle the propagation of lost reasons:
- Copies `lost_reasons` from Quotation to Opportunity.
- Dynamically creates missing `Opportunity Lost Reason` master records (if needed).
- Sets `order_lost_reason` (detailed reason) on the Opportunity if provided.
- Ensures the Opportunity is saved after setting the required fields.

This design is clean and centralizes the logic in a single place, improving maintainability and consistency across the app.

---

### How to Test

1. Create an Opportunity.
2. Create a linked Quotation for that Opportunity.
3. Use the "Declare Lost" action on the Quotation and add a lost reason and detailed reason.
4. Check that:
   - The Opportunity is marked as "Lost".
   - The same lost reasons appear under the Opportunity’s "Lost Reasons" child table.
   - The detailed lost reason is copied to `order_lost_reason`.
   - No validation errors occur, and the Opportunity saves successfully.

---

### Code Location

File: `erpnext/selling/doctype/quotation/quotation.py`  
Method Updated: `update_opportunity_status`

---

