### PR TITLE
fix: allow to make quality inspection after Purchase / Delivery

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1050,6 +1050,16 @@ class StockController(AccountsController):
 
 	def validate_qi_presence(self, row):
 		"""Check if QI is present on row level. Warn on save and stop on submit if missing."""
+		if self.doctype in [
+			"Purchase Receipt",
+			"Purchase Invoice",
+			"Sales Invoice",
+			"Delivery Note",
+		] and frappe.db.get_single_value(
+			"Stock Settings", "allow_to_make_quality_inspection_after_purchase_or_delivery"
+		):
+			return
+
 		if not row.quality_inspection:
 			msg = _("Row #{0}: Quality Inspection is required for Item {1}").format(
 				row.idx, frappe.bold(row.item_code)


### PR DESCRIPTION
Don't throw below validation if "allow to make quality inspection after Purchase / Delivery" 

<img width="377" alt="Screenshot 2025-04-28 at 1 28 58 PM" src="https://github.com/user-attachments/assets/2acae093-ec98-44cb-adc9-6a55c35a109b" />
