### PR TITLE
build(deps): bump rapidfuzz

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
+++ b/erpnext/accounts/doctype/bank_transaction/auto_match_party.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import flt
 from rapidfuzz import fuzz, process
+from rapidfuzz.utils import default_process
 
 
 class AutoMatchParty:
@@ -132,6 +133,7 @@ class AutoMatchbyPartyNameDescription:
 			query=self.get(field),
 			choices={row.get("name"): row.get("party_name") for row in names},
 			scorer=fuzz.token_set_ratio,
+			processor=default_process,
 		)
 		party_name, skip = self.process_fuzzy_result(result)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pycountry~=24.6.1",
     "Unidecode~=1.3.6",
     "barcodenumber~=0.5.0",
-    "rapidfuzz~=2.15.0",
+    "rapidfuzz~=3.12.2",
     "holidays~=0.28",
 
     # integration dependencies


### PR DESCRIPTION
Installation with uv [fails](https://katb.in/laganusegej) for the current version of rapidfuzz

Fixed by them [here](https://github.com/rapidfuzz/RapidFuzz/commit/fd0e3a674df9aea78dbbb7fd514e65ea130e7942)

[Changelog](https://github.com/rapidfuzz/RapidFuzz/blob/main/CHANGELOG.rst) doesn't seem to show any breaking changes

Edit: https://github.com/rapidfuzz/RapidFuzz/blob/main/CHANGELOG.rst#300---2023-04-16 strings were no longer preprocessed by default.
