### PR TITLE
refactor(test): flaky test case in sales invoice

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -58,6 +58,10 @@ class TestAccountingDimension(IntegrationTestCase):
 		self.assertEqual(gle1.get("department"), "_Test Department - _TC")
 
 	def test_mandatory(self):
+		location = frappe.get_doc("Accounting Dimension", "Location")
+		location.dimension_defaults[0].mandatory_for_bs = True
+		location.save()
+
 		si = create_sales_invoice(do_not_save=1)
 		si.append(
 			"items",

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -121,7 +121,6 @@ def create_dimension():
 				"company": "_Test Company",
 				"reference_document": "Location",
 				"default_dimension": "Block 1",
-				"mandatory_for_bs": 1,
 			},
 		)
 

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -159,6 +159,10 @@ class TestPOSClosingEntry(IntegrationTestCase):
 		"""
 
 		create_dimension()
+		location = frappe.get_doc("Accounting Dimension", "Location")
+		location.dimension_defaults[0].mandatory_for_bs = True
+		location.save()
+
 		pos_profile = make_pos_profile(do_not_insert=1, do_not_set_accounting_dimension=1)
 
 		self.assertRaises(frappe.ValidationError, pos_profile.insert)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2230,13 +2230,13 @@ class TestSalesInvoice(ERPNextTestSuite):
 			self.assertEqual(expected_account_values[1], gle.credit)
 
 	def test_rounding_adjustment_3(self):
-		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
-			create_dimension,
-			disable_dimension,
-		)
+		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import create_dimension
 
+		# Dimension creates custom field, which does an implicit DB commit as it is a DDL command
+		# Ensure dimension don't have any mandatory fields
 		create_dimension()
 
+		# rollback from tearDown() happens till here
 		si = create_sales_invoice(do_not_save=True)
 		si.items = []
 		for d in [(1122, 2), (1122.01, 1), (1122.01, 1)]:
@@ -2316,8 +2316,6 @@ class TestSalesInvoice(ERPNextTestSuite):
 		if round_off_gle:
 			self.assertEqual(round_off_gle.cost_center, "_Test Cost Center 2 - _TC")
 			self.assertEqual(round_off_gle.location, "Block 1")
-
-		disable_dimension()
 
 	def test_sales_invoice_with_shipping_rule(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule


### PR DESCRIPTION
part of: https://github.com/frappe/erpnext/issues/47394

Fixes below exception on repeated runs on local setup.

# Cause
Custom field creation has an implicit DB commit as it is a DDL command.

# Fix
Dimension will be created as non-mandatory, which will be commited and then individual test cases can make them mandatory based on need.

<details> 
<summary> Exception </summary>

```
======================================================================
 ERROR  test_sales_invoice_against_supplier (erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice.test_sales_invoice_against_supplier)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py", line 3152, in test_sales_invoice_against_supplier
    si = create_sales_invoice(customer=customer, parent_cost_center="_Test Cost Center - _TC")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    create_party_link = <function create_party_link at 0x739aa3952b60>
    create_supplier = <function create_supplier at 0x739aa4b86c00>
    customer = '_Test Common Supplier'
    make_customer = <function make_customer at 0x739aa3952e80>
    party_link = <PartyLink: doctype=Party Link ACC-PT-LNK-001>
    self = <erpnext.accounts.doctype.sales_invoice.test_sales_invoice.TestSalesInvoice testMethod=test_sales_invoice_against_supplier>
    supplier = '_Test Common Supplier'
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py", line 4597, in create_sales_invoice
    si.submit()
    args = {'customer': '_Test Common Supplier', 'parent_cost_center': '_Test Cost Center - _TC'}
    bundle_id = None
    si = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
    apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x739aae772700>
    args = (<SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>,)
    func = <function Document.submit at 0x739aae772660>
    kwargs = {}
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1214, in submit
    return self._submit()
           ^^^^^^^^^^^^^^
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1197, in _submit
    return self.save()
           ^^^^^^^^^^^
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 536, in _save
    self.run_post_save_methods()
    ignore_permissions = None
    ignore_version = None
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1316, in run_post_save_methods
    self.run_method("on_submit")
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1127, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x739aa389e520>
    kwargs = {}
    method = 'on_submit'
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1511, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    compose = <function Document.hook.<locals>.compose at 0x739aa389d4e0>
    composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x739aa389cae0>
    doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type', 'frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.file.utils.attach_files_to_document'], 'on_change': ['frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone'], 'after_delete': ['frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'validate': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.apply', 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job']}, 'Event': {'after_insert': ['frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar', 'erpnext.crm.utils.link_events_with_prospect'], 'on_update': ['frappe.integrations.doctype.google_calendar.google_calendar.update_event_in_google_calendar'], 'on_trash': ['frappe.integrations.doctype.google_calendar.google_calendar.delete_event_from_google_calendar']}, 'Contact': {'after_insert': ['frappe.integrations.doctype.google_contacts.google_contacts.insert_contacts_to_google_contacts', 'erpnext.telephony.doctype.call_log.call_log.link_existing_conversations'], 'on_update': ['frappe.integrations.doctype.google_contacts.google_contacts.update_contacts_to_google_contacts'], 'on_trash': ['erpnext.support.doctype.issue.issue.update_issue'], 'validate': ['erpnext.crm.utils.update_lead_phone_numbers']}, 'DocType': {'on_update': ['frappe.cache_manager.build_domain_restricted_doctype_cache']}, 'Page': {'on_update': ['frappe.cache_manager.build_domain_restricted_page_cache']}, 'Sales Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.regional.italy.utils.sales_invoice_on_submit'], 'on_cancel': ['erpnext.regional.italy.utils.sales_invoice_on_cancel'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Purchase Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm', 'erpnext.regional.united_arab_emirates.utils.validate_returns']}, 'Journal Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Bank Clearance': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty'], 'on_cancel': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty']}, 'Dunning': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Invoice Discounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Payment Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_cancel': ['erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Period Closing Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Process Deferred Accounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Capitalization': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Repair': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Delivery Note': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Landed Cost Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Purchase Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Reconciliation': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Subcontracting Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'User': {'after_insert': ['frappe.contacts.doctype.contact.contact.update_contact'], 'validate': ['erpnext.setup.doctype.employee.employee.validate_employee_role'], 'on_update': ['erpnext.portal.utils.set_default_role']}, 'Communication': {'on_update': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update', 'erpnext.support.doctype.issue.issue.set_first_response_time'], 'after_insert': ['erpnext.crm.utils.link_communications_with_prospect', 'erpnext.crm.utils.update_modified_timestamp']}, 'Address': {'validate': ['erpnext.regional.italy.utils.set_state_code']}, 'Email Unsubscribe': {'after_insert': ['erpnext.crm.doctype.email_campaign.email_campaign.unsubscribe_recipient']}, 'Integration Request': {'validate': ['erpnext.accounts.doctype.payment_request.payment_request.validate_payment']}}
    f = <function Document.run_method.<locals>.fn at 0x739aa389e520>
    handler = 'erpnext.regional.italy.utils.sales_invoice_on_submit'
    hooks = [<function create_transaction_log at 0x739aa72e3100>, <function sales_invoice_on_submit at 0x739aa3a95e40>]
    kwargs = {}
    method = 'on_submit'
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1489, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x739aa389de40>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x739aa389e520>
    hooks = (<function create_transaction_log at 0x739aa72e3100>, <function sales_invoice_on_submit at 0x739aa3a95e40>)
    kwargs = {}
    method = 'on_submit'
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1124, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    method = 'on_submit'
    method_object = <bound method SalesInvoice.on_submit of <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>>
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 468, in on_submit
    self.make_gl_entries()
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1272, in make_gl_entries
    make_gl_entries(
    auto_accounting_for_stock = 0
    from_repost = False
    gl_entries = [{'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 100.0, 'credit': 0.0, 'debit_in_account_currency': 100.0, 'credit_in_account_currency': 0.0, 'is_opening': 'No', 'party_type': 'Customer', 'party': '_Test Common Supplier', 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Debtors - _TC', 'due_date': '2025-05-06', 'against': 'Sales - _TC', 'debit_in_transaction_currency': 100.0, 'against_voucher': 'T-SINV-00008', 'against_voucher_type': 'Sales Invoice', 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Debtors - _TC', '_Test Cost Center - _TC', '_Test Common Supplier', 'Customer', None, 'T-SINV-00008', 'Sales Invoice', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'credit_in_transaction_currency': 0.0}, {'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 0.0, 'credit': 100.0, 'debit_in_account_currency': 0.0, 'credit_in_account_currency': 100.0, 'is_opening': 'No', 'party_type': None, 'party': None, 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Sales - _TC', 'against': '_Test Common Supplier', 'credit_in_transaction_currency': 100.0, 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Sales - _TC', '_Test Cost Center - _TC', None, None, None, '', '', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'debit_in_transaction_currency': 0.0}]
    make_gl_entries = <function make_gl_entries at 0x739aa6ea2700>
    make_reverse_gl_entries = <function make_reverse_gl_entries at 0x739aa6e107c0>
    self = <SalesInvoice: doctype=Sales Invoice T-SINV-00008 docstatus=1>
    update_outstanding = 'Yes'
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/general_ledger.py", line 42, in make_gl_entries
    create_payment_ledger_entry(
    adv_adj = False
    cancel = False
    from_repost = False
    gl_map = [{'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 100.0, 'credit': 0.0, 'debit_in_account_currency': 100.0, 'credit_in_account_currency': 0.0, 'is_opening': 'No', 'party_type': 'Customer', 'party': '_Test Common Supplier', 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Debtors - _TC', 'due_date': '2025-05-06', 'against': 'Sales - _TC', 'debit_in_transaction_currency': 100.0, 'against_voucher': 'T-SINV-00008', 'against_voucher_type': 'Sales Invoice', 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Debtors - _TC', '_Test Cost Center - _TC', '_Test Common Supplier', 'Customer', None, 'T-SINV-00008', 'Sales Invoice', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'credit_in_transaction_currency': 0.0}, {'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 0.0, 'credit': 100.0, 'debit_in_account_currency': 0.0, 'credit_in_account_currency': 100.0, 'is_opening': 'No', 'party_type': None, 'party': None, 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Sales - _TC', 'against': '_Test Common Supplier', 'credit_in_transaction_currency': 100.0, 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Sales - _TC', '_Test Cost Center - _TC', None, None, None, '', '', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'debit_in_transaction_currency': 0.0}]
    merge_entries = False
    update_outstanding = 'Yes'
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/utils.py", line 1864, in create_payment_ledger_entry
    ple.submit()
    adv_adj = False
    cancel = 0
    entry = {'doctype': 'Payment Ledger Entry', 'posting_date': '2025-05-06', 'company': '_Test Company', 'account_type': 'Receivable', 'account': 'Debtors - _TC', 'party_type': 'Customer', 'party': '_Test Common Supplier', 'cost_center': '_Test Cost Center - _TC', 'finance_book': None, 'due_date': '2025-05-06', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'voucher_detail_no': None, 'against_voucher_type': 'Sales Invoice', 'against_voucher_no': 'T-SINV-00008', 'account_currency': 'INR', 'amount': 100.0, 'amount_in_account_currency': 100.0, 'delinked': False, 'remarks': 'No Remarks', 'department': None, 'location': None}
    from_repost = False
    gl_entries = [{'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 100.0, 'credit': 0.0, 'debit_in_account_currency': 100.0, 'credit_in_account_currency': 0.0, 'is_opening': 'No', 'party_type': 'Customer', 'party': '_Test Common Supplier', 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Debtors - _TC', 'due_date': '2025-05-06', 'against': 'Sales - _TC', 'debit_in_transaction_currency': 100.0, 'against_voucher': 'T-SINV-00008', 'against_voucher_type': 'Sales Invoice', 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Debtors - _TC', '_Test Cost Center - _TC', '_Test Common Supplier', 'Customer', None, 'T-SINV-00008', 'Sales Invoice', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'credit_in_transaction_currency': 0.0}, {'company': '_Test Company', 'posting_date': '2025-05-06', 'fiscal_year': '2025', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'remarks': 'No Remarks', 'debit': 0.0, 'credit': 100.0, 'debit_in_account_currency': 0.0, 'credit_in_account_currency': 100.0, 'is_opening': 'No', 'party_type': None, 'party': None, 'project': None, 'post_net_value': None, 'voucher_detail_no': None, 'voucher_subtype': 'Sales Invoice', 'department': None, 'location': None, 'account': 'Sales - _TC', 'against': '_Test Common Supplier', 'credit_in_transaction_currency': 100.0, 'cost_center': '_Test Cost Center - _TC', 'account_currency': 'INR', 'merge_key': ('Sales - _TC', '_Test Cost Center - _TC', None, None, None, '', '', None, '', 'T-SINV-00008', None, None), 'transaction_currency': 'INR', 'transaction_exchange_rate': 1.0, 'debit_in_transaction_currency': 0.0}]
    partial_cancel = False
    ple = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
    ple_map = [{'doctype': 'Payment Ledger Entry', 'posting_date': '2025-05-06', 'company': '_Test Company', 'account_type': 'Receivable', 'account': 'Debtors - _TC', 'party_type': 'Customer', 'party': '_Test Common Supplier', 'cost_center': '_Test Cost Center - _TC', 'finance_book': None, 'due_date': '2025-05-06', 'voucher_type': 'Sales Invoice', 'voucher_no': 'T-SINV-00008', 'voucher_detail_no': None, 'against_voucher_type': 'Sales Invoice', 'against_voucher_no': 'T-SINV-00008', 'account_currency': 'INR', 'amount': 100.0, 'amount_in_account_currency': 100.0, 'delinked': False, 'remarks': 'No Remarks', 'department': None, 'location': None}]
    update_outstanding = 'Yes'
  File "/home/ruthra/dev/develop/apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
    apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x739aae772700>
    args = (<PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>,)
    func = <function Document.submit at 0x739aae772660>
    kwargs = {}
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1214, in submit
    return self._submit()
           ^^^^^^^^^^^^^^
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1197, in _submit
    return self.save()
           ^^^^^^^^^^^
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 505, in _save
    return self.insert()
           ^^^^^^^^^^^^^
    ignore_permissions = None
    ignore_version = None
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 439, in insert
    self.run_post_save_methods()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
    set_child_names = True
    set_name = None
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1315, in run_post_save_methods
    self.run_method("on_update")
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1127, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x739aa389e020>
    kwargs = {}
    method = 'on_update'
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1511, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    compose = <function Document.hook.<locals>.compose at 0x739aa389cb80>
    composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x739aa389ff60>
    doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type', 'frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.file.utils.attach_files_to_document'], 'on_change': ['frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone'], 'after_delete': ['frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'validate': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.apply', 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job']}, 'Event': {'after_insert': ['frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar', 'erpnext.crm.utils.link_events_with_prospect'], 'on_update': ['frappe.integrations.doctype.google_calendar.google_calendar.update_event_in_google_calendar'], 'on_trash': ['frappe.integrations.doctype.google_calendar.google_calendar.delete_event_from_google_calendar']}, 'Contact': {'after_insert': ['frappe.integrations.doctype.google_contacts.google_contacts.insert_contacts_to_google_contacts', 'erpnext.telephony.doctype.call_log.call_log.link_existing_conversations'], 'on_update': ['frappe.integrations.doctype.google_contacts.google_contacts.update_contacts_to_google_contacts'], 'on_trash': ['erpnext.support.doctype.issue.issue.update_issue'], 'validate': ['erpnext.crm.utils.update_lead_phone_numbers']}, 'DocType': {'on_update': ['frappe.cache_manager.build_domain_restricted_doctype_cache']}, 'Page': {'on_update': ['frappe.cache_manager.build_domain_restricted_page_cache']}, 'Sales Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.regional.italy.utils.sales_invoice_on_submit'], 'on_cancel': ['erpnext.regional.italy.utils.sales_invoice_on_cancel'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Purchase Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm', 'erpnext.regional.united_arab_emirates.utils.validate_returns']}, 'Journal Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Bank Clearance': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty'], 'on_cancel': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty']}, 'Dunning': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Invoice Discounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Payment Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_cancel': ['erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Period Closing Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Process Deferred Accounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Capitalization': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Repair': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Delivery Note': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Landed Cost Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Purchase Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Reconciliation': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Subcontracting Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'User': {'after_insert': ['frappe.contacts.doctype.contact.contact.update_contact'], 'validate': ['erpnext.setup.doctype.employee.employee.validate_employee_role'], 'on_update': ['erpnext.portal.utils.set_default_role']}, 'Communication': {'on_update': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update', 'erpnext.support.doctype.issue.issue.set_first_response_time'], 'after_insert': ['erpnext.crm.utils.link_communications_with_prospect', 'erpnext.crm.utils.update_modified_timestamp']}, 'Address': {'validate': ['erpnext.regional.italy.utils.set_state_code']}, 'Email Unsubscribe': {'after_insert': ['erpnext.crm.doctype.email_campaign.email_campaign.unsubscribe_recipient']}, 'Integration Request': {'validate': ['erpnext.accounts.doctype.payment_request.payment_request.validate_payment']}}
    f = <function Document.run_method.<locals>.fn at 0x739aa389e020>
    handler = 'frappe.core.doctype.permission_log.permission_log.make_perm_log'
    hooks = [<function clear_doctype_notifications at 0x739aa6c1cb80>, <function process_workflow_actions at 0x739aa6374ae0>, <function attach_files_to_document at 0x739aaec82f20>, <function apply at 0x739aa6376a20>, <function update_due_date at 0x739aa6376ac0>, <function apply_permissions_for_non_standard_user_type at 0x739aa63845e0>, <function make_perm_log at 0x739aa6384860>]
    kwargs = {}
    method = 'on_update'
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1489, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x739aa389f060>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x739aa389e020>
    hooks = (<function clear_doctype_notifications at 0x739aa6c1cb80>, <function process_workflow_actions at 0x739aa6374ae0>, <function attach_files_to_document at 0x739aaec82f20>, <function apply at 0x739aa6376a20>, <function update_due_date at 0x739aa6376ac0>, <function apply_permissions_for_non_standard_user_type at 0x739aa63845e0>, <function make_perm_log at 0x739aa6384860>)
    kwargs = {}
    method = 'on_update'
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/model/document.py", line 1124, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    method = 'on_update'
    method_object = <bound method PaymentLedgerEntry.on_update of <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>>
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py", line 167, in on_update
    self.validate_dimensions_for_pl_and_bs()
    adv_adj = False
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/erpnext/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py", line 152, in validate_dimensions_for_pl_and_bs
    frappe.throw(
    account_type = 'Balance Sheet'
    dimension = {'label': 'Location', 'disabled': 0, 'fieldname': 'location', 'default_dimension': 'Block 1', 'company': '_Test Company', 'mandatory_for_pl': 0, 'mandatory_for_bs': 1}
    self = <PaymentLedgerEntry: doctype=Payment Ledger Entry ea1i93mj4n docstatus=1>
  File "/home/ruthra/dev/develop/apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = "Accounting Dimension <b>Location</b> is required for 'Balance Sheet' account Debtors - _TC."
    primary_action = None
    title = None
    wide = False
  File "/home/ruthra/dev/develop/apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x739aa4154540>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/usr/lib/python3.12/inspect.py'>
    is_minimizable = False
    msg = "Accounting Dimension Location is required for 'Balance Sheet' account Debtors - _TC."
    out = {'message': "Accounting Dimension <b>Location</b> is required for 'Balance Sheet' account Debtors - _TC.", 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': '079cd326e32bcfcc2c21084db01697d1e08b524a14fa04faaf00031c'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = None
    wide = False
  File "/home/ruthra/dev/develop/apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
    exc = ValidationError("Accounting Dimension Location is required for 'Balance Sheet' account Debtors - _TC.")
    inspect = <module 'inspect' from '/usr/lib/python3.12/inspect.py'>
    msg = "Accounting Dimension Location is required for 'Balance Sheet' account Debtors - _TC."
    out = {'message': "Accounting Dimension <b>Location</b> is required for 'Balance Sheet' account Debtors - _TC.", 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': '079cd326e32bcfcc2c21084db01697d1e08b524a14fa04faaf00031c'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: Accounting Dimension Location is required for 'Balance Sheet' account Debtors - _TC.
```

</details> 