### PR TITLE
fix: incorrect PR status when using set landed cost based on pi rate

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2551,6 +2551,41 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 
 		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 1)
 
+	def test_pr_status_rate_adjusted_from_pi(self):
+		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 0)
+		frappe.db.set_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", 1)
+
+		pr = make_purchase_receipt(qty=5, rate=100)
+		pi = create_purchase_invoice_from_receipt(pr.name)
+		pi.submit()
+		pr.reload()
+
+		# Inital check
+		self.assertEqual(pr.status, "Completed")
+
+		pi.reload()
+		pi.cancel()
+		pi = create_purchase_invoice_from_receipt(pr.name)
+		pi.items[0].rate = 80
+		pi.submit()
+		pr.reload()
+
+		# Test 1 : Adjustment amount is negative
+		self.assertEqual(pr.status, "Completed")
+
+		pi.reload()
+		pi.cancel()
+		pi = create_purchase_invoice_from_receipt(pr.name)
+		pi.items[0].rate = 120
+		pi.submit()
+		pr.reload()
+
+		# Test 2 : Adjustment amount is positive
+		self.assertEqual(pr.status, "Completed")
+
+		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 1)
+		frappe.db.set_single_value("Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", 0)
+
 	def test_opening_invoice_rounding_adjustment_validation(self):
 		pi = make_purchase_invoice(do_not_save=1)
 		pi.items[0].rate = 99.98

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1147,10 +1147,10 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 	percent_billed = round(
 		100
 		* (
-			(total_billed_amount + (pi_landed_cost_amount * -1 if pi_landed_cost_amount < 0 else 1))
+			(total_billed_amount + (pi_landed_cost_amount * (-1 if pi_landed_cost_amount < 0 else 1)))
 			/ (total_amount or 1)
 		),
-		2,
+		6,
 	)
 	pr_doc.db_set("per_billed", percent_billed)
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1141,17 +1141,13 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 				) * item.qty
 
 			adjusted_amt = flt(adjusted_amt * flt(pr_doc.conversion_rate), item.precision("amount"))
-			pi_landed_cost_amount += flt(adjusted_amt)
+			pi_landed_cost_amount += adjusted_amt
 			item.db_set("amount_difference_with_purchase_invoice", adjusted_amt, update_modified=False)
 
-	percent_billed = round(
-		100
-		* (
-			(total_billed_amount + (pi_landed_cost_amount * (-1 if pi_landed_cost_amount < 0 else 1)))
-			/ (total_amount or 1)
-		),
-		6,
-	)
+	if pi_landed_cost_amount < 0:
+		total_billed_amount += abs(pi_landed_cost_amount)
+
+	percent_billed = round(100 * (total_billed_amount / (total_amount or 1)), 6)
 	pr_doc.db_set("per_billed", percent_billed)
 
 	if update_modified:

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1105,7 +1105,7 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 	# Update Billing % based on pending accepted qty
 	buying_settings = frappe.get_single("Buying Settings")
 
-	total_amount, total_billed_amount = 0, 0
+	total_amount, total_billed_amount, pi_landed_cost_amount = 0, 0, 0
 	item_wise_returned_qty = get_item_wise_returned_qty(pr_doc)
 
 	if adjust_incoming_rate:
@@ -1141,9 +1141,17 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 				) * item.qty
 
 			adjusted_amt = flt(adjusted_amt * flt(pr_doc.conversion_rate), item.precision("amount"))
+			pi_landed_cost_amount += flt(adjusted_amt)
 			item.db_set("amount_difference_with_purchase_invoice", adjusted_amt, update_modified=False)
 
-	percent_billed = round(100 * (total_billed_amount / (total_amount or 1)), 6)
+	percent_billed = round(
+		100
+		* (
+			(total_billed_amount + (pi_landed_cost_amount * -1 if pi_landed_cost_amount < 0 else 1))
+			/ (total_amount or 1)
+		),
+		2,
+	)
 	pr_doc.db_set("per_billed", percent_billed)
 
 	if update_modified:


### PR DESCRIPTION
Fixes #46943 

update_billing_percentage method now considers amount_difference_with_purchase_invoice field when calculating per_billed