### PR TITLE
fix: enabled allow on submit for asset name field

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -87,6 +87,7 @@
    "options": "ACC-ASS-.YYYY.-"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "item_code",
    "fetch_from": "item_code.item_name",
    "fetch_if_empty": 1,
@@ -588,7 +589,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-02-20 14:09:05.421913",
+ "modified": "2025-04-15 16:33:17.189524",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",
@@ -626,6 +627,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -42,14 +42,15 @@ from erpnext.controllers.accounts_controller import AccountsController
 
 class Asset(AccountsController):
 	# begin: auto-generated types
+	# ruff: noqa
+
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from erpnext.assets.doctype.asset_finance_book.asset_finance_book import AssetFinanceBook
+		from frappe.types import DF
 
 		additional_asset_cost: DF.Currency
 		amended_from: DF.Link | None
@@ -117,6 +118,7 @@ class Asset(AccountsController):
 		total_asset_cost: DF.Currency
 		total_number_of_depreciations: DF.Int
 		value_after_depreciation: DF.Currency
+	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):


### PR DESCRIPTION
Enabled allow on submit for `asset_name` field so that renaming can be possible for the assets.