### PR TITLE
fix: prevent cancellation of last asset movement

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -152,9 +152,15 @@ class AssetMovement(Document):
 				""",
 				args,
 			)
-			if latest_movement_entry:
-				current_location = latest_movement_entry[0][0]
-				current_employee = latest_movement_entry[0][1]
+			if not latest_movement_entry:
+				frappe.throw(
+					_(
+						"Asset {0} has only one movement record. Please create another movement before deleting this one to maintain asset tracking."
+					).format(d.asset)
+				)
+
+			current_location = latest_movement_entry[0][0]
+			current_employee = latest_movement_entry[0][1]
 
 			frappe.db.set_value("Asset", d.asset, "location", current_location, update_modified=False)
 			frappe.db.set_value("Asset", d.asset, "custodian", current_employee, update_modified=False)

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -147,6 +147,45 @@ class TestAssetMovement(IntegrationTestCase):
 		movement1.cancel()
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
 
+	def test_last_movement_cancellation_validation(self):
+		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location")
+
+		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
+		asset = frappe.get_doc("Asset", asset_name)
+		asset.calculate_depreciation = 1
+		asset.available_for_use_date = "2020-06-06"
+		asset.purchase_date = "2020-06-06"
+		asset.append(
+			"finance_books",
+			{
+				"expected_value_after_useful_life": 10000,
+				"next_depreciation_date": "2020-12-31",
+				"depreciation_method": "Straight Line",
+				"total_number_of_depreciations": 3,
+				"frequency_of_depreciation": 10,
+			},
+		)
+		if asset.docstatus == 0:
+			asset.submit()
+
+		AssetMovement = frappe.qb.DocType("Asset Movement")
+		AssetMovementItem = frappe.qb.DocType("Asset Movement Item")
+
+		asset_movement = (
+			frappe.qb.from_(AssetMovement)
+			.join(AssetMovementItem)
+			.on(AssetMovementItem.parent == AssetMovement.name)
+			.select(AssetMovement.name)
+			.where(
+				(AssetMovementItem.asset == asset.name)
+				& (AssetMovement.company == asset.company)
+				& (AssetMovement.docstatus == 1)
+			)
+		).run(as_dict=True)
+
+		asset_movement_doc = frappe.get_doc("Asset Movement", asset_movement[0].name)
+		self.assertRaises(frappe.ValidationError, asset_movement_doc.cancel)
+
 
 def create_asset_movement(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
Implemented a validation to prevent the cancellation of the last asset movement. This ensures that the asset's location field is not left empty when no other movements exist. If the last asset movement is attempted to be cancelled, a validation error is raised to maintain data integrity.