### PR TITLE
fix: Proper Postal Code Order and Add Party Name Properly

### DIFF
--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -9,9 +9,9 @@ field_map = {
 	"Address": [
 		"address_line1",
 		"address_line2",
+		"pincode",
 		"city",
 		"state",
-		"pincode",
 		"country",
 		"is_primary_address",
 	],
@@ -43,14 +43,10 @@ def get_columns(filters):
 		"Email Id",
 		"Is Primary Contact:Check",
 	]
-	if filters.get("party_type") == "Supplier" and frappe.db.get_single_value(
-		"Buying Settings", "supp_master_name"
-	) == ["Naming Series", "Auto Name"]:
-		columns.insert(1, "Supplier Name:Data:150")
-	if filters.get("party_type") == "Customer" and frappe.db.get_single_value(
-		"Selling Settings", "cust_master_name"
-	) == ["Naming Series", "Auto Name"]:
-		columns.insert(1, "Customer Name:Data:150")
+
+	if should_add_party_name(party_type):
+		columns.insert(2, f"{party_type} Name:Data:150")
+
 	return columns
 
 
@@ -72,6 +68,7 @@ def get_party_addresses_and_contact(party_type, party, party_group, filters):
 
 	if party:
 		query_filters = {"name": party}
+
 	if filters.get("party_type") in ["Customer", "Supplier"]:
 		field = filters.get("party_type").lower() + "_name"
 	else:
@@ -93,14 +90,18 @@ def get_party_addresses_and_contact(party_type, party, party_group, filters):
 	party_details = get_party_details(party_type, party_list, "Address", party_details)
 	party_details = get_party_details(party_type, party_list, "Contact", party_details)
 
+	add_party_name = should_add_party_name(party_type)
+
 	for party, details in party_details.items():
 		addresses = details.get("address", [])
 		contacts = details.get("contact", [])
 		if not any([addresses, contacts]):
 			result = [party]
 			result.append(party_groups[party])
-			if filters.get("party_type") in ["Customer", "Supplier"]:
+
+			if add_party_name:
 				result.append(party_name_map[party])
+
 			result.extend(add_blank_columns_for("Contact"))
 			result.extend(add_blank_columns_for("Address"))
 			data.append(result)
@@ -112,8 +113,10 @@ def get_party_addresses_and_contact(party_type, party, party_group, filters):
 			for idx in range(0, max_length):
 				result = [party]
 				result.append(party_groups[party])
-				if filters.get("party_type") in ["Customer", "Supplier"]:
+
+				if add_party_name:
 					result.append(party_name_map[party])
+
 				address = addresses[idx] if idx < len(addresses) else add_blank_columns_for("Address")
 				contact = contacts[idx] if idx < len(contacts) else add_blank_columns_for("Contact")
 				result.extend(address)
@@ -130,9 +133,11 @@ def get_party_details(party_type, party_list, doctype, party_details):
 	fields = ["`tabDynamic Link`.link_name", *field_map.get(doctype, [])]
 
 	records = frappe.get_list(doctype, filters=filters, fields=fields, as_list=True)
+
 	for d in records:
 		details = party_details.get(d[0])
 		details.setdefault(frappe.scrub(doctype), []).append(d[1:])
+
 	return party_details
 
 
@@ -151,3 +156,16 @@ def get_party_group(party_type):
 	}
 
 	return group[party_type]
+
+
+def should_add_party_name(party_type):
+	settings_map = {
+		"Supplier": ("Buying Settings", "supp_master_name"),
+		"Customer": ("Selling Settings", "cust_master_name"),
+	}
+
+	if party_type in settings_map:
+		doctype, fieldname = settings_map.get(party_type)
+		return frappe.db.get_single_value(doctype, fieldname) in ["Naming Series", "Auto Name"]
+
+	return False


### PR DESCRIPTION
Fix(#44950) - **Postal Code** Order was changed in column but when data is fetched in that order was not changed so **Postal Code**, **City** and **State** were not proper.

Before : 
<img width="387" alt="Screenshot 2025-04-10 at 1 32 06 AM" src="https://github.com/user-attachments/assets/69878d0f-ce20-482d-bce2-bb7e33490989" />

After: 
<img width="371" alt="Screenshot 2025-04-10 at 1 36 47 AM" src="https://github.com/user-attachments/assets/f6e0bb28-0874-4bb1-a197-f709cb8c7687" />


Fix(#37557) – Previously, the column logic was based on both Party Type and Buying/Selling settings, while the data logic only checked the Party Type, which caused inconsistencies. This has now been fixed by creating a common function to apply the same logic in both places.



Before: 
The **Customer Name** column has not been added, but the data includes it. As a result, the customer name is appearing under the **Address Line 1** column, which is incorrect.
<img width="413" alt="Screenshot 2025-04-10 at 1 39 33 AM" src="https://github.com/user-attachments/assets/c82e57ce-3767-4ae1-a6d5-be03f0cc869d" />


After: 
<img width="516" alt="Screenshot 2025-04-10 at 1 46 38 AM" src="https://github.com/user-attachments/assets/cb1ba9a2-2298-406e-89e1-b23a4f422abd" />

