### PR TITLE
fix: Escape UOM in pricing rule query

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -115,8 +115,8 @@ def _get_pricing_rules(apply_on, args, values):
 		if apply_on_field == "item_code":
 			if args.get("uom", None):
 				item_conditions += (
-					" and ({child_doc}.uom='{item_uom}' or IFNULL({child_doc}.uom, '')='')".format(
-						child_doc=child_doc, item_uom=args.get("uom")
+					" and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
+						child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
 					)
 				)
 			if "variant_of" not in args:
@@ -128,8 +128,8 @@ def _get_pricing_rules(apply_on, args, values):
 	elif apply_on_field == "item_group":
 		item_conditions = _get_tree_conditions(args, "Item Group", child_doc, False)
 		if args.get("uom", None):
-			item_conditions += " and ({child_doc}.uom='{item_uom}' or IFNULL({child_doc}.uom, '')='')".format(
-				child_doc=child_doc, item_uom=args.get("uom")
+			item_conditions += " and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
+				child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
 			)
 
 	conditions += get_other_conditions(conditions, values, args)


### PR DESCRIPTION
Sometimes the UOM can contain the quote character `'` which causes issues (and allows SQL injection too)