### PR TITLE
fix: keep per_billed 100 for billed delivery note after return

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2412,13 +2412,12 @@ class AccountsController(TransactionBase):
 						base_grand_total * flt(d.invoice_portion) / 100, d.precision("base_payment_amount")
 					)
 					d.outstanding = d.payment_amount
-					d.base_outstanding = flt(
-						d.payment_amount * self.get("conversion_rate"), d.precision("base_outstanding")
-					)
+					d.base_outstanding = d.base_payment_amount
 				elif not d.invoice_portion:
 					d.base_payment_amount = flt(
 						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")
 					)
+					d.base_outstanding = d.base_payment_amount
 		else:
 			self.fetch_payment_terms_from_order(
 				po_or_so, doctype, grand_total, base_grand_total, automatically_fetch_payment_terms

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -92,8 +92,8 @@ status_map = {
 	"Delivery Note": [
 		["Draft", None],
 		["To Bill", "eval:self.per_billed < 100 and self.docstatus == 1"],
-		["Return Issued", "eval:self.per_returned == 100 and self.docstatus == 1"],
 		["Completed", "eval:self.per_billed == 100 and self.docstatus == 1"],
+		["Return Issued", "eval:self.per_returned == 100 and self.docstatus == 1"],
 		["Cancelled", "eval:self.docstatus==2"],
 		["Closed", "eval:self.status=='Closed' and self.docstatus != 2"],
 	],

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -991,7 +991,13 @@ class StockController(AccountsController):
 	def update_billing_percentage(self, update_modified=True):
 		target_ref_field = "amount"
 		if self.doctype == "Delivery Note":
-			target_ref_field = "amount - (returned_qty * rate)"
+			total_amount = total_returned = 0
+			for item in self.items:
+				total_amount += flt(item.amount)
+				total_returned += flt(item.returned_qty * item.rate)
+
+			if total_returned < total_amount:
+				target_ref_field = "(amount - (returned_qty * rate))"
 
 		self._update_percent_field(
 			{

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2561,6 +2561,28 @@ class TestDeliveryNote(IntegrationTestCase):
 			for d in bundle_data:
 				self.assertEqual(d.incoming_rate, batch_no_valuation[d.batch_no])
 
+	def test_delivery_note_per_billed_after_return(self):
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		so = make_sales_order(qty=2)
+		dn = make_delivery_note(so.name)
+		dn.submit()
+		self.assertEqual(dn.per_billed, 0)
+
+		si = make_sales_invoice(dn.name)
+		si.location = "Test Location"
+		si.submit()
+
+		dn_return = create_delivery_note(is_return=1, return_against=dn.name, qty=-2, do_not_submit=True)
+		dn_return.items[0].dn_detail = dn.items[0].name
+		dn_return.submit()
+
+		returned = frappe.get_doc("Delivery Note", dn_return.name)
+		returned.update_prevdoc_status()
+		dn.load_from_db()
+		self.assertEqual(dn.per_billed, 100)
+		self.assertEqual(dn.per_returned, 100)
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")


### PR DESCRIPTION
**Issue:**
per_billed value changes to 0 for billed Delivery Note after creating return for it.

**ref:** [33609](https://support.frappe.io/helpdesk/tickets/33609)

**Before:**

https://github.com/user-attachments/assets/bb2b1639-341e-47db-a7df-97a93abc0079

**After:**

https://github.com/user-attachments/assets/df1cd77a-da59-4078-ae7f-47e37af4836d

**Back port needed for version-15**