### PR TITLE
fix: 'time to resolve: failed' on issue

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1228,9 +1228,9 @@ function set_time_to_resolve_and_response(frm, apply_sla_for_resolution) {
 	if (apply_sla_for_resolution) {
 		let time_to_resolve;
 		if (!frm.doc.resolution_date) {
-			time_to_resolve = get_time_left(frm.doc.resolution_by, frm.doc.agreement_status);
+			time_to_resolve = get_time_left(frm.doc.sla_resolution_by, frm.doc.agreement_status);
 		} else {
-			time_to_resolve = get_status(frm.doc.resolution_by, frm.doc.resolution_date);
+			time_to_resolve = get_status(frm.doc.sla_resolution_by, frm.doc.resolution_date);
 		}
 
 		alert += `

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1230,7 +1230,7 @@ function set_time_to_resolve_and_response(frm, apply_sla_for_resolution) {
 		if (!frm.doc.resolution_date) {
 			time_to_resolve = get_time_left(frm.doc.sla_resolution_by, frm.doc.agreement_status);
 		} else {
-			time_to_resolve = get_status(frm.doc.sla_resolution_by, frm.doc.resolution_date);
+			time_to_resolve = get_status(frm.doc.sla_resolution_by, frm.doc.sla_resolution_date);
 		}
 
 		alert += `


### PR DESCRIPTION
Fixed the issue where every issue displayed 'Time to Resolve: Failed', even though the issue did not fail its SLA, and calculated the actual status if the SLA failed or fulfilled after the Issue is marked as Resolved or Closed.

Before:

![image](https://github.com/user-attachments/assets/d344b24b-ba52-45a1-933e-4d68458b68d1)

After:

![image](https://github.com/user-attachments/assets/e03d155a-3847-4b29-a24b-d2523ce56e3e)
