### PR TITLE
fix: add group by after user permission condition

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -519,9 +519,6 @@ def get_accounting_entries(
 		.where(gl_entry.company == filters.company)
 	)
 
-	if group_by_account:
-		query = query.groupby(gl_entry.account)
-
 	ignore_is_opening = frappe.db.get_single_value(
 		"Accounts Settings", "ignore_is_opening_check_for_reporting"
 	)
@@ -550,6 +547,9 @@ def get_accounting_entries(
 
 	if match_conditions:
 		query += "and" + match_conditions
+
+	if group_by_account:
+		query += " GROUP BY `account`"
 
 	return frappe.db.sql(query, params, as_dict=True)
 


### PR DESCRIPTION
**Issue:**
The Trial Balance report shows incorrect data when the user has the user permission.
**ref:** [36339](https://support.frappe.io/helpdesk/tickets/36339)

**Steps to reproduce:**
- Create a user
- Apply user permissions for the company
- Compare the trial balance report with the user and administrator

**User Permission:**
![image](https://github.com/user-attachments/assets/4387a6ba-c565-4440-8cd9-50b9a0db0788)


**Trial Balance Report for Administrator:**
![image](https://github.com/user-attachments/assets/cede444f-49fd-4ec6-81f5-0543b4db4c3f)


**Trial Balance for the User - Before:**
![image](https://github.com/user-attachments/assets/b6945d8a-6a52-479d-84c4-0e2cc1025df8)


**Trial Balance for the User - After:**
![image](https://github.com/user-attachments/assets/b4caf077-27cb-4748-b6db-fe2c07383719)


**Backport needed for v15**

regression: https://github.com/frappe/erpnext/pull/47043