### PR TITLE
fix: fetch exchange rate while creating inter-company order and invoice

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1130,13 +1130,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	currency() {
 		// The transaction date be either transaction_date (from orders) or posting_date (from invoices)
 		let transaction_date = this.frm.doc.transaction_date || this.frm.doc.posting_date;
+		let inter_company_reference = this.frm.doc.inter_company_order_reference || this.frm.doc.inter_company_invoice_reference;
 
 		let me = this;
 		this.set_dynamic_labels();
 		let company_currency = this.get_company_currency();
 		// Added `load_after_mapping` to determine if document is loading after mapping from another doc
 		if(this.frm.doc.currency && this.frm.doc.currency !== company_currency
-				&& !this.frm.doc.__onload?.load_after_mapping) {
+				&& (!this.frm.doc.__onload?.load_after_mapping || inter_company_reference)) {
 
 			this.get_exchange_rate(transaction_date, this.frm.doc.currency, company_currency,
 				function(exchange_rate) {


### PR DESCRIPTION
**Issue:**
While creating an inter-company order and invoice, changing the currency didn't fetch the exchange rate
**ref:** [35665](https://support.frappe.io/helpdesk/tickets/35665)

**Before:**

https://github.com/user-attachments/assets/08ff40d3-d937-432f-aa8d-169e7340c03f


**After:**

https://github.com/user-attachments/assets/9b598ebc-f4d9-4c45-96b0-a22db3fed0c5


 **Backport needed for v15**