### PR TITLE
feat: add column "Item Name" to "BOM Stock Report"

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
@@ -23,6 +23,7 @@ def get_columns():
 	"""return columns"""
 	columns = [
 		_("Item") + ":Link/Item:150",
+		_("Item Name") + "::240",
 		_("Description") + "::300",
 		_("BOM Qty") + ":Float:160",
 		_("BOM UoM") + "::160",
@@ -73,6 +74,7 @@ def get_bom_stock(filters):
 		.on((BOM_ITEM.item_code == BIN.item_code) & (CONDITIONS))
 		.select(
 			BOM_ITEM.item_code,
+			BOM_ITEM.item_name,
 			BOM_ITEM.description,
 			BOM_ITEM.stock_qty,
 			BOM_ITEM.stock_uom,

--- a/erpnext/manufacturing/report/bom_stock_report/test_bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/test_bom_stock_report.py
@@ -94,6 +94,7 @@ def get_expected_data(bom, warehouse, qty_to_produce, show_exploded_view=False):
 		expected_data.append(
 			[
 				item.item_code,
+				item.item_name,
 				item.description,
 				item.stock_qty,
 				item.stock_uom,


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/67d51795-33ce-4dbb-83cb-f4ca150075d3)

## After
![image](https://github.com/user-attachments/assets/6551cd53-3287-47d8-86f8-a9e616189c10)

## Conclusion
In some use cases the report was not useful (e. g. see the first example where there is no clear description and just a numbered _Item Code_). With this PR we can make use of this report which then serves an important need for us.

Possible disadvantage: Width of the report increases -> Horizontal scrolling might be needed, especially without full width toggled.

> no-docs

Ref: IBB-296