### PR TITLE
fix: Check `return_against` and Await API Call

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -64,7 +64,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			&& this.frm.doc.is_pos
 			&& this.frm.doc.is_return
 		) {
-			this.set_total_amount_to_default_mop();
+			await this.set_total_amount_to_default_mop();
 			this.calculate_paid_amount();
 		}
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -894,23 +894,25 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		it should set the return to that mode of payment only.
 		*/
 
-		let return_against_mop = await frappe.call({
-			method: 'erpnext.controllers.sales_and_purchase_return.get_payment_data',
-			args: {
-				invoice: this.frm.doc.return_against
-			}
-		});
-
-		if (return_against_mop.message.length === 1) {
-			this.frm.doc.payments.forEach(payment => {
-				if (payment.mode_of_payment == return_against_mop.message[0].mode_of_payment) {
-					payment.amount = total_amount_to_pay;
-				} else {
-					payment.amount = 0;
+		if(this.frm.doc.return_against){
+			let {message : return_against_mop } = await frappe.call({
+				method: 'erpnext.controllers.sales_and_purchase_return.get_payment_data',
+				args: {
+					invoice: this.frm.doc.return_against
 				}
 			});
-			this.frm.refresh_fields();
-			return;
+
+			if (return_against_mop.length === 1) {
+				this.frm.doc.payments.forEach(payment => {
+					if (payment.mode_of_payment == return_against_mop[0].mode_of_payment) {
+						payment.amount = total_amount_to_pay;
+					} else {
+						payment.amount = 0;
+					}
+				});
+				this.frm.refresh_fields();
+				return;
+			}
 		}
 
 		this.frm.doc.payments.find(payment => {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -843,8 +843,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		frappe.model.set_value(item.doctype, item.name, "stock_qty", valid_serial_nos.length);
 	}
 
-	validate() {
-		this.calculate_taxes_and_totals(false);
+	async validate() {
+		await this.calculate_taxes_and_totals(false);
 	}
 
 	update_stock() {


### PR DESCRIPTION
As mentioned in the [Frappe discuss issue](https://discuss.frappe.io/t/creating-sales-return-invoice-error/145639), the error occurred because `return_against` was not checked before calling the `get_payment_data` API, which requires it as a mandatory field. This check is now added before the API call.

Additionally, since the API call(get_payment_data) is asynchronous, the form was saved before it completed, resulting in incorrect payment values. async/await is now used to ensure values are set correctly before saving.
