### PR TITLE
fix: job card linter error

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2965,56 +2965,31 @@ class TestWorkOrder(IntegrationTestCase):
 			fg_warehouse="_Test Warehouse 2 - _TC",
 		)
 
-		# Initial check
-		self.assertEqual(wo.operations[0].operation, "Test Operation A")
-		self.assertEqual(wo.operations[1].operation, "Test Operation B")
-		self.assertEqual(wo.operations[2].operation, "Test Operation C")
-		self.assertEqual(wo.operations[3].operation, "Test Operation D")
-
 		wo = frappe.copy_doc(wo)
-		wo.operations[3].sequence_id = 2
-		wo.submit()
+		wo.operations[3].sequence_id = None
 
-		# Test 2 : Sort line items in child table based on sequence ID
-		self.assertEqual(wo.operations[0].operation, "Test Operation A")
-		self.assertEqual(wo.operations[1].operation, "Test Operation B")
-		self.assertEqual(wo.operations[2].operation, "Test Operation D")
-		self.assertEqual(wo.operations[3].operation, "Test Operation C")
-
-		wo = frappe.copy_doc(wo)
-		wo.operations[3].sequence_id = 1
-		wo.submit()
-
-		self.assertEqual(wo.operations[0].operation, "Test Operation A")
-		self.assertEqual(wo.operations[1].operation, "Test Operation C")
-		self.assertEqual(wo.operations[2].operation, "Test Operation B")
-		self.assertEqual(wo.operations[3].operation, "Test Operation D")
-
-		wo = frappe.copy_doc(wo)
-		wo.operations[0].sequence_id = 3
-		wo.submit()
-
-		self.assertEqual(wo.operations[0].operation, "Test Operation C")
-		self.assertEqual(wo.operations[1].operation, "Test Operation B")
-		self.assertEqual(wo.operations[2].operation, "Test Operation D")
-		self.assertEqual(wo.operations[3].operation, "Test Operation A")
-
-		wo = frappe.copy_doc(wo)
-		wo.operations[1].sequence_id = 0
-
-		# Test 3 - Error should be thrown if any one operation does not have sequence id but others do
+		# Test 1 : If any one operation does not have sequence ID then error will be thrown
 		self.assertRaises(frappe.ValidationError, wo.submit)
+
+		for op in wo.operations:
+			op.sequence_id = None
+		wo.submit()
+
+		# Test 2 : If none of the operations have sequence ID then they will be sequenced as per their idx
+		for op in wo.operations:
+			self.assertEqual(op.sequence_id, op.idx)
 
 		workstation = frappe.get_doc("Workstation", "Test Workstation A")
 		workstation.production_capacity = 4
 		workstation.save()
-
 		wo = frappe.copy_doc(wo)
-		wo.operations[1].sequence_id = 2
+		wo.operations[2].sequence_id = 2
 		wo.submit()
 
-		# Test 4 - If Sequence ID is same then planned start time for both operations should be same
-		self.assertEqual(wo.operations[1].planned_start_time, wo.operations[2].planned_start_time)
+		# Test 3 : If two operations have the same sequence ID then the next operation will start 10 mins after the longest previous operation ends
+		self.assertEqual(
+			wo.operations[3].planned_start_time, add_to_date(wo.operations[1].planned_end_time, minutes=10)
+		)
 
 
 def make_stock_in_entries_and_get_batches(rm_item, source_warehouse, wip_warehouse):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2979,14 +2979,28 @@ class TestWorkOrder(IntegrationTestCase):
 		for op in wo.operations:
 			self.assertEqual(op.sequence_id, op.idx)
 
+		wo = frappe.copy_doc(wo)
+		wo.operations[0].sequence_id = 2
+
+		# Test 3 : Sequence IDs should not miss the correct sequence of numbers
+		self.assertRaises(frappe.ValidationError, wo.submit)
+
+		wo.operations[1].sequence_id = 1
+
+		# Test 4 : Sequence IDs should be in the correct ascending order
+		self.assertRaises(frappe.ValidationError, wo.submit)
+
 		workstation = frappe.get_doc("Workstation", "Test Workstation A")
 		workstation.production_capacity = 4
 		workstation.save()
 		wo = frappe.copy_doc(wo)
