### PR TITLE
fix(quotation): use `Text Editor` field in alternative items dialog

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -286,7 +286,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 				},
 			},
 			{
-				fieldtype: "Data",
+				fieldtype: "Text Editor",
 				fieldname: "description",
 				label: __("Description"),
 				in_list_view: 1,


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/125f7d47-635c-427c-8852-760549b79066)

After:
![image](https://github.com/user-attachments/assets/94b8990e-0068-480c-9a2b-ef8eaad41597)

(You can scroll to get the "full" information")

<hr>

Reference: support ticket 38113