### PR TITLE
fix: Group GLs by account for TB generation

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -116,6 +116,7 @@ def get_data(filters):
 		root_rgt=None,
 		ignore_closing_entries=not flt(filters.with_period_closing_entry_for_current_period),
 		ignore_opening_entries=True,
+		group_by_account=True,
 	)
 
 	calculate_values(


### PR DESCRIPTION
TB doesn't need account-wise balances to be pulled for the current reporting period. It used the common `set_gl_entries_by_account`  in `financial_statements.py`.  In large DB it ends up taking a lot of memory during execution. Every GL is not needed for TB computation and summary info is enough. Using summary info leads to much less memory usage.

Before:
![image](https://github.com/user-attachments/assets/4b82ad29-b49d-4704-bc65-750f5d9b7449)

After:
![image](https://github.com/user-attachments/assets/9a519731-19de-4957-96f2-a4149035c1c0)
