### PR TITLE
feat: pos hide image should really hide image

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -100,7 +100,9 @@ erpnext.PointOfSale.ItemSelector = class {
 		}
 
 		function get_item_image_html() {
-			if (!me.hide_images && item_image) {
+			if (me.hide_images) {
+				return ``;
+			} else if (!me.hide_images && item_image) {
 				return `<div class="item-qty-pill">
 							<span class="indicator-pill whitespace-nowrap ${indicator_color}">${qty_to_display}</span>
 						</div>


### PR DESCRIPTION
I think if POS Profile is set to hide image, it should be like this,

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/ecda857f-22ba-41dc-8080-2bd35c1caec1" />
