### PR TITLE
Fix: Party Balance set as a no Copy while duplicate PE

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -230,7 +230,8 @@
    "fieldtype": "Currency",
    "label": "Party Balance",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "no_copy": 1
   },
   {
    "bold": 1,


### PR DESCRIPTION
#47218 
Once duplicate Payment Entry and directly save submit then party balance not calculated or better to avoid to copying from source document.
Take Look
**### Before:**
1) Duplicate Existing Payment Entry
![image](https://github.com/user-attachments/assets/d11453b8-4f8d-48e4-9f7f-a519e722cfaa)

2) Before Save
![image](https://github.com/user-attachments/assets/05b1805f-31a8-4f08-ad19-8a0f507e9f02)
3) Actual Issue
![image](https://github.com/user-attachments/assets/9c81084b-4e47-47ae-87ff-b71fa9ca99c0)
![image](https://github.com/user-attachments/assets/dd22e43a-41f6-4e44-8119-c3918c0cae88)

### **After :**
![image](https://github.com/user-attachments/assets/95d31174-da34-4d0f-88f3-d4b1b6cb4b9c)
**Draft **
![image](https://github.com/user-attachments/assets/7c7a2d5b-2c81-47ff-b11b-c86ba0110a43)




