### PR TITLE
fix: better validation message with solution for BOM recursion

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -7,7 +7,7 @@ from collections import deque
 from operator import itemgetter
 
 import frappe
-from frappe import _
+from frappe import _, bold
 from frappe.core.doctype.version.version import get_diff
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, cstr, flt, parse_json, today
@@ -662,9 +662,16 @@ class BOM(WebsiteGenerator):
 	def check_recursion(self, bom_list=None):
 		"""Check whether recursion occurs in any bom"""
 
-		def _throw_error(bom_name):
+		def _throw_error(bom_name, production_item=None):
+			msg = _("BOM recursion: {1} cannot be parent or child of {0}").format(self.name, bom_name)
+			if production_item and bom_name != self.name:
+				msg += "<br><br>"
+				msg += _(
+					"Note: If you want to use the finished good {0} as a raw material, then enable the 'Do Not Explode' checkbox in the Items table against the same raw material."
+				).format(bold(production_item))
+
 			frappe.throw(
-				_("BOM recursion: {1} cannot be parent or child of {0}").format(self.name, bom_name),
+				msg,
 				exc=BOMRecursionError,
 			)
 
@@ -681,7 +688,7 @@ class BOM(WebsiteGenerator):
 			if self.item == item.item_code and item.bom_no:
 				# Same item but with different BOM should not be allowed.
 				# Same item can appear recursively once as long as it doesn't have BOM.
-				_throw_error(item.bom_no)
+				_throw_error(item.bom_no, self.item)
 
 		if self.name in {d.bom_no for d in self.items}:
 			_throw_error(self.name)


### PR DESCRIPTION
If the user wants to use a finished good as a raw material, and another BOM already exists for it, the system does not allow creating a new BOM. In this case, the user should enable the 'Do Not Explode' checkbox in the line item, which mostly users missed. Due to which they think that the finished good can't be use a as a Raw Material. So to address this, the validation message has added the solution.

<img width="748" alt="Screenshot 2025-05-08 at 5 43 00 PM" src="https://github.com/user-attachments/assets/5e8bb757-e758-4a5f-9a5e-286fb26231ee" />
