### PR TITLE
fix: set correct paid/receive amount if doc currency is different from party account currency

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3388,26 +3388,25 @@ def set_paid_amount_and_received_amount(
 	if party_account_currency == bank.account_currency:
 		paid_amount = received_amount = abs(outstanding_amount)
 	else:
-		company_currency = frappe.get_cached_value("Company", doc.get("company"), "default_currency")
-		if payment_type == "Receive":
-			paid_amount = abs(outstanding_amount)
-			if bank_amount:
-				received_amount = bank_amount
-			else:
-				if bank and company_currency != bank.account_currency:
-					received_amount = paid_amount / doc.get("conversion_rate", 1)
-				else:
-					received_amount = paid_amount * doc.get("conversion_rate", 1)
+		# settings if it is for receive
+		paid_amount = abs(outstanding_amount)
+		if bank_amount:
+			received_amount = bank_amount
 		else:
-			received_amount = abs(outstanding_amount)
-			if bank_amount:
-				paid_amount = bank_amount
+			company_currency = frappe.get_cached_value("Company", doc.get("company"), "default_currency")
+			if bank and company_currency != bank.account_currency:
+				# doc currency can be different from bank currency
+				posting_date = doc.get("posting_date") or doc.get("transaction_date")
+				conversion_rate = get_exchange_rate(
+					bank.account_currency, party_account_currency, posting_date
+				)
+				received_amount = paid_amount / conversion_rate
 			else:
-				if bank and company_currency != bank.account_currency:
-					paid_amount = received_amount / doc.get("conversion_rate", 1)
-				else:
-					# if party account currency and bank currency is different then populate paid amount as well
-					paid_amount = received_amount * doc.get("conversion_rate", 1)
+				received_amount = paid_amount * doc.get("conversion_rate", 1)
+
+		# if payment type is pay, then paid amount and received amount are swapped
+		if payment_type == "Pay":
+			paid_amount, received_amount = received_amount, paid_amount
 
 	return paid_amount, received_amount
 


### PR DESCRIPTION
Issue: When the bank account currency is different from the party account currency and company currency and doc currency is also different from party account currency paid/received amount is incorrect.

Steps to replicate:
- Set only one account with account type as "Bank" and currency different from company currency.
- Enable "allow_multi_currency_invoices_against_single_party_account" from Account Settings.
- Create a Purchase invoice in different doc currency.
- Create Payment Entry.

The paid amount will be based on the Purchase Invoice Currency.

Eg:
Company currency: SAR
Invoice currency: AED
Bank account currency: USD

Invoice: 1998.00 AED
Exchange Rate AED to SAR: 1 AED = 1.02 SAR
Exchange Rate USD to SAR: 1 USD = 3.75 SAR
Invoice value in SAR: 2037.96 SAR

paying in USD: This system should auto-calculate in USD. But it’s taking 1998.00 USD


![image](https://github.com/user-attachments/assets/6fe9f918-d76a-44a7-9456-9f119ab0f504)
![image](https://github.com/user-attachments/assets/a38c8d02-9930-46eb-a38c-2f0a37da3675)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35971


    





