### PR TITLE
feat: add checkbox for validating time logs in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -740,7 +740,7 @@ class JobCard(Document):
 					bold("Job Card"), get_link_to_form("Job Card", self.name)
 				)
 			)
-		else:
+		elif frappe.db.get_single_value("Manufacturing Settings", "enforce_time_logs"):
 			for row in self.time_logs:
 				if not row.from_time or not row.to_time:
 					frappe.throw(

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -26,6 +26,7 @@
   "overproduction_percentage_for_work_order",
   "job_card_section",
   "add_corrective_operation_cost_in_finished_good_valuation",
+  "enforce_time_logs",
   "column_break_24",
   "job_card_excess_transfer",
   "capacity_planning",
@@ -235,13 +236,20 @@
    "fieldname": "set_op_cost_and_scrap_from_sub_assemblies",
    "fieldtype": "Check",
    "label": "Set Operating Cost / Scrap Items From Sub-assemblies"
+  },
+  {
+   "default": "0",
+   "description": "Enabling this checkbox will force each Job Card Time Log to have From Time and To Time",
+   "fieldname": "enforce_time_logs",
+   "fieldtype": "Check",
+   "label": "Enforce Time Logs"
   }
  ],
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-05 16:11:11.639916",
+ "modified": "2025-05-16 11:23:16.916512",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Manufacturing Settings",
@@ -255,6 +263,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
@@ -26,6 +26,7 @@ class ManufacturingSettings(Document):
 		default_scrap_warehouse: DF.Link | None
 		default_wip_warehouse: DF.Link | None
 		disable_capacity_planning: DF.Check
+		enforce_time_logs: DF.Check
 		get_rm_cost_from_consumption_entry: DF.Check
 		job_card_excess_transfer: DF.Check
 		make_serial_no_batch_from_work_order: DF.Check


### PR DESCRIPTION
Added a checkbox in `Manufacturing Settings` which decides whether Job Card Time Logs will be forced to have From Time and To Time or not.

fixes #47488 

<img width="653" alt="image" src="https://github.com/user-attachments/assets/29540ae9-2bd5-47e0-8e4e-5a81f84ffcd6" />
