### PR TITLE
fix: warning message for COGS account in the stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -6,7 +6,7 @@ import json
 from collections import defaultdict
 
 import frappe
-from frappe import _
+from frappe import _, bold
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Sum
 from frappe.utils import (
@@ -543,6 +543,14 @@ class StockEntry(StockController):
 						"At row {0}: the Difference Account must not be a Stock type account, please change the Account Type for the account {1} or select a different account"
 					).format(d.idx, get_link_to_form("Account", d.expense_account)),
 					OpeningEntryAccountError,
+				)
+
+			if self.purpose != "Material Issue" and acc_details.account_type == "Cost of Goods Sold":
+				frappe.msgprint(
+					_(
+						"At row {0}: You have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
+					).format(d.idx, bold(get_link_to_form("Account", d.expense_account))),
+					title=_("Warning : Cost of Goods Sold Account"),
 				)
 
 	def validate_warehouse(self):


### PR DESCRIPTION
If the difference account is of type "COGS" in the stock entry then system will show the below warning message

<img width="765" alt="Screenshot 2025-05-07 at 4 03 17 PM" src="https://github.com/user-attachments/assets/9356dc51-1933-4fe8-995c-897d5f05eec7" />
