### PR TITLE
fix: added PR/PI overbilling validation to status updater

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -237,7 +237,19 @@ class PurchaseInvoice(BuyingController):
 				"source_field": "amount",
 				"percent_join_field": "purchase_order",
 				"overflow_type": "billing",
-			}
+			},
+			{
+				"source_dt": "Purchase Invoice Item",
+				"target_dt": "Purchase Receipt Item",
+				"join_field": "pr_detail",
+				"target_field": "billed_amt",
+				"target_parent_dt": "Purchase Receipt",
+				"target_parent_field": "per_billed",
+				"target_ref_field": "amount",
+				"source_field": "amount",
+				"percent_join_field": "purchase_receipt",
+				"overflow_type": "billing",
+			},
 		]
 
 	def onload(self):


### PR DESCRIPTION
Reference support ticket [37286](https://support.frappe.io/helpdesk/tickets/37286)

Added validation to prevent overbilling of Purchase Receipt when no Purchase Order is present.