### PR TITLE
fix: price currency in supplier quotation comparison

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -83,18 +83,10 @@ def prepare_data(supplier_quotation_data, filters):
 	supplier_qty_price_map = {}
 
 	group_by_field = "supplier_name" if filters.get("group_by") == "Group by Supplier" else "item_code"
-	company_currency = frappe.db.get_default("currency")
 	float_precision = cint(frappe.db.get_default("float_precision")) or 2
 
 	for data in supplier_quotation_data:
 		group = data.get(group_by_field)  # get item or supplier value for this row
-
-		supplier_currency = frappe.db.get_value("Supplier", data.get("supplier_name"), "default_currency")
-
-		if supplier_currency:
-			exchange_rate = get_exchange_rate(supplier_currency, company_currency)
-		else:
-			exchange_rate = 1
 
 		row = {
 			"item_code": ""
@@ -103,7 +95,7 @@ def prepare_data(supplier_quotation_data, filters):
 			"supplier_name": "" if group_by_field == "supplier_name" else data.get("supplier_name"),
 			"quotation": data.get("parent"),
 			"qty": data.get("qty"),
-			"price": flt(data.get("amount") * exchange_rate, float_precision),
+			"price": flt(data.get("amount"), float_precision),
 			"uom": data.get("uom"),
 			"price_list_currency": data.get("price_list_currency"),
 			"currency": data.get("currency"),
@@ -210,6 +202,13 @@ def get_columns(filters):
 		{"fieldname": "uom", "label": _("UOM"), "fieldtype": "Link", "options": "UOM", "width": 90},
 		{"fieldname": "qty", "label": _("Quantity"), "fieldtype": "Float", "width": 80},
 		{
+			"fieldname": "stock_uom",
+			"label": _("Stock UOM"),
+			"fieldtype": "Link",
+			"options": "UOM",
+			"width": 90,
+		},
+		{
 			"fieldname": "currency",
 			"label": _("Currency"),
 			"fieldtype": "Link",
@@ -222,13 +221,6 @@ def get_columns(filters):
 			"fieldtype": "Currency",
 			"options": "currency",
 			"width": 110,
-		},
-		{
-			"fieldname": "stock_uom",
-			"label": _("Stock UOM"),
-			"fieldtype": "Link",
-			"options": "UOM",
-			"width": 90,
 		},
 		{
 			"fieldname": "price_per_unit",


### PR DESCRIPTION
Reference support ticket [37040](https://support.frappe.io/helpdesk/tickets/37040)

Fixed an issue where price and per per unit were converted to base currency but symbol shown was of transaction currency. Moved Stock UOM field near to Quantity field.