### PR TITLE
fix: set no_copy to party_balance field in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -228,6 +228,7 @@
    "fieldname": "party_balance",
    "fieldtype": "Currency",
    "label": "Party Balance",
+   "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
   },
@@ -799,7 +800,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-05-08 11:18:10.238085",
+ "modified": "2025-05-15 18:01:04.013025",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",


### PR DESCRIPTION
Issue:Once duplicate Payment Entry and directly save submit then party balance not calculated or better to avoid to copying from source document.


closes: https://github.com/frappe/erpnext/issues/47218
continued: https://github.com/frappe/erpnext/pull/47223