### PR TITLE
fix: stock reco recalculate qty not works for opening stock reco

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -223,6 +223,7 @@ def get_batch_qty(
 	ignore_voucher_nos=None,
 	for_stock_levels=False,
 	consider_negative_batches=False,
+	do_not_check_future_batches=False,
 ):
 	"""Returns batch actual qty if warehouse is passed,
 	        or returns dict of qty by warehouse if warehouse is None
@@ -249,6 +250,7 @@ def get_batch_qty(
 			"ignore_voucher_nos": ignore_voucher_nos,
 			"for_stock_levels": for_stock_levels,
 			"consider_negative_batches": consider_negative_batches,
+			"do_not_check_future_batches": do_not_check_future_batches,
 		}
 	)
 

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1069,7 +1069,7 @@ class TestStockReconciliation(IntegrationTestCase, StockTestMixin):
 
 		sr.reload()
 		self.assertTrue(sr.items[0].serial_and_batch_bundle)
-		self.assertFalse(sr.items[0].current_serial_and_batch_bundle)
+		self.assertTrue(sr.items[0].current_serial_and_batch_bundle)
 
 	def test_not_reconcile_all_batch(self):
 		from erpnext.stock.doctype.batch.batch import get_batch_qty
@@ -1445,6 +1445,74 @@ class TestStockReconciliation(IntegrationTestCase, StockTestMixin):
 		self.assertEqual(sr.items[0].current_valuation_rate, 100)
 		self.assertEqual(sr.difference_amount, 100 * -1)
 		self.assertTrue(sr.items[0].qty == 0)
+
+	def test_stock_reco_recalculate_qty_for_backdated_entry(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		item_code = self.make_item(
+			"Test Batch Item Stock Reco Recalculate Qty",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TEST-BATCH-RRQ-.###",
+			},
+		).name
+
+		warehouse = "_Test Warehouse - _TC"
+
+		sr = create_stock_reconciliation(
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=10,
+			rate=100,
+			use_serial_batch_fields=1,
+		)
+
+		sr.reload()
+		self.assertEqual(sr.items[0].current_qty, 0)
+		self.assertEqual(sr.items[0].current_valuation_rate, 0)
+
+		batch_no = get_batch_from_bundle(sr.items[0].serial_and_batch_bundle)
+		stock_ledgers = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_no": sr.name, "is_cancelled": 0},
+			pluck="name",
+		)
+
+		self.assertTrue(len(stock_ledgers) == 1)
+
+		make_stock_entry(
+			item_code=item_code,
+			target=warehouse,
+			qty=10,
+			basic_rate=100,
+			use_serial_batch_fields=1,
+			batch_no=batch_no,
+		)
+
+		# Make backdated stock reconciliation entry
+		create_stock_reconciliation(
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=10,
+			rate=100,
+			use_serial_batch_fields=1,
+			batch_no=batch_no,
+			posting_date=add_days(nowdate(), -1),
+		)
+
+		stock_ledgers = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_no": sr.name, "is_cancelled": 0},
+			pluck="name",
+		)
+
+		sr.reload()
+		self.assertEqual(sr.items[0].current_qty, 10)
+		self.assertEqual(sr.items[0].current_valuation_rate, 100)
+
+		self.assertTrue(len(stock_ledgers) == 2)
 
 
 def create_batch_item_with_batch(item_name, batch_id):

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -743,6 +743,9 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 		if not self.sle.actual_qty:
 			self.sle.actual_qty = self.get_actual_qty()
 
+		if not self.sle.actual_qty:
+			return 0.0
+
 		return abs(flt(self.stock_value_change) / flt(self.sle.actual_qty))
 
 	def get_actual_qty(self):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -966,7 +966,7 @@ class update_entries_after:
 
 	def reset_actual_qty_for_stock_reco(self, sle):
 		doc = frappe.get_cached_doc("Stock Reconciliation", sle.voucher_no)
-		doc.recalculate_current_qty(sle.voucher_detail_no)
+		doc.recalculate_current_qty(sle.voucher_detail_no, sle.creation, sle.actual_qty > 0)
 
 		if sle.actual_qty < 0:
 			sle.actual_qty = (


### PR DESCRIPTION
1. Create Stock Reco for batch item with qty as 10 on 6th May
2. Create Delivery Note for batch item with qty as 10 on 7th May 
3. Create backdated stock reco for batch item with qty as 4 on 5th May

After the backdated stock reco expected qty as on 7th May is zero but qty was showing 4