### PR TITLE
Fix: Prevent Job Card Submission If Time Logs Are Missing End Time

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -706,6 +706,14 @@ class JobCard(Document):
 				)
 			)
 
+		# Check for incomplete time logs
+		incomplete_logs = [log.idx for log in self.time_logs if log.from_time and not log.to_time]
+		if incomplete_logs:
+			if len(incomplete_logs) == 1:
+				frappe.throw(_("Row {0}: End Time is required for the Time Log").format(incomplete_logs[0]))
+			else:
+				frappe.throw(_("Rows {0}: End Time is required for the Time Logs").format(", ".join(str(idx) for idx in incomplete_logs)))
+
 		precision = self.precision("total_completed_qty")
 		total_completed_qty = flt(
 			flt(self.total_completed_qty, precision) + flt(self.process_loss_qty, precision)

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -712,7 +712,11 @@ class JobCard(Document):
 			if len(incomplete_logs) == 1:
 				frappe.throw(_("Row {0}: End Time is required for the Time Log").format(incomplete_logs[0]))
 			else:
-				frappe.throw(_("Rows {0}: End Time is required for the Time Logs").format(", ".join(str(idx) for idx in incomplete_logs)))
+				frappe.throw(
+					_("Rows {0}: End Time is required for the Time Logs").format(
+						", ".join(str(idx) for idx in incomplete_logs)
+					)
+				)
 
 		precision = self.precision("total_completed_qty")
 		total_completed_qty = flt(


### PR DESCRIPTION
This PR adds a validation to prevent submission of job cards when any linked time log is missing an end time.

Previously, job cards could be submitted even if time logs had only a start time, which led to incomplete tracking and inaccurate reports.

With this fix, all time logs must have both start and end times before the job card can be submitted, ensuring better data accuracy.


[Screencast from 2025-04-11 01:33:28 PM.webm](https://github.com/user-attachments/assets/c429078b-ad7c-419b-9a2e-023f8e4c3102)


closes #46994 