### PR TITLE
fix: timesheet portal showing total billing hours

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -522,7 +522,7 @@ def get_timesheets_list(doctype, txt, filters, limit_start, limit_page_length=20
 				table.name,
 				child_table.activity_type,
 				table.status,
-				table.total_billable_hours,
+				child_table.billing_hours,
 				(table.sales_invoice | child_table.sales_invoice).as_("sales_invoice"),
 				child_table.project,
 			)

--- a/erpnext/templates/includes/timesheet/timesheet_row.html
+++ b/erpnext/templates/includes/timesheet/timesheet_row.html
@@ -5,7 +5,7 @@
 				{{ doc.name }}
 			</span>
 		</div>
-		<div class="col-xs-2 small"> {{ doc.total_billable_hours }} </div>
+		<div class="col-xs-2 small"> {{ doc.billing_hours }} </div>
 		<div class="col-xs-2 small"> {{ doc.project or '' }} </div>
 		<div class="col-xs-2 small"> {{ doc.sales_invoice or '' }} </div>
 		<div class="col-xs-2 small"> {{ _(doc.activity_type) }} </div>


### PR DESCRIPTION
Reference support ticket [38118](https://support.frappe.io/helpdesk/tickets/38118)

Timesheet portal was showing total billable hours of the document instead of billing hours of individual line item

@rohitwaghchaure this is not related to the raw SQL -> QB refactor. Even before that the query was the same.