### PR TITLE
fix: party name in Ledger Summary

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -144,10 +144,10 @@ class PartyLedgerSummaryReport:
 		if self.party_naming_by == "Naming Series":
 			columns.append(
 				{
-					"label": _(self.filters.party_type + "Name"),
+					"label": _(self.filters.party_type + " Name"),
 					"fieldtype": "Data",
 					"fieldname": "party_name",
-					"width": 110,
+					"width": 150,
 				}
 			)
 
@@ -252,12 +252,13 @@ class PartyLedgerSummaryReport:
 		self.party_data = frappe._dict({})
 		for gle in self.gl_entries:
 			party_details = self.party_details.get(gle.party)
+			party_name = party_details.get(f"{scrub(self.filters.party_type)}_name", "")
 			self.party_data.setdefault(
 				gle.party,
 				frappe._dict(
 					{
 						**party_details,
-						"party_name": gle.party,
+						"party_name": party_name,
 						"opening_balance": 0,
 						"invoiced_amount": 0,
 						"paid_amount": 0,


### PR DESCRIPTION
fixes: https://github.com/frappe/erpnext/issues/47344

The issue is in the Customer Ledger Summary and Supplier Ledger Summary


Before: 

![image](https://github.com/user-attachments/assets/6c5f4a42-9e38-4a2d-8cd4-f610b92e8d89)


After:

![image](https://github.com/user-attachments/assets/b4d09ad2-4169-4e10-b51f-030de4086663)
