### PR TITLE
fix: Allow adding Address/Contact fields to `Address And Contacts` report

### DIFF
--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe import _
 
 field_map = {
 	"Contact": ["name", "first_name", "last_name", "phone", "mobile_no", "email_id", "is_primary_contact"],
@@ -31,7 +32,7 @@ def get_columns(filters):
 		f"{party_type}:Link/{party_type}",
 		f"{frappe.unscrub(str(party_type_value))}::150",
 		{
-			"label": "Address",
+			"label": _("Address"),
 			"fieldtype": "Link",
 			"options": "Address",
 			"hidden": 1,
@@ -43,7 +44,7 @@ def get_columns(filters):
 		"State",
 		"Country",
 		"Is Primary Address:Check",
-		{"label": "Contact", "fieldtype": "Link", "options": "Contact", "hidden": 1},
+		{"label": _("Contact"), "fieldtype": "Link", "options": "Contact", "hidden": 1},
 		"First Name",
 		"Last Name",
 		"Phone",

--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -5,8 +5,9 @@
 import frappe
 
 field_map = {
-	"Contact": ["first_name", "last_name", "phone", "mobile_no", "email_id", "is_primary_contact"],
+	"Contact": ["name", "first_name", "last_name", "phone", "mobile_no", "email_id", "is_primary_contact"],
 	"Address": [
+		"name",
 		"address_line1",
 		"address_line2",
 		"city",
@@ -29,6 +30,12 @@ def get_columns(filters):
 	columns = [
 		f"{party_type}:Link/{party_type}",
 		f"{frappe.unscrub(str(party_type_value))}::150",
+		{
+			"label": "Address",
+			"fieldtype": "Link",
+			"options": "Address",
+			"hidden": 1,
+		},
 		"Address Line 1",
 		"Address Line 2",
 		"Postal Code",
@@ -36,6 +43,7 @@ def get_columns(filters):
 		"State",
 		"Country",
 		"Is Primary Address:Check",
+		{"label": "Contact", "fieldtype": "Link", "options": "Contact", "hidden": 1},
 		"First Name",
 		"Last Name",
 		"Phone",


### PR DESCRIPTION
- closes: https://github.com/frappe/erpnext/issues/46851

The Add Column functionality includes fields only from columns with Link-type doctypes. Previously, in the Address and Contact report, only Supplier and Customer were defined as Link fields, so only their related fields could be added using the Add Column feature.

This PR adds Address and Contact as hidden Link fields in the report. Although these links won’t be directly visible in the UI, fields from the Address and Contact doctypes can now be selected and added through the Add Column functionality.