### PR TITLE
fix: pos for small screen and checkout page

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -26,7 +26,6 @@
   "auto_add_item_to_cart",
   "validate_stock_on_save",
   "print_receipt_on_order_complete",
-  "enable_numpad_for_payments",
   "column_break_16",
   "update_stock",
   "ignore_pricing_rule",
@@ -412,12 +411,6 @@
    "options": "Project"
   },
   {
-   "default": "0",
-   "fieldname": "enable_numpad_for_payments",
-   "fieldtype": "Check",
-   "label": "Enable Numpad for Payments"
-  },
-  {
    "default": "1",
    "fieldname": "set_grand_total_to_default_mop",
    "fieldtype": "Check",
@@ -450,7 +443,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-05-09 00:49:39.889607",
+ "modified": "2025-05-09 11:23:28.632136",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -32,7 +32,7 @@
   "ignore_pricing_rule",
   "allow_rate_change",
   "allow_discount_change",
-  "disable_grand_total_to_default_mop",
+  "set_grand_total_to_default_mop",
   "section_break_23",
   "item_groups",
   "column_break_25",
@@ -404,12 +404,6 @@
    "label": "Print Receipt on Order Complete"
   },
   {
-   "default": "0",
-   "fieldname": "disable_grand_total_to_default_mop",
-   "fieldtype": "Check",
-   "label": "Disable auto setting Grand Total to default Payment Mode"
-  },
-  {
    "fieldname": "project",
    "fieldtype": "Link",
    "label": "Project",
@@ -422,6 +416,12 @@
    "fieldname": "enable_numpad_for_payments",
    "fieldtype": "Check",
    "label": "Enable Numpad for Payments"
+  },
+  {
+   "default": "1",
+   "fieldname": "set_grand_total_to_default_mop",
+   "fieldtype": "Check",
+   "label": "Set Grand Total to Default Payment Method"
   }
  ],
  "grid_page_length": 50,
@@ -450,7 +450,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-04-15 14:45:21.005940",
+ "modified": "2025-05-09 00:49:39.889607",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -26,6 +26,7 @@
   "auto_add_item_to_cart",
   "validate_stock_on_save",
   "print_receipt_on_order_complete",
+  "enable_numpad_for_payments",
   "column_break_16",
   "update_stock",
   "ignore_pricing_rule",
@@ -415,6 +416,12 @@
    "oldfieldname": "cost_center",
    "oldfieldtype": "Link",
    "options": "Project"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_numpad_for_payments",
+   "fieldtype": "Check",
+   "label": "Enable Numpad for Payments"
   }
  ],
  "grid_page_length": 50,
@@ -443,7 +450,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-04-09 11:35:13.779613",
+ "modified": "2025-04-15 14:45:21.005940",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -42,7 +42,6 @@ class POSProfile(Document):
 		customer_groups: DF.Table[POSCustomerGroup]
 		disable_rounded_total: DF.Check
 		disabled: DF.Check
-		enable_numpad_for_payments: DF.Check
 		expense_account: DF.Link | None
 		hide_images: DF.Check
 		hide_unavailable_items: DF.Check

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -15,18 +15,17 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 
 class POSProfile(Document):
 	# begin: auto-generated types
-	# ruff: noqa
-
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.types import DF
+
 		from erpnext.accounts.doctype.pos_customer_group.pos_customer_group import POSCustomerGroup
 		from erpnext.accounts.doctype.pos_item_group.pos_item_group import POSItemGroup
 		from erpnext.accounts.doctype.pos_payment_method.pos_payment_method import POSPaymentMethod
 		from erpnext.accounts.doctype.pos_profile_user.pos_profile_user import POSProfileUser
-		from frappe.types import DF
 
 		account_for_change_amount: DF.Link | None
 		allow_discount_change: DF.Check
@@ -41,7 +40,6 @@ class POSProfile(Document):
 		currency: DF.Link
 		customer: DF.Link | None
 		customer_groups: DF.Table[POSCustomerGroup]
-		disable_grand_total_to_default_mop: DF.Check
 		disable_rounded_total: DF.Check
 		disabled: DF.Check
 		enable_numpad_for_payments: DF.Check
