### PR TITLE
fix: data import incorrectly adding duplicate entries

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -90,12 +90,12 @@ class ItemPrice(Document):
 		query = (
 			frappe.qb.from_(item_price)
 			.select(item_price.price_list_rate)
-			.where(
-				(item_price.item_code == self.item_code)
-				& (item_price.price_list == self.price_list)
-				& (item_price.name != self.name)
-			)
+			.where((item_price.item_code == self.item_code) & (item_price.price_list == self.price_list))
 		)
+
+		if not (frappe.flags.in_import and self.is_new()):
+			query = query.where(item_price.name != self.name)
+
 		data_fields = (
 			"uom",
 			"valid_from",


### PR DESCRIPTION
Reference support ticket [36804](https://support.frappe.io/helpdesk/tickets/36804)

The query is designed to return all possible duplicate entries. Assume a scenario in data import (insert new records) where user has given the exact same row as in the database including its ID. In this case, the query will never return the duplicate entry from database because of the & where condition which I have now removed when is data import insertion.