### PR TITLE
fix: add grand_total to show correct status in quick list widget

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
@@ -16,9 +16,9 @@ frappe.listview_settings["Purchase Receipt"] = {
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
 		} else if (flt(doc.per_returned, 2) === 100) {
-			return [__("Return Issued"), "grey", "per_returned,=,100|docstatus,=,1"];
-		} else if (flt(doc.grand_total) !== 0 && flt(doc.per_billed, 2) == 0) {
-			return [__("To Bill"), "orange", "per_billed,<,100|docstatus,=,1"];
+			return [__("Return Issued"), "grey", "per_returned,=,100"];
+		} else if (flt(doc.grand_total || doc.base_grand_total) !== 0 && flt(doc.per_billed, 2) == 0) {
+			return [__("To Bill"), "orange", "per_billed,<,100"];
 		} else if (flt(doc.per_billed, 2) > 0 && flt(doc.per_billed, 2) < 100) {
 			return [__("Partly Billed"), "yellow", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.grand_total) === 0 || flt(doc.per_billed, 2) === 100) {

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
@@ -16,9 +16,9 @@ frappe.listview_settings["Purchase Receipt"] = {
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
 		} else if (flt(doc.per_returned, 2) === 100) {
-			return [__("Return Issued"), "grey", "per_returned,=,100"];
+			return [__("Return Issued"), "grey", "per_returned,=,100|docstatus,=,1"];
 		} else if (flt(doc.grand_total || doc.base_grand_total) !== 0 && flt(doc.per_billed, 2) == 0) {
-			return [__("To Bill"), "orange", "per_billed,<,100"];
+			return [__("To Bill"), "orange", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.per_billed, 2) > 0 && flt(doc.per_billed, 2) < 100) {
 			return [__("Partly Billed"), "yellow", "per_billed,<,100|docstatus,=,1"];
 		} else if (flt(doc.grand_total) === 0 || flt(doc.per_billed, 2) === 100) {


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/c4e24b69-4603-4dd6-bc56-837eef0690d4

After

https://github.com/user-attachments/assets/f8c5d9b4-40b8-48bd-b43e-8f6e9aeb7a3b

Support ticket https://support.frappe.io/helpdesk/tickets/36350

