### PR TITLE
fix: do not check for permission if values are not changed in employee doctype

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -88,7 +88,7 @@ class Employee(NestedSet):
 		if not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"):
 			return
 
-		if not has_permission("User Permission", ptype="write"):
+		if not has_permission("User Permission", ptype="write", raise_exception=False):
 			return
 
 		employee_user_permission_exists = frappe.db.exists(

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -85,9 +85,10 @@ class Employee(NestedSet):
 		self.reset_employee_emails_cache()
 
 	def update_user_permissions(self):
-		if not has_permission("User Permission", ptype="write") or (
-			not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission")
-		):
+		if not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"):
+			return
+
+		if not has_permission("User Permission", ptype="write"):
 			return
 
 		employee_user_permission_exists = frappe.db.exists(


### PR DESCRIPTION
Issue: Employee doesn't have permission for User Permission and is trying to update the name only. Still error message is shown.

Solution:

Check for permission if field values has changed.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/37016