### PR TITLE
fix: allow to change valuation method from FIFO to Moving Average

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -974,6 +974,11 @@ class Item(Document):
 		changed_fields = [
 			field for field in restricted_fields if cstr(self.get(field)) != cstr(values.get(field))
 		]
+
+		# Allow to change valuation method from FIFO to Moving Average not vice versa
+		if self.valuation_method == "Moving Average" and "valuation_method" in changed_fields:
+			changed_fields.remove("valuation_method")
+
 		if not changed_fields:
 			return
 


### PR DESCRIPTION
**Issue**
If the valuation method is FIFO and user want to change it to Moving Average for items then system was not allowing to change the valuation method.


**After Fix**

System will allow to change the valuation method from FIFO to Moving Average but users doesn't able to change the valuation method from Moving Average to FIFO
