### PR TITLE
fix: find table row

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -721,7 +721,7 @@ erpnext.utils.update_child_items = function (opts) {
 							} = r.message;
 
 							const row = dialog.fields_dict.trans_items.df.data.find(
-								(doc) => doc.idx == me.doc.idx
+								(row) => row.name == me.doc.name
 							);
 							if (row) {
 								Object.assign(row, {


### PR DESCRIPTION
In the "Update Items" dialog, we want to figure out which row to update with new item details. Filtering by `row.idx` is unreliable, it is managed by the grid and can change at surprising times (proof: https://github.com/frappe/frappe/pull/28955).

Idea: Let's filter by `name` instead.
However, this could break for new rows without a distinct name. That issue is fixed in https://github.com/frappe/frappe/pull/32512.

Ref: IDM-219