### PR TITLE
fix(Employee): add/delete user permission

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -335,10 +335,7 @@ doc_events = {
 	"User": {
 		"after_insert": "frappe.contacts.doctype.contact.contact.update_contact",
 		"validate": "erpnext.setup.doctype.employee.employee.validate_employee_role",
-		"on_update": [
-			"erpnext.setup.doctype.employee.employee.update_user_permissions",
-			"erpnext.portal.utils.set_default_role",
-		],
+		"on_update": "erpnext.portal.utils.set_default_role",
 	},
 	"Communication": {
 		"on_update": [

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -248,15 +248,6 @@ def validate_employee_role(doc, method=None, ignore_emp_check=False):
 		doc.get("roles").remove(doc.get("roles", {"role": "Employee Self Service"})[0])
 
 
-def update_user_permissions(doc, method):
-	# called via User hook
-	if "Employee" in [d.role for d in doc.get("roles")]:
-		if not has_permission("User Permission", ptype="write", print_logs=False):
-			return
-		employee = frappe.get_doc("Employee", {"user_id": doc.name})
-		employee.update_user_permissions()
-
-
 def get_employee_email(employee_doc):
 	return (
 		employee_doc.get("user_id") or employee_doc.get("personal_email") or employee_doc.get("company_email")

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -85,9 +85,7 @@ class Employee(NestedSet):
 		self.reset_employee_emails_cache()
 
 	def update_user_permissions(self):
-		if not has_permission("User Permission", ptype="write", print_logs=False) or (
-			not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission")
-		):
+		if not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"):
 			return
 
 		employee_user_permission_exists = frappe.db.exists(


### PR DESCRIPTION
- Checking _write_ permissions on **User Permission** is incorrect, because we will either _create_ or _delete_ them.
- The called functions `add_user_permission` / `remove_user_permission` will do the correct permission checks.
- If a user tries to change the value of _User ID_ or _Create User Permission_ but does not have permissions to add/remove **User Permission**, they should get an error. Otherwise we'll get inconsistent system states (e.g. an **Employee** has _Create User Permission_ enabled, but the corresponding **User Permissions** are missing).

Alternative: ignore permissions altogether, HR users need to change these fields but shouldn't have permissions on **User Permission** otherwise.