### PR TITLE
fix: `TypeError` in group field filter in supplier ledger summary

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -100,7 +100,7 @@ class PartyLedgerSummaryReport:
 			conditions.append(doctype.territory.isin(self.filters.territory))
 
 		if self.filters.get(group_field):
-			conditions.append(doctype.get(group_field).isin(self.filters.get(group_field)))
+			conditions.append(doctype[group_field].isin(self.filters.get(group_field)))
 
 		if self.filters.payment_terms_template:
 			conditions.append(doctype.payment_terms == self.filters.payment_terms_template)

--- a/erpnext/accounts/report/supplier_ledger_summary/test_supplier_ledger_summary.py
+++ b/erpnext/accounts/report/supplier_ledger_summary/test_supplier_ledger_summary.py
@@ -59,3 +59,33 @@ class TestSupplierLedgerSummary(AccountsTestMixin, IntegrationTestCase):
 		for field in expected:
 			with self.subTest(field=field):
 				self.assertEqual(report_output[0].get(field), expected.get(field))
+
+	def test_supplier_ledger_summary_with_filters(self):
+		self.create_purchase_invoice()
+
+		supplier_group = frappe.db.get_value("Supplier", self.supplier, "supplier_group")
+
+		filters = {
+			"company": self.company,
+			"from_date": today(),
+			"to_date": today(),
+			"supplier_group": supplier_group,
+		}
+
+		expected = {
+			"party": "_Test Supplier",
+			"party_name": "_Test Supplier",
+			"opening_balance": 0,
+			"invoiced_amount": 300.0,
+			"paid_amount": 0,
+			"return_amount": 0,
+			"closing_balance": 300.0,
+			"currency": "INR",
+			"supplier_name": "_Test Supplier",
+		}
+
+		report_output = execute(filters)[1]
+		self.assertEqual(len(report_output), 1)
+		for field in expected:
+			with self.subTest(field=field):
+				self.assertEqual(report_output[0].get(field), expected.get(field))


### PR DESCRIPTION
regression: https://github.com/frappe/erpnext/pull/46640
Traceback:
```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 115, in generate_report
    result = generate_report_result(report=report, filters=instance.filters, user=instance.owner)
      prepared_report = 'djslghhisv'
      instance = <PreparedReport: djslghhisv>
      report = <Report: Supplier Ledger Summary>
  File "apps/frappe/frappe/__init__.py", line 885, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
      args = ()
      kwargs = {'report': <Report: Supplier Ledger Summary>, 'filters': '{"company":"Bastar Dairy Farm Pvt Ltd","from_date":"2025-03-17","supplier_group":"Agent-Milk Collection","to_date":"2025-04-17"}', 'user': 'Administrator'}
      switched_connection = False
      fn = <function generate_report_result at 0x7fe71cb5c180>
  File "apps/frappe/frappe/desk/query_report.py", line 84, in generate_report_result
    res = get_report_result(report, filters) or []
      report = <Report: Supplier Ledger Summary>
      filters = {'company': 'Bastar Dairy Farm Pvt Ltd', 'from_date': '2025-03-17', 'supplier_group': 'Agent-Milk Collection', 'to_date': '2025-04-17'}
      user = 'Administrator'
      custom_columns = None
      is_tree = False
      parent_field = None
  File "apps/frappe/frappe/desk/query_report.py", line 65, in get_report_result
    res = report.execute_script_report(filters)
      report = <Report: Supplier Ledger Summary>
      filters = {'company': 'Bastar Dairy Farm Pvt Ltd', 'from_date': '2025-03-17', 'supplier_group': 'Agent-Milk Collection', 'to_date': '2025-04-17'}
      res = None
  File "apps/frappe/frappe/core/doctype/report/report.py", line 174, in execute_script_report
    res = self.execute_module(filters)
      self = <Report: Supplier Ledger Summary>
      filters = {'company': 'Bastar Dairy Farm Pvt Ltd', 'from_date': '2025-03-17', 'supplier_group': 'Agent-Milk Collection', 'to_date': '2025-04-17'}
      threshold = 15
      res = []
      start_time = datetime.datetime(2025, 4, 17, 7, 31, 40, 186163)
      prepared_report_watcher = None
  File "apps/frappe/frappe/core/doctype/report/report.py", line 190, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
      self = <Report: Supplier Ledger Summary>
      filters = {'company': 'Bastar Dairy Farm Pvt Ltd', 'from_date': '2025-03-17', 'supplier_group': 'Agent-Milk Collection', 'to_date': '2025-04-17'}
      module = 'Accounts'
      method_name = 'erpnext.accounts.report.supplier_ledger_summary.supplier_ledger_summary.execute'
  File "apps/erpnext/erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.py", line 15, in execute
    return PartyLedgerSummaryReport(filters).run(args)
      filters = {'company': 'Bastar Dairy Farm Pvt Ltd', 'from_date': '2025-03-17', 'supplier_group': 'Agent-Milk Collection', 'to_date': '2025-04-17'}
      args = {'party_type': 'Supplier', 'naming_by': ['Buying Settings', 'supp_master_name']}
  File "apps/erpnext/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py", line 32, in run
    self.get_party_details()
      self = <erpnext.accounts.report.customer_ledger_summary.customer_ledger_summary.PartyLedgerSummaryReport object at 0x7fe717563310>
      args = {'party_type': 'Supplier', 'naming_by': ['Buying Settings', 'supp_master_name']}
  File "apps/erpnext/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py", line 71, in get_party_details
    conditions = self.get_party_conditions(doctype)
      self = <erpnext.accounts.report.customer_ledger_summary.customer_ledger_summary.PartyLedgerSummaryReport object at 0x7fe717563310>
      party_type = 'Supplier'
      doctype = Table('tabSupplier')
  File "apps/erpnext/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py", line 103, in get_party_conditions
    conditions.append(doctype.get(group_field).isin(self.filters.get(group_field)))
      self = <erpnext.accounts.report.customer_ledger_summary.customer_ledger_summary.PartyLedgerSummaryReport object at 0x7fe717563310>
      doctype = Table('tabSupplier')
      conditions = []
      group_field = 'supplier_group'
builtins.TypeError: 'Field' object is not callable

```

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/36464