### PR TITLE
fix: update Journal Entry title correctly

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -147,8 +147,9 @@ class JournalEntry(AccountsController):
 		if self.docstatus == 0:
 			self.apply_tax_withholding()
 
-		if not self.title:
-			self.title = self.get_title()
+		title = self.get_title()
+		if not self.title or self.title != title:
+			self.title = title
 
 	def on_submit(self):
 		self.validate_cheque_info()


### PR DESCRIPTION
**The Journal Entry title is usually set using self.pay_to_recd_from or self.accounts[0].account, but in some scenarios, it's not updating correctly.**

**Test Scenario 1:**
When I duplicate a Journal Entry and change the Accounts table, the document title doesn't reflect the changes.

**Test Scenario 2:**
After submitting a Journal Entry, if I notice an issue in the Accounts table, I cancel and amend the document. Then I update the Accounts table, but the title still doesn't update accordingly.

![WhatsApp Image 2025-05-20 at 3 15 11 PM](https://github.com/user-attachments/assets/20ae8c78-66b2-40c3-927a-b8d98e9bcb6d)


