### PR TITLE
fix: broken CI - uae vat 201 tests failing

### DIFF
--- a/erpnext/setup/setup_wizard/operations/taxes_setup.py
+++ b/erpnext/setup/setup_wizard/operations/taxes_setup.py
@@ -214,13 +214,12 @@ def get_or_create_account(company_name, account):
 	default_root_type = "Liability"
 	root_type = account.get("root_type", default_root_type)
 
+	or_filters = {"account_name": account.get("account_name")}
+	if account.get("account_number"):
+		or_filters.update({"account_number": account.get("account_number")})
+
 	existing_accounts = frappe.get_all(
-		"Account",
-		filters={"company": company_name, "root_type": root_type},
-		or_filters={
-			"account_name": account.get("account_name"),
-			"account_number": account.get("account_number"),
-		},
+		"Account", filters={"company": company_name, "root_type": root_type}, or_filters=or_filters
 	)
 
 	if existing_accounts:


### PR DESCRIPTION
# Issue
**`erpnext.regional.report.uae_vat_201.test_uae_vat_201`** test suite started to fail recently.

Looks like regional tax accounts are not created on company creation. 

<details>
<summary> Exception </summary>

``` shell
 ERROR  test_uae_vat_201_report (erpnext.regional.report.uae_vat_201.test_uae_vat_201.TestUaeVat201.test_uae_vat_201_report)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py", line 30, in setUp
    set_vat_accounts()
    self = <erpnext.regional.report.uae_vat_201.test_uae_vat_201.TestUaeVat201 testMethod=test_uae_vat_201_report>
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py", line 149, in set_vat_accounts
    ).insert()
      ^^^^^^^^
    uae_vat_accounts = []
    vat_accounts = []
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 414, in insert
    self._validate()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <UAEVATSettings: doctype=UAE VAT Settings _Test Company UAE VAT>
    set_child_names = True
    set_name = None
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 741, in _validate
    self._validate_mandatory()
    self = <UAEVATSettings: doctype=UAE VAT Settings _Test Company UAE VAT>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1076, in _validate_mandatory
    raise frappe.MandatoryError(
    idx = 'uae_vat_accounts'
    missing = [('uae_vat_accounts', 'Error: Data missing in table UAE VAT Accounts')]
    msg = 'Error: Data missing in table UAE VAT Accounts'
    self = <UAEVATSettings: doctype=UAE VAT Settings _Test Company UAE VAT>
frappe.exceptions.MandatoryError: [UAE VAT Settings, _Test Company UAE VAT]: uae_vat_accounts
```
</details>

# Cause
[`country_wise_tax.json`](https://github.com/frappe/erpnext/blob/97db9da10ea48ad36991b4b8ba03c39293f5227b/erpnext/setup/setup_wizard/data/country_wise_tax.json#L4809-L4830) should've created regional tax accounts based on country. But, [`get_or_create_account()`](https://github.com/frappe/erpnext/blob/97db9da10ea48ad36991b4b8ba03c39293f5227b/erpnext/setup/setup_wizard/operations/taxes_setup.py#L220-L223) used incorrect 'OR' filter, which incorrectly identified any Liability account without `account_name` as the regional tax account

``` sql
  select `tabAccount`.`name`
  from `tabAccount`
  where `tabAccount`.`company` = 'throwaway 2' and `tabAccount`.`root_type` = 'Liability' and (`tabAccount`.`account_name` = 'Excise 100%' or ( `tabAccount`.`account_number` is NULL OR `tabAccount`.`account_number` = '' ))
  order by `tabAccount`.`creation` ASC
```