### PR TITLE
fix: make asset quantity and amount editable

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -661,10 +661,6 @@ frappe.ui.form.on("Asset", {
 					} else {
 						frm.set_value("purchase_invoice_item", data.purchase_invoice_item);
 					}
-
-					let is_editable = !data.is_multiple_items; // if multiple items, then fields should be read-only
-					frm.set_df_property("gross_purchase_amount", "read_only", is_editable);
-					frm.set_df_property("asset_quantity", "read_only", is_editable);
 				}
 			},
 		});

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1170,7 +1170,6 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 		frappe.throw(_(f"Selected {doctype} does not contain the Item Code {item_code}"))
 
 	first_item = matching_items[0]
-	is_multiple_items = len(matching_items) > 1
 
 	return {
 		"company": purchase_doc.company,
@@ -1179,7 +1178,6 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 		"asset_quantity": first_item.qty,
 		"cost_center": first_item.cost_center or purchase_doc.get("cost_center"),
 		"asset_location": first_item.get("asset_location"),
-		"is_multiple_items": is_multiple_items,
 		"purchase_receipt_item": first_item.name if doctype == "Purchase Receipt" else None,
 		"purchase_invoice_item": first_item.name if doctype == "Purchase Invoice" else None,
 	}


### PR DESCRIPTION
Allow editing of asset quantity and amount when the asset is purchased in a group.
Internal support issue: https://support.frappe.io/helpdesk/tickets/36747