### PR TITLE
fix: POS Invoice can't use Loyalty Points when Global Rounded Total is Disabled

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -178,8 +178,9 @@ def validate_loyalty_points(ref_doc, points_to_redeem):
 
 		loyalty_amount = flt(points_to_redeem * loyalty_program_details.conversion_factor)
 
-		if loyalty_amount > ref_doc.rounded_total:
-			frappe.throw(_("You can't redeem Loyalty Points having more value than the Rounded Total."))
+		total_amount = ref_doc.grand_total if ref_doc.is_rounded_total_disabled() else ref_doc.rounded_total
+		if loyalty_amount > total_amount:
+			frappe.throw(_("You can't redeem Loyalty Points having more value than the Total Amount."))
 
 		if not ref_doc.loyalty_amount and ref_doc.loyalty_amount != loyalty_amount:
 			ref_doc.loyalty_amount = loyalty_amount


### PR DESCRIPTION
### Information about bug

In Global Default, if Disable Rounded Total = True. When create POS Invoice and use Loyalty Points, checkout will result in Error as following,

https://github.com/user-attachments/assets/3882893f-2194-46b3-b248-0da6de5eaa0f

### Module

accounts

### Version

ERPNext: v15.55.4 (version-15)
Frappe Framework: v15.63.0 (version-15)



### Installation method

FrappeCloud

### Relevant log output / Stack trace / Full Error Message.

```shell
13:31:07 web.1         |   File "apps/erpnext/erpnext/accounts/doctype/pos_invoice/pos_invoice.py", line 215, in validate
13:31:07 web.1         |     self.validate_loyalty_transaction()
13:31:07 web.1         |   File "apps/erpnext/erpnext/accounts/doctype/pos_invoice/pos_invoice.py", line 483, in validate_loyalty_transaction
13:31:07 web.1         |     validate_loyalty_points(self, self.loyalty_points)
13:31:07 web.1         |   File "apps/erpnext/erpnext/accounts/doctype/loyalty_program/loyalty_program.py", line 172, in validate_loyalty_points
13:31:07 web.1         |     frappe.throw(_("You can't redeem Loyalty Points having more value than the Rounded Total."))

```