### PR TITLE
refactor: make AR / AP report more memory efficient

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -79,9 +79,12 @@
   "reports_tab",
   "remarks_section",
   "general_ledger_remarks_length",
-  "ignore_is_opening_check_for_reporting",
   "column_break_lvjk",
   "receivable_payable_remarks_length",
+  "accounts_receivable_payable_tuning_section",
+  "receivable_payable_fetch_method",
+  "legacy_section",
+  "ignore_is_opening_check_for_reporting",
   "payment_request_settings",
   "create_pr_in_draft_status"
  ],
@@ -545,6 +548,23 @@
    "fieldname": "use_sales_invoice_in_pos",
    "fieldtype": "Check",
    "label": "Use Sales Invoice"
+  },
+  {
+   "default": "Buffered Cursor",
+   "fieldname": "receivable_payable_fetch_method",
+   "fieldtype": "Select",
+   "label": "Data Fetch Method",
+   "options": "Buffered Cursor\nUnBuffered Cursor"
+  },
+  {
+   "fieldname": "accounts_receivable_payable_tuning_section",
+   "fieldtype": "Section Break",
+   "label": "Accounts Receivable / Payable Tuning"
+  },
+  {
+   "fieldname": "legacy_section",
+   "fieldtype": "Section Break",
+   "label": "Legacy Fields"
   }
  ],
  "grid_page_length": 50,
@@ -553,7 +573,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-30 20:47:17.954736",
+ "modified": "2025-05-05 12:29:38.302027",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -54,6 +54,7 @@ class AccountsSettings(Document):
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
 		post_change_gl_entries: DF.Check
+		receivable_payable_fetch_method: DF.Literal["Buffered Cursor", "UnBuffered Cursor"]
 		receivable_payable_remarks_length: DF.Int
 		reconciliation_queue_size: DF.Int
 		role_allowed_to_over_bill: DF.Link | None

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -54,9 +54,10 @@ class ReceivablePayableReport:
 			self.filters.range = "30, 60, 90, 120"
 		self.ranges = [num.strip() for num in self.filters.range.split(",") if num.strip().isdigit()]
 		self.range_numbers = [num for num in range(1, len(self.ranges) + 2)]
-		self.ple_fetch_method = frappe.db.get_single_value(
-			"Accounts Settings", "receivable_payable_fetch_method"
-		)
+		self.ple_fetch_method = (
+			frappe.db.get_single_value("Accounts Settings", "receivable_payable_fetch_method")
+			or "Buffered Cursor"
+		)  # Fail Safe
 
 	def run(self, args):
 		self.filters.update(args)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -409,3 +409,4 @@ erpnext.patches.v15_0.update_query_report
 erpnext.patches.v15_0.set_purchase_receipt_row_item_to_capitalization_stock_item
 erpnext.patches.v15_0.update_payment_schedule_fields_in_invoices
 erpnext.patches.v15_0.rename_group_by_to_categorize_by
+execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetch_method", "Buffered Cursor")


### PR DESCRIPTION
# Issue
On Large sites, AR / AP consumes quite a lot of memory. It sometimes lead to connection being closed as the process is killed by kernel OOM. This is due to the report design, which fetches the whole Payment Ledger table for processing.

# Interim Fix
Framework has a feature called Unbuffered cursor, which returns results as an iterator. But internally, this fetches records in batched manner (1000).

Report has been refactored to make use of this option.  `Account Settings` will allow users to select fetching method.
![Screenshot from 2025-05-05 14-00-21](https://github.com/user-attachments/assets/b8a89f51-49c5-4efb-9bf5-a39740f3ee92)


# Long Term Solution (WIP)
Proper fix for extremely large data sets will require most of the report to be rewritten in raw SQL.