### PR TITLE
fix(italy): Add tax-related custom fields to POS Invoice Item

### DIFF
--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -378,6 +378,7 @@ def make_custom_fields(update=True):
 			),
 		],
 		"Purchase Invoice Item": invoice_item_fields,
+		"POS Invoice Item": invoice_item_fields,
 		"Sales Order Item": invoice_item_fields,
 		"Delivery Note Item": invoice_item_fields,
 		"Sales Invoice Item": invoice_item_fields + customer_po_fields,


### PR DESCRIPTION
## Bug Fix: Missing Tax Fields in POS Invoice Item for Italy Region

### Summary

This PR adds missing **tax-related custom fields** to the **`POS Invoice Item`** DocType in the **Italy regional module**.

### Problem

When using the Italy regional configuration and creating a POS Invoice, the system throws the following error during tax calculation:

```
AttributeError: 'NoneType' object has no attribute 'fieldtype'
```

This error originates from the `update_itemised_tax_data()` function, which expects the following fields on each POS Invoice Item:

- `tax_rate`
- `tax_amount`
- `total_amount`

These fields are not present in Italy's configuration, leading to the error. This causes tax calculation to fail when saving a POS Invoice.

### Root Cause

Other regional modules like **United Arab Emirates (UAE)** include these fields via `invoice_item_fields`, ensuring compatibility with the tax system. The Italy module did **not** define these fields for the `POS Invoice Item`, even though it uses the same tax processing logic.

### Solution

This PR adds the missing tax fields to `"POS Invoice Item"` inside `make_custom_fields()` in `erpnext/regional/italy/setup.py`, by referencing the already defined `invoice_item_fields`.

### Benefits

- Fixes crash when saving a POS Invoice for Italy

### How to Reproduce

1. Set country to **Italy**
2. Create a POS Invoice with taxes
3. Save → Error appears

### How to Test After Fix

1. Pull changes and run:
   ```bash
   bench --site [your-site-name] execute erpnext.regional.italy.setup.make_custom_fields
   ```
2. Confirm fields (`tax_rate`, `tax_amount`, `total_amount`) exist on **POS Invoice Item**
3. Create and submit a POS Invoice with taxes → No error should occur

`no-docs`