### PR TITLE
fix: backward compatibility for renamed group_by filter on reports

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -63,6 +63,10 @@ def validate_filters(filters, account_details):
 			if not account_details.get(account):
 				frappe.throw(_("Account {0} does not exists").format(account))
 
+	if not filters.get("categorize_by") and filters.get("group_by"):
+		filters["categorize_by"] = filters["group_by"]
+		filters["categorize_by"] = filters["categorize_by"].replace("Group by", "Categorize by")
+
 	if filters.get("account") and filters.get("categorize_by") == "Categorize by Account":
 		filters.account = frappe.parse_json(filters.get("account"))
 		for account in filters.account:

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -15,6 +15,8 @@ def execute(filters=None):
 	if not filters:
 		return [], []
 
+	validate_filters(filters)
+
 	columns = get_columns(filters)
 	supplier_quotation_data = get_data(filters)
 
@@ -22,6 +24,12 @@ def execute(filters=None):
 	message = get_message()
 
 	return columns, data, message, chart_data
+
+
+def validate_filters(filters):
+	if not filters.get("categorize_by") and filters.get("group_by"):
+		filters["categorize_by"] = filters["group_by"]
+		filters["categorize_by"] = filters["categorize_by"].replace("Group by", "Categorize by")
 
 
 def get_data(filters):


### PR DESCRIPTION
Added support for backward compatibility for the renamed group_by filter in the General Ledger Report and Supplier Quotation Comparison Report.