### PR TITLE
Fix duplicate name error in Contract doctype without naming series

### DIFF
--- a/erpnext/crm/doctype/contract/contract.py
+++ b/erpnext/crm/doctype/contract/contract.py
@@ -45,18 +45,23 @@ class Contract(Document):
 		status: DF.Literal["Unsigned", "Active", "Inactive"]
 	# end: auto-generated types
 
+	
 	def autoname(self):
-		name = self.party_name
+		base_name = self.party_name
 
 		if self.contract_template:
-			name += f" - {self.contract_template} Agreement"
+			base_name += f" - {self.contract_template} Agreement"
 
-		# If identical, append contract name with the next number in the iteration
-		if frappe.db.exists("Contract", name):
-			count = len(frappe.get_all("Contract", filters={"name": ["like", f"%{name}%"]}))
-			name = f"{name} - {count}"
+		name = base_name
+		counter = 1
+
+		# Keep incrementing the counter until a unique name is found
+		while frappe.db.exists("Contract", name):
+			name = f"{base_name} - {counter}"
+			counter += 1
 
 		self.name = _(name)
+
 
 	def validate(self):
 		self.validate_dates()


### PR DESCRIPTION

### Problem

The `Contract` doctype overrides `autoname` to build names using the `party_name` . It appends a count based on how many existing records match the name pattern.

However, this approach fails when previously created contracts are deleted. The count becomes unreliable, and the logic can regenerate a name that already existed — causing a duplicate key error.

### Fix

This PR replaces the count-based naming logic with an iterative check. It keeps incrementing a suffix until a unique name is found, ensuring name uniqueness even if records were previously deleted.

### Impact

This fix:

- Resolves duplicate name errors when creating contracts after deletions.
- Prevents confusion when the system tries to reuse names that were deleted.

### Reproduction Steps

1. Create 3 contracts with the same `party_name`
2. Delete the second contract
3. Try to create another contract — a duplicate name error occurs

After this fix, the 4th contract will safely be named with the next available suffix.

https://github.com/user-attachments/assets/c5412b65-cdcf-4c3e-a4d3-e6c46d538b44



