### PR TITLE
fix: update additional cost and total asset cost after asset repair

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -478,6 +478,7 @@
    "fieldname": "total_asset_cost",
    "fieldtype": "Currency",
    "label": "Total Asset Cost",
+   "no_copy": 1,
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -486,6 +487,7 @@
    "fieldname": "additional_asset_cost",
    "fieldtype": "Currency",
    "label": "Additional Asset Cost",
+   "no_copy": 1,
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -589,7 +591,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-04-15 16:33:17.189524",
+ "modified": "2025-04-24 15:31:47.373274",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -135,9 +135,11 @@ class AssetRepair(AccountsController):
 
 			self.increase_asset_value()
 
+			total_repair_cost = self.get_total_value_of_stock_consumed()
 			if self.capitalize_repair_cost:
-				self.asset_doc.total_asset_cost += self.repair_cost
-				self.asset_doc.additional_asset_cost += self.repair_cost
+				total_repair_cost += self.repair_cost
+			self.asset_doc.total_asset_cost += total_repair_cost
+			self.asset_doc.additional_asset_cost += total_repair_cost
 
 			if self.get("stock_consumption"):
 				self.check_for_stock_items_and_warehouse()
@@ -176,9 +178,11 @@ class AssetRepair(AccountsController):
 
 			self.decrease_asset_value()
 
+			total_repair_cost = self.get_total_value_of_stock_consumed()
 			if self.capitalize_repair_cost:
-				self.asset_doc.total_asset_cost -= self.repair_cost
-				self.asset_doc.additional_asset_cost -= self.repair_cost
+				total_repair_cost += self.repair_cost
+			self.asset_doc.total_asset_cost -= total_repair_cost
+			self.asset_doc.additional_asset_cost -= total_repair_cost
 
 			if self.get("capitalize_repair_cost"):
 				self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")


### PR DESCRIPTION
Earlier, after repairing an asset, only the repair expense was getting added to the asset’s cost.
Now, I’ve fixed it so that both the stock item cost and the repair expense are included.

This makes the total and additional cost of the asset more accurate after a repair.