### PR TITLE
fix: dont pass ignore permissions param to whitelist methods

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1235,9 +1235,7 @@ class JournalEntry(AccountsController):
 
 
 @frappe.whitelist()
-def get_default_bank_cash_account(
-	company, account_type=None, mode_of_payment=None, account=None, ignore_permissions=False
-):
+def get_default_bank_cash_account(company, account_type=None, mode_of_payment=None, account=None):
 	from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 
 	if mode_of_payment:
@@ -1275,7 +1273,7 @@ def get_default_bank_cash_account(
 		return frappe._dict(
 			{
 				"account": account,
-				"balance": get_balance_on(account, ignore_account_permission=ignore_permissions),
+				"balance": get_balance_on(account),
 				"account_currency": account_details.account_currency,
 				"account_type": account_details.account_type,
 			}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2848,7 +2848,6 @@ def get_payment_entry(
 	party_type=None,
 	payment_type=None,
 	reference_date=None,
-	ignore_permissions=False,
 	created_from_payment_request=False,
 ):
 	doc = frappe.get_doc(dt, dn)
@@ -2870,14 +2869,14 @@ def get_payment_entry(
 	)
 
 	# bank or cash
-	bank = get_bank_cash_account(doc, bank_account, ignore_permissions=ignore_permissions)
+	bank = get_bank_cash_account(doc, bank_account)
 
 	# if default bank or cash account is not set in company master and party has default company bank account, fetch it
 	if party_type in ["Customer", "Supplier"] and not bank:
 		party_bank_account = get_party_bank_account(party_type, doc.get(scrub(party_type)))
 		if party_bank_account:
 			account = frappe.db.get_value("Bank Account", party_bank_account, "account")
-			bank = get_bank_cash_account(doc, account, ignore_permissions=ignore_permissions)
+			bank = get_bank_cash_account(doc, account)
 
 	paid_amount, received_amount = set_paid_amount_and_received_amount(
 		dt, party_account_currency, bank, outstanding_amount, payment_type, bank_amount, doc
@@ -3183,13 +3182,12 @@ def update_accounting_dimensions(pe, doc):
 		pe.set(dimension, doc.get(dimension))
 
 
-def get_bank_cash_account(doc, bank_account, ignore_permissions=False):
+def get_bank_cash_account(doc, bank_account):
 	bank = get_default_bank_cash_account(
 		doc.company,
 		"Bank",
 		mode_of_payment=doc.get("mode_of_payment"),
 		account=bank_account,
-		ignore_permissions=ignore_permissions,
 	)
 
 	if not bank:


### PR DESCRIPTION
Revert PR #39651 

Remove `ignore_permissions` param from the function `get_payment_entry`

Security Issue: https://github.com/frappe/security/issues/129
Related: https://github.com/frappe/education/pull/330
