### PR TITLE
fix: add 'exclude status' filter in Sales Order Analysis report

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
@@ -60,36 +60,56 @@ frappe.query_reports["Sales Order Analysis"] = {
 		},
 		{
 			fieldname: "status",
-			label: __("Status"),
+			label: __("Include Status"),
 			fieldtype: "MultiSelectList",
 			options: ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed", "Closed"],
-			width: "80",
-			get_data: function (txt) {
-				let status = [
-					"To Pay",
-					"To Bill",
-					"To Deliver",
-					"To Deliver and Bill",
-					"Completed",
-					"Closed",
-				];
+			width: "120",
+			get_data: function(txt) {
+				let status = ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed", "Closed"];
+				let excluded_statuses = frappe.query_report.get_filter_value('exclude_status') || [];
 				let options = [];
 				for (let option of status) {
-					options.push({
-						value: option,
-						label: __(option),
-						description: "",
-					});
+					if (!excluded_statuses.includes(option)) {
+						options.push({
+							value: option,
+							label: __(option),
+							description: ""
+						});
+					}
 				}
 				return options;
 			},
+			on_change: function() {
+				frappe.query_report.refresh();
+			}
 		},
 		{
-			fieldname: "group_by_so",
-			label: __("Group by Sales Order"),
-			fieldtype: "Check",
-			default: 0,
-		},
+			fieldname: "exclude_status",
+			label: __("Exclude Status"),
+			fieldtype: "MultiSelectList",
+			options: ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed", "Closed", "Stopped", "On Hold"],
+			width: "120",
+			get_data: function(txt) {
+				let status = ["To Pay", "To Bill", "To Deliver", "To Deliver and Bill", "Completed", "Closed", "Stopped", "On Hold"];
+				let included_statuses = frappe.query_report.get_filter_value('status') || [];
+				let options = [];
+				for (let option of status) {
+					if (!included_statuses.includes(option)) {
+						options.push({
+							value: option,
+							label: __(option),
+							description: ""
+						});
+					}
+				}
+				return options;
+			},
+			on_change: function() {
+				frappe.query_report.refresh();
+			}
+		}
+		
+		
 	],
 
 	formatter: function (value, row, column, data, default_formatter) {
@@ -105,4 +125,11 @@ frappe.query_reports["Sales Order Analysis"] = {
 		}
 		return value;
 	},
+
+	onload: function(report) {
+		// Set default values for the exclude_status filter
+		setTimeout(function() {
+			report.set_filter_value("exclude_status", ["Stopped", "On Hold"]);
+		}, 500);
+	}
 };

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -39,13 +39,10 @@ def validate_filters(filters):
 	elif date_diff(to_date, from_date) < 0:
 		frappe.throw(_("To Date cannot be before From Date."))
 
-def validate_status_filters(filters):
-    frappe.log_error(f"DEBUG: Received Filters: {filters}", "Status Filters Validation")
-    
+def validate_status_filters(filters):    
     status_list = filters.get('status', [])
     exclude_status_list = filters.get('exclude_status', [])
-    
-    frappe.log_error(f"DEBUG: status_list={status_list}, exclude_status_list={exclude_status_list}", "Status Filters Validation")
+
 
     if status_list and exclude_status_list:
         status_set = set(status_list)


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/47495
added exclude status filter in SO analysis report where the user can select which fields to be excluded.
Also added validation to prevent selecting same fields in 'Exclude status' and 'Include status'