### PR TITLE
fix(accounts): make item_code mandatory for non-opening entries

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -830,6 +830,9 @@ class AccountsController(TransactionBase):
 			self.pricing_rules = []
 
 			for item in self.get("items"):
+				if not item.get("item_code") and self.is_opening == "No":
+					frappe.throw(_("Row #{0}: Please select Item Code first").format(item.idx))
+
 				if item.get("item_code"):
 					ctx: ItemDetailsCtx = ItemDetailsCtx(parent_dict.copy())
 					ctx.update(item.as_dict())

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2235,3 +2235,11 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, si.save)
 		si.contact_person = customer_contact.name
 		si.save()
+
+	def test_missing_item_code_in_item_table(self):
+		si = create_sales_invoice(do_not_save=True)
+		si.items[0].item_code = ""
+		self.assertRaises(frappe.ValidationError, si.save)
+
+		si.items[0].item_code = "_Test Item"
+		si.save()


### PR DESCRIPTION
**Issue:**
Able to save and submit Invoices even if they are non-opening entries.

**Before:**

[missing_item_code_bfr.webm](https://github.com/user-attachments/assets/a99a5f6a-f0eb-4eb7-9113-2d56887bc37a)

**After:**

[missing_item_code_afr.webm](https://github.com/user-attachments/assets/327af11a-fb0b-473f-866a-fedb146e8dad)

**Back port needed for version-15**