### PR TITLE
fix: dont auto-fetch latest exchange rate

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -111,6 +111,13 @@ frappe.ui.form.on("Opportunity", {
 				},
 				__("Create")
 			);
+
+			let company_currency = erpnext.get_currency(frm.doc.company);
+			if (company_currency != frm.doc.currency) {
+				frm.add_custom_button(__("Fetch Latest Exchange Rate"), function () {
+					frm.trigger("currency");
+				});
+			}
 		}
 
 		if (!frm.doc.__islocal && frm.perm[0].write && frm.doc.docstatus == 0) {
@@ -152,7 +159,7 @@ frappe.ui.form.on("Opportunity", {
 
 	currency: function (frm) {
 		let company_currency = erpnext.get_currency(frm.doc.company);
-		if (company_currency != frm.doc.company) {
+		if (company_currency != frm.doc.currency) {
 			frappe.call({
 				method: "erpnext.setup.utils.get_exchange_rate",
 				args: {
@@ -278,7 +285,6 @@ erpnext.crm.Opportunity = class Opportunity extends frappe.ui.form.Controller {
 		}
 
 		this.setup_queries();
-		this.frm.trigger("currency");
 	}
 
 	refresh() {


### PR DESCRIPTION
1. Don't auto-fetch latest exchange rate on Opportunity load
2. Use correct field for comparison

Ref: [37792](https://support.frappe.io/helpdesk/tickets/37792)