### PR TITLE
fix: ignore "Account Closing Balance" doctype on Period Closing Voucher cancellation

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -133,7 +133,12 @@ class PeriodClosingVoucher(AccountsController):
 		self.make_gl_entries()
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry", "Payment Ledger Entry")
+		self.ignore_linked_doctypes = (
+			"GL Entry",
+			"Stock Ledger Entry",
+			"Payment Ledger Entry",
+			"Account Closing Balance",
+		)
 		self.block_if_future_closing_voucher_exists()
 		self.db_set("gle_processing_status", "In Progress")
 		self.cancel_gl_entries()


### PR DESCRIPTION
Issue: If there are more than 5000 gl entries user is not able to cancel the Period Closing Voucher because the cancellation of the Account Closing Balance is queued. 

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1736, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 58, in cancel
    doc.cancel()
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1098, in cancel
    return self._cancel()
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1081, in _cancel
    return self.save()
           ^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 431, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1179, in run_post_save_methods
    self.check_no_back_links_exist()
  File "apps/frappe/frappe/model/document.py", line 1298, in check_no_back_links_exist
    check_if_doc_is_linked(self, method="Cancel")
  File "apps/frappe/frappe/model/delete_doc.py", line 318, in check_if_doc_is_linked
    raise_link_exists_exception(doc, linked_parent_doctype, reference_docname)
  File "apps/frappe/frappe/model/delete_doc.py", line 383, in raise_link_exists_exception
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 606, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 571, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 522, in _raise_exception
    raise exc
frappe.exceptions.LinkExistsError: Cannot delete or cancel because Period Closing Voucher <a href="/app/Form/Period Closing Voucher/ACC-PCV-2025-00000-2">ACC-PCV-2025-00000-2</a> is linked with Account Closing Balance <a href="/app/Form/Account Closing Balance/68p0lamkc3">68p0lamkc3</a> 
desk.bundle.VFSSKUQV.js:453:7393
```

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/38254,https://support.frappe.io/app/hd-ticket/37541