### PR TITLE
fix: not able to reserve extra items against the work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
@@ -27,7 +27,9 @@
   "available_qty_at_source_warehouse",
   "available_qty_at_wip_warehouse",
   "column_break_jash",
-  "stock_reserved_qty"
+  "stock_reserved_qty",
+  "is_additional_item",
+  "voucher_detail_reference"
  ],
  "fields": [
   {
@@ -172,17 +174,35 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_additional_item",
+   "fieldtype": "Check",
+   "label": "Is Additional Item",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "is_additional_item",
+   "fieldname": "voucher_detail_reference",
+   "fieldtype": "Data",
+   "label": "Voucher Detail Reference",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2024-11-20 15:48:16.823384",
+ "modified": "2025-05-12 17:36:00.115181",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Item",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.py
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.py
@@ -22,6 +22,7 @@ class WorkOrderItem(Document):
 		consumed_qty: DF.Float
 		description: DF.Text | None
 		include_item_in_manufacturing: DF.Check
+		is_additional_item: DF.Check
 		item_code: DF.Link | None
 		item_name: DF.Data | None
 		operation: DF.Link | None
@@ -33,9 +34,10 @@ class WorkOrderItem(Document):
 		required_qty: DF.Float
 		returned_qty: DF.Float
 		source_warehouse: DF.Link | None
-		stock_uom: DF.Link | None
 		stock_reserved_qty: DF.Float
+		stock_uom: DF.Link | None
 		transferred_qty: DF.Float
+		voucher_detail_reference: DF.Data | None
 	# end: auto-generated types
 
 	pass

--- a/erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py
+++ b/erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py
@@ -29,6 +29,9 @@ def get_data(report_filters):
 		if d.consumed_qty and d.consumed_qty > d.required_qty:
 			d.extra_consumed_qty = d.consumed_qty - d.required_qty
 
+		if d.is_additional_item:
+			d.extra_consumed_qty = d.consumed_qty
+
 		if d.extra_consumed_qty or not report_filters.show_extra_consumed_materials:
 			wo_items.setdefault((d.name, d.production_item), []).append(d)
 
@@ -81,6 +84,7 @@ def get_fields():
 		"`tabWork Order Item`.`required_qty`",
 		"`tabWork Order Item`.`transferred_qty`",
 		"`tabWork Order Item`.`consumed_qty`",
+		"`tabWork Order Item`.`is_additional_item`",
 		"`tabWork Order`.`status`",
 		"`tabWork Order`.`name`",
 		"`tabWork Order`.`production_item`",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1635,6 +1635,11 @@ class StockEntry(StockController):
 			_validate_work_order(pro_doc)
 
 			if self.fg_completed_qty:
+				if self.docstatus == 1:
+					pro_doc.add_additional_items(self)
+				else:
+					pro_doc.remove_additional_items(self)
+
 				pro_doc.run_method("update_work_order_qty")
 				if self.purpose == "Manufacture":
 					pro_doc.run_method("update_planned_qty")


### PR DESCRIPTION
- Enable reserve stock in the work order
- Make material transfer stock entry against the work order
- Add additional items which is not a part of BOM
- Try to submit the stock entry, the system will throw the error 