### PR TITLE
fix: allow to use batch-wise valuation for moving average items

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -160,11 +160,9 @@ class Batch(Document):
 		from erpnext.stock.utils import get_valuation_method
 
 		if self.is_new():
-			if get_valuation_method(self.item) == "Moving Average":
-				self.use_batchwise_valuation = 0
-				return
+			use_batch_wise_valuation = frappe.db.get_single_value("Stock Settings", "use_batchwise_valuation")
 
-			if frappe.db.get_single_value("Stock Settings", "do_not_use_batchwise_valuation"):
+			if get_valuation_method(self.item) == "Moving Average" and not use_batch_wise_valuation:
 				self.use_batchwise_valuation = 0
 				return
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1978,6 +1978,55 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertEqual(se.items[0].amount, 300)
 		self.assertEqual(se.items[0].basic_amount, 300)
 
+	def test_use_batch_wise_valuation_for_moving_average_item(self):
+		item_code = "_Test Use Batch Wise MA Valuation Item"
+
+		make_item(
+			item_code,
+			{
+				"is_stock_item": 1,
+				"valuation_method": "Moving Average",
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_naming_series": "Test-UBWVMAV-T-NNS.#####",
+			},
+		)
+
+		frappe.db.set_single_value("Stock Settings", "use_batchwise_valuation", 1)
+
+		batches = []
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			to_warehouse="_Test Warehouse - _TC",
+			basic_rate=100,
+			posting_date=add_days(nowdate(), -2),
+		)
+
+		batches.append(get_batch_from_bundle(se.items[0].serial_and_batch_bundle))
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			to_warehouse="_Test Warehouse - _TC",
+			basic_rate=300,
+			posting_date=add_days(nowdate(), -1),
+		)
+
+		batches.append(get_batch_from_bundle(se.items[0].serial_and_batch_bundle))
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=5,
+			from_warehouse="_Test Warehouse - _TC",
+			batch_no=batches[1],
+			posting_date=nowdate(),
+		)
+
+		self.assertEqual(se.items[0].basic_rate, 300)
+
+		frappe.db.set_single_value("Stock Settings", "use_batchwise_valuation", 0)
+
 
 def make_serialized_item(self, **args):
 	args = frappe._dict(args)

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -9,6 +9,7 @@
   "item_defaults_section",
   "item_naming_by",
   "valuation_method",
+  "use_batchwise_valuation",
   "item_group",
   "column_break_4",
   "default_warehouse",
@@ -464,6 +465,7 @@
    "description": "If enabled, the system will use the moving average valuation method to calculate the valuation rate for the batched items and will not consider the individual batch-wise incoming rate.",
    "fieldname": "do_not_use_batchwise_valuation",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Do Not Use Batch-wise Valuation"
   },
   {
@@ -529,6 +531,13 @@
    "fieldname": "allow_to_make_quality_inspection_after_purchase_or_delivery",
    "fieldtype": "Check",
    "label": "Allow to Make Quality Inspection after Purchase / Delivery"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.valuation_method == \"Moving Average\"",
+   "fieldname": "use_batchwise_valuation",
+   "fieldtype": "Check",
+   "label": "Use Batch-wise Valuation"
   }
  ],
  "icon": "icon-cog",
@@ -536,7 +545,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-10 16:19:31.210007",
+ "modified": "2025-04-11 15:57:30.501279",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -65,6 +65,7 @@ class StockSettings(Document):
 		stock_frozen_upto_days: DF.Int
 		stock_uom: DF.Link | None
 		update_existing_price_list_rate: DF.Check
+		use_batchwise_valuation: DF.Check
 		use_naming_series: DF.Check
 		use_serial_batch_fields: DF.Check
 		valuation_method: DF.Literal["FIFO", "Moving Average", "LIFO"]
@@ -110,6 +111,9 @@ class StockSettings(Document):
 		self.validate_use_batch_wise_valuation()
 
 	def validate_use_batch_wise_valuation(self):
+		if self.use_batchwise_valuation:
+			self.do_not_use_batchwise_valuation = 0
+
 		if not self.do_not_use_batchwise_valuation:
 			return
 

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -692,7 +692,9 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 		self.batchwise_valuation_batches = []
 		self.non_batchwise_valuation_batches = []
 
-		if get_valuation_method(self.sle.item_code) == "Moving Average":
+		use_batch_wise_valuation = frappe.db.get_single_value("Stock Settings", "use_batchwise_valuation")
+
+		if get_valuation_method(self.sle.item_code) == "Moving Average" and not use_batch_wise_valuation:
 			self.non_batchwise_valuation_batches = self.batches
 			return
 


### PR DESCRIPTION
<img width="975" alt="Screenshot 2025-04-11 at 4 07 34 PM" src="https://github.com/user-attachments/assets/67540f7b-4aaf-4d89-89d0-45128d73b6b1" />
