### PR TITLE
refactor: portal query in timesheet.py

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -500,7 +500,6 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 	user = frappe.session.user
 	# find customer name from contact.
 	customer = ""
-	timesheets = []
 
 	contact = frappe.db.exists("Contact", {"user": user})
 	if contact:
@@ -509,31 +508,39 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 		customer = contact.get_link_for("Customer")
 
 	if customer:
-		sales_invoices = [
-			d.name for d in frappe.get_all("Sales Invoice", filters={"customer": customer})
-		] or [None]
-		projects = [d.name for d in frappe.get_all("Project", filters={"customer": customer})]
-		# Return timesheet related data to web portal.
-		timesheets = frappe.db.sql(
-			f"""
-			SELECT
-				ts.name, tsd.activity_type, ts.status, ts.total_billable_hours,
-				COALESCE(ts.sales_invoice, tsd.sales_invoice) AS sales_invoice, tsd.project
-			FROM `tabTimesheet` ts, `tabTimesheet Detail` tsd
-			WHERE tsd.parent = ts.name AND
-				(
-					ts.sales_invoice IN %(sales_invoices)s OR
-					tsd.sales_invoice IN %(sales_invoices)s OR
-					tsd.project IN %(projects)s
-				)
-			ORDER BY `end_date` ASC
-			LIMIT {limit_page_length} offset {limit_start}
-		""",
-			dict(sales_invoices=sales_invoices, projects=projects),
-			as_dict=True,
-		)  # nosec
+		sales_invoices = frappe.get_all("Sales Invoice", filters={"customer": customer}, pluck="name")
+		projects = frappe.get_all("Project", filters={"customer": customer}, pluck="name")
 
-	return timesheets
+		# Return timesheet related data to web portal.
+		table = frappe.qb.DocType("Timesheet")
+		child_table = frappe.qb.DocType("Timesheet Detail")
+		query = (
+			frappe.qb.from_(table)
+			.join(child_table)
+			.on(table.name == child_table.parent)
+			.select(
+				table.name,
+				child_table.activity_type,
+				table.status,
+				table.total_billable_hours,
+				(table.sales_invoice | child_table.sales_invoice).as_("sales_invoice"),
+				child_table.project,
+			)
+			.orderby(table.end_date)
+			.limit(limit_page_length)
+			.offset(limit_start)
+		)
+
+		if sales_invoices:
+			query = query.where(
+				(table.sales_invoice.isin(sales_invoices)) | (child_table.sales_invoice.isin(sales_invoices))
+			)
+		if projects:
+			query = query.where(child_table.project.isin(projects))
+
+		return query.run(as_dict=True)
+	else:
+		return {}
 
 
 def get_list_context(context=None):

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -531,12 +531,16 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 			.offset(limit_start)
 		)
 
+		conditions = []
 		if sales_invoices:
-			query = query.where(
-				(table.sales_invoice.isin(sales_invoices)) | (child_table.sales_invoice.isin(sales_invoices))
+			conditions.extend(
+				[table.sales_invoice.isin(sales_invoices), child_table.sales_invoice.isin(sales_invoices)]
 			)
 		if projects:
-			query = query.where(child_table.project.isin(projects))
+			conditions.append(child_table.project.isin(projects))
+
+		if conditions:
+			query = query.where(frappe.qb.terms.Criterion.any(conditions))
 
 		return query.run(as_dict=True)
 	else:


### PR DESCRIPTION
Reference support ticket [37068](https://support.frappe.io/helpdesk/tickets/37068?view=VIEW-HD%20Ticket-003)

Query generated if `debug=True`:
```
SELECT `tabTimesheet`.`name`,`tabTimesheet Detail`.`activity_type`,`tabTimesheet`.`status`,`tabTimesheet`.`total_billable_hours`,`tabTimesheet`.`sales_invoice` OR `tabTimesheet Detail`.`sales_invoice`,`tabTimesheet Detail`.`project` FROM `tabTimesheet` JOIN `tabTimesheet Detail` ON `tabTimesheet`.`name`=`tabTimesheet Detail`.`parent` WHERE `tabTimesheet`.`sales_invoice` IN ('ACC-SINV-2025-00001') OR `tabTimesheet Detail`.`sales_invoice` IN ('ACC-SINV-2025-00001') OR `tabTimesheet Detail`.`project` IN ('PROJ-0001') ORDER BY `tabTimesheet`.`end_date` LIMIT 21
```