### PR TITLE
fix(Payment Entry): set account type if missing

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -542,13 +542,15 @@ class PaymentEntry(AccountsController):
 				self.set(self.party_account_field, party_account)
 				self.party_account = party_account
 
-		if self.paid_from and not self.paid_from_account_currency:
+		if self.paid_from and (not self.paid_from_account_currency or not self.paid_from_account_type):
 			acc = get_account_details(self.paid_from, self.posting_date, self.cost_center)
 			self.paid_from_account_currency = acc.account_currency
+			self.paid_from_account_type = acc.account_type
 
-		if self.paid_to and not self.paid_to_account_currency:
+		if self.paid_to and (not self.paid_to_account_currency or not self.paid_to_account_type):
 			acc = get_account_details(self.paid_to, self.posting_date, self.cost_center)
 			self.paid_to_account_currency = acc.account_currency
+			self.paid_to_account_type = acc.account_type
 
 		self.party_account_currency = (
 			self.paid_from_account_currency


### PR DESCRIPTION
This PR ensures that `set_missing_values` also fetches the _Account Type_ of the _Paid From_ and _Paid To_ accounts. **Payment Entry** has fields where the _Mandatory_ property depends on the _Account Type_, so this is useful for showing mandatory fields correctly.