### PR TITLE
fix(test): clean up data so subsequent test cases don't flake

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -137,6 +137,7 @@ class TestBudget(ERPNextTestSuite):
 
 		budget.load_from_db()
 		budget.cancel()
+		mr.cancel()
 
 	def test_monthly_budget_crossed_for_po(self):
 		budget = make_budget(


### PR DESCRIPTION
Left-over Material Request document causes flakiness in subsequent test cases. Exposed through local testing of new [budget controller class](https://github.com/frappe/erpnext/pull/47274)

Does this mean existing budget validation did not account for cumulative (PO + MR + Actual expense) breach(?) - Edit: Yes.