### PR TITLE
fix: do not mandate depreciation account for assets without depreciation

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -752,15 +752,14 @@ def get_gl_entries_on_asset_disposal(
 
 
 def get_asset_details(asset, finance_book=None):
-	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
-		asset.asset_category, asset.company
+	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
+	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
+
+	fixed_asset_account, accumulated_depr_account, _ = get_asset_accounts(
+		asset.asset_category, asset.company, accumulated_depr_amount
 	)
 	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(asset.company)
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
-
-	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
-
-	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
 
 	return (
 		fixed_asset_account,
@@ -771,6 +770,48 @@ def get_asset_details(asset, finance_book=None):
 		disposal_account,
 		value_after_depreciation,
 	)
+
+
+def get_asset_accounts(asset_category, company, accumulated_depr_amount):
+	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None
+
+	accounts = frappe.db.get_value(
+		"Asset Category Account",
+		filters={"parent": asset_category, "company_name": company},
+		fieldname=[
+			"fixed_asset_account",
+			"accumulated_depreciation_account",
+			"depreciation_expense_account",
+		],
+		as_dict=1,
+	)
+
+	if accounts:
+		fixed_asset_account = accounts.fixed_asset_account
+		accumulated_depreciation_account = accounts.accumulated_depreciation_account
+		depreciation_expense_account = accounts.depreciation_expense_account
+
+	if not fixed_asset_account:
+		frappe.throw(_("Please set Fixed Asset Account in Asset Category {0}").format(asset_category))
+
+	if accumulated_depr_amount:
+		accounts = frappe.get_cached_value(
+			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
+		)
+
+		if not accumulated_depreciation_account:
+			accumulated_depreciation_account = accounts[0]
+		if not depreciation_expense_account:
+			depreciation_expense_account = accounts[1]
+
+		if not accumulated_depreciation_account or not depreciation_expense_account:
+			frappe.throw(
+				_("Please set Depreciation related Accounts in Asset Category {0} or Company {1}").format(
+					asset_category, company
+				)
+			)
+
+	return fixed_asset_account, accumulated_depreciation_account, depreciation_expense_account
 
 
 def get_profit_gl_entries(


### PR DESCRIPTION
This PR updates the asset validation logic to handle non-depreciable assets (e.g., land). Specifically, it skips the mandatory depreciation account check during the sale of an asset if no depreciation is booked for the asset.

Internal support ticket: https://support.frappe.io/helpdesk/tickets/37810