### PR TITLE
fix: Relabel unit price settings for more clarity

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -213,21 +213,24 @@
   },
   {
    "default": "0",
+   "description": "Allows items in the Purchase Order to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
    "fieldname": "allow_zero_qty_in_purchase_order",
    "fieldtype": "Check",
-   "label": "Allow 0 Qty in Purchase Order (Unit Price Items)"
+   "label": "Allow Zero Quantity Items in Purchase Order"
   },
   {
    "default": "0",
+   "description": "Allows items in the Request for Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
    "fieldname": "allow_zero_qty_in_request_for_quotation",
    "fieldtype": "Check",
-   "label": "Allow 0 Qty in Request for Quotation (Unit Price Items)"
+   "label": "Allow Zero Quantity Items in Request for Quotation"
   },
   {
    "default": "0",
+   "description": "Allows items in the Supplier Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
    "fieldname": "allow_zero_qty_in_supplier_quotation",
    "fieldtype": "Check",
-   "label": "Allow 0 Qty in Supplier Quotation (Unit Price Items)"
+   "label": "Allow Zero Quantity Items in Supplier Quotation"
   }
  ],
  "grid_page_length": 50,
@@ -236,7 +239,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-03 17:32:25.939482",
+ "modified": "2025-05-06 12:32:00.195378",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -213,24 +213,24 @@
   },
   {
    "default": "0",
-   "description": "Allows items in the Purchase Order to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
+   "description": "Allows users to submit Purchase Orders with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_purchase_order",
    "fieldtype": "Check",
-   "label": "Allow Zero Quantity Items in Purchase Order"
+   "label": "Allow Purchase Order with Zero Quantity"
   },
   {
    "default": "0",
-   "description": "Allows items in the Request for Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
+   "description": "Allows users to submit Request for Quotations with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_request_for_quotation",
    "fieldtype": "Check",
-   "label": "Allow Zero Quantity Items in Request for Quotation"
+   "label": "Allow Request for Quotation with Zero Quantity"
   },
   {
    "default": "0",
-   "description": "Allows items in the Supplier Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
+   "description": "Allows users to submit Supplier Quotations with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_supplier_quotation",
    "fieldtype": "Check",
-   "label": "Allow Zero Quantity Items in Supplier Quotation"
+   "label": "Allow Supplier Quotation with Zero Quantity"
   }
  ],
  "grid_page_length": 50,
@@ -239,7 +239,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-06 12:32:00.195378",
+ "modified": "2025-05-06 15:21:49.639642",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -225,17 +225,17 @@
   },
   {
    "default": "0",
-   "description": "Allows items in the Sales Order to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
+   "description": "Allows users to submit Sales Orders with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_sales_order",
    "fieldtype": "Check",
-   "label": "Allow Zero Quantity Items in Sales Order"
+   "label": "Allow Sales Order with Zero Quantity"
   },
   {
    "default": "0",
-   "description": "Allows items in the Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
+   "description": "Allows users to submit Quotations with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_quotation",
    "fieldtype": "Check",
-   "label": "Allow Zero Quantity Items in Quotation"
+   "label": "Allow Quotation with Zero Quantity"
   }
  ],
  "grid_page_length": 50,
@@ -244,7 +244,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-06 12:30:13.342694",
+ "modified": "2025-05-06 15:23:14.332971",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -225,15 +225,17 @@
   },
   {
    "default": "0",
+   "description": "Allows items in the Sales Order to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
    "fieldname": "allow_zero_qty_in_sales_order",
    "fieldtype": "Check",
-   "label": "Allow 0 Qty in Sales Order (Unit Price Items)"
+   "label": "Allow Zero Quantity Items in Sales Order"
   },
   {
    "default": "0",
+   "description": "Allows items in the Quotation to have a quantity of 0. Useful when the rate/unit price is agreed upon, but the quantity is not yet determined.",
    "fieldname": "allow_zero_qty_in_quotation",
    "fieldtype": "Check",
-   "label": "Allow 0 Qty in Quotation (Unit Price Items)"
+   "label": "Allow Zero Quantity Items in Quotation"
   }
  ],
  "grid_page_length": 50,
@@ -242,7 +244,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-03 16:39:16.360823",
+ "modified": "2025-05-06 12:30:13.342694",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",


### PR DESCRIPTION
Cause: https://github.com/frappe/erpnext/pull/46214
Closes: https://github.com/frappe/erpnext/issues/47424

> Changes only the Label and Description

### Selling Settings
<img width="600" alt="Screenshot 2025-05-06 at 12 34 24 PM" src="https://github.com/user-attachments/assets/223ab20b-ea61-41a3-8867-b2a456068251" />

### Buying Settings
<img width="600" alt="Screenshot 2025-05-06 at 12 34 55 PM" src="https://github.com/user-attachments/assets/ee4dd5e6-f280-45ec-ad3f-ce16da241aff" />
