### PR TITLE
fix: no validation to compare 'actual start date' and 'actual end date' when creating work order.

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -189,6 +189,7 @@ class WorkOrder(Document):
 		self.reset_use_multi_level_bom()
 		self.set_reserve_stock()
 		self.validate_fg_warehouse_for_reservation()
+		self.validate_dates()
 
 		if self.source_warehouse:
 			self.set_warehouses()
@@ -197,6 +198,11 @@ class WorkOrder(Document):
 
 		self.set_required_items(reset_only_qty=len(self.get("required_items")))
 		self.enable_auto_reserve_stock()
+
+	def validate_dates(self):
+		if self.actual_start_date and self.actual_end_date:
+			if self.actual_end_date < self.actual_start_date:
+				frappe.throw(_("Actual End Date cannot be before Actual Start Date"))
 
 	def validate_fg_warehouse_for_reservation(self):
 		if self.reserve_stock and self.sales_order:


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/47609
![image](https://github.com/user-attachments/assets/314606a6-07b4-458f-9d6a-ac1701274832)
