### PR TITLE
fix: stock entry manufacture - fix operating cost calculation

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1417,6 +1417,7 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 				"expense_account": expense_account,
 				"description": _("Operating Cost as per Work Order / BOM"),
 				"amount": operating_cost_per_unit * flt(stock_entry.fg_completed_qty),
+				"has_operating_cost": 1,
 			},
 		)
 

--- a/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.json
+++ b/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.json
@@ -12,7 +12,8 @@
   "col_break3",
   "amount",
   "base_amount",
-  "has_corrective_cost"
+  "has_corrective_cost",
+  "has_operating_cost"
  ],
  "fields": [
   {
@@ -70,17 +71,25 @@
    "fieldtype": "Check",
    "label": "Has Corrective Cost",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "has_operating_cost",
+   "fieldtype": "Check",
+   "label": "Has Operating Cost",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-20 12:22:03.455762",
+ "modified": "2025-04-29 10:30:26.017072",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Taxes and Charges",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.py
+++ b/erpnext/stock/doctype/landed_cost_taxes_and_charges/landed_cost_taxes_and_charges.py
@@ -21,6 +21,7 @@ class LandedCostTaxesandCharges(Document):
 		exchange_rate: DF.Float
 		expense_account: DF.Link | None
 		has_corrective_cost: DF.Check
+		has_operating_cost: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data


### PR DESCRIPTION
fixes #46788 

1. Adds new field in `Landed Cost Taxes and Charges` - `has_operating_cost`. This check will be 1 if cost is operating cost
2. Operating cost calculation will now consider how much qty has been produced and how much operating cost has been consumed through Stock Entry Manufacture