### PR TITLE
fix: create default warehouses

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -281,6 +281,7 @@ class Company(NestedSet):
 		frappe.clear_cache()
 
 	def create_default_warehouses(self):
+		parent_warehouse = None
 		for wh_detail in [
 			{"warehouse_name": _("All Warehouses"), "is_group": 1},
 			{"warehouse_name": _("Stores"), "is_group": 0},
@@ -288,22 +289,31 @@ class Company(NestedSet):
 			{"warehouse_name": _("Finished Goods"), "is_group": 0},
 			{"warehouse_name": _("Goods In Transit"), "is_group": 0, "warehouse_type": "Transit"},
 		]:
-			if not frappe.db.exists("Warehouse", "{} - {}".format(wh_detail["warehouse_name"], self.abbr)):
-				warehouse = frappe.get_doc(
-					{
-						"doctype": "Warehouse",
-						"warehouse_name": wh_detail["warehouse_name"],
-						"is_group": wh_detail["is_group"],
-						"company": self.name,
-						"parent_warehouse": "{} - {}".format(_("All Warehouses"), self.abbr)
-						if not wh_detail["is_group"]
-						else "",
-						"warehouse_type": wh_detail.get("warehouse_type"),
-					}
-				)
-				warehouse.flags.ignore_permissions = True
-				warehouse.flags.ignore_mandatory = True
-				warehouse.insert()
+			if frappe.db.exists(
+				"Warehouse",
+				{
+					"warehouse_name": wh_detail["warehouse_name"],
+					"company": self.name,
+				},
+			):
+				continue
+
+			warehouse = frappe.get_doc(
+				{
+					"doctype": "Warehouse",
+					"warehouse_name": wh_detail["warehouse_name"],
+					"is_group": wh_detail["is_group"],
+					"company": self.name,
+					"parent_warehouse": parent_warehouse,
+					"warehouse_type": wh_detail.get("warehouse_type"),
+				}
+			)
+			warehouse.flags.ignore_permissions = True
+			warehouse.flags.ignore_mandatory = True
+			warehouse.insert()
+
+			if wh_detail["is_group"]:
+				parent_warehouse = warehouse.name
 
 	def create_default_accounts(self):
 		from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import create_charts


### PR DESCRIPTION
Naming rules for **Warehouse** were hardcoded in `create_default_warehouses`, which prevents custom apps from setting a different naming scheme.