### PR TITLE
fix: set default company address in selling Doctype on change of company

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -778,24 +778,6 @@ frappe.ui.form.on("Sales Invoice", {
 			};
 		});
 	},
-	// When multiple companies are set up. in case company name is changed set default company address
-	company: function (frm) {
-		if (frm.doc.company) {
-			frappe.call({
-				method: "erpnext.setup.doctype.company.company.get_default_company_address",
-				args: { name: frm.doc.company, existing_address: frm.doc.company_address || "" },
-				debounce: 2000,
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value("company_address", r.message);
-					} else {
-						frm.set_value("company_address", "");
-					}
-				},
-			});
-		}
-	},
-
 	onload: function (frm) {
 		frm.redemption_conversion_factor = null;
 	},

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -115,6 +115,33 @@ erpnext.sales_common = {
 				this.toggle_editable_price_list_rate();
 			}
 
+			company() {
+				super.company();
+				this.set_default_company_address();
+			}
+
+			set_default_company_address() {
+				if (!frappe.meta.has_field(this.frm.doc.doctype, "company_address")) return;
+				var me = this;
+				if (this.frm.doc.company) {
+					frappe.call({
+						method: "erpnext.setup.doctype.company.company.get_default_company_address",
+						args: {
+							name: this.frm.doc.company,
+							existing_address: this.frm.doc.company_address || "",
+						},
+						debounce: 2000,
+						callback: function (r) {
+							if (r.message) {
+								me.frm.set_value("company_address", r.message);
+							} else {
+								me.frm.set_value("company_address", "");
+							}
+						},
+					});
+				}
+			}
+
 			customer() {
 				var me = this;
 				erpnext.utils.get_party_details(this.frm, null, null, function () {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -164,27 +164,6 @@ frappe.ui.form.on("Sales Order", {
 		);
 	},
 
-	// When multiple companies are set up. in case company name is changed set default company address
-	company: function (frm) {
-		if (frm.doc.company) {
-			frappe.call({
-				method: "erpnext.setup.doctype.company.company.get_default_company_address",
-				args: {
-					name: frm.doc.company,
-					existing_address: frm.doc.company_address || "",
-				},
-				debounce: 2000,
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value("company_address", r.message);
-					} else {
-						frm.set_value("company_address", "");
-					}
-				},
-			});
-		}
-	},
-
 	onload: function (frm) {
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());


### PR DESCRIPTION
Issue: The Default company address is not changing in the Quotation on the change of company.


Note: Minor refactor directly applying for all the sales doctypes


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/36716

