### PR TITLE
fix: auto append_taxes_from_item_tax_template in backend

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.js
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.js
@@ -22,4 +22,21 @@ frappe.ui.form.on("Accounts Settings", {
 			}
 		);
 	},
+
+	add_taxes_from_taxes_and_charges_template(frm) {
+		toggle_tax_settings(frm, "add_taxes_from_taxes_and_charges_template");
+	},
+	add_taxes_from_item_tax_template(frm) {
+		toggle_tax_settings(frm, "add_taxes_from_item_tax_template");
+	},
 });
+
+function toggle_tax_settings(frm, field_name) {
+	if (frm.doc[field_name]) {
+		const other_field =
+			field_name === "add_taxes_from_item_tax_template"
+				? "add_taxes_from_taxes_and_charges_template"
+				: "add_taxes_from_item_tax_template";
+		frm.set_value(other_field, 0);
+	}
+}

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -32,6 +32,7 @@
   "determine_address_tax_category_from",
   "column_break_19",
   "add_taxes_from_item_tax_template",
+  "add_taxes_from_taxes_and_charges_template",
   "book_tax_discount_loss",
   "round_row_wise_tax",
   "print_settings",
@@ -623,6 +624,13 @@
    "fieldname": "allow_pegged_currencies_exchange_rates",
    "fieldtype": "Check",
    "label": "Allow Implicit Pegged Currency Conversion"
+  },
+  {
+   "default": "0",
+   "description": "If no taxes are set, and Taxes and Charges Template is selected, the system will automatically apply the taxes from the chosen template.",
+   "fieldname": "add_taxes_from_taxes_and_charges_template",
+   "fieldtype": "Check",
+   "label": "Automatically Add Taxes from Taxes and Charges Template"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -25,6 +25,7 @@ class AccountsSettings(Document):
 
 		acc_frozen_upto: DF.Date | None
 		add_taxes_from_item_tax_template: DF.Check
+		add_taxes_from_taxes_and_charges_template: DF.Check
 		allow_multi_currency_invoices_against_single_party_account: DF.Check
 		allow_pegged_currencies_exchange_rates: DF.Check
 		allow_stale: DF.Check
@@ -76,6 +77,7 @@ class AccountsSettings(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_auto_tax_settings()
 		old_doc = self.get_doc_before_save()
 		clear_cache = False
 
@@ -142,3 +144,13 @@ class AccountsSettings(Document):
 		if self.has_value_changed("reconciliation_queue_size"):
 			if cint(self.reconciliation_queue_size) < 5 or cint(self.reconciliation_queue_size) > 100:
 				frappe.throw(_("Queue Size should be between 5 and 100"))
+
+	def validate_auto_tax_settings(self):
+		if self.add_taxes_from_item_tax_template and self.add_taxes_from_taxes_and_charges_template:
+			frappe.throw(
+				_("You cannot enable both the settings '{0}' and '{1}'.").format(
+					frappe.bold(self.meta.get_label("add_taxes_from_item_tax_template")),
+					frappe.bold(self.meta.get_label("add_taxes_from_taxes_and_charges_template")),
+				),
+				title=_("Auto Tax Settings Error"),
+			)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -843,6 +843,10 @@ class TestSalesInvoice(ERPNextTestSuite):
 		w = self.make()
 		self.assertEqual(w.outstanding_amount, w.base_rounded_total)
 
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings",
+		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 0},
+	)
 	def test_rounded_total_with_cash_discount(self):
 		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][2])
 

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -179,6 +179,10 @@ class TestQuotation(IntegrationTestCase):
 		sales_order.delivery_date = nowdate()
 		sales_order.insert()
 
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings",
+		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 0},
+	)
 	def test_make_sales_order_with_terms(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
@@ -718,6 +722,10 @@ class TestQuotation(IntegrationTestCase):
 		quotation.items[0].conversion_factor = 2.23
 		self.assertRaises(frappe.ValidationError, quotation.save)
 
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings",
+		{"add_taxes_from_item_tax_template": 1, "add_taxes_from_taxes_and_charges_template": 0},
+	)
 	def test_item_tax_template_for_quotation(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 
@@ -759,10 +767,7 @@ class TestQuotation(IntegrationTestCase):
 			item_doc.save()
 
 		quotation = make_quotation(item_code="_Test Item Tax Template QTN", qty=1, rate=100, do_not_submit=1)
-		self.assertFalse(quotation.taxes)
 
-		quotation.append_taxes_from_item_tax_template()
-		quotation.save()
 		self.assertTrue(quotation.taxes)
 		for row in quotation.taxes:
 			self.assertEqual(row.account_head, "_Test Vat - _TC")


### PR DESCRIPTION
Issue: Taxes are not auto-appending from Item Tax Template even though settings is enabled.

Earlier: If the user passes a Sales Taxes and Charges Template, the relevant taxes will be fetched.(If setting add_taxes_from_item_tax_template is enabled.)


Current:

- Separate setting for appending taxes from the Taxes and charges template.
-  Any one setting can be enabled.
-If the settings add_taxes_from_item_tax_template is enabled and taxes are empty, then taxes will be appended from the item tax template.

![image](https://github.com/user-attachments/assets/d844dab3-4674-45e0-970e-8ced1638151d)
![image](https://github.com/user-attachments/assets/acafa565-2038-430b-8d07-fa3867c8dfb2)




Frappe Support Issue: https://support.frappe.io/app/hd-ticket/38018