+		wo.operations[0].sequence_id = 1
+		wo.operations[1].sequence_id = 2
 		wo.operations[2].sequence_id = 2
+		wo.operations[3].sequence_id = 3
 		wo.submit()
 
-		# Test 3 : If two operations have the same sequence ID then the next operation will start 10 mins after the longest previous operation ends
+		# Test 5 : If two operations have the same sequence ID then the next operation will start 10 mins after the longest previous operation ends
 		self.assertEqual(
 			wo.operations[3].planned_start_time, add_to_date(wo.operations[1].planned_end_time, minutes=10)
 		)

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -231,16 +231,20 @@ class WorkOrder(Document):
 			self.reserve_stock = 1
 
 	def validate_operations_sequence(self):
-		bool_list = [not op.sequence_id for op in self.operations]
-		if all(bool_list):
+		if all([not op.sequence_id for op in self.operations]):
 			for op in self.operations:
 				op.sequence_id = op.idx
-		elif any(bool_list):
-			frappe.throw(
-				_(
-					"Row #{0}: Incorrect Sequence ID. If any single operation has a Sequence ID then all other operations must have one too."
-				).format(next((op.idx for op in self.operations if not op.sequence_id), None))
-			)
+			return
+
+		sequence_id = 1
+		for op in self.operations:
+			if op.sequence_id != sequence_id:
+				frappe.throw(
+					_("Row #{0}: Sequence ID must be {1} for Operation {2}.").format(
+						op.idx, frappe.bold(sequence_id), frappe.bold(op.operation)
+					)
+				)
+			sequence_id += 1
 
 	def set_warehouses(self):
 		for row in self.required_items:

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -231,7 +231,11 @@ class WorkOrder(Document):
 			self.reserve_stock = 1
 
 	def validate_operations_sequence(self):
-		if any([not op.sequence_id for op in self.operations]):
+		bool_list = [not op.sequence_id for op in self.operations]
+		if all(bool_list):
+			for op in self.operations:
+				op.sequence_id = op.idx
+		elif any(bool_list):
 			frappe.throw(
 				_(
 					"Row #{0}: Incorrect Sequence ID. If any single operation has a Sequence ID then all other operations must have one too."

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -234,17 +234,25 @@ class WorkOrder(Document):
 		if all([not op.sequence_id for op in self.operations]):
 			for op in self.operations:
 				op.sequence_id = op.idx
-			return
-
-		sequence_id = 1
-		for op in self.operations:
-			if op.sequence_id != sequence_id:
-				frappe.throw(
-					_("Row #{0}: Sequence ID must be {1} for Operation {2}.").format(
-						op.idx, frappe.bold(sequence_id), frappe.bold(op.operation)
+		else:
+			sequence_id = 1
+			for op in self.operations:
+				if op.idx == 1 and op.sequence_id != 1:
+					frappe.throw(
+						_("Row #1: Sequence ID must be 1 for Operation {0}.").format(
+							frappe.bold(op.operation)
+						)
 					)
-				)
-			sequence_id += 1
+				elif op.sequence_id != sequence_id and op.sequence_id != sequence_id + 1:
+					frappe.throw(
+						_("Row #{0}: Sequence ID must be {1} or {2} for Operation {3}.").format(
+							op.idx,
+							frappe.bold(sequence_id),
+							frappe.bold(sequence_id + 1),
+							frappe.bold(op.operation),
+						)
+					)
+				sequence_id = op.sequence_id
 
 	def set_warehouses(self):
 		for row in self.required_items:

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -202,6 +202,7 @@
    "fieldname": "sequence_id",
    "fieldtype": "Int",
    "label": "Sequence ID",
+   "non_negative": 1,
    "print_hide": 1
   },
   {
@@ -299,7 +300,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-09 16:21:47.110564",
+ "modified": "2025-05-15 15:10:06.885440",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",


### PR DESCRIPTION
1. Removed logic where idx of operations was changed, causing linter error
2. Moved sequence id validation from on_submit to validate
3. Sequence ID is now non negative