### PR TITLE
fix: completed transactions showing in the list

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -462,6 +462,7 @@ frappe.ui.form.on("Stock Entry", {
 							docstatus: 1,
 							purpose: "Material Transfer",
 							add_to_transit: 1,
+							per_transferred: ["<", 100],
 						},
 					});
 				},


### PR DESCRIPTION
**Issue**

<img width="1017" alt="Screenshot 2025-05-02 at 1 03 14 PM" src="https://github.com/user-attachments/assets/15026b1d-8ed7-4dca-8a12-2593c992df07" />

Completed In transit entry still showing in the Get Items From -> Transit Entry (list)

<img width="915" alt="Screenshot 2025-05-02 at 1 03 00 PM" src="https://github.com/user-attachments/assets/79b939f4-9a2d-4129-8762-685fd8b16966" />
