### PR TITLE
fix: stop additional item

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1613,6 +1613,9 @@ class WorkOrder(Document):
 					item.delete()
 
 	def add_additional_items(self, stock_entry):
+		if frappe.db.get_single_value("Manufacturing Settings", "validate_components_quantities_per_bom"):
+			return
+
 		if stock_entry.purpose != "Material Transfer for Manufacture":
 			return
 


### PR DESCRIPTION
If Validate Components and Quantities Per BOM is enabled then don't allow to add additional items