### PR TITLE
fix: calculate useful days of asset's life correctly for existing asset

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1451,7 +1451,7 @@ class TestDepreciationBasics(AssetSetup):
 		affects `value_after_depreciation`
 		"""
 
-		asset = create_asset(calculate_depreciation=1)
+		asset = create_asset(calculate_depreciation=1, depreciation_strat_date="2021-12-31")
 		asset.opening_accumulated_depreciation = 2000
 		asset.number_of_depreciations_booked = 1
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1451,7 +1451,7 @@ class TestDepreciationBasics(AssetSetup):
 		affects `value_after_depreciation`
 		"""
 
-		asset = create_asset(calculate_depreciation=1, depreciation_strat_date="2021-12-31")
+		asset = create_asset(calculate_depreciation=1, depreciation_start_date="2021-12-31")
 		asset.opening_accumulated_depreciation = 2000
 		asset.number_of_depreciations_booked = 1
 


### PR DESCRIPTION
When an asset has available for use in the middle of the month and it already has opening accumulated depreciation, then the system adjusts the depreciation amount for the first month over the entire depreciation period. This method of adjustment is not ideal.
To improve this, we will update the system so that the depreciation amount for the first month is instead adjusted at the end of the depreciation period.