### PR TITLE
fix: cancel pos closing entry failure for return pos invoices

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -337,7 +337,7 @@ class POSInvoiceMergeLog(Document):
 		for doc in invoice_docs:
 			doc.load_from_db()
 			inv = sales_invoice
-			if doc.is_return:
+			if doc.is_return and credit_notes:
 				for key, value in credit_notes.items():
 					if doc.name in value:
 						inv = key


### PR DESCRIPTION
Fixed the error while cancelling POS Closing Entry with Return POS Invoices.

Screenshot:

![image](https://github.com/user-attachments/assets/db891efa-d50d-4c2f-88d5-a8e70580c1c5)
