### PR TITLE
feat: add option to calculate ageing based on report date or today's date

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -61,6 +61,13 @@ frappe.query_reports["Accounts Payable"] = {
 			default: "Due Date",
 		},
 		{
+			fieldname: "calculate_ageing_with",
+			label: __("Calculate Ageing With"),
+			fieldtype: "Select",
+			options: "Report Date\nToday Date",
+			default: "Report Date",
+		},
+		{
 			fieldname: "range",
 			label: __("Ageing Range"),
 			fieldtype: "Data",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -90,6 +90,13 @@ frappe.query_reports["Accounts Receivable"] = {
 			default: "Due Date",
 		},
 		{
+			fieldname: "calculate_ageing_with",
+			label: __("Calculate Ageing With"),
+			fieldtype: "Select",
+			options: "Report Date\nToday Date",
+			default: "Report Date",
+		},
+		{
 			fieldname: "range",
 			label: __("Ageing Range"),
 			fieldtype: "Data",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -47,7 +47,9 @@ class ReceivablePayableReport:
 		self.ple = qb.DocType("Payment Ledger Entry")
 		self.filters.report_date = getdate(self.filters.report_date or nowdate())
 		self.age_as_on = (
-			getdate(nowdate()) if self.filters.report_date > getdate(nowdate()) else self.filters.report_date
+			getdate(nowdate())
+			if self.filters.calculate_ageing_with == "Today Date"
+			else self.filters.report_date
 		)
 
 		if not self.filters.range:
@@ -784,7 +786,7 @@ class ReceivablePayableReport:
 		self.get_ageing_data(entry_date, row)
 
 		# ageing buckets should not have amounts if due date is not reached
-		if getdate(entry_date) > getdate(self.filters.report_date):
+		if getdate(entry_date) > getdate(self.age_as_on):
 			[setattr(row, f"range{i}", 0.0) for i in self.range_numbers]
 
 		row.total_due = sum(row[f"range{i}"] for i in self.range_numbers)


### PR DESCRIPTION
**Issue:**

In the accounts receivable report for future due date invoices, even when a future posting date is selected, the aging is calculated based on today's date.

**Solution:**

Provide an option to calculate aging based on either the report date or today's date.

Ref: [#38541](https://support.frappe.io/helpdesk/tickets/38541)


**Before:**

![image](https://github.com/user-attachments/assets/7134f45d-e839-43bb-b86f-2cf7d8462691)

**After:**

![image](https://github.com/user-attachments/assets/2cc565d9-6130-42da-9e26-e523bc651bb3)



Backport needed: Version-15