### PR TITLE
fix: Re-insert missing "Serial No Warranty Expiry" Report

### DIFF
--- a/erpnext/stock/report/serial_no_warranty_expiry/serial_no_warranty_expiry.json
+++ b/erpnext/stock/report/serial_no_warranty_expiry/serial_no_warranty_expiry.json
@@ -10,14 +10,14 @@
  "is_standard": "Yes",
  "json": "{\"add_total_row\": 0, \"sort_by\": \"Serial No.modified\", \"sort_order\": \"desc\", \"sort_by_next\": null, \"filters\": [[\"Serial No\", \"warehouse\", \"=\", \"\"]], \"sort_order_next\": \"desc\", \"columns\": [[\"name\", \"Serial No\"], [\"item_code\", \"Serial No\"], [\"amc_expiry_date\", \"Serial No\"], [\"maintenance_status\", \"Serial No\"],[\"item_name\", \"Serial No\"], [\"description\", \"Serial No\"], [\"item_group\", \"Serial No\"], [\"brand\", \"Serial No\"]]}",
  "letterhead": null,
- "modified": "2024-09-26 13:07:23.451182",
+ "modified": "2025-04-24 13:07:23.451182",
  "modified_by": "Administrator",
  "module": "Stock",
- "name": "Serial No Service Contract Expiry",
+ "name": "Serial No Warranty Expiry",
  "owner": "Administrator",
  "prepared_report": 0,
  "ref_doctype": "Serial No",
- "report_name": "Serial No Service Contract Expiry",
+ "report_name": "Serial No Warranty Expiry",
  "report_type": "Report Builder",
  "roles": [
   {


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/44633

https://github.com/frappe/erpnext/pull/46755#issuecomment-2789240059

> For newer installs the issue is that the `name` and `report_name` are wrong (should be "Serial No Warranty Expiry") and due to the clash we have "Serial No Warranty Expiry" missing https://github.com/frappe/erpnext/blob/67fcc172d760683263ee4bdcd231cc347ea02580/erpnext/stock/report/serial_no_warranty_expiry/serial_no_warranty_expiry.json#L16-L20 caused by https://github.com/frappe/erpnext/pull/43444 
For legacy installs, this remains unaffected. 

This fixes itself on migration.

> **To the reviewer:** These two reports, "Serial No Warranty Expiry" and "Serial No Service Contract Expiry," look pretty identical to me and also don't seem very report-worthy. Can we get rid of them?