### PR TITLE
fix(payment request): get advance amount based on transaction currency

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -672,7 +672,12 @@ def get_amount(ref_doc, payment_account=None):
 
 	dt = ref_doc.doctype
 	if dt in ["Sales Order", "Purchase Order"]:
-		grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - ref_doc.advance_paid
+		advance_amount = flt(ref_doc.advance_paid)
+		if ref_doc.party_account_currency != ref_doc.currency:
+			advance_amount = flt(flt(ref_doc.advance_paid) / ref_doc.conversion_rate)
+
+		grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - advance_amount
+
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if (
 			dt == "Sales Invoice"


### PR DESCRIPTION
**Issue:**
Unable to create a payment request for partially paid orders when `
Allow multi-currency invoices against single party account` is enabled.
**ref:** [36142](https://support.frappe.io/helpdesk/tickets/36142)

**Before:**

https://github.com/user-attachments/assets/218f4159-eba8-4e58-904c-7417e7fc5a22


**After:**

https://github.com/user-attachments/assets/b706f2ff-014c-4ffd-9237-188e96b7af54


**Backport needed for v15**