### PR TITLE
fix: do not allocate amount when ref's doctype or name are not set

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2081,7 +2081,7 @@ class PaymentEntry(AccountsController):
 
 			# Re allocate amount to those references which have PR set (Higher priority)
 			for ref in self.references:
-				if not ref.payment_request:
+				if not (ref.reference_doctype and ref.reference_name and ref.payment_request):
 					continue
 
 				# fetch outstanding_amount of `Reference` (Payment Term) and `Payment Request` to allocate new amount
@@ -2132,7 +2132,7 @@ class PaymentEntry(AccountsController):
 					)
 			# Re allocate amount to those references which have no PR (Lower priority)
 			for ref in self.references:
-				if ref.payment_request:
+				if ref.payment_request or not (ref.reference_doctype and ref.reference_name):
 					continue
 
 				key = (ref.reference_doctype, ref.reference_name, ref.get("payment_term"))


### PR DESCRIPTION
## [Support Ticket - 37156](https://support.frappe.io/helpdesk/tickets/37156)

**Issue:** 

When creating a **Payment Entry**, if a row is added in the references table but the `Doctype` or `Name` field is left empty, modifying the **Paid Amount** triggers an error.  

**Steps to Reproduce:**  
1. Create a new Payment Entry.  
2. Add a row in the references table but leave `Doctype` or `Name` blank.  
3. Adjust the **Paid Amount** – the system raises an error.  

<details>
<summary>See Traceback</summary>

### App Versions
```
{
	"erpnext": "15.59.0",
	"frappe": "15.66.1"
}
```
### Route
```
Form/Payment Entry/ACC-PAY-2025-00003
```
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1739, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 340, in run_doc_method
    response = doc.run_method(method, **args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1007, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1367, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1349, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1004, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 2054, in allocate_amount_to_references
    allocated_positive_outstanding, allocated_negative_outstanding = _allocation_to_unset_pr_row(
                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 1964, in _allocation_to_unset_pr_row
    if outstanding_amount > 0 and allocated_positive_outstanding >= 0:
       ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"paid_amount": 400,
		"paid_amount_change": true,
		"allocate_payment_amount": true,
		"docs": "{\"name\":\"ACC-PAY-2025-00003\",\"owner\":\"Administrator\",\"creation\":\"2025-04-29 17:51:40.502936\",\"modified\":\"2025-04-29 17:51:40.559732\",\"modified_by\":\"Administrator\",\"docstatus\":0,\"idx\":0,\"naming_series\":\"ACC-PAY-.YYYY.-\",\"payment_type\":\"Pay\",\"payment_order_status\":\"Initiated\",\"posting_date\":\"2025-04-29\",\"company\":\"Abdeali Tech\",\"party_type\":\"Supplier\",\"party\":\"_Test Supplier\",\"party_name\":\"_Test Supplier\",\"book_advance_payments_in_separate_party_account\":0,\"reconcile_on_advance_payment_date\":0,\"advance_reconciliation_takes_effect_on\":\"Oldest Of Invoice Or Advance\",\"party_balance\":0,\"paid_from\":\"Bank Account - AT\",\"paid_from_account_type\":\"Bank\",\"paid_from_account_currency\":\"INR\",\"paid_from_account_balance\":0,\"paid_to\":\"Creditors - AT\",\"paid_to_account_type\":\"Payable\",\"paid_to_account_currency\":\"INR\",\"paid_to_account_balance\":0,\"paid_amount\":400,\"paid_amount_after_tax\":50000,\"source_exchange_rate\":1,\"base_paid_amount\":400,\"base_paid_amount_after_tax\":50000,\"received_amount\":400,\"received_amount_after_tax\":50000,\"target_exchange_rate\":1,\"base_received_amount\":400,\"base_received_amount_after_tax\":50000,\"total_allocated_amount\":0,\"base_total_allocated_amount\":0,\"unallocated_amount\":400,\"difference_amount\":0,\"apply_tax_withholding_amount\":0,\"base_total_taxes_and_charges\":0,\"total_taxes_and_charges\":0,\"reference_no\":\"dead\",\"reference_date\":\"2025-04-29\",\"status\":\"Draft\",\"custom_remarks\":0,\"remarks\":\"Amount INR 50000 to _Test Supplier\\nTransaction reference no dead dated 2025-04-29\",\"base_in_words\":\"INR Fifty Thousand only.\",\"is_opening\":\"No\",\"in_words\":\"INR Fifty Thousand only.\",\"title\":\"_Test Supplier\",\"doctype\":\"Payment Entry\",\"deductions\":[],\"references\":[{\"docstatus\":0,\"doctype\":\"Payment Entry Reference\",\"name\":\"new-payment-entry-reference-mrejcnniju\",\"__islocal\":1,\"__unsaved\":1,\"owner\":\"Administrator\",\"parent\":\"ACC-PAY-2025-00003\",\"parentfield\":\"references\",\"parenttype\":\"Payment Entry\",\"idx\":1,\"__unedited\":true}],\"taxes\":[],\"__onload\":{\"make_payment_via_journal_entry\":0},\"__last_sync_on\":\"2025-04-29T13:26:36.722Z\",\"__unsaved\":1}",
		"method": "allocate_amount_to_references",
		"args": "{\"paid_amount\":400,\"paid_amount_change\":true,\"allocate_payment_amount\":true}"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/run_doc_method",
	"request_id": null
}
```
### Response Data
```
{
	"exception": "TypeError: '>' not supported between instances of 'NoneType' and 'int'",
	"exc_type": "TypeError",
	"_exc_source": "erpnext (app)"
}
```

</details> 

> [!IMPORTANT]
> Backport to version-15 and version-14 