### PR TITLE
fix: shipping rule doubles discount amount

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -54,6 +54,8 @@ class calculate_taxes_and_totals:
 		self.discount_amount_applied = False
 		self._calculate()
 
+		self.calculate_shipping_charges()
+
 		if self.doc.meta.get_field("discount_amount"):
 			self.set_discount_amount()
 			self.apply_discount_amount()
@@ -64,8 +66,6 @@ class calculate_taxes_and_totals:
 			self.doc.base_grand_total -= self.doc.base_discount_amount
 			self.doc.rounding_adjustment = self.doc.base_rounding_adjustment = 0.0
 			self.set_rounded_total()
-
-		self.calculate_shipping_charges()
 
 		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
 			self.calculate_total_advance()

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -37,6 +37,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	async calculate_taxes_and_totals(update_paid_amount) {
 		this.discount_amount_applied = false;
 		this._calculate_taxes_and_totals();
+		await this.calculate_shipping_charges();
 		this.calculate_discount_amount();
 
 		// # Update grand total as per cash and non trade discount
@@ -47,8 +48,6 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			this.frm.doc.base_rounding_adjustment = 0;
 			this.set_rounded_total();
 		}
-
-		await this.calculate_shipping_charges();
 
 		// Advance calculation applicable to Sales/Purchase Invoice
 		if (

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1757,6 +1757,25 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		sales_order.save()
 		self.assertEqual(sales_order.taxes[0].tax_amount, 0)
 
+	def test_sales_order_with_discount_and_shipping_rule(self):
+		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
+
+		shipping_rule = create_shipping_rule(
+			shipping_rule_type="Selling", shipping_rule_name="Shipping Rule - Combined Test"
+		)
+		sales_order = make_sales_order(do_not_save=True)
+		sales_order.shipping_rule = shipping_rule.name
+		sales_order.additional_discount_percentage = 10
+
+		sales_order.items[0].qty = 2
+		sales_order.save()
+
+		item_total = sales_order.items[0].rate * 2
+		shipping = sales_order.taxes[0].tax_amount
+		expected_total = (item_total + shipping) * 0.9
+
+		self.assertAlmostEqual(sales_order.grand_total, expected_total, places=2)
+
 	def test_sales_order_partial_advance_payment(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 			create_payment_entry,


### PR DESCRIPTION
### Summary
The fix corrects an incorrect order in the calculation of taxes, shipping costs, and discounting. This incorrect sequence resulted in the discount being applied twice to the Grand Total when a shipping rule was present in the document (see Issue #47089; video available). The new sequence fixes the problem and a unit test was created for this case to verify the correct discount application with a shipping rule.

### Changes
The fix moves the `calculate_shipping_charges` method above the `calculate_discount_amount` method.

### Backports
version-14
version-15

### Issue
closes #47089 

### Video
https://github.com/user-attachments/assets/cd980559-cdfc-4b7d-9cd1-362426829009