### PR TITLE
fix: add fetch from to item name in rfq item doctype

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
+++ b/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
@@ -63,6 +63,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "item_code.item_name",
    "fieldname": "item_name",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -261,13 +262,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:33.272106",
+ "modified": "2025-04-28 23:30:22.927989",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation Item",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
This issue exists only on v16/develop. Do not backport.

Without item_name, portal view for RFQ was throwing error.