### PR TITLE
fix: pos additional information fields not updating on removal of data

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -71,9 +71,9 @@ erpnext.PointOfSale.Payment = class {
 
 	set_values_to_frm(values) {
 		const frm = this.events.get_frm();
-		for (const value in values) {
-			frm.set_value(value, values[value]);
-		}
+		this.addl_dlg.fields.forEach((df) => {
+			frm.set_value(df.fieldname, values[df.fieldname]);
+		});
 		frappe.show_alert({
 			message: __("Additional Information updated successfully."),
 			indicator: "green",


### PR DESCRIPTION
Fixed the issue on the POS Payments Screen where if the user clears the field in the Additional Information Dialog and saves, it does not update on the form.