### PR TITLE
fix(portal): User cannot create 0 qty SQ from RFQ

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -456,11 +456,10 @@ def create_supplier_quotation(doc):
 
 def add_items(sq_doc, supplier, items):
 	for data in items:
-		if data.get("qty") > 0:
-			if isinstance(data, dict):
-				data = frappe._dict(data)
+		if isinstance(data, dict):
+			data = frappe._dict(data)
 
-			create_rfq_items(sq_doc, supplier, data)
+		create_rfq_items(sq_doc, supplier, data)
 
 
 def create_rfq_items(sq_doc, supplier, data):

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -200,6 +200,23 @@ class TestRequestforQuotation(IntegrationTestCase):
 		self.assertEqual(sq.items[0].qty, 0)
 		self.assertEqual(sq.items[0].item_code, rfq.items[0].item_code)
 
+	@IntegrationTestCase.change_settings(
+		"Buying Settings",
+		{
+			"allow_zero_qty_in_request_for_quotation": 1,
+			"allow_zero_qty_in_supplier_quotation": 1,
+		},
+	)
+	def test_supplier_quotation_from_zero_qty_rfq_in_portal(self):
+		rfq = make_request_for_quotation(qty=0)
+		rfq.supplier = rfq.suppliers[0].supplier
+		sq_name = create_supplier_quotation(rfq)
+
+		sq = frappe.get_doc("Supplier Quotation", sq_name)
+		self.assertEqual(len(sq.items), 1)
+		self.assertEqual(sq.items[0].qty, 0)
+		self.assertEqual(sq.items[0].item_code, rfq.items[0].item_code)
+
 
 def make_request_for_quotation(**args) -> "RequestforQuotation":
 	"""


### PR DESCRIPTION
Closes: https://github.com/frappe/erpnext/issues/47422#event-17532742841
Caused by: https://github.com/frappe/erpnext/pull/46214

The portal uses `create_supplier_quotation` for SQ creation which excludes 0 qty items

### Fix
![2025-05-06 2 28 16 PM](https://github.com/user-attachments/assets/34a54122-e212-4cab-bfd3-0777b25199ae)
