### PR TITLE
 fix(asset): make purchase date mandatory

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -207,8 +207,8 @@
    "fieldname": "purchase_date",
    "fieldtype": "Date",
    "label": "Purchase Date",
-   "mandatory_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset",
-   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
+   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset",
+   "reqd": 1
   },
   {
    "fieldname": "disposal_date",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -91,7 +91,7 @@ class Asset(AccountsController):
 		opening_number_of_booked_depreciations: DF.Int
 		policy_number: DF.Data | None
 		purchase_amount: DF.Currency
-		purchase_date: DF.Date | None
+		purchase_date: DF.Date
 		purchase_invoice: DF.Link | None
 		purchase_invoice_item: DF.Data | None
 		purchase_receipt: DF.Link | None


### PR DESCRIPTION
Issue: Unable to load the report when asset does not have the purchase date.

Before:

[before.webm](https://github.com/user-attachments/assets/7aa91032-7629-4a73-a1ed-fde95dee3879)

After:

[after.webm](https://github.com/user-attachments/assets/de458383-9174-4322-a1e7-b8da805a3f9b)

Backport needed: Version-15
