### PR TITLE
fix(payment-reconciliation): use reconciliation_takes_effect_on from company

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -21,7 +21,6 @@
   "party_name",
   "book_advance_payments_in_separate_party_account",
   "reconcile_on_advance_payment_date",
-  "advance_reconciliation_takes_effect_on",
   "column_break_11",
   "bank_account",
   "party_bank_account",
@@ -754,18 +753,9 @@
    "options": "No\nYes",
    "print_hide": 1,
    "search_index": 1
-  },
-  {
-   "default": "Oldest Of Invoice Or Advance",
-   "fetch_from": "company.reconciliation_takes_effect_on",
-   "fieldname": "advance_reconciliation_takes_effect_on",
-   "fieldtype": "Select",
-   "hidden": 1,
-   "label": "Advance Reconciliation Takes Effect On",
-   "no_copy": 1,
-   "options": "Advance Payment Date\nOldest Of Invoice Or Advance\nReconciliation Date"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [
@@ -777,7 +767,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-03-24 16:18:19.920701",
+ "modified": "2025-05-08 11:18:10.238085",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",
@@ -817,6 +807,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -80,9 +80,6 @@ class PaymentEntry(AccountsController):
 			PaymentEntryReference,
 		)
 
-		advance_reconciliation_takes_effect_on: DF.Literal[
-			"Advance Payment Date", "Oldest Of Invoice Or Advance", "Reconciliation Date"
-		]
 		amended_from: DF.Link | None
 		apply_tax_withholding_amount: DF.Check
 		auto_repeat: DF.Link | None
@@ -1574,9 +1571,15 @@ class PaymentEntry(AccountsController):
 		else:
 			# For backwards compatibility
 			# Supporting reposting on payment entries reconciled before select field introduction
-			if self.advance_reconciliation_takes_effect_on == "Advance Payment Date":
+			if (
+				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
+				== "Advance Payment Date"
+			):
 				posting_date = self.posting_date
-			elif self.advance_reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
+			elif (
+				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
+				== "Oldest Of Invoice Or Advance"
+			):
 				date_field = "posting_date"
 				if invoice.reference_doctype in ["Sales Order", "Purchase Order"]:
 					date_field = "transaction_date"
@@ -1586,7 +1589,10 @@ class PaymentEntry(AccountsController):
 
 				if getdate(posting_date) < getdate(self.posting_date):
 					posting_date = self.posting_date
-			elif self.advance_reconciliation_takes_effect_on == "Reconciliation Date":
+			elif (
+				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
+				== "Reconciliation Date"
+			):
 				posting_date = nowdate()
 			frappe.db.set_value("Payment Entry Reference", invoice.name, "reconcile_effect_on", posting_date)
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1571,15 +1571,12 @@ class PaymentEntry(AccountsController):
 		else:
 			# For backwards compatibility
 			# Supporting reposting on payment entries reconciled before select field introduction
-			if (
-				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
-				== "Advance Payment Date"
-			):
+			reconciliation_takes_effect_on = frappe.get_cached_value(
+				"Company", self.company, "reconciliation_takes_effect_on"
+			)
+			if reconciliation_takes_effect_on == "Advance Payment Date":
 				posting_date = self.posting_date
-			elif (
-				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
-				== "Oldest Of Invoice Or Advance"
-			):
+			elif reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
 				date_field = "posting_date"
 				if invoice.reference_doctype in ["Sales Order", "Purchase Order"]:
 					date_field = "transaction_date"
@@ -1589,10 +1586,7 @@ class PaymentEntry(AccountsController):
 
 				if getdate(posting_date) < getdate(self.posting_date):
 					posting_date = self.posting_date
-			elif (
-				frappe.get_cached_value("Company", self.company, "reconciliation_takes_effect_on")
-				== "Reconciliation Date"
-			):
+			elif reconciliation_takes_effect_on == "Reconciliation Date":
 				posting_date = nowdate()
 			frappe.db.set_value("Payment Entry Reference", invoice.name, "reconcile_effect_on", posting_date)
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -731,16 +731,13 @@ def update_reference_in_payment_entry(
 	update_advance_paid = []
 
 	# Update Reconciliation effect date in reference
+	reconciliation_takes_effect_on = frappe.get_cached_value(
+		"Company", payment_entry.company, "reconciliation_takes_effect_on"
+	)
 	if payment_entry.book_advance_payments_in_separate_party_account:
-		if (
-			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
-			== "Advance Payment Date"
-		):
+		if reconciliation_takes_effect_on == "Advance Payment Date":
 			reconcile_on = payment_entry.posting_date
-		elif (
-			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
-			== "Oldest Of Invoice Or Advance"
-		):
+		elif reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
 			date_field = "posting_date"
 			if d.against_voucher_type in ["Sales Order", "Purchase Order"]:
 				date_field = "transaction_date"
@@ -748,10 +745,7 @@ def update_reference_in_payment_entry(
 
 			if getdate(reconcile_on) < getdate(payment_entry.posting_date):
 				reconcile_on = payment_entry.posting_date
-		elif (
-			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
-			== "Reconciliation Date"
-		):
+		elif reconciliation_takes_effect_on == "Reconciliation Date":
 			reconcile_on = nowdate()
 
 		reference_details.update({"reconcile_effect_on": reconcile_on})

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -732,9 +732,15 @@ def update_reference_in_payment_entry(
 
 	# Update Reconciliation effect date in reference
 	if payment_entry.book_advance_payments_in_separate_party_account:
-		if payment_entry.advance_reconciliation_takes_effect_on == "Advance Payment Date":
+		if (
+			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
+			== "Advance Payment Date"
+		):
 			reconcile_on = payment_entry.posting_date
-		elif payment_entry.advance_reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
+		elif (
+			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
+			== "Oldest Of Invoice Or Advance"
+		):
 			date_field = "posting_date"
 			if d.against_voucher_type in ["Sales Order", "Purchase Order"]:
 				date_field = "transaction_date"
@@ -742,7 +748,10 @@ def update_reference_in_payment_entry(
 
 			if getdate(reconcile_on) < getdate(payment_entry.posting_date):
 				reconcile_on = payment_entry.posting_date
-		elif payment_entry.advance_reconciliation_takes_effect_on == "Reconciliation Date":
+		elif (
+			frappe.get_cached_value("Company", payment_entry.company, "reconciliation_takes_effect_on")
+			== "Reconciliation Date"
+		):
 			reconcile_on = nowdate()
 
 		reference_details.update({"reconcile_effect_on": reconcile_on})


### PR DESCRIPTION
**Issue:**
Unable to reconcile payment entries based on 'Advance Payment Date' when the payment entry was created in a closed fiscal year.

**Fix:**
Fetch 'reconciliation_takes_effect_on' from the company instead of the payment entry to allow reconciliation even if the payment entry was created in a closed period.


**Ref:** [37649](https://support.frappe.io/helpdesk/tickets/37649)

**Before:**

[before.webm](https://github.com/user-attachments/assets/95452c93-8f16-42cc-a91f-ea49aa431b4d)


**After:**

[after.webm](https://github.com/user-attachments/assets/11117b78-209f-4c60-9b8a-3c68ab6c5c0a)

**backport needed v15**