@@ -58,6 +56,7 @@ class POSProfile(Document):
 		project: DF.Link | None
 		select_print_heading: DF.Link | None
 		selling_price_list: DF.Link | None
+		set_grand_total_to_default_mop: DF.Check
 		tax_category: DF.Link | None
 		taxes_and_charges: DF.Link | None
 		tc_name: DF.Link | None
@@ -70,7 +69,6 @@ class POSProfile(Document):
 		write_off_account: DF.Link
 		write_off_cost_center: DF.Link
 		write_off_limit: DF.Currency
-	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -15,17 +15,18 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 
 class POSProfile(Document):
 	# begin: auto-generated types
+	# ruff: noqa
+
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from erpnext.accounts.doctype.pos_customer_group.pos_customer_group import POSCustomerGroup
 		from erpnext.accounts.doctype.pos_item_group.pos_item_group import POSItemGroup
 		from erpnext.accounts.doctype.pos_payment_method.pos_payment_method import POSPaymentMethod
 		from erpnext.accounts.doctype.pos_profile_user.pos_profile_user import POSProfileUser
+		from frappe.types import DF
 
 		account_for_change_amount: DF.Link | None
 		allow_discount_change: DF.Check
@@ -43,6 +44,7 @@ class POSProfile(Document):
 		disable_grand_total_to_default_mop: DF.Check
 		disable_rounded_total: DF.Check
 		disabled: DF.Check
+		enable_numpad_for_payments: DF.Check
 		expense_account: DF.Link | None
 		hide_images: DF.Check
 		hide_unavailable_items: DF.Check
@@ -68,6 +70,7 @@ class POSProfile(Document):
 		write_off_account: DF.Link
 		write_off_cost_center: DF.Link
 		write_off_limit: DF.Currency
+	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -411,3 +411,4 @@ erpnext.patches.v15_0.update_payment_schedule_fields_in_invoices
 erpnext.patches.v15_0.rename_group_by_to_categorize_by
 execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetch_method", "Buffered Cursor")
 erpnext.patches.v14_0.set_update_price_list_based_on
+erpnext.patches.v15_0.set_grand_total_to_default_mop

