### PR TITLE
fix: Handle duplicate Items qty in Quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -826,6 +826,52 @@ class TestQuotation(IntegrationTestCase):
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
 
+	def test_duplicate_items_in_quotation(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		# item code same but description different
+		make_item("_Test Item 2", {"is_stock_item": 1})
+
+		quotation = make_quotation(qty=1, rate=100, do_not_submit=1)
+
+		# duplicate items
+		for qty in [1, 1, 2, 3]:
+			quotation.append("items", {"item_code": "_Test Item", "qty": qty, "rate": 100})
+
+		quotation.append("items", {"item_code": "_Test Item 2", "qty": 5, "rate": 100})
+
+		quotation.submit()
+
+		sales_order = make_sales_order(quotation.name)
+		sales_order.delivery_date = nowdate()
+
+		self.assertEqual(len(sales_order.items), 6)
+		self.assertEqual(sales_order.items[0].qty, 1)
+		self.assertEqual(sales_order.items[-1].qty, 5)
+
+		# Row 1: 10, Row 4: 1, Row 5: 1
+		sales_order.items[0].qty = 10
+		sales_order.items[3].qty = 1
+		sales_order.items[4].qty = 1
+		sales_order.submit()
+
+		quotation.reload()
+		self.assertEqual(quotation.status, "Partially Ordered")
+
+		sales_order_2 = make_sales_order(quotation.name)
+		sales_order_2.delivery_date = nowdate()
+		self.assertEqual(len(sales_order_2.items), 2)
+		self.assertEqual(sales_order_2.items[0].qty, 1)
+		self.assertEqual(sales_order_2.items[1].qty, 2)
+
+		self.assertEqual(sales_order_2.items[0].quotation_item, quotation.items[3].name)
+		self.assertEqual(sales_order_2.items[1].quotation_item, quotation.items[4].name)
+
+		sales_order_2.submit()
+		quotation.reload()
+		self.assertEqual(quotation.status, "Ordered")
+
 
 def enable_calculate_bundle_price(enable=1):
 	selling_settings = frappe.get_doc("Selling Settings")


### PR DESCRIPTION
## [Frappe Support - 37787](https://support.frappe.io/helpdesk/tickets/37787)

- Closed PR: #47436

### Issue Description:
When a user has duplicate **Item** entries in a **Quotation** and creates a **Sales Order** from that Quotation, the following occurs:
- If some duplicate entries are removed or their quantities are reduced in the Sales Order before submission, the Quotation status is incorrectly set to `Ordered` instead of `Partially Ordered`.

### Expected Behavior:
The Quotation status should be set to `Partially Ordered` when not all items/quantities are transferred to the Sales Order.

### Steps to Reproduce:
1. Create a Quotation with multiple items, including duplicate entries of the same item (e.g., same item code in multiple rows with quantity = 1).
2. Submit the Quotation and create a Sales Order from it.
3. In the Sales Order, remove one of the duplicate rows or reduce its quantity.
4. Submit the Sales Order.
5. Check the status of the original Quotation - it will incorrectly show `Ordered` instead of `Partially Ordered`.

### References:

<details>
<summary>When One Row is removed from Sales Order</summary>


<br>

**Issue**

https://github.com/user-attachments/assets/f94b60e6-b13c-4ec7-90e4-aacb835e1f4b

**Solution**

https://github.com/user-attachments/assets/3475d572-5fd2-44f7-ae2d-76140ef7da61

</details> 


<details>
<summary>When One Row get more qty than Quotation and some row get less</summary>

<br>

**Issue**

https://github.com/user-attachments/assets/3d0739ac-540a-4083-8f2f-0bdbb78db0d7


**Solution**

https://github.com/user-attachments/assets/807db711-2371-42b4-8782-ad2b0afa5b23


</details> 

> [!IMPORTANT]
>  This fix should be backported, but there might be complications with PR [#46214](https://github.com/frappe/erpnext/pull/46214) as it hasn't been backported yet so manual PR is require to make changes in V-15/V-14
