### PR TITLE
fix: calculate useful days of asset's life correctly for existing asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -635,37 +635,40 @@ class Asset(AccountsController):
 		return add_days(self.available_for_use_date, -1)
 
 	# if it returns True, depreciation_amount will not be equal for the first and last rows
-	def check_is_pro_rata(self, row, wdv_or_dd_non_yearly=False):
+	def check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 		has_pro_rata = False
 
 		# if not existing asset, from_date = available_for_use_date
 		# otherwise, if number_of_depreciations_booked = 2, available_for_use_date = 01/01/2020 and frequency_of_depreciation = 12
 		# from_date = 01/01/2022
-		from_date = self.get_modified_available_for_use_date(row, wdv_or_dd_non_yearly)
-		days = date_diff(row.depreciation_start_date, from_date) + 1
-
-		if wdv_or_dd_non_yearly:
-			total_days = get_total_days(row.depreciation_start_date, 12)
+		if row.depreciation_method in ("Straight Line", "Manual"):
+			prev_depreciation_start_date = get_last_day(
+				add_months(
+					row.depreciation_start_date,
+					(row.frequency_of_depreciation * -1) * asset_doc.number_of_depreciations_booked,
+				)
+			)
+			from_date = asset_doc.available_for_use_date
+			days = date_diff(prev_depreciation_start_date, from_date) + 1
+			total_days = get_total_days(prev_depreciation_start_date, row.frequency_of_depreciation)
 		else:
-			# if frequency_of_depreciation is 12 months, total_days = 365
+			from_date = _get_modified_available_for_use_date(asset_doc, row, wdv_or_dd_non_yearly=False)
+			days = date_diff(row.depreciation_start_date, from_date) + 1
 			total_days = get_total_days(row.depreciation_start_date, row.frequency_of_depreciation)
-
+		if days <= 0:
+			frappe.throw(
+				_(
+					"""Error: This asset already has {0} depreciation periods booked.
+					The `depreciation start` date must be at least {1} periods after the `available for use` date.
+					Please correct the dates accordingly."""
+				).format(
+					asset_doc.number_of_depreciations_booked,
+					asset_doc.number_of_depreciations_booked,
+				)
+			)
 		if days < total_days:
 			has_pro_rata = True
-
 		return has_pro_rata
-
-	def get_modified_available_for_use_date(self, row, wdv_or_dd_non_yearly=False):
-		if wdv_or_dd_non_yearly:
-			return add_months(
-				self.available_for_use_date,
-				(self.number_of_depreciations_booked * 12),
-			)
-		else:
-			return add_months(
-				self.available_for_use_date,
-				(self.number_of_depreciations_booked * row.frequency_of_depreciation),
-			)
 
 	def validate_asset_finance_books(self, row):
 		if flt(row.expected_value_after_useful_life) >= flt(self.gross_purchase_amount):
@@ -1288,6 +1291,28 @@ def get_item_details(item_code, asset_category, gross_purchase_amount):
 		)
 
 	return books
+
+
+def _get_modified_available_for_use_date(asset_doc, row, wdv_or_dd_non_yearly=False):
+	"""
+	if Asset has opening booked depreciations = 9,
+	available for use date = 17-07-2023,
+	depreciation start date = 30-04-2024
+	then from date should be 01-04-2024
+	"""
+	if asset_doc.number_of_depreciations_booked > 0:
+		from_date = add_months(
+			asset_doc.available_for_use_date,
+			(asset_doc.number_of_depreciations_booked * row.frequency_of_depreciation) - 1,
+		)
+		if is_last_day_of_the_month(row.depreciation_start_date):
+			return add_days(get_last_day(from_date), 1)
+
+		# get from date when depreciation start date is not last day of the month
+		months_difference = month_diff(row.depreciation_start_date, from_date) - 1
+		return add_days(add_months(row.depreciation_start_date, -1 * months_difference), 1)
+	else:
+		return asset_doc.available_for_use_date
 
 
 def get_asset_account(account_name, asset=None, asset_category=None, company=None):


### PR DESCRIPTION
When an asset has available for use in the middle of the month and it already has opening accumulated depreciation, then the system adjusts the depreciation amount for the first month over the entire depreciation period. This method of adjustment is not ideal.
To improve this, we will update the system so that the depreciation amount for the first month is instead adjusted at the end of the depreciation period.