### PR TITLE
fix: accumulate values for all the fiscal years in Profit And Loss Statement

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -35,7 +35,6 @@ def execute(filters=None):
 		filters=filters,
 		accumulated_values=filters.accumulated_values,
 		ignore_closing_entries=True,
-		ignore_accumulated_values_for_fy=True,
 	)
 
 	expense = get_data(
@@ -46,7 +45,6 @@ def execute(filters=None):
 		filters=filters,
 		accumulated_values=filters.accumulated_values,
 		ignore_closing_entries=True,
-		ignore_accumulated_values_for_fy=True,
 	)
 
 	net_profit_loss = get_net_profit_loss(

--- a/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
@@ -58,7 +58,7 @@ class TestProfitAndLossStatement(AccountsTestMixin, IntegrationTestCase):
 			period_end_date=fy.year_end_date,
 			filter_based_on="Fiscal Year",
 			periodicity="Monthly",
-			accumulated_vallues=True,
+			accumulated_values=True,
 		)
 
 	def test_profit_and_loss_output_and_summary(self):

--- a/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
@@ -58,7 +58,7 @@ class TestProfitAndLossStatement(AccountsTestMixin, IntegrationTestCase):
 			period_end_date=fy.year_end_date,
 			filter_based_on="Fiscal Year",
 			periodicity="Monthly",
-			accumulated_values=True,
+			accumulated_values=False,
 		)
 
 	def test_profit_and_loss_output_and_summary(self):

--- a/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.desk.query_report import export_query
 from frappe.tests import IntegrationTestCase
-from frappe.utils import getdate, today
+from frappe.utils import add_days, getdate, today
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.financial_statements import get_period_list
@@ -109,3 +109,64 @@ class TestProfitAndLossStatement(AccountsTestMixin, IntegrationTestCase):
 		sales_account = frappe.db.get_value("Company", self.company, "default_income_account")
 
 		self.assertIn(sales_account, contents)
+
+	def test_accumulate_filter(self):
+		# ensure 2 fiscal years
+		cur_fy = self.get_fiscal_year()
+		find_for = add_days(cur_fy.year_start_date, -1)
+		_x = frappe.db.get_all(
+			"Fiscal Year",
+			filters={"disabled": 0, "year_start_date": ("<=", find_for), "year_end_date": (">=", find_for)},
+		)[0]
+		prev_fy = frappe.get_doc("Fiscal Year", _x.name)
+		prev_fy.append("companies", {"company": self.company})
+		prev_fy.save()
+
+		# make SI on both of them
+		prev_fy_si = self.create_sales_invoice(qty=1, rate=450, do_not_submit=True)
+		prev_fy_si.posting_date = add_days(prev_fy.year_end_date, -1)
+		prev_fy_si.save().submit()
+		income_acc = prev_fy_si.items[0].income_account
+
+		self.create_sales_invoice(qty=1, rate=120)
+
+		# Unaccumualted
+		filters = frappe._dict(
+			company=self.company,
+			from_fiscal_year=prev_fy.name,
+			to_fiscal_year=cur_fy.name,
+			period_start_date=prev_fy.year_start_date,
+			period_end_date=cur_fy.year_end_date,
+			filter_based_on="Date Range",
+			periodicity="Yearly",
+			accumulated_values=False,
+		)
+		result = execute(filters)
+		columns = [result[0][2], result[0][3]]
+		expected = {
+			"account": income_acc,
+			columns[0].get("fieldname"): 450.0,
+			columns[1].get("fieldname"): 120.0,
+		}
+		actual = [x for x in result[1] if x.get("account") == income_acc]
+		self.assertEqual(len(actual), 1)
+		actual = actual[0]
+		for key in expected.keys():
+			with self.subTest(key=key):
+				self.assertEqual(expected.get(key), actual.get(key))
+
+		# accumualted
+		filters.update({"accumulated_values": True})
+		expected = {
+			"account": income_acc,
+			columns[0].get("fieldname"): 450.0,
+			columns[1].get("fieldname"): 570.0,
+		}
+		result = execute(filters)
+		columns = [result[0][2], result[0][3]]
+		actual = [x for x in result[1] if x.get("account") == income_acc]
+		self.assertEqual(len(actual), 1)
+		actual = actual[0]
+		for key in expected.keys():
+			with self.subTest(key=key):
+				self.assertEqual(expected.get(key), actual.get(key))


### PR DESCRIPTION
Issue: If Accumulated Values is checked in the Profit and Loss Report, then values will be accumulated for the same fiscal year only.

Steps to replicate:
- Create two fiscal years.
- Create two JVs for expense in each fiscal year.
- Now check the Report Profit And Loss Statement with Accumulated Values.

Values will be accumulated only for the same fiscal year.

Filter Based On: Fiscal Year
Periodicity: Yearly
Normal
![image](https://github.com/user-attachments/assets/106b0368-3d02-4082-a468-ead76818c329)


Accumulated:

Before:
![image](https://github.com/user-attachments/assets/52cc677f-dc4e-4591-b4b1-45e262eed878)

After:
![image](https://github.com/user-attachments/assets/182194d3-9288-44e6-a151-c2d82937fb91)

Filter Based On: Date Range
Periodicity: Monthly
Normal
![image](https://github.com/user-attachments/assets/df93302d-1c53-4433-a25f-834aace6a421)

Accumulated
Before:
![image](https://github.com/user-attachments/assets/03eacc00-78d5-427b-b47c-c0de66f13931)

After:
![image](https://github.com/user-attachments/assets/b57b49af-2741-4402-9f98-cb6623dedd9c)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/32125





