### PR TITLE
fix: alias 'name' and 'parent' to prevent child row mapping issues

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -281,7 +281,6 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 		if (me.frm.doc.target_item_code) {
 			return me.frm.call({
 				method: "erpnext.assets.doctype.asset_capitalization.asset_capitalization.get_target_item_details",
-				child: me.frm.doc,
 				args: {
 					item_code: me.frm.doc.target_item_code,
 					company: me.frm.doc.company,
@@ -301,7 +300,6 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 		if (me.frm.doc.target_asset) {
 			return me.frm.call({
 				method: "erpnext.assets.doctype.asset_capitalization.asset_capitalization.get_target_asset_details",
-				child: me.frm.doc,
 				args: {
 					asset: me.frm.doc.target_asset,
 					company: me.frm.doc.company,

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -871,8 +871,8 @@ def get_items_tagged_to_wip_composite_asset(params):
 		"valuation_rate",
 		"amount",
 		"is_fixed_asset",
-		"parent",
-		"name",
+		"parent as purchase_receipt",
+		"name as purchase_receipt_item",
 	]
 
 	pr_items = frappe.get_all(
@@ -901,7 +901,7 @@ def process_stock_item(d):
 	stock_capitalized = frappe.db.exists(
 		"Asset Capitalization Stock Item",
 		{
-			"purchase_receipt_item": d.name,
+			"purchase_receipt_item": d.purchase_receipt_item,
 			"parentfield": "stock_items",
 			"parenttype": "Asset Capitalization",
 			"docstatus": 1,
@@ -912,7 +912,7 @@ def process_stock_item(d):
 		return None
 
 	stock_item_data = frappe._dict(d)
-	stock_item_data.purchase_receipt_item = d.name
+	stock_item_data.purchase_receipt_item = d.purchase_receipt_item
 	return stock_item_data
 
 
@@ -921,7 +921,7 @@ def process_fixed_asset(d):
 		"Asset",
 		{
 			"item_code": d.item_code,
-			"purchase_receipt": d.parent,
+			"purchase_receipt": d.purchase_receipt,
 			"status": ("not in", ["Draft", "Scrapped", "Sold", "Capitalized"]),
 		},
 		["name as asset", "asset_name", "company"],


### PR DESCRIPTION
#### Issue
Child rows in the Purchase Receipt Item table weren’t deleting properly during asset capitalization for WIP composite assets. This happened because the code used generic field names like name and parent, which caused confusion in the code.

https://github.com/user-attachments/assets/96d9901a-e898-4a03-ba4a-1796e17ce1d7

#### Fix
- Changed the fields to use clear aliases: parent as purchase_receipt and name as purchase_receipt_item.

https://github.com/user-attachments/assets/b9801e44-1114-40b1-84b2-e9cd12c1fdb0

