### PR TITLE
fix: prevent duplicate ghost comments on Item timeline after navigation

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -84,6 +84,15 @@ frappe.ui.form.on("Item", {
 		}
 	},
 
+	onload_post_render: function (frm) {
+		if (!frm.timeline) return;
+
+		// Clear timeline UI and refresh to avoid ghost comments
+		frm.timeline.wrapper.empty();
+		frm.timeline.refresh();
+	},
+
+
 	refresh: function (frm) {
 		if (frm.doc.is_stock_item) {
 			frm.add_custom_button(
@@ -637,11 +646,11 @@ $.extend(erpnext.item, {
 				fields: [
 					frm.doc.image
 						? {
-								fieldtype: "Check",
-								label: __("Create a variant with the template image."),
-								fieldname: "use_template_image",
-								default: 0,
-						  }
+							fieldtype: "Check",
+							label: __("Create a variant with the template image."),
+							fieldname: "use_template_image",
+							default: 0,
+						}
 						: null,
 					{
 						fieldtype: "HTML",


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

This PR fixes a UI bug in the Item form where comments would appear duplicated after navigating away and returning, due to the timeline component retaining its previous state in a single-page app context.

### 🔍 Problem

When a user adds a comment to the Item form, and navigates to another page without refreshing, the comment appears twice when returning — once from local memory and once from the backend. This also causes the comment count to double. Deleting one of the comments results in a "Resource not found" error.

### ✅ Solution

In the `onload_post_render` hook of the Item form, we clear the timeline UI and trigger a refresh, ensuring the timeline is fully reloaded from the backend and does not display any stale or duplicate data.

> Screenshots/GIFs


https://github.com/user-attachments/assets/6ef94277-931a-4850-bd51-2b1d59fd924d


```js
onload_post_render: function (frm) {
	if (!frm.timeline) return;

	// Clear timeline UI and refresh to avoid ghost comments
	frm.timeline.wrapper.empty();
	frm.timeline.refresh();
},
