### PR TITLE
fix: change shipping address fetching condition

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -951,6 +951,7 @@ def get_party_shipping_address(doctype: str, name: str) -> str | None:
 	else:
 		return None
 
+
 def get_partywise_advanced_payment_amount(
 	party_type, posting_date=None, future_payment=0, company=None, party=None
 ):

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -940,13 +940,16 @@ def get_party_shipping_address(doctype: str, name: str) -> str | None:
 			["is_shipping_address", "=", 1],
 			["address_type", "=", "Shipping"],
 		],
-		pluck="name",
-		limit=1,
+		fields=["name", "is_shipping_address"],
 		order_by="is_shipping_address DESC",
 	)
 
-	return shipping_addresses[0] if shipping_addresses else None
-
+	if shipping_addresses and shipping_addresses[0].is_shipping_address == 1:
+		return shipping_addresses[0].name
+	if len(shipping_addresses) == 1:
+		return shipping_addresses[0].name
+	else:
+		return None
 
 def get_partywise_advanced_payment_amount(
 	party_type, posting_date=None, future_payment=0, company=None, party=None


### PR DESCRIPTION
**Issue:** 
Auto fetch shipping address is not required in all cases. When multiple shipping addresses are available for a customer and no preferred shipping address is set, the address was randomly getting fetched.

**ref:** [35936](https://support.frappe.io/helpdesk/tickets/35936)

https://github.com/user-attachments/assets/c8de6bee-8f14-4659-961d-29f98cde2d4e

**Backport needed: Version 15, Version 14**