### PR TITLE
Add Title Field Support for Batch across Reports and Serial/Batch Selector

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -399,10 +399,13 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	doctype = "Batch"
 	meta = frappe.get_meta(doctype, cached=True)
 	searchfields = meta.get_search_fields()
+	title_field = meta.get_title_field()
 	page_len = 30
 
-	batches = get_batches_from_stock_ledger_entries(searchfields, txt, filters, start, page_len)
-	batches.extend(get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start, page_len))
+	batches = get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filters, start, page_len)
+	batches.extend(
+		get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start, page_len)
+	)
 
 	filtered_batches = get_filterd_batches(batches)
 
@@ -442,13 +445,13 @@ def get_filterd_batches(data):
 
 	filterd_batch = []
 	for _batch, batch_data in batches.items():
-		if batch_data[1] > 0:
+		if batch_data[2] > 0:
 			filterd_batch.append(tuple(batch_data))
 
 	return filterd_batch
 
 
-def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, page_len=100):
+def get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filters, start=0, page_len=100):
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
 
@@ -460,6 +463,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 		.on(batch_table.name == stock_ledger_entry.batch_no)
 		.select(
 			stock_ledger_entry.batch_no,
+			batch_table[title_field],
 			Sum(stock_ledger_entry.actual_qty).as_("qty"),
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
@@ -498,7 +502,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 	return query.run(as_list=1) or []
 
 
-def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0, page_len=100):
+def get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start=0, page_len=100):
 	bundle = frappe.qb.DocType("Serial and Batch Entry")
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
@@ -513,6 +517,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0
 		.on(batch_table.name == bundle.batch_no)
 		.select(
 			bundle.batch_no,
+			batch_table[title_field],
 			Sum(bundle.qty).as_("qty"),
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -465,6 +465,7 @@ def get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filter
 			stock_ledger_entry.batch_no,
 			batch_table[title_field],
 			Sum(stock_ledger_entry.actual_qty).as_("qty"),
+			batch_table.stock_uom,
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
 		.where(
@@ -519,6 +520,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, fil
 			bundle.batch_no,
 			batch_table[title_field],
 			Sum(bundle.qty).as_("qty"),
+			batch_table.stock_uom,
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
 		.where(

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -545,6 +545,9 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 				},
 				callback: (r) => {
 					if (r.message) {
+						r.message.forEach((row) => {
+							frappe.utils.add_link_title("Batch", row.batch_no, row.batch_no_display);
+						});
 						this.dialog.fields_dict.entries.df.data = r.message;
 						this.dialog.fields_dict.entries.grid.refresh();
 					}

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2165,16 +2165,21 @@ def filter_zero_near_batches(available_batches, kwargs):
 
 def get_qty_based_available_batches(available_batches, qty):
 	batches = []
+	title_field = frappe.get_meta("Batch").get_title_field()
+
 	for batch in available_batches:
 		if qty <= 0:
 			break
 
+		batch_display_name = frappe.get_cached_value("Batch", batch.batch_no, title_field)
 		batch_qty = flt(batch.qty)
+
 		if qty > batch_qty:
 			batches.append(
 				frappe._dict(
 					{
 						"batch_no": batch.batch_no,
+						"batch_no_display": batch_display_name,
 						"qty": batch_qty,
 						"warehouse": batch.warehouse,
 					}
@@ -2186,6 +2191,7 @@ def get_qty_based_available_batches(available_batches, qty):
 				frappe._dict(
 					{
 						"batch_no": batch.batch_no,
+						"batch_no_display": batch_display_name,
 						"qty": qty,
 						"warehouse": batch.warehouse,
 					}

--- a/erpnext/stock/report/available_batch_report/available_batch_report.js
+++ b/erpnext/stock/report/available_batch_report/available_batch_report.js
@@ -88,4 +88,15 @@ frappe.query_reports["Available Batch Report"] = {
 			width: "80",
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch_no" && data && data["batch_no"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
+				data["batch_no"]
+			)}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
@@ -32,4 +32,13 @@ frappe.query_reports["Batch Item Expiry Status"] = {
 			},
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch" && data && !!data["batch"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(data["batch"])}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
@@ -29,31 +29,47 @@ def validate_filters(filters):
 
 def get_columns():
 	return [
-		_("Item") + ":Link/Item:150",
-		_("Item Name") + "::150",
-		_("Batch") + ":Link/Batch:150",
-		_("Stock UOM") + ":Link/UOM:100",
-		_("Quantity") + ":Float:100",
-		_("Expires On") + ":Date:100",
-		_("Expiry (In Days)") + ":Int:130",
+		{"label": _("Item"), "fieldname": "item", "fieldtype": "Link", "options": "Item", "width": 150},
+		{"label": _("Item Name"), "fieldname": "item_name", "fieldtype": "Data", "width": 150},
+		{"label": _("Batch"), "fieldname": "batch", "fieldtype": "Link", "options": "Batch", "width": 150},
+		{"label": _("Quantity"), "fieldname": "quantity", "fieldtype": "Float", "width": 100},
+		{
+			"label": _("Stock UOM"),
+			"fieldname": "stock_uom",
+			"fieldtype": "Link",
+			"options": "UOM",
+			"width": 100,
+		},
+		{"label": _("Expires On"), "fieldname": "expires_on", "fieldtype": "Date", "width": 100},
+		{"label": _("Expiry (In Days)"), "fieldname": "expiry_in_days", "fieldtype": "Int", "width": 130},
+		{
+			"label": _("Batch ID"),
+			"fieldname": "batch_id",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"width": 100,
+			"hidden": 1,
+		},
 	]
 
 
 def get_data(filters):
 	data = []
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	for batch in get_batch_details(filters):
 		data.append(
 			[
 				batch.item,
 				batch.item_name,
-				batch.name,
-				batch.stock_uom,
+				batch[title_field],
 				batch.batch_qty,
+				batch.stock_uom,
 				batch.expiry_date,
 				max((batch.expiry_date - frappe.utils.datetime.date.today()).days, 0)
 				if batch.expiry_date
 				else None,
+				batch.name,
 			]
 		)
 
@@ -62,6 +78,7 @@ def get_data(filters):
 
 def get_batch_details(filters):
 	batch = frappe.qb.DocType("Batch")
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 	query = (
 		frappe.qb.from_(batch)
 		.select(
@@ -72,6 +89,7 @@ def get_batch_details(filters):
 			batch.item_name,
 			batch.stock_uom,
 			batch.batch_qty,
+			batch[title_field],
 		)
 		.where(
 			(batch.disabled == 0)

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
@@ -79,8 +79,8 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 		},
 	],
 	formatter: function (value, row, column, data, default_formatter) {
-		if (column.fieldname == "Batch" && data && !!data["Batch"]) {
-			value = data["Batch"];
+		if (column.fieldname == "batch" && data && !!data["batch"]) {
+			value = data["batch"];
 			column.link_onclick =
 				"frappe.query_reports['Batch-Wise Balance History'].set_batch_route_to_stock_ledger(" +
 				JSON.stringify(data) +
@@ -92,7 +92,7 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 	},
 	set_batch_route_to_stock_ledger: function (data) {
 		frappe.route_options = {
-			batch_no: data["Batch"],
+			batch_no: data["batch_id"],
 		};
 
 		frappe.set_route("query-report", "Stock Ledger");

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -52,12 +52,13 @@ def execute(filters=None):
 								item_map[item]["item_name"],
 								item_map[item]["description"],
 								wh,
-								batch,
+								qty_dict.batch_no,
 								flt(qty_dict.opening_qty, float_precision),
 								flt(qty_dict.in_qty, float_precision),
 								flt(qty_dict.out_qty, float_precision),
 								flt(qty_dict.bal_qty, float_precision),
 								item_map[item]["stock_uom"],
+								qty_dict.batch_id,
 							]
 						)
 
@@ -68,16 +69,37 @@ def get_columns(filters):
 	"""return columns based on filters"""
 
 	columns = [
-		_("Item") + ":Link/Item:100",
-		_("Item Name") + "::150",
-		_("Description") + "::150",
-		_("Warehouse") + ":Link/Warehouse:100",
-		_("Batch") + ":Link/Batch:100",
-		_("Opening Qty") + ":Float:90",
-		_("In Qty") + ":Float:80",
-		_("Out Qty") + ":Float:80",
-		_("Balance Qty") + ":Float:90",
-		_("UOM") + "::90",
+		{"label": _("Item"), "fieldname": "item", "fieldtype": "Link", "options": "Item", "width": 100},
+		{"label": _("Item Name"), "fieldname": "item_name", "width": 150},
+		{"label": _("Description"), "fieldname": "description", "width": 150},
+		{
+			"label": _("Warehouse"),
+			"fieldname": "warehouse",
+			"fieldtype": "Link",
+			"options": "Warehouse",
+			"width": 100,
+		},
+		{
+			"label": _("Batch"),
+			"fieldname": "batch",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"align": "left",
+			"width": 150,
+		},
+		{"label": _("Opening Qty"), "fieldname": "opening_qty", "fieldtype": "Float", "width": 90},
+		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80},
+		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80},
+		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 90},
+		{"label": _("UOM"), "fieldname": "stock_uom", "width": 90},
+		{
+			"label": _("Batch ID"),
+			"fieldname": "batch_id",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"width": 150,
+			"hidden": 1,
+		},
 	]
 
 	return columns
@@ -122,16 +144,22 @@ def get_stock_ledger_entries_for_batch_no(filters):
 		frappe.throw(_("'To Date' is required"))
 
 	posting_datetime = get_datetime(add_to_date(filters["to_date"], days=1))
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	sle = frappe.qb.DocType("Stock Ledger Entry")
+	batch_table = frappe.qb.DocType("Batch")
+
 	query = (
 		frappe.qb.from_(sle)
+		.inner_join(batch_table)
+		.on(batch_table.name == sle.batch_no)
 		.select(
 			sle.item_code,
 			sle.warehouse,
-			sle.batch_no,
+			sle.batch_no.as_("batch_id"),
 			sle.posting_date,
 			fn.Sum(sle.actual_qty).as_("actual_qty"),
+			batch_table[title_field].as_("batch_no"),
 		)
 		.where(
 			(sle.docstatus < 2)
@@ -167,19 +195,23 @@ def get_stock_ledger_entries_for_batch_no(filters):
 def get_stock_ledger_entries_for_batch_bundle(filters):
 	sle = frappe.qb.DocType("Stock Ledger Entry")
 	batch_package = frappe.qb.DocType("Serial and Batch Entry")
-
+	batch_table = frappe.qb.DocType("Batch")
 	to_date = get_datetime(str(filters.to_date) + " 23:59:59")
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	query = (
 		frappe.qb.from_(sle)
 		.inner_join(batch_package)
 		.on(batch_package.parent == sle.serial_and_batch_bundle)
+		.inner_join(batch_table)
+		.on(batch_table.name == batch_package.batch_no)
 		.select(
 			sle.item_code,
 			sle.warehouse,
-			batch_package.batch_no,
+			batch_package.batch_no.as_("batch_id"),
 			sle.posting_date,
 			fn.Sum(batch_package.qty).as_("actual_qty"),
+			batch_table[title_field].as_("batch_no"),
 		)
 		.where(
 			(sle.docstatus < 2)
@@ -224,7 +256,17 @@ def get_item_warehouse_batch_map(filters, float_precision):
 
 	for d in sle:
 		iwb_map.setdefault(d.item_code, {}).setdefault(d.warehouse, {}).setdefault(
-			d.batch_no, frappe._dict({"opening_qty": 0.0, "in_qty": 0.0, "out_qty": 0.0, "bal_qty": 0.0})
+			d.batch_no,
+			frappe._dict(
+				{
+					"batch_id": d.batch_id,
+					"batch_no": d.batch_no,
+					"opening_qty": 0.0,
+					"in_qty": 0.0,
+					"out_qty": 0.0,
+					"bal_qty": 0.0,
+				}
+			),
 		)
 		qty_dict = iwb_map[d.item_code][d.warehouse][d.batch_no]
 		if d.posting_date < from_date:

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
@@ -93,4 +93,15 @@ frappe.query_reports["Serial and Batch Summary"] = {
 			},
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch_no" && data["batch_no"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
+				data["batch_no"]
+			)}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
@@ -96,7 +96,7 @@ frappe.query_reports["Serial and Batch Summary"] = {
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		if (column.fieldname === "batch_no" && data["batch_no"]) {
+		if (column.fieldname === "batch_no" && data && data["batch_no"]) {
 			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
 				data["batch_no"]
 			)}</a>`;


### PR DESCRIPTION
## Summary

This PR introduces Title Field (title_field) support for the Batch DocType in the following areas:

- Serial and Batch Selector
- Serial and Batch Summary Report
- Other Batch Related Reports

Previously, batch-related features used only batch.name (ID) everywhere, but now they smartly use the Batch Title if configured, improving readability for users.

## Why This Is Needed
- In some cases, users may want to use a naming series for Batch IDs, that can help them use duplicate batch numbers if exist across items, by setting a custom field for batch number as the Title Field for Batch, they can achieve this easily. Batch name (like BATCH-0001) is meaningless for users in reports.

- This feature allows reports and batch selectors to show user-friendly batch numbers, improving readability and user experience.

## Backward Compatibility
- No breaking changes: If no title_field is set on Batch, it will fallback to name.