### PR TITLE
Update event.js

### DIFF
--- a/erpnext/public/js/event.js
+++ b/erpnext/public/js/event.js
@@ -47,7 +47,7 @@ frappe.ui.form.on("Event", {
 		frm.add_custom_button(
 			__("Add Sales Partners"),
 			function () {
-				new frappe.desk.eventParticipants(frm, "Sales Partners");
+				new frappe.desk.eventParticipants(frm, "Sales Partner");
 			},
 			__("Add Participants")
 		);


### PR DESCRIPTION
Doctype not found error on clicking the "Add Sales Partners" button of group button "Add Participants" in Event doctype bug fix. Issue: closes #47461 

### Information about bug

The "Add Sales Partners" button of group button "Add Participants" in Event doctype is giving "Not Found" "DocType Sales Partners not found The resource you are looking for is not available" error.
This error is due to the event.js script in erpnext public folder where instead of putting "Sales Partner" which is the correct doctype name in the button logic, it's written as "Sales Partners" which is incorrect.

The code snippet:
frm.add_custom_button(
			__("Add Sales Partners"),
			function () {
				new frappe.desk.eventParticipants(frm, "Sales Partners");
			},
			__("Add Participants")
		);

Error Screenshot:
<img width="862" alt="Image" src="https://github.com/user-attachments/assets/af6d406a-1df4-4c69-bab5-754bdebb19fc" />

### Module

other

### Version

ERPNext Version: All

### Installation method

None

### Relevant log output / Stack trace / Full Error Message.

```shell
request.js:270 
GET http://localhost:8000/api/method/frappe.desk.form.load.getdoctype?doctype=Sales%20Partners&with_parent=1&cached_timestamp=&_=1746682241456 404 (NOT FOUND)
```

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
