### PR TITLE
fix: show general ledger in doc currency in Process Statement Of Accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -129,8 +129,8 @@ def get_statement_dict(doc, get_statement_dict=False):
 
 		tax_id = frappe.get_doc("Customer", entry.customer).tax_id
 		presentation_currency = (
-			get_party_account_currency("Customer", entry.customer, doc.company)
-			or doc.currency
+			doc.currency
+			or get_party_account_currency("Customer", entry.customer, doc.company)
 			or get_company_currency(doc.company)
 		)
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
@@ -102,6 +102,7 @@ def create_process_soa(**args):
 		company=args.company or "_Test Company",
 		customers=args.customers or [{"customer": "_Test Customer"}],
 		enable_auto_email=1 if args.enable_auto_email else 0,
+		currency=args.currency or "",
 		frequency=args.frequency or "Weekly",
 		report=args.report or "General Ledger",
 		from_date=args.from_date or getdate(today()),


### PR DESCRIPTION
Issue: General Ledger is always shown in party currency, even though presentation currency is set in the Process Statement of Account.


![image](https://github.com/user-attachments/assets/bb095481-6bf3-4ab8-89bf-2521eafcc226)

Before:
![image](https://github.com/user-attachments/assets/db895577-ef8e-40c6-9e0c-e16dd9cefc01)

After:
![image](https://github.com/user-attachments/assets/f5b04003-eaf5-4b4d-b6aa-95c0e2bdc7aa)

Closes: https://github.com/frappe/erpnext/issues/47640

