### PR TITLE
fix: fiscal year error on new setup and continuous request

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -432,8 +432,9 @@ $.extend(erpnext.utils, {
 		if (!frappe.boot.setup_complete) {
 			return;
 		}
+		const today = frappe.datetime.get_today();
 		if (!date) {
-			date = frappe.datetime.get_today();
+			date = today;
 		}
 
 		let fiscal_year = "";
@@ -444,7 +445,7 @@ $.extend(erpnext.utils, {
 		) {
 			if (with_dates) fiscal_year = frappe.boot.current_fiscal_year;
 			else fiscal_year = frappe.boot.current_fiscal_year[0];
-		} else {
+		} else if (today != date) {
 			frappe.call({
 				method: "erpnext.accounts.utils.get_fiscal_year",
 				type: "GET", // make it cacheable

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe.defaults import get_user_default
 from frappe.utils import cint
 
 import erpnext.accounts.utils
@@ -57,7 +58,9 @@ def boot_session(bootinfo):
 
 		party_account_types = frappe.db.sql(""" select name, ifnull(account_type, '') from `tabParty Type`""")
 		bootinfo.party_account_types = frappe._dict(party_account_types)
-		fiscal_year = erpnext.accounts.utils.get_fiscal_years(frappe.utils.nowdate(), raise_on_missing=False)
+		fiscal_year = erpnext.accounts.utils.get_fiscal_years(
+			frappe.utils.nowdate(), company=get_user_default("company"), raise_on_missing=False
+		)
 		if fiscal_year:
 			bootinfo.current_fiscal_year = fiscal_year[0]
 


### PR DESCRIPTION
Fixed the continuous API call on every reload. Also, added a fix to fetch the current fiscal year in boot based on the User's default Company.