### PR TITLE
fix: item images on pos item selector

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -161,7 +161,9 @@
 
 				.item-img {
 					@extend .image;
-					border-radius: 8px 8px 0 0;
+					border-radius: 8px 8px;
+					max-height: 100%;
+					max-width: 100%;
 					object-fit: cover;
 				}
 

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -104,10 +104,10 @@ erpnext.PointOfSale.ItemSelector = class {
 				return `<div class="item-qty-pill">
 							<span class="indicator-pill whitespace-nowrap ${indicator_color}">${qty_to_display}</span>
 						</div>
-						<div class="flex items-center justify-center border-b-grey text-6xl text-grey-100" style="height:8rem; min-height:8rem">
+						<div class="item-display">
 							<img
 								onerror="cur_pos.item_selector.handle_broken_image(this)"
-								class="h-full item-img" src="${item_image}"
+								class="item-img" src="${item_image}"
 								alt="${frappe.get_abbr(item.item_name)}"
 							>
 						</div>`;

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -108,7 +108,7 @@ erpnext.PointOfSale.ItemSelector = class {
 							<img
 								onerror="cur_pos.item_selector.handle_broken_image(this)"
 								class="item-img" src="${item_image}"
-								alt="${frappe.get_abbr(item.item_name)}"
+								alt="${item.item_name}"
 							>
 						</div>`;
 			} else {


### PR DESCRIPTION
Fixed Item images were overflowing from the Item Cards in POS.

Before:

![image](https://github.com/user-attachments/assets/d175d64f-750d-41ec-b0e9-9d92afb8391f)

After:

![image](https://github.com/user-attachments/assets/a74aa667-ca1c-410d-a7f1-ee7e9b2edf11)
