### PR TITLE
fix: Payment Schedule on Invoice - Due date should be dynamic derived based on payment terms and bill date or posting date of invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2474,10 +2474,10 @@ class AccountsController(TransactionBase):
 		self.payment_terms_template = po_or_so.payment_terms_template
 
 		for schedule in po_or_so.payment_schedule:
-			payment_term = frappe.get_doc("Payment Term", schedule.payment_term)
+			payment_term = frappe.get_doc("Payment Term", schedule.payment_term) if schedule.payment_term else None
 			payment_schedule = {
 				"payment_term": schedule.payment_term,
-				"due_date": get_due_date(payment_term, due_date),
+				"due_date": get_due_date(payment_term, due_date) if payment_term else schedule.due_date,
 				"invoice_portion": schedule.invoice_portion,
 				"mode_of_payment": schedule.mode_of_payment,
 				"description": schedule.description,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2375,7 +2375,7 @@ class AccountsController(TransactionBase):
 				and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 			):
 				self.fetch_payment_terms_from_order(
-					po_or_so, doctype, grand_total, base_grand_total, automatically_fetch_payment_terms
+					po_or_so, doctype, due_date, grand_total, base_grand_total, automatically_fetch_payment_terms
 				)
 				if self.get("payment_terms_template"):
 					self.ignore_default_payment_terms_template = 1
@@ -2421,7 +2421,7 @@ class AccountsController(TransactionBase):
 					)
 		else:
 			self.fetch_payment_terms_from_order(
-				po_or_so, doctype, grand_total, base_grand_total, automatically_fetch_payment_terms
+				po_or_so, doctype, due_date, grand_total, base_grand_total, automatically_fetch_payment_terms
 			)
 			self.ignore_default_payment_terms_template = 1
 
@@ -2463,7 +2463,7 @@ class AccountsController(TransactionBase):
 		return frappe.get_all("Payment Schedule", filters={"parent": po_or_so})
 
 	def fetch_payment_terms_from_order(
-		self, po_or_so, po_or_so_doctype, grand_total, base_grand_total, automatically_fetch_payment_terms
+		self, po_or_so, po_or_so_doctype, due_date, grand_total, base_grand_total, automatically_fetch_payment_terms
 	):
 		"""
 		Fetch Payment Terms from Purchase/Sales Order on creating a new Purchase/Sales Invoice.
@@ -2474,9 +2474,10 @@ class AccountsController(TransactionBase):
 		self.payment_terms_template = po_or_so.payment_terms_template
 
 		for schedule in po_or_so.payment_schedule:
+			payment_term = frappe.get_doc("Payment Term", schedule.payment_term)
 			payment_schedule = {
 				"payment_term": schedule.payment_term,
-				"due_date": schedule.due_date,
+				"due_date": get_due_date(payment_term, due_date),
 				"invoice_portion": schedule.invoice_portion,
 				"mode_of_payment": schedule.mode_of_payment,
 				"description": schedule.description,

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1777,6 +1777,7 @@ def create_item_wise_repost_entries(
 		repost_entry.based_on = "Item and Warehouse"
 
 		repost_entry.item_code = sle.item_code
+		repost_entry.company = sle.company
 		repost_entry.warehouse = sle.warehouse
 		repost_entry.posting_date = sle.posting_date
 		repost_entry.posting_time = sle.posting_time

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1777,7 +1777,6 @@ def create_item_wise_repost_entries(
 		repost_entry.based_on = "Item and Warehouse"
 
 		repost_entry.item_code = sle.item_code
-		repost_entry.company = sle.company
 		repost_entry.warehouse = sle.warehouse
 		repost_entry.posting_date = sle.posting_date
 		repost_entry.posting_time = sle.posting_time


### PR DESCRIPTION
Due date on payment schedule should be dynamically derived based on payment terms (credit days) on PO and Bill date or posting date of invoice. Currently, it's just copying that whatever due date is on the PO/SO schedule For blanket orders, the PO / SO date could be sometime in past (say 1st Jan) and due date could be 31st Jan (30 days). However, when invoice is submitted on 1st Mar, the system should calculate the due date as 31st Mar (1st + 30 days) instead of updating the due date as 30st Jan (doing the later marks the invoice as overdue on submit).

Merge into develop, 
backport into version-15-hotfix
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
