### PR TITLE
feat: Ledger Preview for Stock Entry

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1581,7 +1581,7 @@ def get_accounting_ledger_preview(doc, filters):
 
 	doc.docstatus = 1
 
-	if doc.get("update_stock") or doc.doctype in ("Purchase Receipt", "Delivery Note"):
+	if doc.get("update_stock") or doc.doctype in ("Purchase Receipt", "Delivery Note", "Stock Entry"):
 		doc.update_stock_ledger()
 
 	doc.make_gl_entries()
@@ -1622,7 +1622,7 @@ def get_stock_ledger_preview(doc, filters):
 		"stock_value_difference",
 	]
 
-	if doc.get("update_stock") or doc.doctype in ("Purchase Receipt", "Delivery Note"):
+	if doc.get("update_stock") or doc.doctype in ("Purchase Receipt", "Delivery Note", "Stock Entry"):
 		doc.docstatus = 1
 		doc.update_stock_ledger()
 		columns = get_sl_columns(filters)

--- a/erpnext/public/js/utils/ledger_preview.js
+++ b/erpnext/public/js/utils/ledger_preview.js
@@ -60,23 +60,27 @@ erpnext.accounts.ledger_preview = {
 	},
 
 	make_dialog(label, fieldname, columns, data) {
-		let me = this;
-		let dialog = new frappe.ui.Dialog({
-			size: "extra-large",
-			title: __(label),
-			fields: [
-				{
-					fieldtype: "HTML",
-					fieldname: fieldname,
-				},
-			],
-		});
+		if (data.length === 0 && fieldname === "accounting_ledger_preview_html") {
+			frappe.msgprint("<strong>" + __("No Impact on Accounting Ledger") + "</strong>");
+		} else {
+			let me = this;
+			let dialog = new frappe.ui.Dialog({
+				size: "extra-large",
+				title: __(label),
+				fields: [
+					{
+						fieldtype: "HTML",
+						fieldname: fieldname,
+					},
+				],
+			});
 
-		setTimeout(function () {
-			me.get_datatable(columns, data, dialog.get_field(fieldname).wrapper);
-		}, 200);
+			setTimeout(function () {
+				me.get_datatable(columns, data, dialog.get_field(fieldname).wrapper);
+			}, 200);
 
-		dialog.show();
+			dialog.show();
+		}
 	},
 
 	get_datatable(columns, data, wrapper) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1081,6 +1081,8 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 		}
 		erpnext.hide_company(this.frm);
 		erpnext.utils.add_item(this.frm);
+		erpnext.accounts.ledger_preview.show_accounting_ledger_preview(this.frm);
+		erpnext.accounts.ledger_preview.show_stock_ledger_preview(this.frm);
 	}
 
 	serial_no(doc, cdt, cdn) {


### PR DESCRIPTION
This PR adds Ledger Preview functionality to the Stock Entry form, allowing users to view the expected impact on the Accounting Ledger and Stock Ledger before submission.

`no-docs`