### PR TITLE
fix: fix sub assembly qty calculation in production plan when bom level >= 1

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1804,6 +1804,7 @@ def get_sub_assembly_items(
 							continue
 						else:
 							stock_qty = stock_qty - _bin_dict.projected_qty
+				sub_assembly_items.append(d.item_code)
 			elif warehouse:
 				bin_details.setdefault(d.item_code, get_bin_details(d, company, for_warehouse=warehouse))
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1804,7 +1804,7 @@ def get_sub_assembly_items(
 							continue
 						else:
 							stock_qty = stock_qty - _bin_dict.projected_qty
-				sub_assembly_items.append(d.item_code)
+							sub_assembly_items.append(d.item_code)
 			elif warehouse:
 				bin_details.setdefault(d.item_code, get_bin_details(d, company, for_warehouse=warehouse))
 


### PR DESCRIPTION
Reference support ticket [35392](https://support.frappe.io/helpdesk/tickets/35392)

Fixed an issue where sub assembly item qty calculation logic was wrong if BOM Level of item was greater than or equal to 1