### PR TITLE
feat: non depreciable asset category

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -119,6 +119,7 @@ class Asset(AccountsController):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_category()
 		self.validate_precision()
 		self.set_purchase_doc_row_item()
 		self.validate_asset_values()
@@ -351,6 +352,17 @@ class Asset(AccountsController):
 					_("Row #{}: Finance Book should not be empty since you're using multiple.").format(d.idx),
 					title=_("Missing Finance Book"),
 				)
+
+	def validate_category(self):
+		non_depreciable_category = frappe.db.get_value(
+			"Asset Category", self.asset_category, "non_depreciable_category"
+		)
+		if self.calculate_depreciation and non_depreciable_category:
+			frappe.throw(
+				_(
+					"This asset category is marked as non-depreciable. Please disable depreciation calculation or choose a different category."
+				)
+			)
 
 	def validate_precision(self):
 		if self.gross_purchase_amount:

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -286,45 +286,6 @@ def get_credit_and_debit_entry(
 	return credit_entry, debit_entry
 
 
-def get_depreciation_accounts(asset_category, company):
-	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None
-
-	accounts = frappe.db.get_value(
-		"Asset Category Account",
-		filters={"parent": asset_category, "company_name": company},
-		fieldname=[
-			"fixed_asset_account",
-			"accumulated_depreciation_account",
-			"depreciation_expense_account",
-		],
-		as_dict=1,
-	)
-
-	if accounts:
-		fixed_asset_account = accounts.fixed_asset_account
-		accumulated_depreciation_account = accounts.accumulated_depreciation_account
-		depreciation_expense_account = accounts.depreciation_expense_account
-
-	if not accumulated_depreciation_account or not depreciation_expense_account:
-		accounts = frappe.get_cached_value(
-			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
-		)
-
-		if not accumulated_depreciation_account:
-			accumulated_depreciation_account = accounts[0]
-		if not depreciation_expense_account:
-			depreciation_expense_account = accounts[1]
-
-	if not fixed_asset_account or not accumulated_depreciation_account or not depreciation_expense_account:
-		frappe.throw(
-			_("Please set Depreciation related Accounts in Asset Category {0} or Company {1}").format(
-				asset_category, company
-			)
-		)
-
-	return fixed_asset_account, accumulated_depreciation_account, depreciation_expense_account
-
-
 def get_credit_and_debit_accounts(accumulated_depreciation_account, depreciation_expense_account):
 	root_type = frappe.get_value("Account", depreciation_expense_account, "root_type")
 
@@ -722,8 +683,8 @@ def get_asset_details(asset, finance_book=None):
 	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
 	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
 
-	fixed_asset_account, accumulated_depr_account, _ = get_asset_accounts(
-		asset.asset_category, asset.company, accumulated_depr_amount
+	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
+		asset.asset_category, asset.company
 	)
 	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(asset.company)
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
@@ -739,8 +700,12 @@ def get_asset_details(asset, finance_book=None):
 	)
 
 
-def get_asset_accounts(asset_category, company, accumulated_depr_amount):
+def get_depreciation_accounts(asset_category, company):
 	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None
+
+	non_depreciable_category = frappe.db.get_value(
+		"Asset Category", asset_category, "non_depreciable_category"
+	)
 
 	accounts = frappe.db.get_value(
 		"Asset Category Account",
@@ -761,7 +726,7 @@ def get_asset_accounts(asset_category, company, accumulated_depr_amount):
 	if not fixed_asset_account:
 		frappe.throw(_("Please set Fixed Asset Account in Asset Category {0}").format(asset_category))
 
-	if accumulated_depr_amount:
+	if not non_depreciable_category:
 		accounts = frappe.get_cached_value(
 			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
 		)

--- a/erpnext/assets/doctype/asset_category/asset_category.json
+++ b/erpnext/assets/doctype/asset_category/asset_category.json
@@ -12,6 +12,7 @@
   "column_break_3",
   "depreciation_options",
   "enable_cwip_accounting",
+  "non_depreciable_category",
   "finance_book_detail",
   "finance_books",
   "section_break_2",
@@ -63,10 +64,16 @@
    "fieldname": "enable_cwip_accounting",
    "fieldtype": "Check",
    "label": "Enable Capital Work in Progress Accounting"
+  },
+  {
+   "default": "0",
+   "fieldname": "non_depreciable_category",
+   "fieldtype": "Check",
+   "label": "Non Depreciable Category"
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:06:33.840414",
+ "modified": "2025-05-13 15:33:03.791814",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Category",
@@ -111,6 +118,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/assets/doctype/asset_category/asset_category.py
+++ b/erpnext/assets/doctype/asset_category/asset_category.py
@@ -17,15 +17,14 @@ class AssetCategory(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from erpnext.assets.doctype.asset_category_account.asset_category_account import (
-			AssetCategoryAccount,
-		)
+		from erpnext.assets.doctype.asset_category_account.asset_category_account import AssetCategoryAccount
 		from erpnext.assets.doctype.asset_finance_book.asset_finance_book import AssetFinanceBook
 
 		accounts: DF.Table[AssetCategoryAccount]
 		asset_category_name: DF.Data
 		enable_cwip_accounting: DF.Check
 		finance_books: DF.Table[AssetFinanceBook]
+		non_depreciable_category: DF.Check
 	# end: auto-generated types
 
 	def validate(self):


### PR DESCRIPTION
This PR includes following changes:
- Added a new checkbox field 'Non Depreciable Category' in the Asset Category Doctype to mark categories that should not allow depreciation.
- Implemented validation to restrict depreciation calculation if the asset belongs to a non-depreciable category.
- Removed the mandatory requirement for the depreciation-related accounts when depreciation is not applicable.
<img width="1129" alt="Screenshot 2025-05-14 at 12 26 18 PM" src="https://github.com/user-attachments/assets/d82d0d52-3735-4ccf-9e99-cb040b38570c" />


- [x] Update docs