### PR TITLE
fix: convert to text before setting value

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -160,7 +160,7 @@ frappe.ui.form.on("Supplier", {
 					address_dict: frm.doc.supplier_primary_address,
 				},
 				callback: function (r) {
-					frm.set_value("primary_address", r.message);
+					frm.set_value("primary_address", frappe.utils.html2text(r.message));
 				},
 			});
 		}


### PR DESCRIPTION
Before
<img width="422" alt="address shows br" src="https://github.com/user-attachments/assets/e7a1e8dd-7d39-4468-8566-0a74b7bdcd73" />


After

<img width="422" alt="address looks fine" src="https://github.com/user-attachments/assets/1f0d8b77-5414-4e3d-86e3-df2e62dcda08" />