--- a/erpnext/patches/v15_0/set_grand_total_to_default_mop.py
+++ b/erpnext/patches/v15_0/set_grand_total_to_default_mop.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	POSProfile = frappe.qb.DocType("POS Profile")
+
+	frappe.qb.update(POSProfile).set(POSProfile.set_grand_total_to_default_mop, 1).where(
+		POSProfile.disable_grand_total_to_default_mop == 0
+	).run()

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -945,9 +945,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var me = this;
 		var payment_status = true;
 		if(this.frm.doc.is_pos && (update_paid_amount===undefined || update_paid_amount)) {
-			let r = await frappe.db.get_value("POS Profile", this.frm.doc.pos_profile, "disable_grand_total_to_default_mop");
+			let r = await frappe.db.get_value("POS Profile", this.frm.doc.pos_profile, "set_grand_total_to_default_mop");
 
-			if (r.message.disable_grand_total_to_default_mop) {
+			if (!r.message.set_grand_total_to_default_mop) {
 				return;
 			}
 

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -884,12 +884,9 @@
 						padding-left: var(--margin-md);
 
 						.invoice-fields {
-							overflow-y: scroll;
 							height: 100%;
-							padding-left: var(--padding-sm);
-							padding-right: var(--padding-sm);
-							min-height: 15rem;
-							height: calc(100vh - 350px);
+							margin-left: auto;
+							padding: var(--padding-sm);
 						}
 					}
 

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -897,19 +897,6 @@
 						flex: 1;
 						display: flex;
 						align-items: flex-end;
-						opacity: 0;
-						transform: translateX(100px);
-						transition: all 0.6s ease-out;
-
-						&.scroll-in {
-							opacity: 1;
-							transform: translateX(0px);
-						}
-
-						&.scroll-out {
-							opacity: 0;
-							transform: translateX(100px);
-						}
 
 						.numpad-container {
 							display: grid;

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -776,6 +776,7 @@
 
 		.submit-order-btn {
 			@extend .primary-action;
+			margin-top: 0%;
 			background-color: var(--btn-primary);
 			color: var(--neutral);
 		}
@@ -799,7 +800,7 @@
 					padding-right: var(--padding-sm);
 					margin-right: var(--margin-sm);
 					min-height: 15rem;
-					overflow-x: scroll;
+					overflow-y: scroll;
 					height: calc(100vh - 350px);
 
 					> .payment-mode-wrapper {
@@ -885,21 +886,42 @@
 						.invoice-fields {
 							overflow-y: scroll;
 							height: 100%;
+							padding-left: var(--padding-sm);
 							padding-right: var(--padding-sm);
+							min-height: 15rem;
+							height: calc(100vh - 350px);
 						}
 					}
 
-					> .number-pad {
+					.number-pad {
+						position: absolute;
+						z-index: 4;
+						right: 0px;
 						flex: 1;
 						display: flex;
-						justify-content: flex-end;
 						align-items: flex-end;
+						opacity: 0;
+						transform: translateX(100px);
+						transition: all 0.6s ease-out;
+
+						&.scroll-in {
+							opacity: 1;
+							transform: translateX(0px);
+						}
+
+						&.scroll-out {
+							opacity: 0;
+							transform: translateX(100px);
+						}
 
 						.numpad-container {
 							display: grid;
 							grid-template-columns: repeat(3, minmax(0, 1fr));
 							gap: var(--margin-md);
 							margin-bottom: var(--margin-md);
+							background-color: var(--fg-color);
+							border-radius: var(--border-radius-md);
+							padding: var(--padding-sm);
 
 							> .numpad-btn {
 								@extend .pointer-no-select;
@@ -908,7 +930,7 @@
 								align-items: center;
 								justify-content: center;
 								padding: var(--padding-md);
-								box-shadow: var(--shadow-sm);
+								box-shadow: var(--shadow-base);
 							}
 						}
 					}

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -5,9 +5,9 @@
 	padding: 1%;
 
 	section {
-		min-height: 45rem;
-		height: calc(100vh - 200px);
-		max-height: calc(100vh - 200px);
+		min-height: 30rem;
+		height: calc(100vh - 125px);
+		max-height: calc(100vh - 125px);
 	}
 
 	.frappe-control {
@@ -375,6 +375,7 @@
 					flex-direction: column;
 					flex: 1 1 0%;
 					overflow-y: scroll;
+					min-height: 50px;
 
 					> .cart-item-wrapper {
 						@extend .pointer-no-select;
@@ -785,117 +786,131 @@
 			margin-bottom: var(--margin-md);
 		}
 
-		> .payment-modes {
+		> .payment-split-container {
 			display: flex;
-			padding-bottom: var(--padding-sm);
-			margin-bottom: var(--margin-sm);
-			overflow-x: scroll;
-			overflow-y: hidden;
-			flex-shrink: 0;
 
-			> .payment-mode-wrapper {
-				min-width: 40%;
-				padding: var(--padding-xs);
+			> .payment-container-left {
+				width: 50%;
+				margin-bottom: var(--margin-md);
 
-				> .mode-of-payment {
-					@extend .pos-card;
-					@extend .pointer-no-select;
-					padding: var(--padding-md) var(--padding-lg);
+				.payment-modes {
+					display: flex;
+					flex-direction: column;
+					padding-right: var(--padding-sm);
+					margin-right: var(--margin-sm);
+					min-height: 15rem;
+					overflow-x: scroll;
+					height: calc(100vh - 350px);
 
-					> .pay-amount {
-						display: inline;
-						float: right;
-						font-weight: 700;
-					}
+					> .payment-mode-wrapper {
+						min-width: 40%;
+						padding: var(--padding-xs);
 
-					> .mode-of-payment-control {
-						display: none;
-						align-items: center;
-						margin-top: var(--margin-sm);
-						margin-bottom: var(--margin-xs);
-					}
-
-					> .loyalty-amount-name {
-						display: none;
-						float: right;
-						font-weight: 700;
-						white-space: nowrap;
-						overflow: hidden;
-						text-overflow: ellipsis;
-					}
-
-					> .cash-shortcuts {
-						display: none;
-						grid-template-columns: repeat(3, minmax(0, 1fr));
-						gap: var(--margin-sm);
-						font-size: var(--text-sm);
-						text-align: center;
-
-						> .shortcut {
+						> .mode-of-payment {
+							@extend .pos-card;
 							@extend .pointer-no-select;
-							border-radius: var(--border-radius-sm);
-							background-color: var(--control-bg);
-							font-weight: 500;
-							padding: var(--padding-xs) var(--padding-sm);
-							transition: all 0.15s ease-in-out;
+							padding: var(--padding-md) var(--padding-lg);
 
-							&:hover {
-								background-color: var(--control-bg);
+							> .pay-amount {
+								display: inline;
+								float: right;
+								font-weight: 700;
 							}
+
+							> .mode-of-payment-control {
+								display: none;
+								align-items: center;
+								margin-top: var(--margin-sm);
+								margin-bottom: var(--margin-xs);
+							}
+
+							> .loyalty-amount-name {
+								display: none;
+								float: right;
+								font-weight: 700;
+								white-space: nowrap;
+								overflow: hidden;
+								text-overflow: ellipsis;
+							}
+
+							> .cash-shortcuts {
+								display: none;
+								grid-template-columns: repeat(3, minmax(0, 1fr));
+								gap: var(--margin-sm);
+								font-size: var(--text-sm);
+								text-align: center;
+
+								> .shortcut {
+									@extend .pointer-no-select;
+									border-radius: var(--border-radius-sm);
+									background-color: var(--control-bg);
+									font-weight: 500;
+									padding: var(--padding-xs) var(--padding-sm);
+									transition: all 0.15s ease-in-out;
+
+									&:hover {
+										background-color: var(--control-bg);
+									}
+								}
+							}
+						}
+
+						> .loyalty-card {
+							display: flex;
+							flex-direction: column;
 						}
 					}
 				}
-
-				> .loyalty-card {
-					display: flex;
-					flex-direction: column;
-				}
 			}
-		}
 
-		> .fields-numpad-container {
-			display: flex;
-			flex: 1;
-			height: 100%;
-			position: relative;
-			justify-content: flex-end;
-
-			> .fields-section {
-				flex: 1;
+			> .payment-container-right {
 				display: flex;
 				flex-direction: column;
 				width: 50%;
-				height: 100%;
-				padding-bottom: var(--margin-md);
 
-				.invoice-fields {
-					overflow-y: scroll;
+				.fields-numpad-container {
+					display: flex;
+					flex-direction: column;
+					flex: 1;
 					height: 100%;
-					padding-right: var(--padding-sm);
-				}
-			}
+					position: relative;
+					justify-content: flex-end;
 
-			> .number-pad {
-				flex: 1;
-				display: flex;
-				justify-content: flex-end;
-				align-items: flex-end;
-				max-width: 50%;
-
-				.numpad-container {
-					display: grid;
-					grid-template-columns: repeat(3, minmax(0, 1fr));
-					gap: var(--margin-md);
-					margin-bottom: var(--margin-md);
-
-					> .numpad-btn {
-						@extend .pointer-no-select;
-						border-radius: var(--border-radius-md);
+					> .fields-section {
+						flex: 1;
 						display: flex;
-						align-items: center;
-						justify-content: center;
-						padding: var(--padding-md);
-						box-shadow: var(--shadow-sm);
+						flex-direction: column;
+						padding-left: var(--margin-md);
+
+						.invoice-fields {
+							overflow-y: scroll;
+							height: 100%;
+							padding-right: var(--padding-sm);
+						}
+					}
+
+					> .number-pad {
+						flex: 1;
+						display: flex;
+						justify-content: flex-end;
+						align-items: flex-end;
+
+						.numpad-container {
+							display: grid;
+							grid-template-columns: repeat(3, minmax(0, 1fr));
+							gap: var(--margin-md);
+							margin-bottom: var(--margin-md);
+
+							> .numpad-btn {
+								@extend .pointer-no-select;
+								border-radius: var(--border-radius-md);
+								display: flex;
+								align-items: center;
+								justify-content: center;
+								padding: var(--padding-md);
+								box-shadow: var(--shadow-sm);
+							}
+						}
 					}
 				}
 			}

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -156,7 +156,25 @@ erpnext.PointOfSale.Controller = class {
 			},
 		});
 
+		this.fetch_invoice_fields();
 		this.add_pos_closed_listener();
+	}
+
+	fetch_invoice_fields() {
+		const me = this;
+		frappe.db.get_doc("POS Settings", undefined).then((doc) => {
+			me.settings.invoice_fields = doc.invoice_fields.map((field) => {
+				return {
+					fieldname: field.fieldname,
+					label: field.label,
+					fieldtype: field.fieldtype,
+					reqd: field.reqd,
+					options: field.options,
+					default_value: field.default_value,
+					read_only: field.read_only,
+				};
+			});
+		});
 	}
 
 	add_pos_closed_listener() {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -156,6 +156,10 @@ erpnext.PointOfSale.Controller = class {
 			},
 		});
 
+		this.add_pos_closed_listener();
+	}
+
+	add_pos_closed_listener() {
 		frappe.realtime.on(`poe_${this.pos_opening}_closed`, (data) => {
 			const route = frappe.get_route_str();
 			if (data && route == "point-of-sale") {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -157,7 +157,7 @@ erpnext.PointOfSale.Controller = class {
 		});
 
 		this.fetch_invoice_fields();
-		this.add_pos_closed_listener();
+		this.setup_listener_for_pos_closing();
 	}
 
 	fetch_invoice_fields() {
@@ -177,7 +177,7 @@ erpnext.PointOfSale.Controller = class {
 		});
 	}
 
-	add_pos_closed_listener() {
+	setup_listener_for_pos_closing() {
 		frappe.realtime.on(`poe_${this.pos_opening}_closed`, (data) => {
 			const route = frappe.get_route_str();
 			if (data && route == "point-of-sale") {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -426,6 +426,7 @@ erpnext.PointOfSale.Controller = class {
 	init_payments() {
 		this.payment = new erpnext.PointOfSale.Payment({
 			wrapper: this.$components_wrapper,
+			settings: this.settings,
 			events: {
 				get_frm: () => this.frm || {},
 

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -171,6 +171,9 @@ erpnext.PointOfSale.ItemCart = class {
 
 			me.toggle_item_highlight(this);
 
+			const scrollTop = $cart_item.offset().top - me.$cart_items_wrapper.offset().top;
+			me.$cart_items_wrapper.animate({ scrollTop });
+
 			const payment_section_hidden = !me.$totals_section.find(".edit-cart-btn").is(":visible");
 			if (!payment_section_hidden) {
 				// payment section is visible

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -4,6 +4,7 @@ erpnext.PointOfSale.Payment = class {
 		this.wrapper = wrapper;
 		this.events = events;
 		this.enable_numpad = settings.enable_numpad_for_payments;
+		this.set_gt_to_default_mop = settings.set_grand_total_to_default_mop;
 
 		this.init_component();
 	}
@@ -386,7 +387,7 @@ erpnext.PointOfSale.Payment = class {
 		this.render_payment_mode_dom();
 		this.make_invoice_fields_control();
 		this.update_totals_section();
-		this.unset_grand_total_to_default_mop();
+		this.set_grand_total_to_default_mop();
 	}
 
 	after_render() {
@@ -671,15 +672,8 @@ erpnext.PointOfSale.Payment = class {
 			.toLowerCase();
 	}
 
-	async unset_grand_total_to_default_mop() {
-		const doc = this.events.get_frm().doc;
-		let r = await frappe.db.get_value(
-			"POS Profile",
-			doc.pos_profile,
-			"disable_grand_total_to_default_mop"
-		);
-
-		if (!r.message.disable_grand_total_to_default_mop) {
+	set_grand_total_to_default_mop() {
+		if (this.set_gt_to_default_mop) {
 			this.focus_on_default_mop();
 		}
 	}

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -5,6 +5,7 @@ erpnext.PointOfSale.Payment = class {
 		this.events = events;
 		this.enable_numpad = settings.enable_numpad_for_payments;
 		this.set_gt_to_default_mop = settings.set_grand_total_to_default_mop;
+		this.invoice_fields = settings.invoice_fields;
 
 		this.init_component();
 	}
@@ -27,8 +28,11 @@ erpnext.PointOfSale.Payment = class {
 					<div class="payment-container-right">
 						<div class="fields-numpad-container">
 							<div class="fields-section">
-								<div class="section-label">${__("Additional Information")}</div>
-								<div class="invoice-fields"></div>
+								<div class="invoice-fields">
+									<button class="btn btn-default btn-sm btn-shadow addl-fields hidden">${__(
+										"Add Additional Information"
+									)}</button>
+								</div>
 							</div>
 							<div class="number-pad"></div>
 						</div>
@@ -48,48 +52,61 @@ erpnext.PointOfSale.Payment = class {
 		this.$invoice_fields_section = this.$component.find(".fields-section");
 	}
 
-	make_invoice_fields_control() {
-		this.reqd_invoice_fields = [];
-		frappe.db.get_doc("POS Settings", undefined).then((doc) => {
-			const fields = doc.invoice_fields;
-			if (!fields.length) return;
+	make_invoice_field_dialog() {
+		const me = this;
+		if (!me.invoice_fields.length) return;
+		me.addl_dlg = new frappe.ui.Dialog({
+			title: __("Additional Information"),
+			fields: me.invoice_fields,
+			size: "small",
+			primary_action_label: __("Save"),
+			primary_action(values) {
+				me.set_values_to_frm(values);
+				this.hide();
+			},
+		});
+		me.add_btn_field_click_listener();
+		me.set_value_on_dialog_fields();
+		me.make_addl_info_dialog_btn_visible();
+	}
 
-			this.$invoice_fields = this.$invoice_fields_section.find(".invoice-fields");
-			this.$invoice_fields.html("");
-			const frm = this.events.get_frm();
+	set_values_to_frm(values) {
+		const frm = this.events.get_frm();
+		for (const value in values) {
+			frm.set_value(value, values[value]);
+		}
+		frappe.show_alert({
+			message: __("Additional Information saved."),
+			indicator: "green",
+		});
+	}
 
-			fields.forEach((df) => {
-				this.$invoice_fields.append(
-					`<div class="invoice_detail_field ${df.fieldname}-field" data-fieldname="${df.fieldname}"></div>`
-				);
-				let df_events = {
-					onchange: function () {
-						frm.set_value(this.df.fieldname, this.get_value());
-					},
-				};
-				if (df.fieldtype == "Button") {
-					df_events = {
-						click: function () {
-							if (frm.script_manager.has_handlers(df.fieldname, frm.doc.doctype)) {
-								frm.script_manager.trigger(df.fieldname, frm.doc.doctype, frm.doc.docname);
-							}
-						},
-					};
-				}
-				if (df.reqd && (df.fieldtype !== "Button" || !df.read_only)) {
-					this.reqd_invoice_fields.push({ fieldname: df.fieldname, label: df.label });
-				}
-
-				this[`${df.fieldname}_field`] = frappe.ui.form.make_control({
-					df: {
-						...df,
-						...df_events,
-					},
-					parent: this.$invoice_fields.find(`.${df.fieldname}-field`),
-					render_input: true,
+	add_btn_field_click_listener() {
+		const frm = this.events.get_frm();
+		this.addl_dlg.fields.forEach((df) => {
+			if (df.fieldtype === "Button") {
+				this.addl_dlg.fields_dict[df.fieldname].$input.on("click", function () {
+					if (frm.script_manager.has_handlers(df.fieldname, frm.doc.doctype)) {
+						frm.script_manager.trigger(df.fieldname, frm.doc.doctype, frm.doc.docname);
+					}
 				});
-				this[`${df.fieldname}_field`].set_value(frm.doc[df.fieldname]);
-			});
+			}
+		});
+	}
+
+	set_value_on_dialog_fields() {
+		const doc = this.events.get_frm().doc;
+		this.addl_dlg.fields.forEach((df) => {
+			if (doc[df.fieldname] || df.default_value) {
+				this.addl_dlg.set_value(df.fieldname, doc[df.fieldname] || df.default_value);
+			}
+		});
+	}
+
+	make_addl_info_dialog_btn_visible() {
+		this.$invoice_fields_section.find(".addl-fields").removeClass("hidden");
+		this.$invoice_fields_section.find(".addl-fields").on("click", () => {
+			this.addl_dlg.show();
 		});
 	}
 
@@ -385,7 +402,7 @@ erpnext.PointOfSale.Payment = class {
 
 	render_payment_section() {
 		this.render_payment_mode_dom();
-		this.make_invoice_fields_control();
+		this.make_invoice_field_dialog();
 		this.update_totals_section();
 		this.set_grand_total_to_default_mop();
 	}
@@ -680,17 +697,20 @@ erpnext.PointOfSale.Payment = class {
 
 	validate_reqd_invoice_fields() {
 		const doc = this.events.get_frm().doc;
-		let validation_flag = true;
-		for (let field of this.reqd_invoice_fields) {
-			if (!doc[field.fieldname]) {
-				validation_flag = false;
+		for (const df of this.addl_dlg.fields) {
+			if (df.reqd && !doc[df.fieldname]) {
 				frappe.show_alert({
-					message: __("{0} is a mandatory field.", [field.label]),
-					indicator: "orange",
+					message: __(
+						"Invoice cannot be submitted without filling the mandatory Additional Information fields."
+					),
+					indicator: "red",
 				});
 				frappe.utils.play_sound("error");
+				this.addl_dlg.show();
+				this.addl_dlg.fields_dict[df.fieldname].$input.focus();
+				return false;
 			}
 		}
-		return validation_flag;
+		return true;
 	}
 };

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -29,7 +29,7 @@ erpnext.PointOfSale.Payment = class {
 							<div class="fields-section">
 								<div class="invoice-fields">
 									<button class="btn btn-default btn-sm btn-shadow addl-fields hidden">${__(
-										"Add Additional Information"
+										"Update Additional Information"
 									)}</button>
 								</div>
 							</div>
@@ -75,7 +75,7 @@ erpnext.PointOfSale.Payment = class {
 			frm.set_value(value, values[value]);
 		}
 		frappe.show_alert({
-			message: __("Additional Information saved."),
+			message: __("Additional Information updated successfully."),
 			indicator: "green",
 		});
 	}

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -657,7 +657,7 @@ erpnext.PointOfSale.Payment = class {
 		const remaining = grand_total - doc.paid_amount;
 		const change = doc.change_amount || remaining <= 0 ? -1 * remaining : undefined;
 		const currency = doc.currency;
-		const label = __("Change Amount");
+		const label = doc.paid_amount > grand_total ? __("Change Amount") : __("Remaining Amount");
 
 		this.$totals.html(
 			`<div class="col">

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -3,7 +3,6 @@ erpnext.PointOfSale.Payment = class {
 	constructor({ events, wrapper, settings }) {
 		this.wrapper = wrapper;
 		this.events = events;
-		this.enable_numpad = settings.enable_numpad_for_payments;
 		this.set_gt_to_default_mop = settings.set_grand_total_to_default_mop;
 		this.invoice_fields = settings.invoice_fields;
 
@@ -152,11 +151,6 @@ erpnext.PointOfSale.Payment = class {
 		const me = this;
 
 		this.$payment_modes.on("click", ".mode-of-payment", function (e) {
-			if (me.enable_numpad) {
-				$(`.number-pad`).removeClass("scroll-out");
-				$(`.number-pad`).addClass("scroll-in");
-			}
-
 			const mode_clicked = $(this);
 			// if clicked element doesn't have .mode-of-payment class then return
 			if (!$(e.target).is(mode_clicked)) return;
@@ -191,13 +185,6 @@ erpnext.PointOfSale.Payment = class {
 				me.selected_mode = me[`${mode}_control`];
 				me.selected_mode && me.selected_mode.$input.get(0).focus();
 				me.auto_set_remaining_amount();
-			}
-		});
-
-		this.$invoice_fields_section.on("click", ".invoice_detail_field", function (e) {
-			if (me.enable_numpad) {
-				$(`.number-pad`).removeClass("scroll-in");
-				$(`.number-pad`).addClass("scroll-out");
 			}
 		});
 

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-unused-vars */
 erpnext.PointOfSale.Payment = class {
-	constructor({ events, wrapper }) {
+	constructor({ events, wrapper, settings }) {
 		this.wrapper = wrapper;
 		this.events = events;
+		this.enable_numpad = settings.enable_numpad_for_payments;
 
 		this.init_component();
 	}
@@ -133,6 +134,11 @@ erpnext.PointOfSale.Payment = class {
 		const me = this;
 
 		this.$payment_modes.on("click", ".mode-of-payment", function (e) {
+			if (me.enable_numpad) {
+				$(`.number-pad`).removeClass("scroll-out");
+				$(`.number-pad`).addClass("scroll-in");
+			}
+
 			const mode_clicked = $(this);
 			// if clicked element doesn't have .mode-of-payment class then return
 			if (!$(e.target).is(mode_clicked)) return;
@@ -167,6 +173,23 @@ erpnext.PointOfSale.Payment = class {
 				me.selected_mode = me[`${mode}_control`];
 				me.selected_mode && me.selected_mode.$input.get(0).focus();
 				me.auto_set_remaining_amount();
+			}
+		});
+
+		this.$invoice_fields_section.on("click", ".invoice_detail_field", function (e) {
+			if (me.enable_numpad) {
+				$(`.number-pad`).removeClass("scroll-in");
+				$(`.number-pad`).addClass("scroll-out");
+			}
+		});
+
+		frappe.ui.form.on("POS Invoice", "contact_mobile", (frm) => {
+			const contact = frm.doc.contact_mobile;
+			const request_button = $(this.request_for_payment_field?.$input[0]);
+			if (contact) {
+				request_button.removeClass("btn-default").addClass("btn-primary");
+			} else {
+				request_button.removeClass("btn-primary").addClass("btn-default");
 			}
 		});
 

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -17,14 +17,20 @@ erpnext.PointOfSale.Payment = class {
 	prepare_dom() {
 		this.wrapper.append(
 			`<section class="payment-container">
-				<div class="section-label payment-section">${__("Payment Method")}</div>
-				<div class="payment-modes"></div>
-				<div class="fields-numpad-container">
-					<div class="fields-section">
-						<div class="section-label">${__("Additional Information")}</div>
-						<div class="invoice-fields"></div>
+				<div class="payment-split-container">
+					<div class="payment-container-left">
+						<div class="section-label payment-section">${__("Payment Method")}</div>
+						<div class="payment-modes"></div>
 					</div>
-					<div class="number-pad"></div>
+					<div class="payment-container-right">
+						<div class="fields-numpad-container">
+							<div class="fields-section">
+								<div class="section-label">${__("Additional Information")}</div>
+								<div class="invoice-fields"></div>
+							</div>
+							<div class="number-pad"></div>
+						</div>
+					</div>
 				</div>
 				<div class="totals-section">
 					<div class="totals"></div>


### PR DESCRIPTION
This PR was initially raised by @devdiogenes to fix the POS Screen for smaller screens. While fixing, there were problems with the Checkout Page. 

Moved the POS Settings Invoice Fields inside a Dialog (refer to the Screenshots). However, planning to redesign the Payment Selection.

Thanks, @devdiogenes and @HarryPaulo, for your contributions.


Screenshots:
![image](https://github.com/user-attachments/assets/b2635d85-ce84-411a-a9ba-46aea73f43d1)

![image](https://github.com/user-attachments/assets/3fb21079-e34a-463f-a548-e1f9ef782874)
