### PR TITLE
fix: Use `Currency` instead of `Float` in GL report to show details

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -562,13 +562,14 @@ def get_account_type_map(company):
 
 
 def get_result_as_list(data, filters):
-	balance, _balance_in_account_currency = 0, 0
+	balance = 0
 
 	for d in data:
 		if not d.get("posting_date"):
-			balance, _balance_in_account_currency = 0, 0
+			balance = 0
 
 		balance = get_balance(d, balance, "debit", "credit")
+
 		d["balance"] = balance
 
 		d["account_currency"] = filters.account_currency

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -602,7 +602,7 @@ def get_columns(filters):
 		currency = filters["presentation_currency"]
 	else:
 		company = filters.get("company") or get_default_company()
-		currency = get_company_currency(company)
+		filters["presentation_currency"] = currency = get_company_currency(company)
 
 	columns = [
 		{

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -574,6 +574,8 @@ def get_result_as_list(data, filters):
 
 		d["account_currency"] = filters.account_currency
 
+		d["presentation_currency"] = filters.presentation_currency
+
 	return data
 
 
@@ -621,19 +623,22 @@ def get_columns(filters):
 		{
 			"label": _("Debit ({0})").format(currency),
 			"fieldname": "debit",
-			"fieldtype": "Float",
+			"fieldtype": "Currency",
+			"options": "presentation_currency",
 			"width": 130,
 		},
 		{
 			"label": _("Credit ({0})").format(currency),
 			"fieldname": "credit",
-			"fieldtype": "Float",
+			"fieldtype": "Currency",
+			"options": "presentation_currency",
 			"width": 130,
 		},
 		{
 			"label": _("Balance ({0})").format(currency),
 			"fieldname": "balance",
-			"fieldtype": "Float",
+			"fieldtype": "Currency",
+			"options": "presentation_currency",
 			"width": 130,
 		},
 	]

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -599,11 +599,8 @@ def get_columns(filters):
 	if filters.get("presentation_currency"):
 		currency = filters["presentation_currency"]
 	else:
-		if filters.get("company"):
-			currency = get_company_currency(filters["company"])
-		else:
-			company = get_default_company()
-			currency = get_company_currency(company)
+		company = filters.get("company") or get_default_company()
+		currency = get_company_currency(company)
 
 	columns = [
 		{


### PR DESCRIPTION
## [Support Ticket - 32607](https://support.frappe.io/helpdesk/tickets/32607)

**Issue:**  
When **System Settings** have different values for `Float Precision` and `Currency Precision`, the `COA Tree` and GL Report show inconsistent balance values due to precision mismatch.

**Solution:**  
In the GL Report, display `Credit`, `Debit`, and `Balance` values using **Currency**  instead of **Float** field.

> [!NOTE]
> Backport to v-15 and v-14 