### PR TITLE
fix: Account Report / Account Currency Filter

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -98,8 +98,6 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 	presentation_currency = currency_info["presentation_currency"]
 	company_currency = currency_info["company_currency"]
 
-	account_currencies = list(set(entry["account_currency"] for entry in gl_entries))
-
 	for entry in gl_entries:
 		debit = flt(entry["debit"])
 		credit = flt(entry["credit"])

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -107,7 +107,7 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 		credit_in_account_currency = flt(entry["credit_in_account_currency"])
 		account_currency = entry["account_currency"]
 
-		if len(account_currencies) == 1 and account_currency == presentation_currency:
+		if account_currency == presentation_currency:
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency
 		else:


### PR DESCRIPTION
Do not convert the account currency via the company currency if the account currency is the same as the presentation currency.

`len(account_currencies) == 1` introduced by https://github.com/frappe/erpnext/pull/25654 seems not be necessary and creates issues, when viewing the balance sheet for example in the account currency, which is not the company currency. In this case the old behavior with `len(account_currencies) == 1` was, that the account debit/credit in the account currency was recalculated based on the company currency giving a difference to the actual account debit/credit.

Company Currency = EUR
Account Currency = USD

Old balance sheet view in EUR:

- Account has 100 USD which is shown correctly converted to EUR

Old balance sheet view in USD:

- Account has 100 USD which is converted via the EUR value on the account instead of taking the real 100 USD value to present

New balance sheet view in EUR:

- Account has 100 USD which is shown correctly converted to EUR

New balance sheet view in USD:

- Account has 100 USD which is NOT converted showing 100 USD
